### PR TITLE
feat: add founder-call booking entries to landing, pricing, and billing

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2983,6 +2983,7 @@
   "billing.perkUnlimitedMembers": "Unlimited team members",
   "billing.switchBillingInterval": "Switch billing interval",
   "billing.viewPricingPage": "View plans and pricing",
+  "billing.bookFounderCall": "Book a call with our founder",
   "workspace.deletePaidBlockedTitle": "Cancel the subscription first",
   "workspace.deletePaidBlockedDescription": "This workspace has an active Plus subscription. Cancel it in billing settings before deleting the workspace.",
   "workspace.deletePaidBlockedGoToBilling": "Go to billing",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -2981,6 +2981,7 @@
   "billing.perkUnlimitedMembers": "团队成员数量不限",
   "billing.switchBillingInterval": "切换计费周期",
   "billing.viewPricingPage": "查看套餐与价格详情",
+  "billing.bookFounderCall": "和创始人聊聊",
   "workspace.deletePaidBlockedTitle": "请先取消订阅",
   "workspace.deletePaidBlockedDescription": "该工作空间有生效中的 Plus 订阅。请先在账单设置中取消订阅，再删除工作空间。",
   "workspace.deletePaidBlockedGoToBilling": "前往账单设置",

--- a/packages/components/src/components/settings/billing-setting-pure.tsx
+++ b/packages/components/src/components/settings/billing-setting-pure.tsx
@@ -7,6 +7,7 @@ import { Progress } from '@/ui/progress';
 import { Skeleton } from '@/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { PricingPageLink } from '../shared/pricing-page-link';
+import { FounderCallLink } from '../shared/founder-call-link';
 import { SubscribeConsentNotice } from '../shared/subscribe-consent-notice';
 import { settingContainerClass } from '.';
 
@@ -512,7 +513,10 @@ export function BillingSettingsView({
               ))}
             </ul>
 
-            <PricingPageLink />
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+              <PricingPageLink />
+              <FounderCallLink />
+            </div>
 
             {canManage ? (
               <div className="border-t border-border/60 pt-4">

--- a/packages/components/src/components/shared/founder-call-link.tsx
+++ b/packages/components/src/components/shared/founder-call-link.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from 'react-i18next';
+import { ExternalLink } from 'lucide-react';
+import { openExternalUrl } from '@/lib/native-browser';
+import { cn } from '@/lib/utils';
+
+/** `utm_source=app` marks bookings that came from inside the product. */
+const FOUNDER_CALL_URL = 'https://calendar.notion.so/meet/remch183/hqic3xqu?utm_source=app';
+
+/**
+ * Subtle text link to book a call with the founder, shown on the billing
+ * upgrade card next to `PricingPageLink`. Opens in the system browser on
+ * Electron / a new tab on web (`openExternalUrl` handles both).
+ */
+export function FounderCallLink({ className }: { className?: string }) {
+  const { t } = useTranslation();
+
+  return (
+    <button
+      type="button"
+      onClick={() => void openExternalUrl(FOUNDER_CALL_URL)}
+      className={cn(
+        'inline-flex items-center gap-1 text-xs text-muted-foreground hover:underline',
+        className
+      )}
+    >
+      {t('billing.bookFounderCall')}
+      <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+    </button>
+  );
+}

--- a/site-docs/app/pricing.css
+++ b/site-docs/app/pricing.css
@@ -741,6 +741,29 @@
   transform: translateX(3px);
 }
 
+/* Low-key secondary action under the primary CTA (e.g. book a founder call) */
+.pricing-card-secondary-cta {
+  position: relative;
+  z-index: 1;
+  display: block;
+  margin-top: 0.65rem;
+  color: hsl(var(--landing-ink) / 0.6);
+  font-size: 0.8rem;
+  line-height: 1;
+  text-align: center;
+  text-decoration: underline;
+  text-decoration-color: hsl(var(--landing-ink) / 0.25);
+  text-underline-offset: 3px;
+  transition:
+    color 160ms ease,
+    text-decoration-color 160ms ease;
+}
+
+.pricing-card-secondary-cta:hover {
+  color: hsl(var(--landing-ink));
+  text-decoration-color: hsl(var(--ocean-aqua) / 0.5);
+}
+
 /* Card features list */
 .pricing-card-features {
   position: relative;

--- a/site-docs/app/underwater.css
+++ b/site-docs/app/underwater.css
@@ -2772,6 +2772,13 @@ html.underwater-landing-page.dark
   text-decoration: none;
 }
 
+/* Ghost button under the primary CTA — same width so the pair reads as one stack. */
+.uw-cta__book-call {
+  min-width: min(18rem, 100%);
+  justify-content: center;
+  text-decoration: none;
+}
+
 .uw-cta__secondary {
   display: flex;
   flex-wrap: wrap;

--- a/site-docs/components/landing-cta-section.tsx
+++ b/site-docs/components/landing-cta-section.tsx
@@ -22,6 +22,9 @@ export type LandingCtaCopy = {
   allPlatformsHref: string;
   webApp: string;
   webAppHref: string;
+  /** Low-key "book a call with the founder" link in the secondary row. */
+  bookCall: string;
+  bookCallHref: string;
   labels: PlatformDownloadLabels;
 };
 
@@ -51,6 +54,14 @@ export function LandingCtaSection({ copy }: { copy: LandingCtaCopy }) {
         <p className="uw-cta__lead">{copy.lead}</p>
 
         <div className="uw-cta__actions">
+          <a
+            className="uw-cta__book-call underwater-btn underwater-btn--ghost"
+            href={copy.bookCallHref}
+            rel="noreferrer"
+            target="_blank"
+          >
+            {copy.bookCall}
+          </a>
           <a
             className="uw-cta__primary underwater-btn underwater-btn--primary"
             href={primary.href}

--- a/site-docs/components/landing.tsx
+++ b/site-docs/components/landing.tsx
@@ -4,6 +4,7 @@ import type { MobileDeepSectionCopy } from './landing-mobile-deep-section';
 import type { OrchestrationSectionCopy } from './landing-orchestration-section';
 import type { PowerSectionCopy } from './landing-power-section';
 import type { SubscriptionsSectionCopy } from './landing-subscriptions-section';
+import { founderCallUrl } from '@site/lib/founder-call';
 import { SiteFooter } from './site-footer';
 import { SiteNav } from './site-nav';
 import { UnderwaterExperience } from './underwater-experience';
@@ -125,6 +126,8 @@ const copy: Record<LandingLocale, LandingCopy> = {
       allPlatformsHref: '/download',
       webApp: 'Web app',
       webAppHref: '/login',
+      bookCall: 'Book a founder call',
+      bookCallHref: founderCallUrl('landing'),
       labels: {
         macArm: 'Download for macOS',
         macIntel: 'Intel Mac',
@@ -241,6 +244,8 @@ const copy: Record<LandingLocale, LandingCopy> = {
       allPlatformsHref: '/zh/download',
       webApp: 'Web App',
       webAppHref: '/login',
+      bookCall: '和创始人聊聊',
+      bookCallHref: founderCallUrl('landing'),
       labels: {
         macArm: '下载 macOS 版',
         macIntel: 'Intel Mac',

--- a/site-docs/components/pricing-page.tsx
+++ b/site-docs/components/pricing-page.tsx
@@ -14,6 +14,8 @@
 import NumberFlow from '@number-flow/react';
 import { useMemo, useState, type CSSProperties, type ReactNode } from 'react';
 
+import { founderCallUrl } from '@site/lib/founder-call';
+
 import { LandingEffects } from './landing-interactions';
 import { SiteFooter } from './site-footer';
 import { SiteNav } from './site-nav';
@@ -51,6 +53,8 @@ type PricingPlan = {
   featured?: boolean;
   cta: string;
   href: string;
+  /** Optional low-key link under the primary CTA (e.g. book a founder call). */
+  secondaryCta?: { label: string; href: string };
   tone: PlanTone;
   features: readonly PlanFeature[];
 };
@@ -203,6 +207,7 @@ const copy = {
         description: 'For organizations with contracts, governance, and deployment requirements.',
         cta: 'Contact us',
         href: 'mailto:sales@lody.ai',
+        secondaryCta: { label: 'Book a founder call', href: founderCallUrl('pricing') },
         tone: 'deep',
         features: [
           'Custom contracts and invoicing',
@@ -401,6 +406,7 @@ const copy = {
         description: '为有合同、治理、安全审查和部署需求的组织设计。',
         cta: '联系我们',
         href: 'mailto:sales@lody.ai',
+        secondaryCta: { label: '和创始人聊聊', href: founderCallUrl('pricing') },
         tone: 'deep',
         features: [
           '定制合同与发票',
@@ -825,6 +831,17 @@ function PricingCard({
         <span>{plan.cta}</span>
         <ArrowIcon />
       </a>
+
+      {plan.secondaryCta ? (
+        <a
+          className="pricing-card-secondary-cta"
+          href={plan.secondaryCta.href}
+          rel="noreferrer"
+          target="_blank"
+        >
+          {plan.secondaryCta.label}
+        </a>
+      ) : null}
 
       <ul className="pricing-card-features">
         {plan.features.map((feature) => {

--- a/site-docs/components/site-footer.tsx
+++ b/site-docs/components/site-footer.tsx
@@ -4,6 +4,8 @@
  * Product nav lives in SiteNav only.
  */
 
+import { founderCallUrl } from '@site/lib/founder-call';
+
 export type SiteFooterLocale = 'en' | 'zh';
 
 const X_HREF = 'https://x.com/lody_ai';
@@ -13,6 +15,7 @@ const copy = {
     rights: '© 2026 Lody',
     support: 'Support',
     supportHref: '/support',
+    bookCall: 'Book a founder call',
     terms: 'Terms',
     termsHref: '/terms',
     privacy: 'Privacy',
@@ -22,6 +25,7 @@ const copy = {
     rights: '© 2026 Lody',
     support: '支持',
     supportHref: '/zh/support',
+    bookCall: '和创始人聊聊',
     terms: '条款',
     termsHref: '/zh/terms',
     privacy: '隐私',
@@ -43,6 +47,9 @@ export function SiteFooter({ locale }: { locale: SiteFooterLocale }) {
         </p>
         <nav className="underwater-footer__links" aria-label="Footer">
           <a href={t.supportHref}>{t.support}</a>
+          <a href={founderCallUrl('footer')} rel="noreferrer" target="_blank">
+            {t.bookCall}
+          </a>
           <a href={t.termsHref}>{t.terms}</a>
           <a href={t.privacyHref}>{t.privacy}</a>
           <a href={X_HREF} rel="noreferrer" target="_blank">

--- a/site-docs/lib/founder-call.ts
+++ b/site-docs/lib/founder-call.ts
@@ -1,0 +1,10 @@
+/**
+ * "Book a call with the founder" booking link, shared by the landing closing
+ * CTA, the pricing Enterprise card, and the site footer. `utm_source` marks
+ * which entry the booking came from.
+ */
+export const FOUNDER_CALL_URL = 'https://calendar.notion.so/meet/remch183/hqic3xqu';
+
+export function founderCallUrl(source: 'landing' | 'pricing' | 'footer'): string {
+  return `${FOUNDER_CALL_URL}?utm_source=${source}`;
+}


### PR DESCRIPTION
Risk: low — marketing copy/links and one settings-page link; no data model, auth, or billing-logic changes.
Confidence: high — typecheck, oxlint, i18n check, prettier, and a full site-docs build all pass; the new entries are verified in the prerendered HTML for /, /price, /zh, /zh/price.

## What

Adds a "Book a founder call" entry point (Notion Calendar link) in three places:

- **Landing closing CTA**: ghost button stacked above the primary download button, plus a footer link on all marketing pages
- **Pricing**: the Enterprise card keeps "Contact us" (mailto:sales@lody.ai) and gains a secondary "Book a founder call" link
- **App billing settings**: the upgrade card gains a "Book a call with our founder" link next to "View plans and pricing"

The booking URL is centralized in `site-docs/lib/founder-call.ts` with `utm_source` per entry (landing / pricing / footer; `app` for the in-product link). zh copy: 和创始人聊聊.

## Validation

- `pnpm --filter @lody/site-docs typecheck`, `pnpm --filter @lody/components typecheck` ✅
- oxlint (0 errors), `scripts/check-i18n.mjs` ✅, prettier clean on changed files ✅
- `pnpm --filter @lody/site-docs build` ✅ — booking links confirmed in prerendered output
- Note: test failures in `@lody/shared` (loro-streams presence URL) and `@lody/components` (stale convex-query mocks) are pre-existing — they reproduce on the base commit without these changes.