### PR TITLE
feat(agents): add built-in reauthentication [risk:medium]

### DIFF
--- a/apps/cli/src/session/acp-error-classification.test.ts
+++ b/apps/cli/src/session/acp-error-classification.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   ACP_ERROR_CODES,
   getACPErrorUserMessage,
+  isAuthenticationRequiredACPError,
   isAgentDisconnectedError,
   isAcpSessionNotFoundError,
   mapACPErrorToFailureReason,
@@ -81,6 +82,40 @@ describe('ACP error classification', () => {
     if (!parsed) {
       throw new Error('expected ACP error to parse');
     }
+    expect(mapACPErrorToFailureReason(parsed)).toBe('acp_internal_error');
+  });
+
+  it.each([
+    'Not logged in · Please run /login',
+    'Session expired. Please run /login to sign in again.',
+    'refresh token cannot be refreshed',
+    'Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.',
+  ])('maps provider reauthentication errors to acp_auth_required: %s', (details) => {
+    const parsed = parseACPError({
+      code: ACP_ERROR_CODES.INTERNAL_ERROR,
+      message: 'Internal error',
+      data: { details },
+    });
+
+    if (!parsed) {
+      throw new Error('expected ACP error to parse');
+    }
+    expect(isAuthenticationRequiredACPError(parsed)).toBe(true);
+    expect(mapACPErrorToFailureReason(parsed)).toBe('acp_auth_required');
+    expect(shouldTerminateOnACPError(parsed, 'acp_auth_required')).toBe(true);
+  });
+
+  it('does not treat unrelated token refresh errors as provider login failures', () => {
+    const parsed = parseACPError({
+      code: ACP_ERROR_CODES.INTERNAL_ERROR,
+      message: 'Internal error',
+      data: { details: 'Failed to refresh the model catalog cache token' },
+    });
+
+    if (!parsed) {
+      throw new Error('expected ACP error to parse');
+    }
+    expect(isAuthenticationRequiredACPError(parsed)).toBe(false);
     expect(mapACPErrorToFailureReason(parsed)).toBe('acp_internal_error');
   });
 

--- a/apps/cli/src/session/acp-error-classification.ts
+++ b/apps/cli/src/session/acp-error-classification.ts
@@ -50,6 +50,15 @@ const getACPDiagnosticText = (error: unknown, parsedError?: ParsedACPError | nul
   return formatErrorMessage(error);
 };
 
+const AUTHENTICATION_REQUIRED_PATTERNS = [
+  /\bnot logged in\b/i,
+  /\bauthentication required\b/i,
+  /\bplease run\s+\/login\b/i,
+  /\bsession expired\b[\s\S]{0,160}\b(?:log|sign) in again\b/i,
+  /\brefresh token\b[\s\S]{0,160}\b(?:already used|expired|revoked|cannot be refreshed|could not be refreshed)\b/i,
+  /\baccess token\b[\s\S]{0,160}\bcould not be refreshed\b[\s\S]{0,160}\brefresh token\b/i,
+] as const;
+
 export const parseACPError = (error: unknown): ParsedACPError | null => {
   if (!error || typeof error !== 'object') {
     return null;
@@ -94,10 +103,26 @@ export const isAcpSessionNotFoundError = (error: unknown): boolean => {
   return /\bsession not found\b/i.test(getACPDiagnosticText(error, parsed));
 };
 
+/**
+ * Some provider runtimes still wrap expired OAuth credentials in an ACP
+ * internal error instead of using ACP's dedicated auth-required code. Keep the
+ * compatibility match narrow and limited to provider-owned instructions that
+ * explicitly require another login.
+ */
+export const isAuthenticationRequiredACPError = (error: unknown): boolean => {
+  const parsed = parseACPError(error);
+  if (parsed?.code === ACP_ERROR_CODES.AUTH_REQUIRED) {
+    return true;
+  }
+  const diagnosticText = getACPDiagnosticText(error, parsed);
+  return AUTHENTICATION_REQUIRED_PATTERNS.some((pattern) => pattern.test(diagnosticText));
+};
+
 export const mapACPErrorToFailureReason = (error: ParsedACPError): ChatFailedReason => {
+  if (isAuthenticationRequiredACPError(error)) {
+    return 'acp_auth_required';
+  }
   switch (error.code) {
-    case ACP_ERROR_CODES.AUTH_REQUIRED:
-      return 'acp_auth_required';
     case ACP_ERROR_CODES.INTERNAL_ERROR:
       // Some ACP adapters wrap a stale JSON-RPC transport as "-32603 Internal error".
       // Treat known transport-disposal text as a recoverable agent disconnect instead
@@ -130,12 +155,13 @@ export const shouldTerminateOnACPError = (
   error: ParsedACPError,
   failureReason: ChatFailedReason
 ): boolean => {
+  if (failureReason === 'acp_auth_required') {
+    return true;
+  }
   if (failureReason === 'acp_upstream_api_error') {
     return false;
   }
-  return (
-    error.code === ACP_ERROR_CODES.AUTH_REQUIRED || error.code === ACP_ERROR_CODES.INTERNAL_ERROR
-  );
+  return error.code === ACP_ERROR_CODES.INTERNAL_ERROR;
 };
 
 export const shouldRecoverStaleACPConnectionPrompt = (args: {

--- a/packages/components/src/components/settings/acp-authentication-panel.tsx
+++ b/packages/components/src/components/settings/acp-authentication-panel.tsx
@@ -38,6 +38,7 @@ export function AcpAuthenticationPanel({
   runtimeOverrides,
   env,
   compact = false,
+  reauthentication = false,
   onAuthenticated,
 }: {
   machineId: MachineId | null;
@@ -48,6 +49,7 @@ export function AcpAuthenticationPanel({
   runtimeOverrides?: BuiltinRuntimeOverrides;
   env?: Record<string, string>;
   compact?: boolean;
+  reauthentication?: boolean;
   onAuthenticated?: () => void | Promise<void>;
 }) {
   const { t } = useTranslation();
@@ -254,7 +256,7 @@ export function AcpAuthenticationPanel({
             <LogIn className="h-3.5 w-3.5" />
             {phase === 'error' || phase === 'cancelled'
               ? t('agents.authentication.retry', 'Retry {{provider}} sign-in', { provider })
-              : phase === 'authenticated'
+              : phase === 'authenticated' || reauthentication
                 ? t('agents.authentication.signInAgain', 'Sign in again')
                 : t('agents.authentication.signIn', 'Sign in with {{provider}}', { provider })}
           </Button>

--- a/packages/components/src/components/settings/provider-row.tsx
+++ b/packages/components/src/components/settings/provider-row.tsx
@@ -4,6 +4,7 @@ import { useAtomValue } from 'jotai';
 import { Loader2, RefreshCw, Trash2 } from 'lucide-react';
 import {
   REGISTRY_ACP_AGENTS,
+  isBuiltinAgentType,
   type AgentConfigCliType,
   type AgentConfigMeta,
   type MachineAcpBinaryProgressMessage,
@@ -27,6 +28,7 @@ import { cn } from '@/lib/utils';
 import { activeWorkspaceRuntimeAtom } from '@/atoms/runtime';
 import { useMachineAcpBinaryProgress } from '@/hooks/use-machine-acp-binary-progress';
 import { AgentIcon } from '@/components/icons/agent-icon';
+import { AcpAuthenticationPanel } from './acp-authentication-panel';
 import {
   canShowSubscriptionRateLimits,
   formatRateLimitWindowShortLabel,
@@ -64,6 +66,7 @@ export function ProviderRow({ config, machine, onEdit, onDelete, onRefresh }: Pr
   }, [showRateLimits, machine?.raceLimits, agentType]);
 
   const typeBadge = cliType === 'builtin' ? null : cliType === 'custom' ? 'Custom' : 'Registry';
+  const canReauthenticate = cliType === 'builtin' && isBuiltinAgentType(agentType);
 
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -209,6 +212,21 @@ export function ProviderRow({ config, machine, onEdit, onDelete, onRefresh }: Pr
           ))}
         </div>
       )}
+      {canReauthenticate ? (
+        <div className="px-3 pb-2.5 pt-0.5 sm:ps-11">
+          <AcpAuthenticationPanel
+            machineId={machine?.id ?? config.machineId}
+            configId={config.id}
+            cliType={config.cliType}
+            agentType={config.agentType}
+            customAcp={config.customAcp}
+            runtimeOverrides={config.runtimeOverrides}
+            env={config.env}
+            compact
+            reauthentication
+          />
+        </div>
+      ) : null}
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/packages/components/src/stories/ProviderRow.stories.tsx
+++ b/packages/components/src/stories/ProviderRow.stories.tsx
@@ -152,6 +152,7 @@ export const ClaudeNoLimits: Story = {
   args: {
     config: makeConfig({ name: 'Claude Code', cliType: 'builtin', agentType: 'claude' }),
     machine: makeMachine(),
+    showActions: true,
   },
 };
 

--- a/packages/components/tests/provider-row-reauthentication.test.tsx
+++ b/packages/components/tests/provider-row-reauthentication.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentConfigId, AgentConfigMeta, MachineId, MachineViewMeta } from '@lody/shared';
+
+import { ProviderRow } from '../src/components/settings/provider-row';
+import { initI18n } from '../src/i18n';
+
+vi.mock('../src/components/settings/acp-authentication-panel', () => ({
+  AcpAuthenticationPanel: ({ reauthentication }: { reauthentication?: boolean }) => (
+    <button type="button" data-reauthentication={String(reauthentication)}>
+      Sign in again
+    </button>
+  ),
+}));
+
+const machineId = 'machine-test' as MachineId;
+const machine: MachineViewMeta = {
+  id: machineId,
+  name: 'Workstation',
+  cliVersion: '0.76.0',
+  os: 'macOS',
+  sessions: [],
+  raceLimits: {},
+};
+
+const makeConfig = (
+  overrides: Pick<AgentConfigMeta, 'cliType' | 'agentType'>
+): AgentConfigMeta => ({
+  id: `config-${overrides.agentType}` as AgentConfigId,
+  machineId,
+  name: overrides.agentType,
+  env: {},
+  ...overrides,
+});
+
+describe('ProviderRow reauthentication', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await initI18n('en');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  const renderConfig = async (config: AgentConfigMeta) => {
+    await act(async () => {
+      root.render(
+        <ProviderRow config={config} machine={machine} onEdit={vi.fn()} onRefresh={vi.fn()} />
+      );
+    });
+  };
+
+  it.each(['claude', 'codex', 'kimi'] as const)(
+    'offers Sign in again for the built-in %s provider',
+    async (agentType) => {
+      await renderConfig(makeConfig({ cliType: 'builtin', agentType }));
+
+      const button = container.querySelector<HTMLButtonElement>(
+        'button[data-reauthentication="true"]'
+      );
+      expect(button?.textContent).toContain('Sign in again');
+    }
+  );
+
+  it('does not offer provider-owned login for registry agents', async () => {
+    await renderConfig(makeConfig({ cliType: 'registry', agentType: 'auggie' }));
+
+    expect(container.querySelector('button[data-reauthentication]')).toBeNull();
+  });
+});


### PR DESCRIPTION
Risk: 🟡 medium | Confidence: medium — Agent auth recovery touches shared CLI and UI paths; targeted tests, typechecks, lint, boundary checks, and builds pass, while the refactor baseline still has three unrelated shared-package test failures.

## Summary

- keep a Sign in again action available for active built-in Claude, Codex, and Kimi providers
- classify narrow expired or revoked credential diagnostics as acp_auth_required
- reuse the existing in-chat authentication panel when a session needs login

## Verification

- CLI auth classification tests: 14 passed
- provider-row reauthentication tests: 4 passed
- CLI and components typechecks passed
- public-boundary check passed for 3,414 files and 18 manifests
- changed-file lint passed with zero errors
- application builds passed after providing required Electron build-time origins

The full parent workspace check reaches three existing packages/shared failures unrelated to this diff: one terminal socket expectation still uses the pre-refactor path, and two Loro Streams presence tests lack an injected base URL.