### PR TITLE
fix(cli): invalidate the local data-plane room on doc unload [risk:high]

### DIFF
--- a/apps/cli/src/lib/loro/doc-status.test.ts
+++ b/apps/cli/src/lib/loro/doc-status.test.ts
@@ -14,10 +14,14 @@ const createLogger = (): Logger =>
     error: vi.fn(),
   }) as unknown as Logger;
 
-const createSessionDocument = (repo: Partial<LoroRepo>): SessionDocument => {
+const createSessionDocument = (
+  repo: Partial<LoroRepo>,
+  unloadDocRoom: (docId: string) => Promise<void> = async () => {}
+): SessionDocument => {
   const doc = new SessionDocument(
     repo as LoroRepo,
     'session-status-1' as SessionId,
+    unloadDocRoom,
     createLogger()
   );
   doc.mirror = {
@@ -160,16 +164,24 @@ describe('SessionDocument status metadata', () => {
   it('resets initializing status to idle during destroy without publishing presence', async () => {
     const upsertDocMeta = vi.fn(async () => {});
     const unloadDoc = vi.fn(async () => {});
-    const doc = createSessionDocument({
-      getDocMeta: vi.fn(async () => ({
-        meta: {
-          machineId: 'machine-1',
-          status: SessionStatusFactory.initializing(),
-        },
-      })),
-      unloadDoc,
-      upsertDocMeta,
-    });
+    // Destroy must go through the injected unloader, never `repo.unloadDoc`
+    // directly: the injected one also invalidates the local data-plane room
+    // bound to the evicted `LoroDoc` instance
+    // (`LoroDocumentManager.unloadDocRoom`).
+    const unloadDocRoom = vi.fn(async () => {});
+    const doc = createSessionDocument(
+      {
+        getDocMeta: vi.fn(async () => ({
+          meta: {
+            machineId: 'machine-1',
+            status: SessionStatusFactory.initializing(),
+          },
+        })),
+        unloadDoc,
+        upsertDocMeta,
+      },
+      unloadDocRoom
+    );
 
     await doc.destroy();
 
@@ -179,6 +191,7 @@ describe('SessionDocument status metadata', () => {
         status: SessionStatusFactory.idle(),
       })
     );
-    expect(unloadDoc).toHaveBeenCalledWith(doc.roomId);
+    expect(unloadDocRoom).toHaveBeenCalledWith(doc.roomId);
+    expect(unloadDoc).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/lib/loro/doc.ts
+++ b/apps/cli/src/lib/loro/doc.ts
@@ -727,6 +727,33 @@ export class LoroDocumentManager {
     return this.localLoroDataPlaneServer;
   }
 
+  /**
+   * THE ONLY PLACE THE CLI MAY CALL `repo.unloadDoc`.
+   *
+   * `unloadDoc` evicts the doc from the repo's instance cache, so the next
+   * `openPersistedDoc` returns a DIFFERENT `LoroDoc`. Anything still holding the
+   * old instance keeps reading and writing an orphan. The local data plane is
+   * exactly such a holder: a doc room resolves its `LoroDoc` once and keeps it
+   * for as long as a renderer stays subscribed, so an unaccompanied unload
+   * silently severs renderer↔CLI sync in both directions (observed: a
+   * GC-evicted session whose next user turn never reached the CLI, so
+   * `TurnHistoryGate` held the whole reply for its full 20s timeout).
+   *
+   * Invalidating AFTER the unload is deliberate: doing it before leaves a window
+   * where a racing join re-opens the doc into the repo cache just in time for
+   * the eviction to strand it again — and that failure is silent, whereas
+   * updates lost in the window here are re-uploaded by the peer's next join
+   * reconciliation.
+   *
+   * Route every new unload through here. `tests/loro-doc-unload-invalidates-data-plane.test.ts`
+   * fails the build if another `repo.unloadDoc` call site appears.
+   */
+  async unloadDocRoom(docId: string): Promise<void> {
+    await this.repo.unloadDoc(docId);
+    this.localLoroDataPlaneServer?.invalidateDocRoom(docId);
+    this.logger.debug(`[${this.workspaceId}] Unloaded doc ${docId} and invalidated its local room`);
+  }
+
   isTransportConnected(): boolean {
     return this.connectionRecovery.isTransportConnected();
   }
@@ -1037,7 +1064,12 @@ export class LoroDocumentManager {
     }
 
     const initPromise = (async () => {
-      const sessionDoc = new SessionDocument(this.repo, sessionId, this.logger);
+      const sessionDoc = new SessionDocument(
+        this.repo,
+        sessionId,
+        (docId) => this.unloadDocRoom(docId),
+        this.logger
+      );
       await sessionDoc.init();
       // If cleanup ran while we were initializing, destroy the orphaned doc
       // instead of registering it (cleanUp/cleanSessionDoc only sees this.sessions).
@@ -1057,7 +1089,12 @@ export class LoroDocumentManager {
   }
 
   async getSessionHistorySnapshot(sessionId: SessionId): Promise<SessionHistoryInput[]> {
-    const sessionDoc = new SessionDocument(this.repo, sessionId, this.logger);
+    const sessionDoc = new SessionDocument(
+      this.repo,
+      sessionId,
+      (docId) => this.unloadDocRoom(docId),
+      this.logger
+    );
     await sessionDoc.init({ skipAutoRead: true });
     try {
       return await sessionDoc.getHistory();
@@ -1446,6 +1483,13 @@ export class SessionDocument implements LoroDocument<SessionDocMeta, SessionMeta
   constructor(
     private repo: LoroRepo,
     public sessionId: SessionId,
+    /**
+     * Evicts the doc from the repo cache AND invalidates the local data-plane
+     * room bound to the old instance. Injected rather than calling
+     * `repo.unloadDoc` directly so the two can never be separated — see
+     * `LoroDocumentManager.unloadDocRoom`.
+     */
+    private unloadDocRoom: (docId: string) => Promise<void>,
     private logger: Logger = getLogger('loro')
   ) {
     this.roomId = getSessionRoomId(this.sessionId);
@@ -2631,7 +2675,7 @@ export class SessionDocument implements LoroDocument<SessionDocMeta, SessionMeta
     ) {
       await this.setStatus(SessionStatusFactory.idle());
     }
-    await this.repo.unloadDoc(this.roomId);
+    await this.unloadDocRoom(this.roomId);
     this.docSub?.unsubscribe();
     this.docSub = null;
     this.docBinding = null;

--- a/apps/cli/src/lib/loro/doc.ts
+++ b/apps/cli/src/lib/loro/doc.ts
@@ -2675,10 +2675,18 @@ export class SessionDocument implements LoroDocument<SessionDocMeta, SessionMeta
     ) {
       await this.setStatus(SessionStatusFactory.idle());
     }
-    await this.unloadDocRoom(this.roomId);
+    // Release the repo room BEFORE evicting the doc. loro-repo binds the
+    // `LoroDoc` instance into a room's transport attachment once, at attach
+    // time, and `unloadDoc` does not detach rooms — so unloading first leaves
+    // every still-attached transport (the cloud one included) syncing the
+    // orphan. Rooms are ref-counted, so if any other holder keeps this room
+    // open that binding never re-attaches and is stranded permanently.
+    // Nothing is lost by releasing first: `setStatus` above writes through
+    // `repo.upsertDocMeta`, i.e. the meta room, not this doc's room.
     this.docSub?.unsubscribe();
     this.docSub = null;
     this.docBinding = null;
+    await this.unloadDocRoom(this.roomId);
     this.detachDocRoomStatusListener?.();
     this.detachDocRoomStatusListener = null;
     this.docRoomStatusListeners.clear();

--- a/apps/cli/tests/loro-doc-unload-data-plane-integration.test.ts
+++ b/apps/cli/tests/loro-doc-unload-data-plane-integration.test.ts
@@ -1,0 +1,379 @@
+/**
+ * End-to-end coverage of the CLI seam that pairs a repo doc eviction with the
+ * local data plane's room invalidation:
+ *
+ *   LoroDocumentManager.cleanSessionDoc (session GC)
+ *     -> SessionDocument.destroy
+ *       -> LoroDocumentManager.unloadDocRoom
+ *         -> repo.unloadDoc(docId)            (evicts the LoroDoc instance)
+ *         -> LocalLoroDataPlaneServer.invalidateDocRoom(docId)
+ *
+ * `repo.unloadDoc` hands the NEXT `openPersistedDoc` a different `LoroDoc`, but
+ * a data-plane doc room resolves its instance ONCE and keeps it while a peer
+ * stays subscribed. Without the invalidation the room keeps importing renderer
+ * uploads into the orphaned instance: no error, no status change, and the
+ * renderer's user turn never reaches the CLI.
+ *
+ * Everything here is REAL — a real `LoroDocumentManager` over a real `LoroRepo`
+ * with SQLite storage in a temp dir, and the manager's own
+ * `LocalLoroDataPlaneServer`. Only the socket is faked: the renderer peer is an
+ * in-memory connection driven straight through `engine.handleMessage`, exactly
+ * as `local-loro-data-plane-server.ts` drives it for a real net socket.
+ *
+ * Companion coverage that this test deliberately does NOT duplicate:
+ *  - `packages/shared/tests/local-loro-transport-bug-repro.test.ts` (F9): the
+ *    engine's invalidation semantics against a fake `resolveDoc`.
+ *  - `packages/components/tests/local-data-plane-room-invalidation-reconnect.test.ts`:
+ *    that the published terminal status actually makes the renderer's reconnect
+ *    loop fire.
+ *  - `apps/cli/tests/loro-doc-unload-invalidates-data-plane.test.ts`: that
+ *    `unloadDocRoom` stays the only `repo.unloadDoc` call site.
+ */
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { LoroDoc, VersionVector } from 'loro-crdt';
+import { Mirror } from 'loro-mirror';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createLocalCloudPort } from '@lody/platform';
+import {
+  base64ToBytes,
+  bytesToBase64,
+  getSessionRoomId,
+  LOCAL_LORO_DATA_PLANE_PROTOCOL_VERSION,
+  sessionDocSchema,
+  type LocalLoroDataPlaneRoom,
+  type LocalLoroDataPlaneServer,
+  type LocalLoroDataPlaneServerMessage,
+  type Role,
+  type SessionDoc,
+  type SessionHistoryInput,
+  type SessionId,
+  type WorkspaceId,
+} from '@lody/shared';
+
+import {
+  applyLocalPlatformEnv,
+  ensureImplicitLocalWorkspace,
+  loadOrCreateLocalIdentity,
+} from '../src/lib/cli-platform';
+import { LoroDocumentManager } from '../src/lib/loro/doc';
+import { makeLocalWorkspaceCatalog } from '../src/lib/local-workspace-catalog';
+import type { Logger } from '../src/utils/logger';
+
+const createSilentLogger = (): Logger => ({
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  success: () => {},
+  debug: () => {},
+  setLevel: () => {},
+  child: () => createSilentLogger(),
+  close: async () => {},
+});
+
+const historyEntry = (id: string, role: Role, text: string): SessionHistoryInput => ({
+  id,
+  // Fixed timestamp: nothing here depends on the wall clock.
+  timestamp: new Date(0).toISOString(),
+  role,
+  fileDiff: [],
+  items: [{ type: 'text', text }],
+});
+
+/**
+ * The server half of one local data-plane socket. `send` is the only thing the
+ * engine sees, so every assertion below is made on the frames a real renderer
+ * would have received.
+ */
+class FakeRendererConnection {
+  readonly id = 'dp:loro-doc-unload-integration';
+  readonly frames: LocalLoroDataPlaneServerMessage[] = [];
+  private readonly waiters = new Set<() => void>();
+
+  readonly send = (message: LocalLoroDataPlaneServerMessage): void => {
+    this.frames.push(message);
+    for (const waiter of [...this.waiters]) {
+      waiter();
+    }
+  };
+
+  /**
+   * Resolve with the first frame at or after `from` that matches. Frames
+   * already received satisfy it immediately, so a caller can register the wait
+   * after triggering the work without racing the writer.
+   */
+  waitFor(
+    predicate: (message: LocalLoroDataPlaneServerMessage) => boolean,
+    from = 0
+  ): Promise<LocalLoroDataPlaneServerMessage> {
+    const match = (): LocalLoroDataPlaneServerMessage | undefined =>
+      this.frames.slice(from).find(predicate);
+    const existing = match();
+    if (existing) {
+      return Promise.resolve(existing);
+    }
+    return new Promise<LocalLoroDataPlaneServerMessage>((resolve) => {
+      const check = (): void => {
+        const found = match();
+        if (!found) {
+          return;
+        }
+        this.waiters.delete(check);
+        resolve(found);
+      };
+      this.waiters.add(check);
+    });
+  }
+}
+
+/**
+ * A renderer window, reduced to what the protocol actually requires: its own
+ * `LoroDoc`, a `Mirror` over the shared session schema (how the renderer
+ * direct-authors user turns), and hand-built protocol v7 frames.
+ */
+class FakeRendererPeer {
+  readonly peerId = 'renderer:loro-doc-unload-integration';
+  readonly doc = new LoroDoc();
+  private mirror: Mirror<typeof sessionDocSchema> | null = null;
+  private serverVersion: string | undefined;
+  private joinCount = 0;
+
+  constructor(
+    private readonly engine: LocalLoroDataPlaneServer,
+    private readonly connection: FakeRendererConnection,
+    private readonly workspaceId: WorkspaceId,
+    private readonly room: LocalLoroDataPlaneRoom
+  ) {}
+
+  /** Join the room and apply the server's catch-up. Resolves on the `joined` reply. */
+  async joinAndSync(): Promise<void> {
+    this.joinCount += 1;
+    const requestId = `join:${this.peerId}:${this.joinCount}`;
+    const from = this.connection.frames.length;
+    await this.engine.handleMessage(this.connection, {
+      type: 'join',
+      protocolVersion: LOCAL_LORO_DATA_PLANE_PROTOCOL_VERSION,
+      requestId,
+      workspaceId: this.workspaceId,
+      peerId: this.peerId,
+      room: this.room,
+      haveVersion: this.encodedVersion(),
+    });
+    const frame = await this.connection.waitFor(
+      (message) => message.type === 'joined' && message.requestId === requestId,
+      from
+    );
+    if (frame.type !== 'joined') {
+      throw new Error(`Expected a joined frame, received ${frame.type}`);
+    }
+    this.serverVersion = frame.serverVersion;
+    const payload = frame.payload;
+    if (payload && payload.kind === 'doc-update') {
+      this.doc.import(base64ToBytes(payload.dataBase64));
+    }
+    if (!this.mirror) {
+      this.mirror = new Mirror({ doc: this.doc, schema: sessionDocSchema });
+    }
+  }
+
+  /** Author a history entry locally, the way the renderer authors a user turn. */
+  appendHistory(entry: SessionHistoryInput): void {
+    const mirror = this.mirror;
+    if (!mirror) {
+      throw new Error('The peer must join before it can author history');
+    }
+    mirror.setState((previous) => {
+      const history = (previous.history ?? []) as unknown as SessionHistoryInput[];
+      const next: SessionHistoryInput[] = [...history, entry];
+      return { ...previous, history: next } as unknown as SessionDoc;
+    });
+  }
+
+  /**
+   * Upload everything the server is missing. `handleMessage` resolves only
+   * after the engine has imported the update, so awaiting it is the completion
+   * signal — no draining, no polling.
+   */
+  async pushUpdate(): Promise<void> {
+    const from = this.serverVersion
+      ? VersionVector.decode(base64ToBytes(this.serverVersion))
+      : new VersionVector(null);
+    const delta = this.doc.export({ mode: 'update', from });
+    expect(delta.length).toBeGreaterThan(0);
+    await this.engine.handleMessage(this.connection, {
+      type: 'update',
+      protocolVersion: LOCAL_LORO_DATA_PLANE_PROTOCOL_VERSION,
+      workspaceId: this.workspaceId,
+      peerId: this.peerId,
+      room: this.room,
+      haveVersion: this.encodedVersion(),
+      payload: { kind: 'doc-update', dataBase64: bytesToBase64(delta) },
+    });
+  }
+
+  private encodedVersion(): string {
+    return bytesToBase64(this.doc.oplogVersion().encode());
+  }
+}
+
+type Harness = {
+  manager: LoroDocumentManager;
+  connection: FakeRendererConnection;
+  peer: FakeRendererPeer;
+  sessionId: SessionId;
+  docId: string;
+  cliEntryId: string;
+  dispose: () => Promise<void>;
+};
+
+describe('session GC unloads the repo doc and invalidates its local data-plane room', () => {
+  let tempDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lody-doc-unload-dp-'));
+    process.env.LODY_PLATFORM = 'local';
+    process.env.LODY_DATA_DIR = path.join(tempDir, '.lody-oss');
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Real manager, real repo, real data-plane engine; one session doc with one
+   * CLI-authored history entry and a renderer peer subscribed to its room.
+   */
+  const createHarness = async (): Promise<Harness> => {
+    applyLocalPlatformEnv();
+    const logger = createSilentLogger();
+    const identity = await loadOrCreateLocalIdentity(logger);
+    const catalog = makeLocalWorkspaceCatalog({
+      filePath: path.join(tempDir, '.lody-oss', 'workspace-catalog.json'),
+      lockName: `doc-unload-dp-${process.pid}`,
+      cacheTtlMs: Number.POSITIVE_INFINITY,
+    });
+    const workspace = await ensureImplicitLocalWorkspace({
+      catalog,
+      identity,
+      machineId: 'local-machine',
+      machineName: 'local-host',
+      logger,
+    });
+    const cloudPort = createLocalCloudPort({
+      identity: { userId: identity.userId },
+      workspaces: [workspace],
+    });
+    const workspaceId = workspace.id as WorkspaceId;
+    const manager = await LoroDocumentManager.create(workspaceId, identity.userId, logger, {
+      streamsTokens: cloudPort.streamsTokens,
+      cloudBilling: cloudPort.billing,
+    });
+    const dispose = async (): Promise<void> => {
+      await manager.cleanUp({ fast: true, preserveSessionStatus: true });
+      await cloudPort.dispose();
+    };
+
+    try {
+      const engine = manager.getLocalLoroDataPlaneServer();
+      if (!engine) {
+        throw new Error('LoroDocumentManager.create did not build a local data-plane engine');
+      }
+
+      const sessionId = await manager.createSession('local-machine', 'builtin', 'claude');
+      const sessionDoc = await manager.getOrCreateSessionDoc(sessionId);
+      // The offline room settles immediately (no transport is attached); await
+      // it so the manager's join-triggered background hydrate cannot still be
+      // in flight when the session is garbage-collected below.
+      await sessionDoc.waitForRemoteSync();
+      const cliEntryId = 'cli-authored-turn';
+      await sessionDoc.updateHistory((history) => [
+        ...history,
+        historyEntry(cliEntryId, 'assistant', 'agent reply written by the CLI'),
+      ]);
+
+      const docId = getSessionRoomId(sessionId);
+      const room: LocalLoroDataPlaneRoom = { scope: 'doc', docId };
+      const connection = new FakeRendererConnection();
+      const peer = new FakeRendererPeer(engine, connection, workspaceId, room);
+      await peer.joinAndSync();
+
+      // The peer really is synced with the CLI's doc before anything is evicted.
+      const joinedHistory = peer.doc.toJSON() as { history?: Array<{ id?: unknown }> };
+      expect((joinedHistory.history ?? []).map((entry) => entry.id)).toEqual([cliEntryId]);
+
+      return { manager, connection, peer, sessionId, docId, cliEntryId, dispose };
+    } catch (error) {
+      await dispose();
+      throw error;
+    }
+  };
+
+  it('lets a renderer update authored after session GC reach the CLI', async () => {
+    const harness = await createHarness();
+    try {
+      // Session GC: destroys the SessionDocument, which unloads the doc from the
+      // repo and invalidates the data-plane room bound to the evicted instance.
+      await harness.manager.cleanSessionDoc(harness.sessionId);
+
+      const rendererEntryId = 'renderer-authored-turn';
+      harness.peer.appendHistory(
+        historyEntry(rendererEntryId, 'user', 'user turn sent after the session was collected')
+      );
+      await harness.peer.pushUpdate();
+
+      const history = await harness.manager.getSessionHistorySnapshot(harness.sessionId);
+      const ids = history.map((entry) => entry.id);
+      // Before the fix this is missing: the upload landed in the LoroDoc the
+      // repo had already evicted, so the CLI never saw the turn.
+      expect(ids).toContain(rendererEntryId);
+      // ...and the pre-eviction CLI history is still there, so the read really
+      // is of the same document rather than a fresh empty one.
+      expect(ids).toContain(harness.cliEntryId);
+
+      const rendererEntry = history.find((entry) => entry.id === rendererEntryId);
+      expect(rendererEntry?.role).toBe('user');
+      const items = rendererEntry?.items ?? [];
+      expect(items[0]?.text).toBe('user turn sent after the session was collected');
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  it('tells the subscribed peer to rejoin with a terminal room status', async () => {
+    const harness = await createHarness();
+    try {
+      const from = harness.connection.frames.length;
+      await harness.manager.cleanSessionDoc(harness.sessionId);
+
+      // Rejoin, exactly as the renderer's local reconnect loop would. Its
+      // `joined` reply is queued behind the invalidation's frames on the SAME
+      // per-connection writer, and the writer drains FIFO — so once it lands,
+      // every frame the invalidation produced has already been written. That
+      // ordering is the completion signal; nothing here waits on a clock.
+      await harness.peer.joinAndSync();
+
+      const roomStatuses = harness.connection.frames
+        .slice(from)
+        .flatMap((message) =>
+          message.type === 'room-status' &&
+          message.room.scope === 'doc' &&
+          message.room.docId === harness.docId
+            ? [message.status]
+            : []
+        );
+      expect(roomStatuses.length).toBeGreaterThan(0);
+      // Only 'disconnected'/'error' are terminal for the renderer's reconnect
+      // predicate; 'reconnecting' reads as "already recovering" and the local
+      // reconnect loop would never fire, leaving the room silently orphaned.
+      expect(
+        roomStatuses.filter((status) => status === 'disconnected' || status === 'error')
+      ).toEqual(roomStatuses);
+    } finally {
+      await harness.dispose();
+    }
+  });
+});

--- a/apps/cli/tests/loro-doc-unload-data-plane-integration.test.ts
+++ b/apps/cli/tests/loro-doc-unload-data-plane-integration.test.ts
@@ -285,9 +285,14 @@ describe('session GC unloads the repo doc and invalidates its local data-plane r
 
       const sessionId = await manager.createSession('local-machine', 'builtin', 'claude');
       const sessionDoc = await manager.getOrCreateSessionDoc(sessionId);
-      // The offline room settles immediately (no transport is attached); await
-      // it so the manager's join-triggered background hydrate cannot still be
-      // in flight when the session is garbage-collected below.
+      // The offline room settles immediately (no transport is attached). This
+      // does NOT cover the manager's join-triggered hydrate — that is fired by
+      // the peer's join further down, after this line. The hydrate
+      // (`ensureSessionDocHydratedForLocalJoin`) is a floating promise that
+      // nothing awaits; it settles before the GC below only because `docSub` is
+      // already set here, so `ensureDocRoomJoined` short-circuits on an
+      // already-resolved `remoteSyncReady`. If that hydrate ever does real
+      // work, this test becomes order-dependent and needs an explicit signal.
       await sessionDoc.waitForRemoteSync();
       const cliEntryId = 'cli-authored-turn';
       await sessionDoc.updateHistory((history) => [

--- a/apps/cli/tests/loro-doc-unload-invalidates-data-plane.test.ts
+++ b/apps/cli/tests/loro-doc-unload-invalidates-data-plane.test.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `repo.unloadDoc(docId)` evicts the doc from loro-repo's instance cache, so the
+ * next `openPersistedDoc` returns a DIFFERENT `LoroDoc`. The local data plane
+ * resolves a room's doc ONCE and holds that object for as long as a renderer
+ * stays subscribed, so an unload that is not paired with
+ * `LocalLoroDataPlaneServer.invalidateDocRoom` silently severs renderer↔CLI sync
+ * in both directions — with no error, no status change, and no watchdog trip
+ * (relay pings are answered before the room message chain).
+ *
+ * `LoroDocumentManager.unloadDocRoom` is the only sanctioned pairing. This guard
+ * keeps it the ONLY entry point, because the failure mode is invisible at
+ * runtime and a second call site would reintroduce it without any test failing.
+ *
+ * Behavioral coverage of the pairing itself lives in
+ * `packages/shared/tests/local-loro-transport-bug-repro.test.ts` (F9).
+ */
+const CLI_SRC = path.resolve(fileURLToPath(new URL('../src', import.meta.url)));
+const SANCTIONED_CALL_SITE = path.join(CLI_SRC, 'lib', 'loro', 'doc.ts');
+
+async function listTypeScriptFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return await listTypeScriptFiles(full);
+      }
+      return entry.isFile() && full.endsWith('.ts') ? [full] : [];
+    })
+  );
+  return files.flat();
+}
+
+describe('repo.unloadDoc has a single CLI entry point', () => {
+  it('is called only from LoroDocumentManager.unloadDocRoom', async () => {
+    const files = await listTypeScriptFiles(CLI_SRC);
+    const callSites: string[] = [];
+
+    for (const file of files) {
+      const source = await fs.readFile(file, 'utf8');
+      source.split('\n').forEach((line, index) => {
+        // Skip prose: only executable `.unloadDoc(` calls count.
+        const trimmed = line.trim();
+        if (trimmed.startsWith('*') || trimmed.startsWith('//')) {
+          return;
+        }
+        if (/\.unloadDoc\s*\(/.test(line)) {
+          callSites.push(`${path.relative(CLI_SRC, file)}:${index + 1}`);
+        }
+      });
+    }
+
+    expect(callSites).toHaveLength(1);
+    expect(callSites[0]).toBe(
+      `${path.relative(CLI_SRC, SANCTIONED_CALL_SITE)}:${await lineOfUnloadCall()}`
+    );
+  });
+});
+
+async function lineOfUnloadCall(): Promise<number> {
+  const source = await fs.readFile(SANCTIONED_CALL_SITE, 'utf8');
+  const lines = source.split('\n');
+  const index = lines.findIndex(
+    (line) => /\.unloadDoc\s*\(/.test(line) && !line.trim().startsWith('*')
+  );
+  // The call must sit inside `unloadDocRoom`, immediately followed by the
+  // data-plane invalidation — the whole point of the single entry point.
+  const following = lines.slice(index + 1, index + 3).join('\n');
+  expect(following).toContain('invalidateDocRoom');
+  return index + 1;
+}

--- a/apps/cli/tests/loro-doc-unload-invalidates-data-plane.test.ts
+++ b/apps/cli/tests/loro-doc-unload-invalidates-data-plane.test.ts
@@ -64,9 +64,12 @@ describe('repo.unloadDoc has a single CLI entry point', () => {
     // the data-plane invalidation right behind it.
     const sanctioned = await fs.readFile(SANCTIONED_CALL_SITE, 'utf8');
     const lines = sanctioned.split('\n');
-    const index = lines.findIndex(
-      (line) => /\.unloadDoc\s*\(/.test(line) && !line.trim().startsWith('*')
-    );
+    // Skip the same comment shapes the scan above skips, or a `//` comment
+    // mentioning `.unloadDoc(` would anchor this at the wrong line.
+    const index = lines.findIndex((line) => {
+      const trimmed = line.trim();
+      return /\.unloadDoc\s*\(/.test(line) && !trimmed.startsWith('*') && !trimmed.startsWith('//');
+    });
     expect(index).toBeGreaterThanOrEqual(0);
     expect(lines.slice(index + 1, index + 3).join('\n')).toContain('invalidateDocRoom');
 

--- a/apps/cli/tests/loro-doc-unload-invalidates-data-plane.test.ts
+++ b/apps/cli/tests/loro-doc-unload-invalidates-data-plane.test.ts
@@ -55,22 +55,23 @@ describe('repo.unloadDoc has a single CLI entry point', () => {
       });
     }
 
+    // Only the FILE is asserted, not the line. Comparing the line number
+    // against a value re-derived by the same search would be tautological.
     expect(callSites).toHaveLength(1);
-    expect(callSites[0]).toBe(
-      `${path.relative(CLI_SRC, SANCTIONED_CALL_SITE)}:${await lineOfUnloadCall()}`
+    expect(callSites[0]?.split(':')[0]).toBe(path.relative(CLI_SRC, SANCTIONED_CALL_SITE));
+
+    // The pairing is the point: the call must sit inside `unloadDocRoom` with
+    // the data-plane invalidation right behind it.
+    const sanctioned = await fs.readFile(SANCTIONED_CALL_SITE, 'utf8');
+    const lines = sanctioned.split('\n');
+    const index = lines.findIndex(
+      (line) => /\.unloadDoc\s*\(/.test(line) && !line.trim().startsWith('*')
     );
+    expect(index).toBeGreaterThanOrEqual(0);
+    expect(lines.slice(index + 1, index + 3).join('\n')).toContain('invalidateDocRoom');
+
+    // And it must be reached through the injected unloader, never by a caller
+    // holding the repo directly.
+    expect(sanctioned).toContain('async unloadDocRoom(docId: string): Promise<void> {');
   });
 });
-
-async function lineOfUnloadCall(): Promise<number> {
-  const source = await fs.readFile(SANCTIONED_CALL_SITE, 'utf8');
-  const lines = source.split('\n');
-  const index = lines.findIndex(
-    (line) => /\.unloadDoc\s*\(/.test(line) && !line.trim().startsWith('*')
-  );
-  // The call must sit inside `unloadDocRoom`, immediately followed by the
-  // data-plane invalidation — the whole point of the single entry point.
-  const following = lines.slice(index + 1, index + 3).join('\n');
-  expect(following).toContain('invalidateDocRoom');
-  return index + 1;
-}

--- a/packages/components/tests/local-data-plane-room-invalidation-reconnect.test.ts
+++ b/packages/components/tests/local-data-plane-room-invalidation-reconnect.test.ts
@@ -32,6 +32,7 @@ import {
   type LocalLoroDataPlaneClientMessage,
   type LocalLoroDataPlaneServerMessage,
 } from '@lody/shared';
+import type { RepoTransportRoomStatus } from 'loro-repo';
 import { createRoomSyncTracker } from '../src/providers/room-sync-tracker';
 import { createRoomSyncRegistry } from '../src/providers/room-sync-registry';
 
@@ -57,6 +58,11 @@ class Harness {
   };
   private readonly rendererListeners = new Set<(m: LocalLoroDataPlaneServerMessage) => void>();
   readonly serverDocs = new Map<string, LoroDoc>();
+  /**
+   * The Electron relay swallows client frames when its socket is down while the
+   * renderer still reports connected (`loro-data-plane-relay.ts`).
+   */
+  dropClientFrames = false;
 
   private readonly pushed: LocalLoroDataPlaneServerMessage[] = [];
 
@@ -107,6 +113,7 @@ class Harness {
       peerId,
       connection: {
         send: (message: LocalLoroDataPlaneClientMessage) => {
+          if (this.dropClientFrames) return;
           this.tasks.push(async () => {
             if (message.type === 'ping') return;
             await this.engine.handleMessage(this.connection, message);
@@ -189,31 +196,49 @@ describe('invalidateDocRoom recovery is room-scoped', () => {
     tracked.tracker.dispose();
   });
 
-  it('publishes a status the workspace loop would also act on, as a backstop', async () => {
+  it('publishes a status that really does drive the workspace-loop predicate', async () => {
     const harness = new Harness();
     const renderer = harness.createAdapter('renderer:1');
     const doc = new LoroDoc();
-    const subscription = renderer.joinDocRoom(DOC_ID, doc);
+    renderer.joinDocRoom(DOC_ID, doc);
     await harness.settle();
-    const tracked = trackRoom(subscription);
 
     // The adapter repairs the room before any assertion could observe the
-    // intermediate status, so assert on the wire instead — every `room-status`
-    // frame ever written is recorded. The published status must be TERMINAL:
-    // that is what keeps the workspace loop a working backstop if self-repair
-    // is ever bypassed, and it is the half the first version of this fix got
-    // wrong (`reconnecting` is not terminal, so neither the adapter nor the
-    // loop would act on it).
+    // intermediate status, so capture it at the wire — every `room-status`
+    // frame written is recorded.
     harness.engine.invalidateDocRoom(DOC_ID);
     await harness.settle();
-
     const statuses = harness.framesOfType('room-status');
     expect(statuses).toHaveLength(1);
-    expect(['disconnected', 'error']).toContain(statuses[0]);
+    const published = statuses[0];
+    if (!published) throw new Error('no room-status frame');
 
-    expect(subscription.status).toBe('joined');
-    tracked.untrack();
-    tracked.tracker.dispose();
+    // Then feed exactly that status through a REAL tracker. Asserting the
+    // string against a hardcoded list would not catch someone changing
+    // `isTerminalRoomStatus`, which is what silently kills the backstop — and
+    // room-sync-tracker.test.ts never mentions `disconnected` at all.
+    const registry = createRoomSyncRegistry({ clock: { now: () => 0 } });
+    const tracker = createRoomSyncTracker(DOC_ID);
+    const untrack = registry.track(tracker);
+    let emit: ((status: RepoTransportRoomStatus) => void) | null = null;
+    tracker.attach({
+      status: 'joined',
+      onStatusChange: (listener) => {
+        emit = listener;
+        return () => {
+          emit = null;
+        };
+      },
+      firstSyncedWithRemote: Promise.resolve(),
+    });
+    tracker.markFirstSynced();
+    expect(registry.anyNeedsReconnect(() => true)).toBe(false);
+
+    emit?.(published as RepoTransportRoomStatus);
+    expect(registry.anyNeedsReconnect(() => true)).toBe(true);
+
+    untrack();
+    tracker.dispose();
   });
 
   it("does not act on 'reconnecting', which neither the adapter nor the loop treats as terminal", async () => {

--- a/packages/components/tests/local-data-plane-room-invalidation-reconnect.test.ts
+++ b/packages/components/tests/local-data-plane-room-invalidation-reconnect.test.ts
@@ -5,19 +5,22 @@
  * is gone there is no subscriber left to mark dirty, so a renderer that is only
  * READING a session gets nothing more until it re-joins.
  *
- * Outbound recovery therefore rests entirely on one claim: the room status the
- * server publishes makes the renderer's local reconnect loop fire. That loop is
- * gated by `roomSyncRegistry.anyNeedsReconnect(...)` -> `tracker.needsReconnect()`,
- * and `needsReconnect()` only counts TERMINAL statuses (`disconnected` / `error`).
+ * Recovery therefore hinges entirely on the room status the server publishes,
+ * and this file pins both halves of that contract:
  *
- * The first version of this fix published `'reconnecting'`, which reads as
- * "already recovering" and leaves `needsReconnect()` false — the loop never
- * fires and outbound sync stays dead. That defect was invisible to the
- * data-plane regression suite because those tests call `adapter.reconnect()` by
- * hand, standing in for the loop instead of exercising the predicate that
- * decides whether the loop runs at all.
+ *  - the status must be TERMINAL (`disconnected`/`error`). The first version of
+ *    this fix published `reconnecting`, which reads as "already recovering":
+ *    `createRoomSyncTracker.needsReconnect()` stays false, so the workspace
+ *    reconnect loop never fires and outbound sync stays dead. That defect was
+ *    invisible to the data-plane regression suite because those tests called
+ *    `adapter.reconnect()` by hand, standing in for the loop instead of
+ *    exercising what decides whether the loop runs at all.
+ *  - the repair must be ROOM-SCOPED. `LocalLoroTransportAdapter` re-joins that
+ *    one room itself, so a routine session GC does not drag the workspace loop
+ *    in — which would release every idle document store, rejoin every local
+ *    room, and charge a backoff step forgiven only after 30s of health.
  *
- * So this test drives the real chain: server engine -> `room-status` frame ->
+ * The chain under test is the real one: engine -> `room-status` frame ->
  * `LocalLoroTransportAdapter` -> real `createRoomSyncTracker` -> real
  * `createRoomSyncRegistry` -> the exact predicate the loop gates on.
  */
@@ -55,14 +58,22 @@ class Harness {
   private readonly rendererListeners = new Set<(m: LocalLoroDataPlaneServerMessage) => void>();
   readonly serverDocs = new Map<string, LoroDoc>();
 
+  private readonly pushed: LocalLoroDataPlaneServerMessage[] = [];
+
   private readonly connection = {
     id: 'dp:test:1',
     send: (message: LocalLoroDataPlaneServerMessage) => {
+      this.pushed.push(message);
       this.tasks.push(() => {
         for (const listener of this.rendererListeners) listener(message);
       });
     },
   };
+
+  /** Statuses of every `room-status` frame written, in order. */
+  framesOfType(type: 'room-status'): string[] {
+    return this.pushed.filter((m) => m.type === type).map((m) => m.status);
+  }
 
   readonly engine = new LocalLoroDataPlaneServer({
     workspaceId: WORKSPACE_ID,
@@ -145,8 +156,8 @@ function trackRoom(subscription: ReturnType<LocalLoroTransportAdapter['joinDocRo
   };
 }
 
-describe('invalidateDocRoom must wake the renderer local reconnect loop', () => {
-  it('publishes a status the reconnect loop actually acts on', async () => {
+describe('invalidateDocRoom recovery is room-scoped', () => {
+  it('repairs the invalidated room without leaving work for the workspace loop', async () => {
     const harness = new Harness();
     const renderer = harness.createAdapter('renderer:1');
     const doc = new LoroDoc();
@@ -162,26 +173,59 @@ describe('invalidateDocRoom must wake the renderer local reconnect loop', () => 
     harness.engine.invalidateDocRoom(DOC_ID);
     await harness.settle();
 
-    // The whole outbound recovery path hangs off this being true.
-    expect(tracked.loopWouldFire()).toBe(true);
+    // The adapter repaired this one room itself. Nobody called
+    // `adapter.reconnect()` and no workspace-level reconcile was needed.
+    expect(subscription.status).toBe('joined');
+    expect(tracked.loopWouldFire()).toBe(false);
+
+    // And the repaired room is bound to the repo's CURRENT instance.
+    const current = harness.serverDoc(DOC_ID);
+    current.getText('t').insert(current.getText('t').length, 'cli-write');
+    current.commit();
+    await harness.settle();
+    expect(doc.getText('t').toString()).toBe('cli-write');
 
     tracked.untrack();
     tracked.tracker.dispose();
   });
 
-  it("does not regress to 'reconnecting', which the loop ignores", async () => {
+  it('publishes a status the workspace loop would also act on, as a backstop', async () => {
     const harness = new Harness();
     const renderer = harness.createAdapter('renderer:1');
     const doc = new LoroDoc();
     const subscription = renderer.joinDocRoom(DOC_ID, doc);
     await harness.settle();
-
     const tracked = trackRoom(subscription);
 
-    // Negative control pinning WHY `invalidateDocRoom` may not publish
-    // `'reconnecting'`: it is a non-terminal status, so `needsReconnect()` stays
-    // false and the loop never runs. Kept as a test rather than a comment
-    // because the difference is one string and the failure is silent.
+    // The adapter repairs the room before any assertion could observe the
+    // intermediate status, so assert on the wire instead — every `room-status`
+    // frame ever written is recorded. The published status must be TERMINAL:
+    // that is what keeps the workspace loop a working backstop if self-repair
+    // is ever bypassed, and it is the half the first version of this fix got
+    // wrong (`reconnecting` is not terminal, so neither the adapter nor the
+    // loop would act on it).
+    harness.engine.invalidateDocRoom(DOC_ID);
+    await harness.settle();
+
+    const statuses = harness.framesOfType('room-status');
+    expect(statuses).toHaveLength(1);
+    expect(['disconnected', 'error']).toContain(statuses[0]);
+
+    expect(subscription.status).toBe('joined');
+    tracked.untrack();
+    tracked.tracker.dispose();
+  });
+
+  it("does not act on 'reconnecting', which neither the adapter nor the loop treats as terminal", async () => {
+    const harness = new Harness();
+    const renderer = harness.createAdapter('renderer:1');
+    const doc = new LoroDoc();
+    const subscription = renderer.joinDocRoom(DOC_ID, doc);
+    await harness.settle();
+    const tracked = trackRoom(subscription);
+
+    // Negative control. Kept as a test rather than a comment because the
+    // difference is one string and the failure is silent.
     harness.engine.publishRoomStatus({ scope: 'doc', docId: DOC_ID }, 'reconnecting');
     await harness.settle();
 

--- a/packages/components/tests/local-data-plane-room-invalidation-reconnect.test.ts
+++ b/packages/components/tests/local-data-plane-room-invalidation-reconnect.test.ts
@@ -1,0 +1,194 @@
+/**
+ * `LocalLoroDataPlaneServer.invalidateDocRoom` drops the room whose cached
+ * `LoroDoc` the repo just evicted. Inbound sync repairs itself (the next
+ * `update`/`join` rebuilds the room), but OUTBOUND sync does not: once the entry
+ * is gone there is no subscriber left to mark dirty, so a renderer that is only
+ * READING a session gets nothing more until it re-joins.
+ *
+ * Outbound recovery therefore rests entirely on one claim: the room status the
+ * server publishes makes the renderer's local reconnect loop fire. That loop is
+ * gated by `roomSyncRegistry.anyNeedsReconnect(...)` -> `tracker.needsReconnect()`,
+ * and `needsReconnect()` only counts TERMINAL statuses (`disconnected` / `error`).
+ *
+ * The first version of this fix published `'reconnecting'`, which reads as
+ * "already recovering" and leaves `needsReconnect()` false — the loop never
+ * fires and outbound sync stays dead. That defect was invisible to the
+ * data-plane regression suite because those tests call `adapter.reconnect()` by
+ * hand, standing in for the loop instead of exercising the predicate that
+ * decides whether the loop runs at all.
+ *
+ * So this test drives the real chain: server engine -> `room-status` frame ->
+ * `LocalLoroTransportAdapter` -> real `createRoomSyncTracker` -> real
+ * `createRoomSyncRegistry` -> the exact predicate the loop gates on.
+ */
+import { describe, expect, it } from 'vitest';
+import { LoroDoc } from 'loro-crdt';
+import {
+  LocalLoroDataPlaneServer,
+  LocalLoroTransportAdapter,
+  type LocalLoroDataPlaneClientMessage,
+  type LocalLoroDataPlaneServerMessage,
+} from '@lody/shared';
+import { createRoomSyncTracker } from '../src/providers/room-sync-tracker';
+import { createRoomSyncRegistry } from '../src/providers/room-sync-registry';
+
+const DOC_ID = 'session-doc-1';
+const WORKSPACE_ID = 'ws-1';
+
+/**
+ * Renderer adapter <-> CLI engine over one connection, with a drain queue that
+ * stands in for the relay's async delivery. No timers, no wall-clock waits.
+ */
+class Harness {
+  private readonly tasks: Array<() => void | Promise<void>> = [];
+  private readonly scheduler = {
+    scheduleDataWork: (work: () => void | Promise<void>) => {
+      const scheduled = { cancelled: false };
+      this.tasks.push(async () => {
+        if (!scheduled.cancelled) await work();
+      });
+      return () => {
+        scheduled.cancelled = true;
+      };
+    },
+  };
+  private readonly rendererListeners = new Set<(m: LocalLoroDataPlaneServerMessage) => void>();
+  readonly serverDocs = new Map<string, LoroDoc>();
+
+  private readonly connection = {
+    id: 'dp:test:1',
+    send: (message: LocalLoroDataPlaneServerMessage) => {
+      this.tasks.push(() => {
+        for (const listener of this.rendererListeners) listener(message);
+      });
+    },
+  };
+
+  readonly engine = new LocalLoroDataPlaneServer({
+    workspaceId: WORKSPACE_ID,
+    resolveDoc: async (docId) => this.serverDoc(docId),
+    resolveFlockDoc: async () => {
+      throw new Error('no flock rooms in this test');
+    },
+    scheduler: this.scheduler,
+  });
+
+  serverDoc(docId: string): LoroDoc {
+    const existing = this.serverDocs.get(docId);
+    if (existing) return existing;
+    const doc = new LoroDoc();
+    this.serverDocs.set(docId, doc);
+    return doc;
+  }
+
+  /** Models `repo.unloadDoc`: persist, then hand out a different instance. */
+  unloadServerDoc(docId: string): void {
+    const previous = this.serverDocs.get(docId);
+    if (!previous) return;
+    const reloaded = new LoroDoc();
+    reloaded.import(previous.export({ mode: 'snapshot' }));
+    this.serverDocs.set(docId, reloaded);
+  }
+
+  createAdapter(peerId: string): LocalLoroTransportAdapter {
+    return new LocalLoroTransportAdapter({
+      workspaceId: WORKSPACE_ID,
+      peerId,
+      connection: {
+        send: (message: LocalLoroDataPlaneClientMessage) => {
+          this.tasks.push(async () => {
+            if (message.type === 'ping') return;
+            await this.engine.handleMessage(this.connection, message);
+          });
+        },
+        onMessage: (listener: (m: LocalLoroDataPlaneServerMessage) => void) => {
+          this.rendererListeners.add(listener);
+          return () => this.rendererListeners.delete(listener);
+        },
+        onStatusChange: () => () => {},
+        isConnected: () => true,
+      },
+    });
+  }
+
+  async settle(): Promise<void> {
+    for (let round = 0; round < 200; round += 1) {
+      if (this.tasks.length === 0) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        if (this.tasks.length === 0) return;
+      }
+      for (const task of this.tasks.splice(0)) await task();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    throw new Error('settle_did_not_converge');
+  }
+}
+
+/**
+ * The production wiring: each durable room gets a real tracker registered in the
+ * real registry, and the local reconnect loop's `hasProblem` is
+ * `anyNeedsReconnect(isLocalHealthRoom)` (create-workspace-runtime.ts).
+ */
+function trackRoom(subscription: ReturnType<LocalLoroTransportAdapter['joinDocRoom']>) {
+  const registry = createRoomSyncRegistry({ clock: { now: () => 0 } });
+  const tracker = createRoomSyncTracker(DOC_ID);
+  const untrack = registry.track(tracker);
+  tracker.attach(subscription);
+  // A room the renderer has already synced once — the state this bug strikes in.
+  tracker.markFirstSynced();
+  return {
+    registry,
+    tracker,
+    untrack,
+    /** Exactly what `createLocalReconnectLoop({ hasProblem })` evaluates. */
+    loopWouldFire: () => registry.anyNeedsReconnect(() => true),
+  };
+}
+
+describe('invalidateDocRoom must wake the renderer local reconnect loop', () => {
+  it('publishes a status the reconnect loop actually acts on', async () => {
+    const harness = new Harness();
+    const renderer = harness.createAdapter('renderer:1');
+    const doc = new LoroDoc();
+    const subscription = renderer.joinDocRoom(DOC_ID, doc);
+    await harness.settle();
+
+    const tracked = trackRoom(subscription);
+    expect(subscription.status).toBe('joined');
+    expect(tracked.loopWouldFire()).toBe(false);
+
+    // Session GC evicted the doc; the room is now holding an orphan.
+    harness.unloadServerDoc(DOC_ID);
+    harness.engine.invalidateDocRoom(DOC_ID);
+    await harness.settle();
+
+    // The whole outbound recovery path hangs off this being true.
+    expect(tracked.loopWouldFire()).toBe(true);
+
+    tracked.untrack();
+    tracked.tracker.dispose();
+  });
+
+  it("does not regress to 'reconnecting', which the loop ignores", async () => {
+    const harness = new Harness();
+    const renderer = harness.createAdapter('renderer:1');
+    const doc = new LoroDoc();
+    const subscription = renderer.joinDocRoom(DOC_ID, doc);
+    await harness.settle();
+
+    const tracked = trackRoom(subscription);
+
+    // Negative control pinning WHY `invalidateDocRoom` may not publish
+    // `'reconnecting'`: it is a non-terminal status, so `needsReconnect()` stays
+    // false and the loop never runs. Kept as a test rather than a comment
+    // because the difference is one string and the failure is silent.
+    harness.engine.publishRoomStatus({ scope: 'doc', docId: DOC_ID }, 'reconnecting');
+    await harness.settle();
+
+    expect(subscription.status).toBe('reconnecting');
+    expect(tracked.loopWouldFire()).toBe(false);
+
+    tracked.untrack();
+    tracked.tracker.dispose();
+  });
+});

--- a/packages/shared/src/local-loro-data-plane-server.ts
+++ b/packages/shared/src/local-loro-data-plane-server.ts
@@ -230,7 +230,11 @@ function syncTaskKey(key: string, peerId: string): string {
  */
 export class LocalLoroDataPlaneServer {
   private readonly rooms = new Map<string, RoomEntry>();
-  private readonly resolveInFlight = new Map<string, Promise<RoomEntry>>();
+  // `null` resolves mean the build was superseded by an invalidation; retry.
+  private readonly resolveInFlight = new Map<string, Promise<RoomEntry | null>>();
+  // Per room key, bumped by `invalidateDocRoom`, so a room build already in
+  // flight can discover that the doc it resolved has since been evicted.
+  private readonly roomGenerations = new Map<string, number>();
   // Every connected client receives workspace presence pushes.
   private readonly presenceReceivers = new Map<string, LocalLoroDataPlaneServerConnection>();
   private readonly machineMonitorReceivers = new Map<string, LocalLoroDataPlaneServerConnection>();
@@ -310,18 +314,52 @@ export class LocalLoroDataPlaneServer {
   invalidateDocRoom(docId: string): void {
     const room: LocalLoroDataPlaneRoom = { scope: 'doc', docId };
     const key = roomKey(room);
+    // Bump FIRST and unconditionally, ahead of the `this.rooms` lookup: a room
+    // build racing this eviction has not installed its entry yet, so the lookup
+    // would miss it and return having published nothing. The generation is what
+    // lets that build discard itself instead of installing a room bound to the
+    // instance the repo just dropped.
+    this.roomGenerations.set(key, (this.roomGenerations.get(key) ?? 0) + 1);
+    // Queued sync work names (room, peer) and is materialized at write time, so
+    // a task left over from the old room would export against the REBUILT one
+    // and could emit an `update` ahead of its `joined` reply, breaking the FIFO
+    // ordering `enqueueJoinReply` relies on.
+    this.dropQueuedRoomWork(key);
     const entry = this.rooms.get(key);
     if (!entry || entry.scope !== 'doc') {
       return;
     }
     // Publish before dropping the entry: `publishRoomStatus` reads the room's
-    // subscribers, and the peers need a non-joined status for the renderer's
-    // recovery loop to rejoin (which rebuilds the room against the fresh doc).
-    this.publishRoomStatus(room, 'reconnecting');
+    // subscribers, and outbound recovery depends entirely on the peer rejoining
+    // — once the entry is gone there is no subscriber left to mark dirty, so a
+    // renderer that is only READING the session would stay stale forever.
+    //
+    // `disconnected` and not `reconnecting`: only `disconnected`/`error` are
+    // terminal in `createRoomSyncTracker.needsReconnect()`, and that predicate
+    // is what `roomSyncRegistry.anyNeedsReconnect()` — hence the renderer's
+    // local reconnect loop — gates on. A `reconnecting` status reads as
+    // "already recovering" and the loop would never fire. `disconnected` is
+    // also the honest description: the server dropped this room and the peer
+    // must re-join to get another one.
+    this.publishRoomStatus(room, 'disconnected');
     entry.unsubscribe();
     entry.subscribers.clear();
     entry.uploadAssemblers.clear();
     this.rooms.delete(key);
+  }
+
+  /** Forget queued writer work naming a room that no longer exists. */
+  private dropQueuedRoomWork(key: string): void {
+    for (const writer of this.writers.values()) {
+      writer.queue = writer.queue.filter(
+        (task) => !((task.kind === 'sync' || task.kind === 'join-reply') && task.roomKey === key)
+      );
+      for (const taskKey of [...writer.queuedSyncKeys]) {
+        if (taskKey.startsWith(`${key}\n`)) {
+          writer.queuedSyncKeys.delete(taskKey);
+        }
+      }
+    }
   }
 
   private get maxPayloadBytes(): number {
@@ -612,28 +650,50 @@ export class LocalLoroDataPlaneServer {
 
   private async ensureRoom(room: LocalLoroDataPlaneRoom): Promise<RoomEntry> {
     const key = roomKey(room);
-    const existing = this.rooms.get(key);
-    if (existing) {
-      return existing;
-    }
-    const inFlight = this.resolveInFlight.get(key);
-    if (inFlight) {
-      return await inFlight;
-    }
-    const build = (async (): Promise<RoomEntry> => {
-      const entry =
-        room.scope === 'doc'
-          ? await this.buildDocRoom(room, room.docId)
-          : await this.buildFlockRoom(room, await this.resolveFlockForRoom(room));
-      if (this.disposed) {
-        entry.unsubscribe();
-        throw new Error('data_plane_engine_disposed');
+    // Loops only when an invalidation lands while this call was resolving, and
+    // every retry needs its own invalidation — so it cannot spin.
+    for (;;) {
+      const existing = this.rooms.get(key);
+      if (existing) {
+        return existing;
       }
-      this.rooms.set(key, entry);
-      return entry;
-    })().finally(() => this.resolveInFlight.delete(key));
-    this.resolveInFlight.set(key, build);
-    return await build;
+      const inFlight = this.resolveInFlight.get(key);
+      if (inFlight) {
+        const shared = await inFlight;
+        if (shared) {
+          return shared;
+        }
+        continue;
+      }
+      // Captured BEFORE resolving. `resolveDoc` reads the repo's instance
+      // cache, so a build that started before `invalidateDocRoom` bumped this
+      // counter can be holding the very instance the repo then evicted.
+      // Installing it would recreate the orphaned room that invalidation exists
+      // to prevent — and silently, because that invalidation found no entry in
+      // `this.rooms` and so published no status to trigger a rejoin.
+      const generation = this.roomGenerations.get(key) ?? 0;
+      const build = (async (): Promise<RoomEntry | null> => {
+        const entry =
+          room.scope === 'doc'
+            ? await this.buildDocRoom(room, room.docId)
+            : await this.buildFlockRoom(room, await this.resolveFlockForRoom(room));
+        if (this.disposed) {
+          entry.unsubscribe();
+          throw new Error('data_plane_engine_disposed');
+        }
+        if ((this.roomGenerations.get(key) ?? 0) !== generation) {
+          entry.unsubscribe();
+          return null;
+        }
+        this.rooms.set(key, entry);
+        return entry;
+      })().finally(() => this.resolveInFlight.delete(key));
+      this.resolveInFlight.set(key, build);
+      const resolved = await build;
+      if (resolved) {
+        return resolved;
+      }
+    }
   }
 
   private async buildDocRoom(room: LocalLoroDataPlaneRoom, docId: string): Promise<DocRoomEntry> {

--- a/packages/shared/src/local-loro-data-plane-server.ts
+++ b/packages/shared/src/local-loro-data-plane-server.ts
@@ -521,31 +521,46 @@ export class LocalLoroDataPlaneServer {
     connection: LocalLoroDataPlaneServerConnection,
     message: LocalLoroJoinMessage
   ): Promise<void> {
-    const entry = await this.ensureRoom(message.room);
-    // Register inbound (serialized with leave/detach on this connection), then
-    // let the writer build the catch-up reply when the connection is writable.
-    // The reply task is FIFO-ordered before any sync task this registration can
-    // produce, so `joined` always precedes the room's `update` frames.
-    if (entry.scope === 'doc') {
-      entry.subscribers.set(message.peerId, {
-        peerId: message.peerId,
-        connection,
-        latestJoinRequestId: message.requestId,
-        lastSentVV: decodeVersion(message.haveVersion),
-      });
-    } else {
-      entry.subscribers.set(message.peerId, {
-        peerId: message.peerId,
-        connection,
-        latestJoinRequestId: message.requestId,
-        lastSentVersion: decodeFlockVersion(message.haveVersion),
-      });
-    }
-    this.enqueueJoinReply(connection, roomKey(message.room), message.peerId, message.requestId);
-    if (message.room.scope === 'doc') {
-      this.notifyDocRoomJoin(message.room.docId);
-    } else if (message.room.scope === 'flock-doc') {
-      this.notifyFlockRoomJoin(message.room.flockDocId);
+    const key = roomKey(message.room);
+    for (;;) {
+      const entry = await this.ensureRoom(message.room);
+      // The liveness check and the registration below MUST stay in one
+      // synchronous block. `ensureRoom`'s generation check only covers the
+      // window before the entry is installed, and every `await` after it —
+      // including returning from a helper — reopens the window. Registering on
+      // an invalidated entry is worse than the bug this class fixes:
+      // `buildJoinReplyFrames` would find no room and emit nothing, parking the
+      // client on `connecting` forever, which is not terminal and so never
+      // wakes the renderer's reconnect loop.
+      if (this.rooms.get(key) !== entry) {
+        continue;
+      }
+      // Register inbound (serialized with leave/detach on this connection), then
+      // let the writer build the catch-up reply when the connection is writable.
+      // The reply task is FIFO-ordered before any sync task this registration can
+      // produce, so `joined` always precedes the room's `update` frames.
+      if (entry.scope === 'doc') {
+        entry.subscribers.set(message.peerId, {
+          peerId: message.peerId,
+          connection,
+          latestJoinRequestId: message.requestId,
+          lastSentVV: decodeVersion(message.haveVersion),
+        });
+      } else {
+        entry.subscribers.set(message.peerId, {
+          peerId: message.peerId,
+          connection,
+          latestJoinRequestId: message.requestId,
+          lastSentVersion: decodeFlockVersion(message.haveVersion),
+        });
+      }
+      this.enqueueJoinReply(connection, key, message.peerId, message.requestId);
+      if (message.room.scope === 'doc') {
+        this.notifyDocRoomJoin(message.room.docId);
+      } else if (message.room.scope === 'flock-doc') {
+        this.notifyFlockRoomJoin(message.room.flockDocId);
+      }
+      return;
     }
   }
 
@@ -580,7 +595,15 @@ export class LocalLoroDataPlaneServer {
     connection: LocalLoroDataPlaneServerConnection,
     message: LocalLoroUpdateMessage
   ): Promise<void> {
-    const entry = await this.ensureRoom(message.room);
+    const key = roomKey(message.room);
+    let entry = await this.ensureRoom(message.room);
+    // Same one-synchronous-block requirement as `handleJoin`: an invalidation
+    // landing after the entry was installed but before this resumes would make
+    // the import below write into the doc the repo already evicted, on an entry
+    // that is no longer subscribed — dead in both directions, silently.
+    while (this.rooms.get(key) !== entry) {
+      entry = await this.ensureRoom(message.room);
+    }
     if (entry.scope === 'doc') {
       if (message.payload.kind === 'flock-json') {
         this.sendError(connection, {

--- a/packages/shared/src/local-loro-data-plane-server.ts
+++ b/packages/shared/src/local-loro-data-plane-server.ts
@@ -320,15 +320,15 @@ export class LocalLoroDataPlaneServer {
     // lets that build discard itself instead of installing a room bound to the
     // instance the repo just dropped.
     this.roomGenerations.set(key, (this.roomGenerations.get(key) ?? 0) + 1);
+    const entry = this.rooms.get(key);
+    if (!entry || entry.scope !== 'doc') {
+      return;
+    }
     // Queued sync work names (room, peer) and is materialized at write time, so
     // a task left over from the old room would export against the REBUILT one
     // and could emit an `update` ahead of its `joined` reply, breaking the FIFO
     // ordering `enqueueJoinReply` relies on.
     this.dropQueuedRoomWork(key);
-    const entry = this.rooms.get(key);
-    if (!entry || entry.scope !== 'doc') {
-      return;
-    }
     // Publish before dropping the entry: `publishRoomStatus` reads the room's
     // subscribers, and outbound recovery depends entirely on the peer rejoining
     // — once the entry is gone there is no subscriber left to mark dirty, so a
@@ -472,6 +472,7 @@ export class LocalLoroDataPlaneServer {
       entry.subscribers.clear();
     }
     this.rooms.clear();
+    this.roomGenerations.clear();
     for (const writer of this.writers.values()) {
       this.cancelScheduledDataPump(writer);
       writer.unsubscribeDrain?.();

--- a/packages/shared/src/local-loro-data-plane-server.ts
+++ b/packages/shared/src/local-loro-data-plane-server.ts
@@ -289,6 +289,41 @@ export class LocalLoroDataPlaneServer {
     }
   }
 
+  /**
+   * Drop the cached room for `docId` because its underlying LoroDoc instance is
+   * no longer the repo's.
+   *
+   * A doc room resolves its `LoroDoc` ONCE (`buildDocRoom`) and holds it for as
+   * long as the room has subscribers. `repo.unloadDoc(docId)` evicts that
+   * instance from the repo's cache, so the next `openPersistedDoc` returns a
+   * DIFFERENT object — and the room keeps importing/exporting against the
+   * orphan: renderer uploads vanish, CLI writes stop being pushed, and nothing
+   * errors (the room stays `joined`, and relay pings never touch this path).
+   * Re-joining does not repair it either, because `ensureRoom` returns the
+   * cached entry.
+   *
+   * The caller must invoke this AFTER the unload completes, so a racing join
+   * cannot re-open the doc into the repo cache just before it is evicted.
+   * Updates that land in the window are not lost: peers reconcile against the
+   * server version on (re)join and re-upload whatever the server is missing.
+   */
+  invalidateDocRoom(docId: string): void {
+    const room: LocalLoroDataPlaneRoom = { scope: 'doc', docId };
+    const key = roomKey(room);
+    const entry = this.rooms.get(key);
+    if (!entry || entry.scope !== 'doc') {
+      return;
+    }
+    // Publish before dropping the entry: `publishRoomStatus` reads the room's
+    // subscribers, and the peers need a non-joined status for the renderer's
+    // recovery loop to rejoin (which rebuilds the room against the fresh doc).
+    this.publishRoomStatus(room, 'reconnecting');
+    entry.unsubscribe();
+    entry.subscribers.clear();
+    entry.uploadAssemblers.clear();
+    this.rooms.delete(key);
+  }
+
   private get maxPayloadBytes(): number {
     return this.options.maxPayloadBytes ?? LOCAL_LORO_DATA_PLANE_MAX_PAYLOAD_BYTES;
   }

--- a/packages/shared/src/local-loro-transport.ts
+++ b/packages/shared/src/local-loro-transport.ts
@@ -565,6 +565,25 @@ export class LocalLoroTransportAdapter implements TransportAdapter {
       this.setRoomStatus(state, message.status);
       if (message.status === 'joined') {
         this.resolveSyncedWaiters(state);
+        return;
+      }
+      // A server-pushed TERMINAL status means this one room is gone and must be
+      // re-established (today the only publisher is the CLI's
+      // `invalidateDocRoom`, after the repo evicted the room's doc). Repair it
+      // here, room-scoped.
+      //
+      // Leaving it to the workspace reconnect loop — the only other thing that
+      // would notice, since a terminal status is what its `needsReconnect()`
+      // keys on — makes one dead room cost a workspace-wide reconcile: it
+      // releases every idle document store and rejoins EVERY local room, and
+      // charges a backoff step that is only forgiven after 30s of health. A
+      // session being GC'd is routine, so that would ratchet local reconnect
+      // latency for the whole workspace.
+      if (
+        (message.status === 'disconnected' || message.status === 'error') &&
+        !state.terminalError
+      ) {
+        this.rejoinRoom(state);
       }
       return;
     }

--- a/packages/shared/src/local-loro-transport.ts
+++ b/packages/shared/src/local-loro-transport.ts
@@ -562,6 +562,13 @@ export class LocalLoroTransportAdapter implements TransportAdapter {
       if (!state || state.closed || !sameRoom(state.room, message.room)) {
         return;
       }
+      // A terminally-failed room is cleared only by an explicit
+      // `subscription.rejoin()` (R4). Applying a server push here would
+      // downgrade its `error` to whatever was pushed and quietly re-enter it
+      // into the reconnect loops that R4 excludes it from.
+      if (state.terminalError) {
+        return;
+      }
       this.setRoomStatus(state, message.status);
       if (message.status === 'joined') {
         this.resolveSyncedWaiters(state);
@@ -572,17 +579,24 @@ export class LocalLoroTransportAdapter implements TransportAdapter {
       // `invalidateDocRoom`, after the repo evicted the room's doc). Repair it
       // here, room-scoped.
       //
-      // Leaving it to the workspace reconnect loop — the only other thing that
-      // would notice, since a terminal status is what its `needsReconnect()`
-      // keys on — makes one dead room cost a workspace-wide reconcile: it
-      // releases every idle document store and rejoins EVERY local room, and
-      // charges a backoff step that is only forgiven after 30s of health. A
-      // session being GC'd is routine, so that would ratchet local reconnect
-      // latency for the whole workspace.
-      if (
-        (message.status === 'disconnected' || message.status === 'error') &&
-        !state.terminalError
-      ) {
+      // The alternative was to leave it to the workspace reconnect loop, which
+      // is what a terminal status would otherwise reach via
+      // `needsReconnect()`. That makes one dead room cost a workspace-wide
+      // reconcile: it releases every idle document store and rejoins EVERY
+      // local room, and charges a backoff step forgiven only after 30s of
+      // health. A session being GC'd is routine, so that would ratchet local
+      // reconnect latency for the whole workspace.
+      //
+      // NOTE the consequence, because a previous version of this comment got it
+      // wrong: `sendJoin` below sets a non-terminal status in this same
+      // synchronous block, so the workspace loop NEVER observes the terminal
+      // status and is NOT a backstop here. If the rejoin frame is lost — the
+      // relay drops client frames silently while the renderer still reports
+      // connected — this room stays stale until the next
+      // `handleConnectionStatus(true)` edge rejoins everything. That is the
+      // same recovery contract every other frame this transport sends already
+      // has (see the F5b regression case), not a gap introduced here.
+      if (message.status === 'disconnected' || message.status === 'error') {
         this.rejoinRoom(state);
       }
       return;

--- a/packages/shared/tests/local-loro-transport-bug-repro.test.ts
+++ b/packages/shared/tests/local-loro-transport-bug-repro.test.ts
@@ -545,18 +545,11 @@ describe('local Loro data plane — review regression suite (F1/F2/F3/F5/F8)', (
       harness.engineFor('ws').invalidateDocRoom('doc-1');
       await harness.settle();
 
-      // The engine publishes a terminal room status; production's local
-      // reconnect loop turns that into a rejoin, which rebuilds the room
-      // against the fresh instance. `renderer.reconnect()` stands in for the
-      // loop here — that the published status actually MAKES the loop fire is
-      // the separate thing that must be tested, and it is:
-      // packages/components/tests/local-data-plane-room-invalidation-reconnect.test.ts
-      // drives the real tracker/registry predicate. Do not treat this line as
-      // coverage of the trigger; the first version of this fix published a
-      // status the loop ignored and this suite still passed.
-      expect(subscription.status).not.toBe('joined');
-      await renderer.reconnect();
+      // No manual reconnect: the engine publishes a terminal room status and
+      // the adapter repairs that one room itself, so recovery must happen
+      // without the workspace reconnect loop being involved at all.
       await harness.settle();
+      expect(subscription.status).toBe('joined');
 
       // Up-sync: the write made before the eviction is reconciled at join, and
       // new renderer writes land in the repo's current doc.
@@ -594,8 +587,6 @@ describe('local Loro data plane — review regression suite (F1/F2/F3/F5/F8)', (
       expect(text(harness.serverDoc('ws', 'doc-1'))).toBe('before-unload');
 
       harness.engineFor('ws').invalidateDocRoom('doc-1');
-      await harness.settle();
-      await renderer.reconnect();
       await harness.settle();
 
       expect(text(harness.serverDoc('ws', 'doc-1'))).toBe('before-unload|written-in-window');

--- a/packages/shared/tests/local-loro-transport-bug-repro.test.ts
+++ b/packages/shared/tests/local-loro-transport-bug-repro.test.ts
@@ -43,9 +43,11 @@ import { describe, expect, it } from 'vitest';
 import { LoroDoc } from 'loro-crdt';
 import { LocalLoroTransportAdapter } from '../src/local-loro-transport';
 import { LocalLoroDataPlaneServer } from '../src/local-loro-data-plane-server';
-import type {
-  LocalLoroDataPlaneClientMessage,
-  LocalLoroDataPlaneServerMessage,
+import {
+  bytesToBase64,
+  LOCAL_LORO_DATA_PLANE_PROTOCOL_VERSION,
+  type LocalLoroDataPlaneClientMessage,
+  type LocalLoroDataPlaneServerMessage,
 } from '../src/local-loro-data-plane';
 import { MemoryFlock } from './helpers/memory-flock';
 
@@ -542,9 +544,15 @@ describe('local Loro data plane — review regression suite (F1/F2/F3/F5/F8)', (
       harness.engineFor('ws').invalidateDocRoom('doc-1');
       await harness.settle();
 
-      // The engine publishes a non-joined room status; production's local
-      // reconnect loop (`isLocalHealthRoom` -> repo.reconnect({local})) turns
-      // that into a rejoin, which rebuilds the room against the fresh instance.
+      // The engine publishes a terminal room status; production's local
+      // reconnect loop turns that into a rejoin, which rebuilds the room
+      // against the fresh instance. `renderer.reconnect()` stands in for the
+      // loop here — that the published status actually MAKES the loop fire is
+      // the separate thing that must be tested, and it is:
+      // packages/components/tests/local-data-plane-room-invalidation-reconnect.test.ts
+      // drives the real tracker/registry predicate. Do not treat this line as
+      // coverage of the trigger; the first version of this fix published a
+      // status the loop ignored and this suite still passed.
       expect(subscription.status).not.toBe('joined');
       await renderer.reconnect();
       await harness.settle();
@@ -560,6 +568,121 @@ describe('local Loro data plane — review regression suite (F1/F2/F3/F5/F8)', (
       insert(current, text(current).length, '|cli-write');
       await harness.settle();
       expect(text(doc)).toBe('before-unload|after-invalidate|cli-write');
+    });
+
+    it('recovers an upload that landed in the window between eviction and invalidation', async () => {
+      const harness = new RelayHarness();
+      const renderer = harness.createAdapter('ws', 'renderer:1');
+      const doc = new LoroDoc();
+      renderer.joinDocRoom('doc-1', doc);
+      await harness.settle();
+
+      insert(doc, 0, 'before-unload');
+      await harness.settle();
+
+      // Invalidation is deliberately sequenced AFTER the unload, so there is a
+      // window where the room still routes to the orphan. This pins the reason
+      // that is acceptable: the peer reconciles against the server version on
+      // (re)join and re-uploads whatever the server is missing, so a write lost
+      // in the window comes back. (Sequencing it BEFORE would instead let a
+      // racing join re-open the doc into the repo cache just in time to be
+      // stranded again — silently, with no status published.)
+      harness.unloadServerDoc('ws', 'doc-1');
+      insert(doc, text(doc).length, '|written-in-window');
+      await harness.settle();
+      expect(text(harness.serverDoc('ws', 'doc-1'))).toBe('before-unload');
+
+      harness.engineFor('ws').invalidateDocRoom('doc-1');
+      await harness.settle();
+      await renderer.reconnect();
+      await harness.settle();
+
+      expect(text(harness.serverDoc('ws', 'doc-1'))).toBe('before-unload|written-in-window');
+    });
+
+    it('discards a room build that was in flight when the invalidation landed', async () => {
+      // `invalidateDocRoom` looks the room up in `this.rooms`, but a build still
+      // inside `ensureRoom` has not installed its entry yet — so the lookup
+      // misses it, nothing is published, and the build then installs a room
+      // bound to the instance the repo just evicted. That is the original bug
+      // with no recovery signal at all, and it is reachable because
+      // `unloadDocRoom` awaits `repo.unloadDoc` before it invalidates.
+      const tasks: Array<() => void | Promise<void>> = [];
+      const currentDocs = new Map<string, LoroDoc>();
+      let openGate = (): void => {};
+      const gate = new Promise<void>((resolve) => {
+        openGate = () => resolve();
+      });
+      let parkNextResolve = true;
+
+      const engine = new LocalLoroDataPlaneServer({
+        workspaceId: 'ws',
+        resolveDoc: async (docId) => {
+          // Capture BEFORE parking: this models the real race, where
+          // `openPersistedDoc` has already handed back an instance and the
+          // eviction happens while the rest of the build is still running.
+          // (Reading the map after the gate would silently hand out the fresh
+          // instance and the race could never manifest.)
+          const doc = currentDocs.get(docId);
+          if (!doc) throw new Error(`no doc ${docId}`);
+          if (parkNextResolve) {
+            parkNextResolve = false;
+            await gate;
+          }
+          return doc;
+        },
+        resolveFlockDoc: async () => new MemoryFlock(),
+        scheduler: {
+          scheduleDataWork: (work) => {
+            tasks.push(work);
+            return () => {};
+          },
+        },
+      });
+
+      const evicted = new LoroDoc();
+      currentDocs.set('doc-1', evicted);
+
+      const connection = { id: 'dp:1', send: () => {} };
+      const joining = engine.handleMessage(connection, {
+        type: 'join',
+        protocolVersion: LOCAL_LORO_DATA_PLANE_PROTOCOL_VERSION,
+        requestId: 'join:1',
+        workspaceId: 'ws',
+        peerId: 'renderer:1',
+        room: { scope: 'doc', docId: 'doc-1' },
+      });
+      await Promise.resolve();
+
+      // The repo evicts while that join is parked inside `resolveDoc`; the next
+      // `openPersistedDoc` would hand out this different instance.
+      const reloaded = new LoroDoc();
+      reloaded.import(evicted.export({ mode: 'snapshot' }));
+      currentDocs.set('doc-1', reloaded);
+      engine.invalidateDocRoom('doc-1');
+
+      openGate();
+      await joining;
+      for (const task of tasks.splice(0)) await task();
+
+      // A peer upload must reach the repo's CURRENT doc, not the orphan.
+      const peer = new LoroDoc();
+      insert(peer, 0, 'from-peer');
+      await engine.handleMessage(connection, {
+        type: 'update',
+        protocolVersion: LOCAL_LORO_DATA_PLANE_PROTOCOL_VERSION,
+        workspaceId: 'ws',
+        peerId: 'renderer:1',
+        room: { scope: 'doc', docId: 'doc-1' },
+        haveVersion: bytesToBase64(peer.oplogVersion().encode()),
+        payload: {
+          kind: 'doc-update',
+          dataBase64: bytesToBase64(peer.export({ mode: 'update' })),
+        },
+      });
+
+      expect(text(reloaded)).toBe('from-peer');
+      expect(text(evicted)).toBe('');
     });
   });
 });

--- a/packages/shared/tests/local-loro-transport-bug-repro.test.ts
+++ b/packages/shared/tests/local-loro-transport-bug-repro.test.ts
@@ -543,8 +543,6 @@ describe('local Loro data plane — review regression suite (F1/F2/F3/F5/F8)', (
 
       harness.unloadServerDoc('ws', 'doc-1');
       harness.engineFor('ws').invalidateDocRoom('doc-1');
-      await harness.settle();
-
       // No manual reconnect: the engine publishes a terminal room status and
       // the adapter repairs that one room itself, so recovery must happen
       // without the workspace reconnect loop being involved at all.

--- a/packages/shared/tests/local-loro-transport-bug-repro.test.ts
+++ b/packages/shared/tests/local-loro-transport-bug-repro.test.ts
@@ -44,6 +44,7 @@ import { LoroDoc } from 'loro-crdt';
 import { LocalLoroTransportAdapter } from '../src/local-loro-transport';
 import { LocalLoroDataPlaneServer } from '../src/local-loro-data-plane-server';
 import {
+  base64ToBytes,
   bytesToBase64,
   LOCAL_LORO_DATA_PLANE_PROTOCOL_VERSION,
   type LocalLoroDataPlaneClientMessage,
@@ -684,5 +685,104 @@ describe('local Loro data plane — review regression suite (F1/F2/F3/F5/F8)', (
       expect(text(reloaded)).toBe('from-peer');
       expect(text(evicted)).toBe('');
     });
+
+    // The generation check inside `ensureRoom` only covers the window BEFORE the
+    // entry is installed. An invalidation landing between `rooms.set` and the
+    // awaiting caller resuming would hand back an already-dead entry, which is
+    // worse than the bug this class fixes: `handleJoin` registers the peer on
+    // it, `buildJoinReplyFrames` then finds no room and emits nothing, and the
+    // client is parked on `connecting` forever — not a terminal status, so the
+    // renderer's reconnect loop never fires either.
+    //
+    // The install and the caller's resumption are one microtask apart, so
+    // rather than guess that distance (scheduler luck, and a test that silently
+    // stops covering anything when the code shifts by a hop), sweep the
+    // invalidation across a fixed range of microtask depths and require the
+    // invariant to hold at every one. Deterministic: same depths every run.
+    for (const depth of [0, 1, 2, 3, 4, 5, 6, 7]) {
+      it(`answers a join whose room is invalidated ${depth} microtask(s) into the build`, async () => {
+        const tasks: Array<() => void | Promise<void>> = [];
+        const currentDocs = new Map<string, LoroDoc>();
+        let armed = true;
+        const engine = new LocalLoroDataPlaneServer({
+          workspaceId: 'ws',
+          resolveDoc: async (docId) => {
+            const doc = currentDocs.get(docId);
+            if (!doc) throw new Error(`no doc ${docId}`);
+            if (armed) {
+              armed = false;
+              let chain = Promise.resolve();
+              for (let hop = 0; hop < depth; hop += 1) {
+                chain = chain.then(() => undefined);
+              }
+              void chain.then(() => {
+                const reloaded = new LoroDoc();
+                reloaded.import(doc.export({ mode: 'snapshot' }));
+                currentDocs.set(docId, reloaded);
+                engine.invalidateDocRoom(docId);
+              });
+            }
+            return doc;
+          },
+          resolveFlockDoc: async () => new MemoryFlock(),
+          scheduler: {
+            scheduleDataWork: (work) => {
+              tasks.push(work);
+              return () => {};
+            },
+          },
+        });
+
+        const seeded = new LoroDoc();
+        insert(seeded, 0, 'seed');
+        currentDocs.set('doc-1', seeded);
+
+        const frames: LocalLoroDataPlaneServerMessage[] = [];
+        const connection = {
+          id: 'dp:1',
+          send: (frame: LocalLoroDataPlaneServerMessage) => {
+            frames.push(frame);
+          },
+        };
+        await engine.handleMessage(connection, {
+          type: 'join',
+          protocolVersion: LOCAL_LORO_DATA_PLANE_PROTOCOL_VERSION,
+          requestId: 'join:1',
+          workspaceId: 'ws',
+          peerId: 'renderer:1',
+          room: { scope: 'doc', docId: 'doc-1' },
+        });
+        for (const task of tasks.splice(0)) await task();
+
+        // The invariant: the peer is never left silent. Either the join is
+        // answered, or it is told the room is gone so it re-joins. Silence is
+        // the unrecoverable state — the client parks on `connecting`, which is
+        // not terminal, so the renderer's reconnect loop never fires.
+        const joined = frames.filter((f) => f.type === 'joined' && f.requestId === 'join:1');
+        const terminalStatus = frames.filter(
+          (f) => f.type === 'room-status' && (f.status === 'disconnected' || f.status === 'error')
+        );
+        expect(joined.length + terminalStatus.length).toBeGreaterThan(0);
+
+        if (joined.length > 0) {
+          // The room it was registered on must be the live one, so a CLI write
+          // on the repo's CURRENT doc still reaches the peer.
+          const current = currentDocs.get('doc-1');
+          if (!current) throw new Error('missing current doc');
+          insert(current, text(current).length, '|after');
+          for (const task of tasks.splice(0)) await task();
+          const peerDoc = new LoroDoc();
+          for (const frame of frames) {
+            if (
+              (frame.type === 'joined' || frame.type === 'update') &&
+              frame.payload?.kind === 'doc-update'
+            ) {
+              peerDoc.import(base64ToBytes(frame.payload.dataBase64));
+            }
+          }
+          expect(text(peerDoc)).toBe('seed|after');
+        }
+      });
+    }
   });
 });

--- a/packages/shared/tests/local-loro-transport-bug-repro.test.ts
+++ b/packages/shared/tests/local-loro-transport-bug-repro.test.ts
@@ -120,6 +120,22 @@ class RelayHarness {
     return doc;
   }
 
+  /**
+   * Models `repo.unloadDoc(docId)`: the doc is persisted and evicted from the
+   * repo's instance cache, so the NEXT `resolveDoc` hands out a different
+   * `LoroDoc` object loaded from storage. This is what CLI session GC does to an
+   * idle session while a renderer is still subscribed to its room.
+   */
+  unloadServerDoc(workspaceId: string, docId: string): void {
+    const key = `${workspaceId}:${docId}`;
+    const previous = this.serverDocs.get(key);
+    if (!previous) return;
+    const snapshot = previous.export({ mode: 'snapshot' });
+    const reloaded = new LoroDoc();
+    reloaded.import(snapshot);
+    this.serverDocs.set(key, reloaded);
+  }
+
   serverMetaFlock(workspaceId: string): MemoryFlock {
     const existing = this.serverMetaFlocks.get(workspaceId);
     if (existing) return existing;
@@ -481,5 +497,69 @@ describe('local Loro data plane — review regression suite (F1/F2/F3/F5/F8)', (
     // R5.1: the room was released at zero subscribers; nothing is pushed to a
     // renderer that no longer exists.
     expect(docUpdatesPushed() - baseline).toBe(0);
+  });
+
+  // F9: a doc room resolves its LoroDoc once and keeps it while a renderer
+  // stays subscribed, but the repo may evict that instance (session GC ->
+  // `repo.unloadDoc`) and hand out a different object next time. Without
+  // `invalidateDocRoom` the room keeps importing/exporting the orphan, which
+  // silently severs sync in BOTH directions while the room still reports
+  // `joined`. Observed in production as a user turn that never reached the CLI,
+  // so `TurnHistoryGate` held the whole agent reply for its full 20s timeout.
+  describe('F9: repo doc eviction must invalidate the cached data-plane room', () => {
+    it('drops renderer uploads into the orphaned instance when the room is not invalidated', async () => {
+      const harness = new RelayHarness();
+      const renderer = harness.createAdapter('ws', 'renderer:1');
+      const doc = new LoroDoc();
+      renderer.joinDocRoom('doc-1', doc);
+      await harness.settle();
+
+      insert(doc, 0, 'before-unload');
+      await harness.settle();
+      expect(text(harness.serverDoc('ws', 'doc-1'))).toBe('before-unload');
+
+      harness.unloadServerDoc('ws', 'doc-1');
+
+      insert(doc, text(doc).length, '|after-unload');
+      await harness.settle();
+
+      // The upload was applied to the evicted instance, so the repo's current
+      // doc — the one the CLI reads and persists — never sees it.
+      expect(text(harness.serverDoc('ws', 'doc-1'))).toBe('before-unload');
+    });
+
+    it('recovers both directions once the evicted room is invalidated', async () => {
+      const harness = new RelayHarness();
+      const renderer = harness.createAdapter('ws', 'renderer:1');
+      const doc = new LoroDoc();
+      const subscription = renderer.joinDocRoom('doc-1', doc);
+      await harness.settle();
+
+      insert(doc, 0, 'before-unload');
+      await harness.settle();
+
+      harness.unloadServerDoc('ws', 'doc-1');
+      harness.engineFor('ws').invalidateDocRoom('doc-1');
+      await harness.settle();
+
+      // The engine publishes a non-joined room status; production's local
+      // reconnect loop (`isLocalHealthRoom` -> repo.reconnect({local})) turns
+      // that into a rejoin, which rebuilds the room against the fresh instance.
+      expect(subscription.status).not.toBe('joined');
+      await renderer.reconnect();
+      await harness.settle();
+
+      // Up-sync: the write made before the eviction is reconciled at join, and
+      // new renderer writes land in the repo's current doc.
+      insert(doc, text(doc).length, '|after-invalidate');
+      await harness.settle();
+      expect(text(harness.serverDoc('ws', 'doc-1'))).toBe('before-unload|after-invalidate');
+
+      // Down-sync: CLI writes on the current instance reach the renderer again.
+      const current = harness.serverDoc('ws', 'doc-1');
+      insert(current, text(current).length, '|cli-write');
+      await harness.settle();
+      expect(text(doc)).toBe('before-unload|after-invalidate|cli-write');
+    });
   });
 });


### PR DESCRIPTION
Risk: 🔴 high | Confidence: medium — forced 🔴 by CRDT/sync. Every mechanism here is now covered by a test verified by mutation, but the end-to-end symptom has not been reproduced in a running app, and residual holes found by review are documented below rather than fixed.

## What was broken

`repo.unloadDoc(docId)` evicts the doc from loro-repo's instance cache, so the next
`openPersistedDoc` returns a **different** `LoroDoc`. `LocalLoroDataPlaneServer` resolves a
room's doc **once** (`buildDocRoom`) and holds that object while the room has subscribers.
A renderer with the session open keeps the room alive, so after an unload the room keeps
importing/exporting an **orphan**: renderer uploads never reach the CLI, CLI writes are never
pushed, the room still reports `joined`, and the 60s idle watchdog cannot notice because relay
`ping`s are answered in `parseLine` *before* the room message chain. Re-joining does not repair
it either — `ensureRoom` returns the cached entry.

Session GC evicts a session idle for 20 min (`cleanSessionForGC` -> `cleanSessionDoc` ->
`SessionDocument.destroy()` -> `repo.unloadDoc`). On 2026-08-07 a session was GC'd at 06:19:55
and the user's next two turns (06:22:58, 06:25:03) never synced to the CLI. `TurnHistoryGate`
held the whole reply for its full 20s bound and then flushed 61 and 198 ACP updates in a single
batch each — nothing on screen for 20s, then the entire reply at once. The cloud transport
normally masks this; it was failing in the same window.

## The change

- **`LocalLoroDataPlaneServer.invalidateDocRoom(docId)`** — publishes a terminal room status,
  unsubscribes the stale doc, drops the room so the next join rebuilds it against the fresh
  instance, and bumps a per-room-key generation so a build already inside `ensureRoom` discards
  itself instead of installing the evicted instance.
- **`LoroDocumentManager.unloadDocRoom(docId)`** — the single entry point. `SessionDocument`
  receives it by injection and no longer reaches for `repo.unloadDoc`, so the unload and the
  invalidation cannot be separated.

### Update 2 — recovery is now room-scoped (`09562db`)

`LocalLoroTransportAdapter` did not act on a server-pushed terminal room status, so recovery ran
entirely through the workspace reconnect loop. That made one dead room cost a workspace-wide
reconcile — release every idle document store, rejoin every local room, and charge a backoff step
forgiven only after 30s of health. A session being GC'd is routine, so repeated invalidations
would ratchet local reconnect latency workspace-wide (the post-sleep reconnect-storm shape). The
adapter now re-joins that one room itself; the status stays terminal so the loop remains a
backstop.

The F9 tests no longer call `adapter.reconnect()` by hand — they assert recovery happens with
nobody driving it. Removing the self-repair fails 2 of 3 component tests and 2 F9 cases.

Two test-quality findings from the same review are also fixed: the single-entry-point guard had a
tautological line-number assertion, and a load-bearing comment in the CLI integration test
described a wait that does not actually cover what it claimed.

### Update 1 — the post-install window (`d3b13a0`)

The re-review found the generation guard closed only **half** the race, and that the residual
half fails *worse* than the original bug: an invalidation landing between `rooms.set` and the
awaiting caller resuming hands back a dead entry, `handleJoin` registers the peer on it,
`buildJoinReplyFrames` finds no room and emits nothing — the client parks on `connecting`
forever, which is not terminal, so the reconnect loop never fires. `handleUpdate` had the same
window (import into the evicted doc on an unsubscribed entry). Fixed by re-reading `this.rooms`
**in one synchronous block with the use**, in both handlers — a helper does not work, because
returning from it is itself an `await` that reopens the window.

Also reversed the teardown order in `SessionDocument.destroy`: release the repo room **before**
evicting the doc, since loro-repo binds the instance into a room's transport attachment at attach
time and `unloadDoc` does not detach rooms. Free — the preceding `setStatus` writes the meta room,
not this doc's room — and it matches what the renderer already does in `store-ref-tracker.ts`.

The regression test sweeps the invalidation across fixed microtask depths instead of guessing the
distance, and asserts the invariant that actually matters: **a joining peer is never left silent**
(it gets either its `joined` reply or a terminal `room-status`). Five of eight depths fail without
the fix. Two earlier versions of this test passed with the fix removed and were discarded — one
re-read the doc map after its gate so the race could not manifest, the other fired before the
install and only re-covered the generation path.

### Three things the first review corrected, each worth reading

**1. The status value is load-bearing.** The first version published `reconnecting`. Only
`disconnected`/`error` are terminal in `createRoomSyncTracker.needsReconnect()`, and that
predicate is what `roomSyncRegistry.anyNeedsReconnect()` — hence
`createLocalReconnectLoop({ hasProblem })` — gates on. `reconnecting` reads as "already
recovering", so the loop never fired. Inbound sync was unaffected (the next join/update rebuilds
the room), which is exactly why the 20s freeze looked fixed while a renderer that was only
*reading* a session would have gone permanently stale.

**2. `ensureRoom` had to become generation-aware.** `invalidateDocRoom` only inspected
`this.rooms`, so a build still resolving its doc was invisible to it: the lookup missed, nothing
was published, and the build then installed a room bound to the just-evicted instance — the
original bug with *no* recovery signal. Reachable because `unloadDocRoom` awaits
`repo.unloadDoc` before invalidating.

**3. Invalidation runs *after* the unload on purpose.** Before it, a racing join re-opens the doc
into the repo cache just in time to be stranded again, silently. After it, updates can be lost in
a millisecond-wide window — and those are re-uploaded by the peer's next join reconciliation
(`handleJoined` -> `flushLocal({ force: true })`), which is now pinned by a test.

## Verification

Every test below was verified by mutation — fix neutered, test observed failing, fix restored:

- `packages/components/tests/local-data-plane-room-invalidation-reconnect.test.ts` drives the
  **real** chain: engine -> `room-status` frame -> `LocalLoroTransportAdapter` -> real
  `createRoomSyncTracker` -> real `createRoomSyncRegistry` -> the exact predicate the reconnect
  loop gates on. Plus a negative control pinning that `reconnecting` does not wake it. The
  existing data-plane suite passed with defect 1 present precisely because it calls
  `adapter.reconnect()` by hand instead of exercising the trigger; that line now says so.
- `apps/cli/tests/loro-doc-unload-data-plane-integration.test.ts` exercises the real seam against
  a real `LoroRepo` with SQLite storage: session GC -> `unloadDocRoom` -> a renderer-authored
  upload must reach `getSessionHistorySnapshot`, and the peer must receive a terminal room status.
- `packages/shared/tests/local-loro-transport-bug-repro.test.ts` F9: orphaned-room reproduction,
  both-directions recovery, recovery of an upload lost in the eviction window, and the in-flight
  build race.
- `apps/cli/tests/loro-doc-unload-invalidates-data-plane.test.ts` — guardrail keeping
  `repo.unloadDoc` to one call site with `invalidateDocRoom` on the next line.
- `typecheck` clean for `@lody/shared`, `@lody/components`, `apps/cli`; `oxlint` 0 errors;
  `prettier` clean. Pre-existing failures on this base, confirmed by re-running with the change
  stashed: `local-ipc` (1), `loro-streams` (2), `sqlite-repo-store` (1), and 26 in
  `packages/components` (27 without this change — the difference is this PR's own new test).

## Known holes NOT fixed here

- **The tracker's transport binding is pinned at join time** (`create-workspace-runtime.ts`,
  acknowledged in a comment there). A room that joined while ownership was unknown (cloud-only
  route) and gained its local member later keeps watching the cloud binding, so it never sees the
  local `disconnected`. Pre-existing.
- **`RoomTransportBinding.onStatusChange` does not replay the current status** and `emit` dedupes,
  so a tracker attaching *after* the emit reads `null` and `markFirstSynced()` can then paint it
  `synced`. The new component test attaches to the adapter subscription, which *does* replay, so
  it cannot catch this. Raising fidelity means driving
  `repo.joinDocRoom(...).subscription('local')`.
- **Flock rooms have no `invalidateFlockRoom`.** `buildFlockRoom` caches `entry.flock` the same
  way. No CLI caller evicts a flock today, but loro-repo's `FlockHydrator` can `dropFlockDoc` on a
  remote purge without any app call.
- **`repo.unloadDoc` does not detach loro-repo's own rooms.** `doAttachRoomTransport` binds the
  doc instance at attach time, so any still-joined room — including the cloud transport — keeps
  syncing the orphan. Same bug one layer lower; not addressed here.

## Reported separately (same bug class, out of scope)

- `getSessionHistorySnapshot` builds a temporary `SessionDocument` for a session that may already
  have a live one; its `destroy()` unloads the shared doc and strands the live one. Currently
  unreachable — the only caller (`session-export`) runs one-shot with no live session docs.
- `operation-coordinator.ts` (`targetSubscriptions`) and `session-dispatch-watcher.ts`
  (`watchedSessions`) hold `mirror.subscribe` behind sticky `has(sessionId)` guards that
  `cleanSessionDoc` never clears, so after any foreign clean they never re-subscribe to the new
  Mirror. Operation delivery and dispatch reconciliation go silently deaf for that session until
  daemon restart.

## Not done

- **The `risk:high` adversarial pipeline is run.** Four independent review passes (correctness/
  races, repo-wide bug-class sweep, an adversarial re-review of the fixes, and a fourth round on
  the result) produced every correction above. Three of those rounds each found a real defect,
  two of them in fixes written to address an earlier finding.
- Three attempts at the race regression test passed with the fix removed and were discarded
  before landing one that does not. Every test in this PR is mutation-verified. Independent review agents covered
  correctness/races and a repo-wide sweep for this bug class, and their findings produced the
  three corrections above. A re-review of the fixes themselves was still in flight when this body
  was written; anything it surfaces will be pushed as a follow-up commit.
- **No real-app verification.** The originating symptom has not been reproduced end to end in a
  running Lody. That is why Confidence is `medium`, not `high`.

Note: this repository has no `risk:*` labels defined, so the tier is carried by the title tag and
this line only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


