### PR TITLE
fix(cli): read rotated daemon log files [risk:medium]

### DIFF
--- a/apps/cli/src/agent/claude-task-lifecycle.ts
+++ b/apps/cli/src/agent/claude-task-lifecycle.ts
@@ -89,8 +89,7 @@ type TaskLifecycleAcpStatus = NonNullable<
 >;
 
 export type ClaudeTaskLifecycleConversionResult =
-  | { ok: true; notification: AcpSessionNotification }
-  | { ok: false; reason: string };
+  { ok: true; notification: AcpSessionNotification } | { ok: false; reason: string };
 
 export const convertClaudeTaskLifecycleNotification = (
   params: unknown

--- a/apps/cli/src/agent/managed-agent-runtime.ts
+++ b/apps/cli/src/agent/managed-agent-runtime.ts
@@ -75,11 +75,7 @@ export type ManagedRuntimeStatus =
   | { kind: 'installed'; platformArch: string; version: string; command: string };
 
 export type ManagedRuntimeProgressPhase =
-  | 'downloading'
-  | 'verifying'
-  | 'extracting'
-  | 'publishing'
-  | 'complete';
+  'downloading' | 'verifying' | 'extracting' | 'publishing' | 'complete';
 
 export type ManagedRuntimeProgressEvent = {
   runtimeName: ManagedRuntimeName;

--- a/apps/cli/src/commands/app.test.ts
+++ b/apps/cli/src/commands/app.test.ts
@@ -132,14 +132,12 @@ describe('resolveLocalProjectForApp', () => {
   });
 
   it('still resolves the deterministic project id when the daemon is down', async () => {
-    const send = vi.fn(
-      async (): Promise<LocalProjectControlResponse> => ({
-        ok: false,
-        type: 'local-project/add',
-        error: 'daemon_unavailable',
-        message: 'Local CLI daemon is not running.',
-      })
-    );
+    const send = vi.fn(async (): Promise<LocalProjectControlResponse> => ({
+      ok: false,
+      type: 'local-project/add',
+      error: 'daemon_unavailable',
+      message: 'Local CLI daemon is not running.',
+    }));
 
     const target = await resolveLocalProjectForApp({
       machineId: MACHINE_ID,
@@ -156,14 +154,12 @@ describe('resolveLocalProjectForApp', () => {
   });
 
   it('propagates other control failures', async () => {
-    const send = vi.fn(
-      async (): Promise<LocalProjectControlResponse> => ({
-        ok: false,
-        type: 'local-project/add',
-        error: 'path_invalid',
-        message: 'Selected path is not a directory',
-      })
-    );
+    const send = vi.fn(async (): Promise<LocalProjectControlResponse> => ({
+      ok: false,
+      type: 'local-project/add',
+      error: 'path_invalid',
+      message: 'Selected path is not a directory',
+    }));
 
     await expect(
       resolveLocalProjectForApp({

--- a/apps/cli/src/commands/daemon.ts
+++ b/apps/cli/src/commands/daemon.ts
@@ -1,6 +1,4 @@
 import { Command } from 'commander';
-import fs from 'node:fs';
-import path from 'node:path';
 import chalk from 'chalk';
 import { fetchCliRuntimeState } from '@lody/cli-supervisor';
 import {
@@ -17,30 +15,13 @@ import { AuthClient, performLoginWithAuthCredential } from '@/lib/auth';
 import { createHybridLogger, getLogger } from '@/utils/logger';
 import { buildDaemonStartPassthroughArgs, type DaemonStartOptions } from './daemon-start-options';
 import { formatDaemonBackendStatus } from './daemon-status-format';
+import { readLatestLogTail } from '@/utils/log-files';
 
 async function exitDaemonCommand(code: number): Promise<void> {
   process.exitCode = code;
   // Flush buffered analytics before the one-shot daemon command exits.
   await flushTelemetry();
   process.exit(code);
-}
-
-function findLatestLogFile(): string | null {
-  try {
-    if (!fs.existsSync(LODY_LOG_DIR)) return null;
-    const files = fs
-      .readdirSync(LODY_LOG_DIR)
-      .filter((f) => f.endsWith('.log'))
-      .map((f) => ({
-        name: f,
-        mtime: fs.statSync(path.join(LODY_LOG_DIR, f)).mtimeMs,
-      }))
-      .sort((a, b) => b.mtime - a.mtime);
-    const latest = files[0];
-    return latest ? path.join(LODY_LOG_DIR, latest.name) : null;
-  } catch {
-    return null;
-  }
 }
 
 type StopResult =
@@ -374,20 +355,18 @@ export const daemonCommand = new Command('daemon')
       .option('-n, --lines <count>', 'number of lines to show', '50')
       .action(async (options: { lines: string }) => {
         const lineCount = parseInt(options.lines, 10) || 50;
-        const logFile = findLatestLogFile();
-
-        if (!logFile) {
-          console.log(`No log files found in ${LODY_LOG_DIR}`);
-          await exitDaemonCommand(1);
-          return;
-        }
 
         try {
-          const content = fs.readFileSync(logFile, 'utf8');
-          const lines = content.split('\n');
-          const tail = lines.slice(-lineCount).join('\n');
-          console.log(chalk.dim(`--- ${logFile} (last ${lineCount} lines) ---`));
-          console.log(tail);
+          const tail = await readLatestLogTail(LODY_LOG_DIR, lineCount);
+          if (!tail) {
+            console.log(`No log files found in ${LODY_LOG_DIR}`);
+            await exitDaemonCommand(1);
+            return;
+          }
+          console.log(
+            chalk.dim(`--- ${LODY_LOG_DIR}/${tail.files.join(', ')} (last ${lineCount} lines) ---`)
+          );
+          console.log(tail.text);
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
           console.error(`Failed to read log file: ${message}`);

--- a/apps/cli/src/commands/session.ts
+++ b/apps/cli/src/commands/session.ts
@@ -2408,8 +2408,7 @@ export function resolveCreateCurrentSessionId(
   env: NodeJS.ProcessEnv = process.env
 ): SessionId | undefined {
   return (normalizeCliValue(options.currentSessionId) ?? normalizeCliValue(env.LODY_SESSION_ID)) as
-    | SessionId
-    | undefined;
+    SessionId | undefined;
 }
 
 export function assertSupportedParentDepth(
@@ -2442,8 +2441,7 @@ async function resolveCreateContext(args: {
   }
   const parentSessionId = (parentSelector ??
     (args.options.useCurrentSessionAsParent === true ? currentSessionId : undefined)) as
-    | SessionId
-    | undefined;
+    SessionId | undefined;
   if (args.options.useCurrentSessionAsParent === true && !parentSessionId) {
     throw new Error('No current session is available for --use-current-session-as-parent.');
   }
@@ -2471,8 +2469,7 @@ async function resolveCreateContext(args: {
   // An explicit taskId wins; otherwise inherit from the session that asked for
   // this one, which is what keeps agent-spawned work on the same task.
   const taskId = (normalizeCliValue(args.options.taskId) ?? currentSession?.taskId) as
-    | TaskId
-    | undefined;
+    TaskId | undefined;
   const targetMachine = await resolveTargetMachineForCreate({
     manager: args.manager,
     workspaceId,
@@ -2670,8 +2667,7 @@ export function buildSessionRestoreMetaPatch(): Partial<SessionMeta> {
 export function buildLegacyMachineRestoreQueueCleanupPatch(
   sessionId: SessionId,
   machineMeta:
-    | Pick<MachineLegacyMetaFields, 'needToArchiveSessions' | 'needToDeleteSessions'>
-    | undefined
+    Pick<MachineLegacyMetaFields, 'needToArchiveSessions' | 'needToDeleteSessions'> | undefined
 ): Pick<MachineLegacyMetaFields, 'needToArchiveSessions' | 'needToDeleteSessions'> | null {
   const nextNeedToArchiveSessions = { ...(machineMeta?.needToArchiveSessions ?? {}) };
   const nextNeedToDeleteSessions = { ...(machineMeta?.needToDeleteSessions ?? {}) };
@@ -4164,8 +4160,7 @@ const sessionArchiveCommand = new Command('archive')
           );
           const machineRoomId = getMachineRoomId(session.machineId);
           const machineMeta = (await manager.repo.getDocMeta(machineRoomId))?.meta as
-            | MachineLegacyMetaFields
-            | undefined;
+            MachineLegacyMetaFields | undefined;
           await manager.repo.upsertDocMeta(machineRoomId, {
             needToArchiveSessions: {
               ...(machineMeta?.needToArchiveSessions ?? {}),
@@ -4215,8 +4210,7 @@ const sessionRestoreCommand = new Command('restore')
           const nowMs = getServerNow();
           const machineRoomId = getMachineRoomId(session.machineId);
           const machineMeta = (await manager.repo.getDocMeta(machineRoomId))?.meta as
-            | MachineLegacyMetaFields
-            | undefined;
+            MachineLegacyMetaFields | undefined;
           const machinePatch = buildLegacyMachineRestoreQueueCleanupPatch(sessionId, machineMeta);
           if (machinePatch) {
             await manager.repo.upsertDocMeta(machineRoomId, machinePatch);
@@ -4276,8 +4270,7 @@ const sessionDeleteCommand = new Command('delete')
           const requestedAt = getServerNow();
           const machineRoomId = getMachineRoomId(machineId);
           const machineMeta = (await manager.repo.getDocMeta(machineRoomId))?.meta as
-            | MachineLegacyMetaFields
-            | undefined;
+            MachineLegacyMetaFields | undefined;
           const machineFlockHandle = await manager.repo.openFlockDoc(
             getMachineFlockDocId(workspace.id as WorkspaceId, machineId)
           );
@@ -4346,8 +4339,7 @@ const sessionDeleteCommand = new Command('delete')
           const requestedAt = getServerNow();
           const machineRoomId = getMachineRoomId(machineId);
           const machineMeta = (await manager.repo.getDocMeta(machineRoomId))?.meta as
-            | MachineLegacyMetaFields
-            | undefined;
+            MachineLegacyMetaFields | undefined;
           const machinePatch = buildLegacyMachineRestoreQueueCleanupPatch(sessionId, machineMeta);
           if (machinePatch) {
             await manager.repo.upsertDocMeta(machineRoomId, machinePatch);

--- a/apps/cli/src/lib/auth.ts
+++ b/apps/cli/src/lib/auth.ts
@@ -40,10 +40,7 @@ export interface AuthInfo {
 }
 
 export type ValidateTokenFailureReason =
-  | 'invalid'
-  | 'request_failed'
-  | 'invalid_response'
-  | 'network_error';
+  'invalid' | 'request_failed' | 'invalid_response' | 'network_error';
 
 export type ValidateTokenResult =
   | {
@@ -61,8 +58,7 @@ export type ValidateTokenResult =
     };
 
 export type LoginResult =
-  | ({ success: true } & AuthInfo)
-  | { success: false; error: string; retryable?: boolean };
+  ({ success: true } & AuthInfo) | { success: false; error: string; retryable?: boolean };
 export type LogoutResult = { success: true; user?: UserInfo } | { success: false; error: string };
 
 const UserInfoSchema = z

--- a/apps/cli/src/lib/bug-report.test.ts
+++ b/apps/cli/src/lib/bug-report.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { MachineId, WorkspaceId } from '@lody/shared';
 import {
+  collectBugReportLogs,
   formatBugReportLogDate,
   mergeBugReportLogs,
   submitBugReportFromMachine,
@@ -40,6 +45,80 @@ describe('mergeBugReportLogs', () => {
 
   it('returns an empty string when there are no log files', () => {
     expect(mergeBugReportLogs([])).toBe('');
+  });
+});
+
+describe('collectBugReportLogs', () => {
+  const tempDirs: string[] = [];
+
+  const createTempLogDir = (): string => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lody-bug-report-'));
+    tempDirs.push(dir);
+    return dir;
+  };
+
+  const writeLog = (dir: string, name: string, content: string): void => {
+    fs.writeFileSync(path.join(dir, name), name.endsWith('.gz') ? zlib.gzipSync(content) : content);
+  };
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0, tempDirs.length)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  const now = new Date(2026, 7, 7, 16, 54);
+
+  it('collects a day that has rolled past `<date>.log`', async () => {
+    const dir = createTempLogDir();
+    // The regression: a busy machine has no `<date>.log` at all, so the report
+    // shipped nothing for the day the user is reporting about.
+    writeLog(dir, '2026-08-07.log.gz', 'today archived\n');
+    writeLog(dir, '2026-08-07.log.1', 'today live\n');
+
+    const parts = await collectBugReportLogs(now, dir);
+
+    expect(parts.map((part) => part.fileName)).toEqual(['2026-08-07.log.gz', '2026-08-07.log.1']);
+    expect(parts.map((part) => part.content)).toEqual(['today archived\n', 'today live\n']);
+  });
+
+  it('includes yesterday before today and skips days with no files', async () => {
+    const dir = createTempLogDir();
+    writeLog(dir, '2026-08-05.log', 'two days ago\n');
+    writeLog(dir, '2026-08-06.log.gz', 'yesterday\n');
+    writeLog(dir, '2026-08-07.log', 'today\n');
+
+    const parts = await collectBugReportLogs(now, dir);
+
+    expect(parts.map((part) => part.fileName)).toEqual(['2026-08-06.log.gz', '2026-08-07.log']);
+  });
+
+  it('spends the day budget on the newest rotations first', async () => {
+    const dir = createTempLogDir();
+    writeLog(dir, '2026-08-07.log.gz', 'x'.repeat(6 * 1024 * 1024));
+    writeLog(dir, '2026-08-07.log.1', 'y'.repeat(3 * 1024 * 1024));
+
+    const parts = await collectBugReportLogs(now, dir);
+    const budget = 4 * 1024 * 1024;
+
+    // The live rotation arrives whole; the archive only fills what is left, and
+    // the day as a whole stays inside the budget the upload cap is derived from.
+    expect(parts.map((part) => part.fileName)).toEqual(['2026-08-07.log.gz', '2026-08-07.log.1']);
+    const live = parts[1];
+    expect(live?.truncated).toBe(false);
+    expect(live?.content.length).toBe(3 * 1024 * 1024);
+    const archived = parts[0];
+    expect(archived?.truncated).toBe(true);
+    expect(archived?.content.length).toBe(budget - 3 * 1024 * 1024);
+    expect(
+      parts.reduce((total, part) => total + Buffer.byteLength(part.content, 'utf8'), 0)
+    ).toBeLessThanOrEqual(budget);
+  });
+
+  it('returns nothing when the log directory is absent', async () => {
+    await expect(
+      collectBugReportLogs(now, path.join(createTempLogDir(), 'absent'))
+    ).resolves.toEqual([]);
   });
 });
 

--- a/apps/cli/src/lib/bug-report.ts
+++ b/apps/cli/src/lib/bug-report.ts
@@ -1,12 +1,12 @@
-import * as fs from 'fs/promises';
-import * as path from 'path';
 import { z } from 'zod';
 import type { MachineBugReportResponse, MachineId, WorkspaceId } from '@lody/shared';
 import { LODY_LOG_DIR } from '../utils/log-retention';
+import { listDailyLogFiles, readDailyLogFile } from '../utils/log-files';
 import type { MachineAccessCheckResult } from './workspace';
 
-// Convex HTTP actions cap the request body at 20 MiB. Two daily logs can reach
-// 20 MB each, so only the tail of each file is shipped.
+// Convex HTTP actions cap the request body at 20 MiB. A single day can span
+// several 20 MB rotations, so this is the budget for each day as a whole and
+// buys that day's most recent output.
 const LOG_TAIL_MAX_BYTES = 4 * 1024 * 1024;
 const TRUNCATION_MARKER = '...[truncated: only the tail of this log file is included]\n';
 
@@ -47,25 +47,41 @@ export const mergeBugReportLogs = (parts: BugReportLogPart[]): string =>
     .join('\n\n');
 
 /**
- * Read the machine's daily CLI logs for today and yesterday (winston
- * DailyRotateFile names them `<YYYY-MM-DD>.log` in local time). Missing files
- * are skipped — a fresh install may not have yesterday's log.
+ * Read the machine's CLI logs for today and yesterday (winston DailyRotateFile
+ * dates them in local time). A day is NOT one file: once it exceeds the
+ * transport's `maxSize` it rolls to `<date>.log.1`, `<date>.log.2`, … and
+ * gzips the file it rolled away from, so reading `<date>.log` alone finds
+ * nothing on exactly the busy machines whose logs matter most.
+ *
+ * Each day is walked newest rotation first so its byte budget buys the most
+ * recent output, then emitted oldest first. Missing days are skipped — a fresh
+ * install may not have yesterday's log.
  */
 export const collectBugReportLogs = async (
   now: Date = new Date(),
   logDir: string = LODY_LOG_DIR
 ): Promise<BugReportLogPart[]> => {
   const dates = [new Date(now.getTime() - 24 * 60 * 60 * 1000), now];
+  const available = listDailyLogFiles(logDir);
   const parts: BugReportLogPart[] = [];
   for (const date of dates) {
-    const fileName = `${formatBugReportLogDate(date)}.log`;
-    try {
-      const raw = await fs.readFile(path.join(logDir, fileName), 'utf8');
-      const { text, truncated } = tailOfLog(raw, LOG_TAIL_MAX_BYTES);
-      parts.push({ fileName, content: text, truncated });
-    } catch {
-      // Skip unreadable/missing daily logs.
+    const day = formatBugReportLogDate(date);
+    const dayParts: BugReportLogPart[] = [];
+    let remaining = LOG_TAIL_MAX_BYTES;
+    for (const file of available.filter((candidate) => candidate.date === day)) {
+      if (remaining <= 0) break;
+      let raw: string;
+      try {
+        raw = await readDailyLogFile(file);
+      } catch {
+        // Skip unreadable rotations.
+        continue;
+      }
+      const { text, truncated } = tailOfLog(raw, remaining);
+      remaining -= Buffer.byteLength(text, 'utf8');
+      dayParts.push({ fileName: file.name, content: text, truncated });
     }
+    parts.push(...dayParts.reverse());
   }
   return parts;
 };

--- a/apps/cli/src/lib/local-project-control-service.ts
+++ b/apps/cli/src/lib/local-project-control-service.ts
@@ -248,8 +248,7 @@ async function runGitCommand(rootPath: string, args: string[]): Promise<GitComma
     };
   } catch (error) {
     const withOutput = error as
-      | (Error & { code?: number | string; stdout?: string; stderr?: string })
-      | undefined;
+      (Error & { code?: number | string; stdout?: string; stderr?: string }) | undefined;
     const message = formatErrorMessage(error);
     return {
       status: typeof withOutput?.code === 'number' ? withOutput.code : null,

--- a/apps/cli/src/lib/local-project-history-precheck.ts
+++ b/apps/cli/src/lib/local-project-history-precheck.ts
@@ -27,8 +27,7 @@ export type LocalProjectSetupRequest = Extract<
 >;
 
 export type RemoteLocalProjectControlRequest =
-  | LocalProjectHistoryRequest
-  | LocalProjectSetupRequest;
+  LocalProjectHistoryRequest | LocalProjectSetupRequest;
 
 export type LocalProjectHistoryPrecheckOk = {
   ok: true;
@@ -43,8 +42,7 @@ export type LocalProjectHistoryPrecheckError = {
 };
 
 export type LocalProjectHistoryPrecheckResult =
-  | LocalProjectHistoryPrecheckOk
-  | LocalProjectHistoryPrecheckError;
+  LocalProjectHistoryPrecheckOk | LocalProjectHistoryPrecheckError;
 
 const HISTORY_REQUEST_TYPES: ReadonlySet<LocalProjectHistoryRequestType> = new Set([
   'local-project/sync-history',

--- a/apps/cli/src/lib/local-workspace-catalog.ts
+++ b/apps/cli/src/lib/local-workspace-catalog.ts
@@ -88,9 +88,7 @@ export class CatalogPermissionError extends Data.TaggedError('CatalogPermissionE
 }> {}
 
 export type LocalWorkspaceCatalogError =
-  | CatalogMissingError
-  | CatalogCorruptError
-  | CatalogPermissionError;
+  CatalogMissingError | CatalogCorruptError | CatalogPermissionError;
 
 export type CacheRemoteWorkspacesInput = {
   identity: LocalCatalogIdentity;
@@ -333,13 +331,11 @@ export function makeLocalWorkspaceCatalog(
         });
         const remoteMissing = snapshot.workspaces
           .filter((workspace) => !remoteIds.has(workspace.workspaceId))
-          .map(
-            (workspace): LocalCatalogWorkspace => ({
-              ...workspace,
-              state: 'remote_missing',
-              remoteMissingAt: workspace.remoteMissingAt ?? now,
-            })
-          );
+          .map((workspace): LocalCatalogWorkspace => ({
+            ...workspace,
+            state: 'remote_missing',
+            remoteMissingAt: workspace.remoteMissingAt ?? now,
+          }));
         return {
           ...snapshot,
           identity: input.identity,

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -3639,8 +3639,7 @@ export class MessageHandler {
     try {
       const machineRoomId = getMachineRoomId(this.machineId);
       const machineMeta = (await this.workspaceDocument.repo.getDocMeta(machineRoomId))?.meta as
-        | MachineMeta
-        | undefined;
+        MachineMeta | undefined;
       const supportsStreamsRpc = !!this.machineRpcServer;
 
       const hasMeta = !!machineMeta;
@@ -4185,8 +4184,7 @@ export class MessageHandler {
     }
 
     const machineMeta = (await this.workspaceDocument.repo.getDocMeta(machineRoomId))?.meta as
-      | MachineLegacyMetaFields
-      | undefined;
+      MachineLegacyMetaFields | undefined;
     if (!machineMeta?.needToArchiveSessions?.[sessionId]) {
       if (!removedFlockRow) {
         this.logger.debug(`[archive] Archive request already cleared (${sessionId})`);
@@ -4736,8 +4734,7 @@ export class MessageHandler {
     }
 
     const machineMeta = (await this.workspaceDocument.repo.getDocMeta(machineRoomId))?.meta as
-      | MachineLegacyMetaFields
-      | undefined;
+      MachineLegacyMetaFields | undefined;
     if (!machineMeta?.needToDeleteSessions?.[sessionId]) {
       if (removedFlockRow || removedLaunchConfigRow) {
         this.logger.debug(`[delete] Delete Flock request removed (${sessionId})`);
@@ -6165,8 +6162,7 @@ export class MessageHandler {
 
       const machineRoomId = getMachineRoomId(this.machineId);
       const machineMeta = (await this.workspaceDocument.repo.getDocMeta(machineRoomId))?.meta as
-        | MachineMeta
-        | undefined;
+        MachineMeta | undefined;
       const existingName = machineMeta?.name?.trim();
       // The CLI startup name is only a bootstrap default. Settings-page renames own the
       // persisted display name, so reconnect/registration must not overwrite synced edits.

--- a/apps/cli/src/lib/terminal-workdir-resolver.ts
+++ b/apps/cli/src/lib/terminal-workdir-resolver.ts
@@ -15,9 +15,7 @@ import {
 import { getLodyDataDir } from '@lody/shared/node/installation-profile';
 
 export type TerminalSessionMetaLookup =
-  | { type: 'found'; meta: SessionMeta }
-  | { type: 'deleted' }
-  | { type: 'missing' };
+  { type: 'found'; meta: SessionMeta } | { type: 'deleted' } | { type: 'missing' };
 
 export type TerminalWorkdirResolverOptions = {
   sessionId: SessionId;

--- a/apps/cli/src/mcp/lody-mcp-server.ts
+++ b/apps/cli/src/mcp/lody-mcp-server.ts
@@ -1538,7 +1538,7 @@ const buildSessionList = async (input: SessionListToolInput): Promise<unknown> =
       execution: SessionExecutionSnapshot;
     }> = [];
     const readChunkSize = MAX_MCP_STATUS_BATCH_SIZE;
-    for (let offset = 0; offset < candidates.length && matches.length <= limit; ) {
+    for (let offset = 0; offset < candidates.length && matches.length <= limit;) {
       const chunk = candidates.slice(offset, offset + readChunkSize);
       offset += chunk.length;
       const liveStatuses = await readSessionLiveStatusesMany({

--- a/apps/cli/src/monitor/cli-resource-monitor.ts
+++ b/apps/cli/src/monitor/cli-resource-monitor.ts
@@ -193,8 +193,7 @@ export class CliResourceMonitor {
     cpuCount: number;
     processMemoryKind: 'rss-sum' | 'physical-footprint-sum' | 'working-set-sum';
     processTreeUsage:
-      | { memoryBytes: number; cpuTimeMicros: number; processCount: number }
-      | undefined;
+      { memoryBytes: number; cpuTimeMicros: number; processCount: number } | undefined;
   }): AcpSessionMonitorSnapshot {
     const { session } = args;
     let current: CumulativeResourceSample;

--- a/apps/cli/src/orchestration/operation-coordinator.ts
+++ b/apps/cli/src/orchestration/operation-coordinator.ts
@@ -918,8 +918,7 @@ export class LodyOperationCoordinator {
   ): Promise<'available' | 'unavailable' | 'unknown'> {
     const startedAt = performance.now();
     const agentConfigId = operation.frozenContinuationConfig.agentConfigId as
-      | AgentConfigId
-      | undefined;
+      AgentConfigId | undefined;
     const finish = (
       result: 'available' | 'unavailable' | 'unknown',
       lookup: AgentConfigPointLookup | null,

--- a/apps/cli/src/orchestration/operation-store.ts
+++ b/apps/cli/src/orchestration/operation-store.ts
@@ -571,8 +571,7 @@ export class LodyOperationStore {
            WHERE requester_session_id = ? AND operation_id = ? AND item_index = ?`
           )
           .get(requesterSessionId, operationId, itemIndex) as
-          | { claim_token: string; claimed_at_ms: number }
-          | undefined;
+          { claim_token: string; claimed_at_ms: number } | undefined;
         const nowMs = this.now();
         if (row && row.claim_token !== claimToken && row.claimed_at_ms + claimDurationMs > nowMs) {
           return { claimed: false, retryAtMs: row.claimed_at_ms + claimDurationMs };

--- a/apps/cli/src/session/acp-error-classification.test.ts
+++ b/apps/cli/src/session/acp-error-classification.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   ACP_ERROR_CODES,
   getACPErrorUserMessage,
+  isAuthenticationRequiredACPError,
   isAgentDisconnectedError,
   isAcpSessionNotFoundError,
   mapACPErrorToFailureReason,
@@ -81,6 +82,40 @@ describe('ACP error classification', () => {
     if (!parsed) {
       throw new Error('expected ACP error to parse');
     }
+    expect(mapACPErrorToFailureReason(parsed)).toBe('acp_internal_error');
+  });
+
+  it.each([
+    'Not logged in · Please run /login',
+    'Session expired. Please run /login to sign in again.',
+    'refresh token cannot be refreshed',
+    'Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.',
+  ])('maps provider reauthentication errors to acp_auth_required: %s', (details) => {
+    const parsed = parseACPError({
+      code: ACP_ERROR_CODES.INTERNAL_ERROR,
+      message: 'Internal error',
+      data: { details },
+    });
+
+    if (!parsed) {
+      throw new Error('expected ACP error to parse');
+    }
+    expect(isAuthenticationRequiredACPError(parsed)).toBe(true);
+    expect(mapACPErrorToFailureReason(parsed)).toBe('acp_auth_required');
+    expect(shouldTerminateOnACPError(parsed, 'acp_auth_required')).toBe(true);
+  });
+
+  it('does not treat unrelated token refresh errors as provider login failures', () => {
+    const parsed = parseACPError({
+      code: ACP_ERROR_CODES.INTERNAL_ERROR,
+      message: 'Internal error',
+      data: { details: 'Failed to refresh the model catalog cache token' },
+    });
+
+    if (!parsed) {
+      throw new Error('expected ACP error to parse');
+    }
+    expect(isAuthenticationRequiredACPError(parsed)).toBe(false);
     expect(mapACPErrorToFailureReason(parsed)).toBe('acp_internal_error');
   });
 

--- a/apps/cli/src/session/acp-error-classification.ts
+++ b/apps/cli/src/session/acp-error-classification.ts
@@ -50,6 +50,15 @@ const getACPDiagnosticText = (error: unknown, parsedError?: ParsedACPError | nul
   return formatErrorMessage(error);
 };
 
+const AUTHENTICATION_REQUIRED_PATTERNS = [
+  /\bnot logged in\b/i,
+  /\bauthentication required\b/i,
+  /\bplease run\s+\/login\b/i,
+  /\bsession expired\b[\s\S]{0,160}\b(?:log|sign) in again\b/i,
+  /\brefresh token\b[\s\S]{0,160}\b(?:already used|expired|revoked|cannot be refreshed|could not be refreshed)\b/i,
+  /\baccess token\b[\s\S]{0,160}\bcould not be refreshed\b[\s\S]{0,160}\brefresh token\b/i,
+] as const;
+
 export const parseACPError = (error: unknown): ParsedACPError | null => {
   if (!error || typeof error !== 'object') {
     return null;
@@ -94,10 +103,26 @@ export const isAcpSessionNotFoundError = (error: unknown): boolean => {
   return /\bsession not found\b/i.test(getACPDiagnosticText(error, parsed));
 };
 
+/**
+ * Some provider runtimes still wrap expired OAuth credentials in an ACP
+ * internal error instead of using ACP's dedicated auth-required code. Keep the
+ * compatibility match narrow and limited to provider-owned instructions that
+ * explicitly require another login.
+ */
+export const isAuthenticationRequiredACPError = (error: unknown): boolean => {
+  const parsed = parseACPError(error);
+  if (parsed?.code === ACP_ERROR_CODES.AUTH_REQUIRED) {
+    return true;
+  }
+  const diagnosticText = getACPDiagnosticText(error, parsed);
+  return AUTHENTICATION_REQUIRED_PATTERNS.some((pattern) => pattern.test(diagnosticText));
+};
+
 export const mapACPErrorToFailureReason = (error: ParsedACPError): ChatFailedReason => {
+  if (isAuthenticationRequiredACPError(error)) {
+    return 'acp_auth_required';
+  }
   switch (error.code) {
-    case ACP_ERROR_CODES.AUTH_REQUIRED:
-      return 'acp_auth_required';
     case ACP_ERROR_CODES.INTERNAL_ERROR:
       // Some ACP adapters wrap a stale JSON-RPC transport as "-32603 Internal error".
       // Treat known transport-disposal text as a recoverable agent disconnect instead
@@ -130,12 +155,13 @@ export const shouldTerminateOnACPError = (
   error: ParsedACPError,
   failureReason: ChatFailedReason
 ): boolean => {
+  if (failureReason === 'acp_auth_required') {
+    return true;
+  }
   if (failureReason === 'acp_upstream_api_error') {
     return false;
   }
-  return (
-    error.code === ACP_ERROR_CODES.AUTH_REQUIRED || error.code === ACP_ERROR_CODES.INTERNAL_ERROR
-  );
+  return error.code === ACP_ERROR_CODES.INTERNAL_ERROR;
 };
 
 export const shouldRecoverStaleACPConnectionPrompt = (args: {

--- a/apps/cli/src/session/session-dispatch-watcher.ts
+++ b/apps/cli/src/session/session-dispatch-watcher.ts
@@ -132,11 +132,7 @@ export type SessionRpcTurnOffer = {
 };
 
 export type SessionRpcTurnOfferDisposition =
-  | 'accepted'
-  | 'duplicate'
-  | 'already-terminal'
-  | 'not-owned'
-  | 'error';
+  'accepted' | 'duplicate' | 'already-terminal' | 'not-owned' | 'error';
 
 type StashedRpcTurn = {
   entry: SessionHistoryInput;

--- a/apps/cli/src/session/session-preparation-service.ts
+++ b/apps/cli/src/session/session-preparation-service.ts
@@ -2,12 +2,7 @@ import type { SessionId } from '@lody/shared';
 import { formatErrorMessage } from '@/utils/format-error';
 
 export type SessionPreparationState =
-  | 'preparing'
-  | 'initialized'
-  | 'session-ready'
-  | 'claimed'
-  | 'expired'
-  | 'failed';
+  'preparing' | 'initialized' | 'session-ready' | 'claimed' | 'expired' | 'failed';
 
 export interface SessionPreparationResource {
   initialized: Promise<void>;
@@ -38,8 +33,7 @@ type PreparationRecord<T extends SessionPreparationResource> = {
 };
 
 export type SessionPreparationClaimResult<T extends SessionPreparationResource> =
-  | { status: 'claimed'; resource: T }
-  | { status: 'miss'; cleanup: Promise<void> | null };
+  { status: 'claimed'; resource: T } | { status: 'miss'; cleanup: Promise<void> | null };
 
 export class SessionPreparationService<T extends SessionPreparationResource> {
   private readonly records = new Map<SessionId, PreparationRecord<T>>();

--- a/apps/cli/src/utils/log-files.test.ts
+++ b/apps/cli/src/utils/log-files.test.ts
@@ -1,0 +1,159 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  listDailyLogFiles,
+  parseDailyLogFileName,
+  readDailyLogFile,
+  readLatestLogTail,
+} from './log-files';
+
+const tempDirs: string[] = [];
+
+function createTempLogDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'lody-log-files-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeLog(dir: string, name: string, content: string, mtimeMs?: number): void {
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, name.endsWith('.gz') ? zlib.gzipSync(content) : content);
+  if (mtimeMs !== undefined) {
+    const mtime = new Date(mtimeMs);
+    fs.utimesSync(filePath, mtime, mtime);
+  }
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0, tempDirs.length)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('parseDailyLogFileName', () => {
+  it("parses the day's first file as rotation zero", () => {
+    expect(parseDailyLogFileName('2026-08-07.log')).toEqual({
+      date: '2026-08-07',
+      index: 0,
+      compressed: false,
+    });
+  });
+
+  it('parses size-rotation counters and gzip archives', () => {
+    expect(parseDailyLogFileName('2026-08-07.log.1')).toEqual({
+      date: '2026-08-07',
+      index: 1,
+      compressed: false,
+    });
+    expect(parseDailyLogFileName('2026-08-07.log.gz')).toEqual({
+      date: '2026-08-07',
+      index: 0,
+      compressed: true,
+    });
+    expect(parseDailyLogFileName('2026-07-31.log.26.gz')).toEqual({
+      date: '2026-07-31',
+      index: 26,
+      compressed: true,
+    });
+  });
+
+  it('rejects entries that are not daily logs', () => {
+    expect(parseDailyLogFileName('.b7e1328-audit.json')).toBeNull();
+    expect(parseDailyLogFileName('notes.txt')).toBeNull();
+    expect(parseDailyLogFileName('session.jsonl')).toBeNull();
+  });
+});
+
+describe('listDailyLogFiles', () => {
+  it('orders by day and rotation counter rather than mtime', () => {
+    const dir = createTempLogDir();
+    // Archiving `<date>.log` rewrites it as `.gz` at the same moment the live
+    // `.log.1` is opened, so mtime alone can rank the archive above the file
+    // that is still being written.
+    writeLog(dir, '2026-08-06.log.gz', 'yesterday', 1_000);
+    writeLog(dir, '2026-08-07.log.gz', 'earlier today', 9_000);
+    writeLog(dir, '2026-08-07.log.1', 'live', 2_000);
+
+    expect(listDailyLogFiles(dir).map((file) => file.name)).toEqual([
+      '2026-08-07.log.1',
+      '2026-08-07.log.gz',
+      '2026-08-06.log.gz',
+    ]);
+  });
+
+  it('returns an empty list for a missing directory', () => {
+    expect(listDailyLogFiles(path.join(createTempLogDir(), 'absent'))).toEqual([]);
+  });
+});
+
+describe('readDailyLogFile', () => {
+  it('decompresses archived rotations', async () => {
+    const dir = createTempLogDir();
+    writeLog(dir, '2026-08-07.log.gz', 'archived line\n');
+    const [file] = listDailyLogFiles(dir);
+    expect(file).toBeDefined();
+    await expect(readDailyLogFile(file!)).resolves.toBe('archived line\n');
+  });
+});
+
+describe('readLatestLogTail', () => {
+  it('reads the live rotation once the day has rolled past `<date>.log`', async () => {
+    const dir = createTempLogDir();
+    // The regression: after the first size roll no file is named `<date>.log`,
+    // and matching on that suffix alone reports an empty log directory.
+    writeLog(dir, '2026-08-07.log.gz', 'a\nb\n');
+    writeLog(dir, '2026-08-07.log.1', 'c\nd\n');
+
+    const tail = await readLatestLogTail(dir, 2);
+
+    expect(tail).toEqual({ files: ['2026-08-07.log.1'], text: 'c\nd' });
+  });
+
+  it('walks back through rotations when the live file is shorter than requested', async () => {
+    const dir = createTempLogDir();
+    writeLog(dir, '2026-08-06.log', 'old\n');
+    writeLog(dir, '2026-08-07.log.gz', 'a\nb\n');
+    writeLog(dir, '2026-08-07.log.1', 'c\n');
+
+    const tail = await readLatestLogTail(dir, 3);
+
+    expect(tail).toEqual({ files: ['2026-08-07.log.gz', '2026-08-07.log.1'], text: 'a\nb\nc' });
+  });
+
+  it('does not insert blank lines at rotation boundaries', async () => {
+    const dir = createTempLogDir();
+    writeLog(dir, '2026-08-07.log.gz', 'a\n');
+    writeLog(dir, '2026-08-07.log.1', 'b\n');
+
+    await expect(readLatestLogTail(dir, 10)).resolves.toMatchObject({ text: 'a\nb' });
+  });
+
+  it('stops the walk at an unreadable archive instead of failing', async () => {
+    const dir = createTempLogDir();
+    fs.writeFileSync(path.join(dir, '2026-08-07.log.gz'), 'not actually gzip');
+    writeLog(dir, '2026-08-07.log.1', 'live\n');
+
+    await expect(readLatestLogTail(dir, 10)).resolves.toEqual({
+      files: ['2026-08-07.log.1'],
+      text: 'live',
+    });
+  });
+
+  it('surfaces a failure to read the live file', async () => {
+    const dir = createTempLogDir();
+    fs.writeFileSync(path.join(dir, '2026-08-07.log.1'), 'not actually gzip.gz');
+    fs.renameSync(path.join(dir, '2026-08-07.log.1'), path.join(dir, '2026-08-07.log.1.gz'));
+
+    await expect(readLatestLogTail(dir, 10)).rejects.toThrow();
+  });
+
+  it('returns null when the directory holds no log files', async () => {
+    const dir = createTempLogDir();
+    fs.writeFileSync(path.join(dir, '.audit.json'), '{}');
+
+    await expect(readLatestLogTail(dir, 10)).resolves.toBeNull();
+  });
+});

--- a/apps/cli/src/utils/log-files.ts
+++ b/apps/cli/src/utils/log-files.ts
@@ -1,0 +1,140 @@
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { promisify } from 'node:util';
+
+const gunzip = promisify(zlib.gunzip);
+
+/**
+ * winston-daily-rotate-file names the day's first file `<date>.log` and appends a
+ * size-rotation counter to every file it opens after that (`<date>.log.1`,
+ * `<date>.log.2`, …). Because the file transport also sets `zippedArchive`, the
+ * file it rolls away from is gzipped in place, so `<date>.log` stops existing as
+ * soon as the day's first `maxSize` roll happens.
+ *
+ * Every reader of the log directory must go through this module. Matching on
+ * `.log` alone silently finds nothing on any machine that logs more than
+ * `maxSize` in a day.
+ */
+const DAILY_LOG_FILE_PATTERN = /^(.*)\.log(?:\.(\d+))?(\.gz)?$/i;
+
+export type DailyLogFileName = {
+  /** The `%DATE%` portion of the name, e.g. `2026-08-07`. */
+  date: string;
+  /** Size-rotation counter; `0` for the day's first file, which carries no counter. */
+  index: number;
+  compressed: boolean;
+};
+
+export type DailyLogFile = DailyLogFileName & {
+  path: string;
+  name: string;
+  mtimeMs: number;
+};
+
+export function parseDailyLogFileName(name: string): DailyLogFileName | null {
+  const match = DAILY_LOG_FILE_PATTERN.exec(name);
+  if (!match) return null;
+  return {
+    date: match[1] ?? '',
+    index: match[2] === undefined ? 0 : Number(match[2]),
+    compressed: match[3] !== undefined,
+  };
+}
+
+/**
+ * Lists the daily log files in `logDir`, newest first. Non-log entries and
+ * subdirectories (ACP `.jsonl` capture) are ignored.
+ */
+export function listDailyLogFiles(logDir: string): DailyLogFile[] {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(logDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: DailyLogFile[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const parsed = parseDailyLogFileName(entry.name);
+    if (!parsed) continue;
+    const filePath = path.join(logDir, entry.name);
+    try {
+      files.push({
+        ...parsed,
+        path: filePath,
+        name: entry.name,
+        mtimeMs: fs.statSync(filePath).mtimeMs,
+      });
+    } catch {
+      // The file disappeared between readdir and stat (rotation, retention).
+    }
+  }
+
+  // Date then rotation counter is the authoritative order; mtime is only a tie
+  // breaker. Sorting by mtime alone inverts the newest pair, because archiving
+  // `<date>.log` to `<date>.log.gz` rewrites it at the same moment the live
+  // `<date>.log.1` is opened.
+  files.sort(
+    (a, b) =>
+      b.date.localeCompare(a.date) ||
+      b.index - a.index ||
+      Number(a.compressed) - Number(b.compressed) ||
+      b.mtimeMs - a.mtimeMs
+  );
+  return files;
+}
+
+/** Reads one daily log file, decompressing archived rotations. */
+export async function readDailyLogFile(file: DailyLogFile): Promise<string> {
+  const raw = await fsPromises.readFile(file.path);
+  if (!file.compressed) return raw.toString('utf8');
+  return (await gunzip(raw)).toString('utf8');
+}
+
+export type LatestLogTail = {
+  /** Names of the files the tail was read from, oldest first. */
+  files: string[];
+  text: string;
+};
+
+/**
+ * Reads the last `lineCount` lines of the log directory, walking back through
+ * size rotations when the live file is too short to satisfy the request. Older
+ * rotations are best-effort: only the newest file has to be readable.
+ *
+ * Returns `null` when the directory holds no log files at all.
+ */
+export async function readLatestLogTail(
+  logDir: string,
+  lineCount: number,
+  maxFiles = 5
+): Promise<LatestLogTail | null> {
+  const candidates = listDailyLogFiles(logDir).slice(0, maxFiles);
+  if (candidates.length === 0) return null;
+
+  const files: string[] = [];
+  let lines: string[] = [];
+  for (const [position, file] of candidates.entries()) {
+    let content: string;
+    try {
+      content = await readDailyLogFile(file);
+    } catch (error) {
+      // The live file is what the caller asked for; failing to read it is a
+      // real error. A corrupt archive further back only ends the walk.
+      if (position === 0) throw error;
+      break;
+    }
+    const fileLines = content.split('\n');
+    // Drop the separator-only trailing element so concatenating rotations does
+    // not insert a blank line at every file boundary.
+    if (fileLines[fileLines.length - 1] === '') fileLines.pop();
+    files.unshift(file.name);
+    lines = fileLines.concat(lines);
+    if (lines.length >= lineCount) break;
+  }
+
+  return { files, text: lines.slice(-lineCount).join('\n') };
+}

--- a/apps/cli/src/utils/log-retention.ts
+++ b/apps/cli/src/utils/log-retention.ts
@@ -1,13 +1,19 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { getLodyDataDir } from '@lody/shared/node/installation-profile';
+import { parseDailyLogFileName } from './log-files';
 
 export const LODY_LOG_DIR = path.join(getLodyDataDir(), 'logs');
 export const LODY_LOG_RETENTION_DAYS = 7;
 export const LODY_LOG_RETENTION_MS = LODY_LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 export const LODY_LOG_RETENTION_MAX_FILES = `${LODY_LOG_RETENTION_DAYS}d`;
 
-const MANAGED_LOG_FILE_PATTERN = /\.log(?:\.\d+)?(?:\.gz)?$|\.jsonl(?:\.gz)?$/i;
+const MANAGED_JSONL_FILE_PATTERN = /\.jsonl(?:\.gz)?$/i;
+
+// Daily-log naming lives in `log-files.ts` so retention and the log readers
+// cannot drift apart on what a rotated file is called.
+const isManagedLogFile = (name: string): boolean =>
+  parseDailyLogFileName(name) !== null || MANAGED_JSONL_FILE_PATTERN.test(name);
 
 function removeEmptyDirectories(dirPath: string, preserveRoot: boolean): void {
   const entries = fs.readdirSync(dirPath, { withFileTypes: true });
@@ -55,7 +61,7 @@ export function cleanupExpiredLogs(
         continue;
       }
 
-      if (!entry.isFile() || !MANAGED_LOG_FILE_PATTERN.test(entry.name)) {
+      if (!entry.isFile() || !isManagedLogFile(entry.name)) {
         continue;
       }
 

--- a/apps/electron/src/main/renderer-recovery.ts
+++ b/apps/electron/src/main/renderer-recovery.ts
@@ -17,8 +17,7 @@ function resolveLogFilePath(): string {
 }
 
 export type ReloadTarget =
-  | { type: 'url'; url: string }
-  | { type: 'file'; filePath: string; hash?: string }
+  { type: 'url'; url: string } | { type: 'file'; filePath: string; hash?: string }
 
 type RendererWatchdogState = {
   reloadTarget: ReloadTarget | null

--- a/apps/electron/src/main/services/cli-service.ts
+++ b/apps/electron/src/main/services/cli-service.ts
@@ -646,12 +646,10 @@ export class CliService {
         this.localControlClient
           .sessionControl(message, { timeoutMs, onResponse: options.onResponse })
           .pipe(
-            Effect.map(
-              (responses): SendLocalSessionControlResult => ({
-                ok: true,
-                responses
-              })
-            ),
+            Effect.map((responses): SendLocalSessionControlResult => ({
+              ok: true,
+              responses
+            })),
             Effect.catchTag('IpcTimeoutError', () =>
               Effect.succeed({ ok: false as const, error: 'request_timeout' })
             ),

--- a/packages/components/src/components/settings/acp-authentication-panel.tsx
+++ b/packages/components/src/components/settings/acp-authentication-panel.tsx
@@ -38,6 +38,7 @@ export function AcpAuthenticationPanel({
   runtimeOverrides,
   env,
   compact = false,
+  reauthentication = false,
   onAuthenticated,
 }: {
   machineId: MachineId | null;
@@ -48,6 +49,7 @@ export function AcpAuthenticationPanel({
   runtimeOverrides?: BuiltinRuntimeOverrides;
   env?: Record<string, string>;
   compact?: boolean;
+  reauthentication?: boolean;
   onAuthenticated?: () => void | Promise<void>;
 }) {
   const { t } = useTranslation();
@@ -254,7 +256,7 @@ export function AcpAuthenticationPanel({
             <LogIn className="h-3.5 w-3.5" />
             {phase === 'error' || phase === 'cancelled'
               ? t('agents.authentication.retry', 'Retry {{provider}} sign-in', { provider })
-              : phase === 'authenticated'
+              : phase === 'authenticated' || reauthentication
                 ? t('agents.authentication.signInAgain', 'Sign in again')
                 : t('agents.authentication.signIn', 'Sign in with {{provider}}', { provider })}
           </Button>

--- a/packages/components/src/components/settings/provider-row.tsx
+++ b/packages/components/src/components/settings/provider-row.tsx
@@ -4,6 +4,7 @@ import { useAtomValue } from 'jotai';
 import { Loader2, RefreshCw, Trash2 } from 'lucide-react';
 import {
   REGISTRY_ACP_AGENTS,
+  isBuiltinAgentType,
   type AgentConfigCliType,
   type AgentConfigMeta,
   type MachineAcpBinaryProgressMessage,
@@ -27,6 +28,7 @@ import { cn } from '@/lib/utils';
 import { activeWorkspaceRuntimeAtom } from '@/atoms/runtime';
 import { useMachineAcpBinaryProgress } from '@/hooks/use-machine-acp-binary-progress';
 import { AgentIcon } from '@/components/icons/agent-icon';
+import { AcpAuthenticationPanel } from './acp-authentication-panel';
 import {
   canShowSubscriptionRateLimits,
   formatRateLimitWindowShortLabel,
@@ -64,6 +66,7 @@ export function ProviderRow({ config, machine, onEdit, onDelete, onRefresh }: Pr
   }, [showRateLimits, machine?.raceLimits, agentType]);
 
   const typeBadge = cliType === 'builtin' ? null : cliType === 'custom' ? 'Custom' : 'Registry';
+  const canReauthenticate = cliType === 'builtin' && isBuiltinAgentType(agentType);
 
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -209,6 +212,21 @@ export function ProviderRow({ config, machine, onEdit, onDelete, onRefresh }: Pr
           ))}
         </div>
       )}
+      {canReauthenticate ? (
+        <div className="px-3 pb-2.5 pt-0.5 sm:ps-11">
+          <AcpAuthenticationPanel
+            machineId={machine?.id ?? config.machineId}
+            configId={config.id}
+            cliType={config.cliType}
+            agentType={config.agentType}
+            customAcp={config.customAcp}
+            runtimeOverrides={config.runtimeOverrides}
+            env={config.env}
+            compact
+            reauthentication
+          />
+        </div>
+      ) : null}
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/packages/components/src/stories/ProviderRow.stories.tsx
+++ b/packages/components/src/stories/ProviderRow.stories.tsx
@@ -152,6 +152,7 @@ export const ClaudeNoLimits: Story = {
   args: {
     config: makeConfig({ name: 'Claude Code', cliType: 'builtin', agentType: 'claude' }),
     machine: makeMachine(),
+    showActions: true,
   },
 };
 

--- a/packages/components/tests/provider-row-reauthentication.test.tsx
+++ b/packages/components/tests/provider-row-reauthentication.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentConfigId, AgentConfigMeta, MachineId, MachineViewMeta } from '@lody/shared';
+
+import { ProviderRow } from '../src/components/settings/provider-row';
+import { initI18n } from '../src/i18n';
+
+vi.mock('../src/components/settings/acp-authentication-panel', () => ({
+  AcpAuthenticationPanel: ({ reauthentication }: { reauthentication?: boolean }) => (
+    <button type="button" data-reauthentication={String(reauthentication)}>
+      Sign in again
+    </button>
+  ),
+}));
+
+const machineId = 'machine-test' as MachineId;
+const machine: MachineViewMeta = {
+  id: machineId,
+  name: 'Workstation',
+  cliVersion: '0.76.0',
+  os: 'macOS',
+  sessions: [],
+  raceLimits: {},
+};
+
+const makeConfig = (
+  overrides: Pick<AgentConfigMeta, 'cliType' | 'agentType'>
+): AgentConfigMeta => ({
+  id: `config-${overrides.agentType}` as AgentConfigId,
+  machineId,
+  name: overrides.agentType,
+  env: {},
+  ...overrides,
+});
+
+describe('ProviderRow reauthentication', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    await initI18n('en');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  const renderConfig = async (config: AgentConfigMeta) => {
+    await act(async () => {
+      root.render(
+        <ProviderRow config={config} machine={machine} onEdit={vi.fn()} onRefresh={vi.fn()} />
+      );
+    });
+  };
+
+  it.each(['claude', 'codex', 'kimi'] as const)(
+    'offers Sign in again for the built-in %s provider',
+    async (agentType) => {
+      await renderConfig(makeConfig({ cliType: 'builtin', agentType }));
+
+      const button = container.querySelector<HTMLButtonElement>(
+        'button[data-reauthentication="true"]'
+      );
+      expect(button?.textContent).toContain('Sign in again');
+    }
+  );
+
+  it('does not offer provider-owned login for registry agents', async () => {
+    await renderConfig(makeConfig({ cliType: 'registry', agentType: 'auggie' }));
+
+    expect(container.querySelector('button[data-reauthentication]')).toBeNull();
+  });
+});


### PR DESCRIPTION
Risk: 🟡 medium | Confidence: high — fixes two log readers and moves the retention deleter onto the shared parser; covered by new `log-files` / `collectBugReportLogs` tests plus a real run against a rotated `~/.lody/logs`

## Problem

A user reported `npx lody@latest daemon logs` printing `No log files found in …` on a machine whose daemon was logging normally.

`daemon logs` selected files with `.endsWith('.log')`. winston-daily-rotate-file opens `<date>.log`, then rolls to `<date>.log.1`, `.log.2`, … at the 20 MB `maxSize` and gzips the file it rolled away from. So once a day crosses 20 MB, **nothing on disk ends in `.log`** — the live file carries the highest counter and the rest are `.log[.N].gz`:

```
2026-08-07.log.gz     16:44   ← today's first 20 MB, archived
2026-08-07.log.1      16:54   ← live, still being written
```

It worked on older versions because `createHybridLogger` did not set `zippedArchive` before #1628; the rotated `<date>.log` stayed on disk as plain text, so the scan found it (stale, but non-empty).

`collectBugReportLogs` had the same assumption — a fixed `<date>.log` read inside a silent `catch` — so bug reports from exactly the busy machines worth diagnosing shipped without today's logs.

## Change

New `apps/cli/src/utils/log-files.ts` is the single owner of daily-log naming:

- `parseDailyLogFileName` / `listDailyLogFiles` — understands `<date>.log`, `.log.N`, `.gz`, ordered by day then rotation counter. **Ordering cannot use mtime alone**: archiving `<date>.log` rewrites it as `.gz` at the same moment the live `<date>.log.1` is opened, which ranks the archive above the file still being written.
- `readDailyLogFile` — decompresses archives.
- `readLatestLogTail` — reads the live rotation and keeps walking back into archives until it has the requested lines, so a roll that just happened no longer truncates the answer. Only the newest file has to be readable; a corrupt archive ends the walk instead of failing the command.

`log-retention.ts` now shares that parser rather than keeping a second copy of the naming rules — the two had already drifted, which is what produced this bug. Retention's matched set is unchanged (its `.jsonl` half is untouched).

`collectBugReportLogs` spends a 4 MB budget **per day** newest-rotation-first, so total upload size is unchanged (2 days × 4 MB) but the bytes are the most recent ones.

## Verification

- 24 new tests; `log-files.test.ts`, `bug-report.test.ts`, `log-retention.test.ts`, `daemon-shared.test.ts` → 28 passing.
- `tsgo --noEmit` clean.
- Real end-to-end against a rotated `~/.lody/logs/`: `daemon logs -n 6` now reads `2026-08-07.log.1`; `-n 100000` decompresses `2026-08-07.log.gz` and spans both files.

Pre-existing failures confirmed unrelated by re-running on a stashed clean tree: `@lody/shared` (2 files / 3 tests) and 12 CLI files / 25 tests that expect `.lody` but get `.lody-oss` because this submodule's tests default to the `local` profile when run standalone.

## Note on diff size

18 files outside this fix are line-wrap churn from the prescribed `pnpm format` step. Kept at the author's request; no behavior change. The fix itself is `utils/log-files.ts`, `utils/log-retention.ts`, `commands/daemon.ts`, `lib/bug-report.ts` and their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
