### PR TITLE
fix(components): stop file tree from full-rendering and re-rendering all rows [risk:medium]

### DIFF
--- a/packages/components/src/components/icons/file-icons/index.tsx
+++ b/packages/components/src/components/icons/file-icons/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type ComponentType } from 'react';
 import {
   compoundExtensionMap,
   extensionMap,
@@ -97,20 +97,47 @@ export const FolderIcon = ({ folderPath, className = 'h-4 w-4' }: FolderIconProp
   return <img src={iconUrl} alt="" className={className} />;
 };
 
-// Factory function to create icon components for TreeView
+// Factory functions to create icon components for tree rows.
+//
+// These are cached by RESOLVED ICON NAME rather than by path. Two things follow,
+// and both matter for the file tree:
+//
+//  1. Component identity is stable across tree rebuilds. Returning a fresh
+//     component type per call made React unmount and remount every icon
+//     whenever the parent rebuilt its tree data with the same paths, which also
+//     defeated row memoization.
+//  2. The cache is bounded by the icon set shipped in this package (a few
+//     hundred SVG names), not by the number of files in the repository.
+const fileIconComponentCache = new Map<string, ComponentType<{ className?: string }>>();
+const folderIconComponentCache = new Map<string, ComponentType<{ className?: string }>>();
+
 export const createFileIconComponent = (filePath: string) => {
-  const FileIconComponent = ({ className }: { className?: string }) => (
-    <FileIcon filePath={filePath} className={className} />
+  const iconName = getFileIconName(filePath);
+  const cached = fileIconComponentCache.get(iconName);
+  if (cached) {
+    return cached;
+  }
+  const iconUrl = getFileIconUrl(iconName);
+  const FileIconComponent = ({ className = 'h-4 w-4' }: { className?: string }) => (
+    <img src={iconUrl} alt="" className={className} />
   );
-  FileIconComponent.displayName = 'FileIconComponent';
+  FileIconComponent.displayName = `FileIconComponent(${iconName})`;
+  fileIconComponentCache.set(iconName, FileIconComponent);
   return FileIconComponent;
 };
 
 export const createFolderIconComponent = (folderPath: string) => {
-  const FolderIconComponent = ({ className }: { className?: string }) => (
-    <FolderIcon folderPath={folderPath} className={className} />
+  const iconName = getFolderIconName(folderPath);
+  const cached = folderIconComponentCache.get(iconName);
+  if (cached) {
+    return cached;
+  }
+  const iconUrl = getFolderIconUrl(iconName);
+  const FolderIconComponent = ({ className = 'h-4 w-4' }: { className?: string }) => (
+    <img src={iconUrl} alt="" className={className} />
   );
-  FolderIconComponent.displayName = 'FolderIconComponent';
+  FolderIconComponent.displayName = `FolderIconComponent(${iconName})`;
+  folderIconComponentCache.set(iconName, FolderIconComponent);
   return FolderIconComponent;
 };
 

--- a/packages/components/src/components/sessions/AGENTS.md
+++ b/packages/components/src/components/sessions/AGENTS.md
@@ -514,6 +514,18 @@ Code Collab file surfaces (data chain: [packages/components/AGENTS.md](../../../
   `session-file-content-view.tsx`.
 - v2 semantics for file tree, All Changes, refresh/save conflicts, and CLI-local
   turn diff RPC: `specs/code-collab-v2.md`.
+- **File tree: ONE row renderer** (`VirtualFileTree` in `components/file-tree-view.tsx`)
+  and ONE virtualization gate, counting VISIBLE rows. A second tree-wide count
+  used to swap in Radix `TreeView`, so a lazily growing tree thrashed between two
+  row implementations — do not reintroduce either. An empty virtual range renders
+  NO rows (never `rows.map`) and keeps the total-size spacer: the ScrollArea
+  viewport is an ANCESTOR ref, so it is still null when TanStack reads
+  `getScrollElement()`, making the first range always empty — a full-render
+  fallback there mounted the whole tree. Re-`measure()` on viewport attach/resize
+  (as `shared/option-selector.tsx` does). Rows are `memo`'d against per-frame
+  scroll re-renders, which needs `pruneExpandedFileTreeIds` to return its input
+  Set on a no-op prune (watcher ticks churn `data`) and icon factories to cache by
+  resolved icon name. Coverage: `tests/file-tree-virtual-rows.test.tsx`.
 - **Viewers are intentionally NOT code-split** (file viewer, diff viewer, diff
   panel, inner Monaco/Markdown are static imports). Code-splitting only pays off
   over a network; in the local Electron bundle a lazy `import()` adds no benefit

--- a/packages/components/src/components/sessions/components/file-tree-view.tsx
+++ b/packages/components/src/components/sessions/components/file-tree-view.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
 import { useAtomValue } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ChevronRight, CloudOff, FileWarning, FolderOpen, RefreshCw } from 'lucide-react';
 import { getMachineFlockLocalProjects, type FileTreeItem, type SessionMeta } from '@lody/shared';
-import { TreeDataItem, TreeView } from '@/components/tree-view';
+import { type TreeDataItem } from '@/components/tree-view';
 import { FileTreeSkeleton, FileTreeStatePanel } from './file-tree-states';
 import { useFileWorkspaceTree } from '@/hooks/use-code-session';
 import { useCodeCollabSessionFileProvider } from '@/hooks/use-code-collab-session-file-provider';
@@ -20,7 +20,6 @@ import { cn } from '@/lib/utils';
 import {
   flattenVisibleFileTreeRows,
   pruneExpandedFileTreeIds,
-  shouldVirtualizeFileTreeData,
   shouldVirtualizeVisibleFileTreeRows,
   type VirtualFileTreeRow as VirtualFileTreeRowModel,
 } from '@/lib/file-tree-virtualization';
@@ -77,7 +76,6 @@ type FileTreeRenderBranch =
   | 'unavailable'
   | 'provider-unavailable'
   | 'empty'
-  | 'virtual-tree'
   | 'tree';
 
 // Full-height wrapper so the skeleton fills the panel and clips overflow instead
@@ -161,36 +159,60 @@ function VirtualFileTree({
   readonly data: readonly TreeDataItem[];
   readonly viewportRef: RefObject<HTMLDivElement | null>;
 }) {
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => new Set());
   const [selectedId, setSelectedId] = useState<string | undefined>();
 
   useEffect(() => {
+    // `pruneExpandedFileTreeIds` returns the same reference when nothing was
+    // pruned, so a churning `data` reference does not schedule a real update.
     setExpandedIds((current) => pruneExpandedFileTreeIds(current, data));
   }, [data]);
 
   const rows = useMemo(() => flattenVisibleFileTreeRows(data, expandedIds), [data, expandedIds]);
   const getVirtualItemKey = useCallback((index: number) => rows[index]?.item.id ?? index, [rows]);
+  const shouldVirtualizeRows = shouldVirtualizeVisibleFileTreeRows(rows.length);
   const rowVirtualizer = useVirtualizer<HTMLDivElement, HTMLDivElement>({
     count: rows.length,
     getScrollElement: () => viewportRef.current,
     estimateSize: () => VIRTUAL_FILE_TREE_ROW_HEIGHT_PX,
     getItemKey: getVirtualItemKey,
     overscan: VIRTUAL_FILE_TREE_OVERSCAN,
+    enabled: shouldVirtualizeRows,
     useAnimationFrameWithResizeObserver: true,
   });
-  const virtualItems = rowVirtualizer.getVirtualItems();
-  const shouldVirtualizeRows = shouldVirtualizeVisibleFileTreeRows(rows.length);
-  const renderMode =
-    shouldVirtualizeRows && virtualItems.length > 0 ? 'virtualized' : 'static-visible';
 
+  // The virtualizer reads `getScrollElement()` from a layout effect, and the
+  // Radix ScrollArea viewport it points at is an ANCESTOR host node: React
+  // attaches that ref only after this child's layout effects have already run,
+  // so the first pass always sees `null` and produces an empty range. The
+  // viewport can also legitimately measure 0 while the panel is still being
+  // laid out. Re-measure once the scrollport is attached and on every resize.
+  //
+  // This must never fall back to rendering every row: doing so mounted the
+  // entire expanded tree at exactly the moment virtualization was needed.
+  useEffect(() => {
+    if (!shouldVirtualizeRows) return undefined;
+    const viewport = viewportRef.current;
+    if (!viewport) return undefined;
+    rowVirtualizer.measure();
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const observer = new ResizeObserver(() => rowVirtualizer.measure());
+    observer.observe(viewport);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rowVirtualizer is stable; re-run when the gate flips.
+  }, [shouldVirtualizeRows, viewportRef]);
+
+  const virtualItems = rowVirtualizer.getVirtualItems();
+  const renderMode = shouldVirtualizeRows ? 'virtualized' : 'static-visible';
+
+  // Log transitions only. This used to re-log on every range change, which put
+  // an allocation into the debug ring buffer on each scroll frame.
   useEffect(() => {
     logCodeCollabDebug('file tree virtual rows state', {
       visibleRowCount: rows.length,
-      shouldVirtualizeRows,
-      virtualItemCount: virtualItems.length,
       renderMode,
     });
-  }, [renderMode, rows.length, shouldVirtualizeRows, virtualItems.length]);
+  }, [renderMode, rows.length]);
 
   const toggleDirectory = useCallback((itemId: string) => {
     setExpandedIds((current) => {
@@ -204,7 +226,7 @@ function VirtualFileTree({
     });
   }, []);
 
-  if (!shouldVirtualizeRows || virtualItems.length === 0) {
+  if (!shouldVirtualizeRows) {
     return (
       <div role="tree" className="min-w-0">
         {rows.map((row) => (
@@ -220,6 +242,9 @@ function VirtualFileTree({
     );
   }
 
+  // Keep the total-size spacer even while the range is empty: it gives the
+  // scrollport the scrollable height that lets a measure pass resolve a real
+  // range, instead of collapsing to zero height and never recovering.
   return (
     <div
       role="tree"
@@ -245,7 +270,12 @@ function VirtualFileTree({
   );
 }
 
-function VirtualFileTreeRow({
+// Memoized: TanStack Virtual re-renders the list on every scroll frame, so
+// without this each frame re-ran every mounted row. `flattenVisibleFileTreeRows`
+// allocates fresh row objects per flatten, but a flatten only happens when the
+// tree data or the expanded set actually changes — scrolling alone reuses the
+// same row objects, so a plain reference comparison is enough to skip the work.
+const VirtualFileTreeRow = memo(function VirtualFileTreeRow({
   row,
   selected,
   virtualStart,
@@ -292,6 +322,8 @@ function VirtualFileTreeRow({
       disabled={disabled}
       className={cn(
         'group flex w-full items-center pr-2 text-left text-sm outline-none hover:bg-hover hover:text-hover-foreground focus-visible:bg-hover focus-visible:ring-1 focus-visible:ring-ring',
+        // `w-full` resolves against the positioned ancestor once absolute, so
+        // the hover/selection background still spans the full row.
         virtualStart !== undefined && 'absolute left-0 top-0',
         selected &&
           'bg-selection text-selection-foreground hover:bg-selection hover:text-selection-foreground',
@@ -337,7 +369,7 @@ function VirtualFileTreeRow({
       </span>
     </button>
   );
-}
+});
 
 function ControlledFileTreeView({
   handleOpenFile,
@@ -370,7 +402,6 @@ function ControlledFileTreeView({
       : providerFileTree.state;
     return fileTreeToTreeData(tree, handleOpenFile, handleLazyDirectoryOpen);
   }, [changedFilePathSet, providerFileTree.state, handleOpenFile, handleLazyDirectoryOpen]);
-  const shouldVirtualizeTree = shouldVirtualizeFileTreeData(fileTreeData);
   const message = providerFileTree.message ?? fileProviderMessage;
 
   // Collapse the connecting/ready phases into a single "loading" surface: the
@@ -386,9 +417,7 @@ function ControlledFileTreeView({
           ? 'unavailable'
           : providerFileTree.state.length === 0
             ? 'empty'
-            : shouldVirtualizeTree
-              ? 'virtual-tree'
-              : 'tree';
+            : 'tree';
 
   useEffect(() => {
     logCodeCollabDebug('file tree (controlled) render branch', {
@@ -435,16 +464,7 @@ function ControlledFileTreeView({
   return (
     <ScrollArea className="h-full" viewportRef={scrollViewportRef}>
       <div className="p-1">
-        {renderBranch === 'virtual-tree' ? (
-          <VirtualFileTree data={fileTreeData} viewportRef={scrollViewportRef} />
-        ) : (
-          <TreeView
-            data={fileTreeData}
-            defaultNodeIcon={DefaultFolderIcon}
-            defaultLeafIcon={DefaultFileIcon}
-            className="p-0"
-          />
-        )}
+        <VirtualFileTree data={fileTreeData} viewportRef={scrollViewportRef} />
       </div>
     </ScrollArea>
   );
@@ -619,7 +639,6 @@ const AutoFileTreeView = ({
     () => fileTreeToTreeData(activeFileTree, handleOpenFile, handleLazyDirectoryOpen),
     [activeFileTree, handleLazyDirectoryOpen, handleOpenFile]
   );
-  const shouldVirtualizeTree = shouldVirtualizeFileTreeData(fileTreeData);
   const localStatus = localProjectFileData.status;
   const localError = localProjectFileData.error;
   const localHasEntry = Boolean(localProjectFileData.entry);
@@ -639,9 +658,7 @@ const AutoFileTreeView = ({
         ? 'local-error'
         : activeFileTree.length === 0
           ? 'empty'
-          : shouldVirtualizeTree
-            ? 'virtual-tree'
-            : 'tree'
+          : 'tree'
     : shouldUseProviderFileList
       ? !providerFileTree.ready
         ? 'provider-loading'
@@ -649,9 +666,7 @@ const AutoFileTreeView = ({
           ? 'provider-unavailable'
           : activeFileTree.length === 0
             ? 'empty'
-            : shouldVirtualizeTree
-              ? 'virtual-tree'
-              : 'tree'
+            : 'tree'
       : effectiveFileProviderPending
         ? 'provider-pending'
         : 'unavailable';
@@ -763,16 +778,7 @@ const AutoFileTreeView = ({
   return (
     <ScrollArea className="h-full" viewportRef={scrollViewportRef}>
       <div className="p-1">
-        {fileTreeRenderBranch === 'virtual-tree' ? (
-          <VirtualFileTree data={fileTreeData} viewportRef={scrollViewportRef} />
-        ) : (
-          <TreeView
-            data={fileTreeData}
-            defaultNodeIcon={DefaultFolderIcon}
-            defaultLeafIcon={DefaultFileIcon}
-            className="p-0"
-          />
-        )}
+        <VirtualFileTree data={fileTreeData} viewportRef={scrollViewportRef} />
 
         {shouldUseLocalFileList && localListTruncated ? (
           <div className="pt-2 text-xs text-muted-foreground">{localTruncatedLabel}</div>

--- a/packages/components/src/lib/file-tree-virtualization.ts
+++ b/packages/components/src/lib/file-tree-virtualization.ts
@@ -9,27 +9,14 @@ export type VirtualFileTreeRow = {
 
 export const FILE_TREE_VIRTUALIZE_THRESHOLD = 50;
 
-export function countTreeDataItems(items: readonly TreeDataItem[]): number {
-  let count = 0;
-  const walk = (nodes: readonly TreeDataItem[]) => {
-    for (const node of nodes) {
-      count += 1;
-      if (node.children?.length) {
-        walk(node.children);
-      }
-    }
-  };
-  walk(items);
-  return count;
-}
-
-export function shouldVirtualizeFileTreeData(
-  items: readonly TreeDataItem[],
-  threshold = FILE_TREE_VIRTUALIZE_THRESHOLD
-): boolean {
-  return countTreeDataItems(items) > threshold;
-}
-
+/**
+ * Whether the flat row list is long enough to virtualize.
+ *
+ * This is the SINGLE virtualization gate for the file tree, and it counts
+ * VISIBLE rows. An earlier second gate counted every node in the tree including
+ * collapsed ones, and crossing it swapped the whole renderer, so a lazily
+ * growing tree could thrash between two very different row implementations.
+ */
 export function shouldVirtualizeVisibleFileTreeRows(
   rowCount: number,
   threshold = FILE_TREE_VIRTUALIZE_THRESHOLD
@@ -56,10 +43,18 @@ export function flattenVisibleFileTreeRows(
   return rows;
 }
 
-export function pruneExpandedFileTreeIds(
-  expandedIds: ReadonlySet<string>,
+/**
+ * Drop expanded ids that no longer name an expandable node in `items`.
+ *
+ * Returns the SAME set reference when nothing was pruned. The caller feeds this
+ * straight into `setState`, and the file tree's source data churns by reference
+ * on every file-watcher tick — allocating a fresh equal Set each time forced an
+ * extra render plus a re-flatten and a virtualizer pass per tick.
+ */
+export function pruneExpandedFileTreeIds<T extends ReadonlySet<string>>(
+  expandedIds: T,
   items: readonly TreeDataItem[]
-): Set<string> {
+): T | Set<string> {
   const validIds = new Set<string>();
   const walk = (nodes: readonly TreeDataItem[]) => {
     for (const node of nodes) {
@@ -70,5 +65,9 @@ export function pruneExpandedFileTreeIds(
     }
   };
   walk(items);
-  return new Set([...expandedIds].filter((id) => validIds.has(id)));
+  const retained = [...expandedIds].filter((id) => validIds.has(id));
+  if (retained.length === expandedIds.size) {
+    return expandedIds;
+  }
+  return new Set(retained);
 }

--- a/packages/components/src/stories/FileTreeList.stories.tsx
+++ b/packages/components/src/stories/FileTreeList.stories.tsx
@@ -1,96 +1,106 @@
+import { useMemo } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { TreeView, type TreeDataItem } from '@/components/tree-view';
-import {
-  createFileIconComponent,
-  createFolderIconComponent,
-  DefaultFileIcon,
-  DefaultFolderIcon,
-} from '@/components/icons/file-icons';
+import { fn } from 'storybook/test';
+import { FileTreeProviderView } from '@/components/sessions/components/file-tree-view';
+import { createFakeSessionFileProvider } from '@/lib/session-file-provider';
 
-// Mirrors the repo-root file list rendered by FileTreeView (collapsed folders +
-// files). TreeView is the shared row renderer, so this story exercises the same
-// row height / padding used in the session "Files" tab.
-const folder = (name: string): TreeDataItem => ({
-  id: name,
-  name,
-  icon: createFolderIconComponent(name),
-  openIcon: createFolderIconComponent(name),
-  forceNode: true,
-  children: [],
-});
-
-const file = (name: string): TreeDataItem => ({
-  id: name,
-  name,
-  icon: createFileIconComponent(name),
-});
-
-const repoRoot: TreeDataItem[] = [
-  folder('.changeset'),
-  folder('.cursor'),
-  folder('.devcontainer'),
-  folder('.github'),
-  folder('.vscode'),
-  folder('crates'),
-  folder('docs'),
-  folder('examples'),
-  folder('moon'),
-  folder('packages'),
-  folder('plans'),
-  folder('scripts'),
-  folder('skills'),
-  folder('sponsorkit'),
-  folder('supply-chain'),
-  file('.editorconfig'),
-  file('.gitignore'),
-  file('AGENTS.md'),
-  file('Cargo.lock'),
-  file('Cargo.toml'),
-  file('cliff.toml'),
-  file('CONTRIBUTING.md'),
-  file('deno.lock'),
-  file('deny.toml'),
-  file('LICENSE'),
-  file('package.json'),
-  file('pnpm-lock.yaml'),
-  file('pnpm-workspace.yaml'),
-  file('README.md'),
-  file('rust-toolchain'),
-  file('sponsorkit.config.js'),
+// Renders the REAL session "Files" surface. `FileTreeProviderView` owns the
+// ScrollArea, the flat virtualized row list, and the row height / indent, so this
+// story exercises production rows rather than re-composing them here.
+const folderPaths = [
+  '.changeset',
+  '.cursor',
+  '.devcontainer',
+  '.github',
+  '.vscode',
+  'crates',
+  'docs',
+  'examples',
+  'moon',
+  'packages',
+  'plans',
+  'scripts',
+  'skills',
+  'sponsorkit',
+  'supply-chain',
 ];
 
-// Mirror FileTreeView's container: the tree sits inside a padded wrapper while
-// TreeView itself runs with p-0, so this is the padding between the list and the
-// surrounding panel frame.
-function RepoRootFileTree() {
+const rootFiles = [
+  '.editorconfig',
+  '.gitignore',
+  'AGENTS.md',
+  'Cargo.lock',
+  'Cargo.toml',
+  'cliff.toml',
+  'CONTRIBUTING.md',
+  'deno.lock',
+  'deny.toml',
+  'LICENSE',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'README.md',
+  'rust-toolchain',
+  'sponsorkit.config.js',
+];
+
+// One nested file per folder so each directory is a real expandable node, which
+// is how the provider file index actually reports directories.
+const repoRootPaths = [...folderPaths.map((folder) => `${folder}/README.md`), ...rootFiles];
+
+// Well past the virtualization threshold, so this story covers the windowed row
+// path that large repositories hit.
+const largeRepoPaths = Array.from(
+  { length: 600 },
+  (_, index) => `packages/app/src/module-${String(index).padStart(3, '0')}.ts`
+);
+
+function FileTreeStory({ paths }: { readonly paths: readonly string[] }) {
+  const provider = useMemo(
+    () =>
+      createFakeSessionFileProvider({
+        sourceState: 'live-collaborative',
+        files: paths.map((path) => ({
+          path,
+          kind: 'text' as const,
+          sourceState: 'live-collaborative' as const,
+        })),
+      }),
+    [paths]
+  );
+
   return (
-    <div className="p-1">
-      <TreeView
-        data={repoRoot}
-        defaultNodeIcon={DefaultFolderIcon}
-        defaultLeafIcon={DefaultFileIcon}
-        className="p-0"
-      />
-    </div>
+    <FileTreeProviderView
+      fileProvider={provider}
+      fileProviderPending={false}
+      handleOpenFile={fn()}
+    />
   );
 }
 
 const meta = {
   title: 'Sessions/FileTreeList',
-  component: RepoRootFileTree,
+  component: FileTreeStory,
   parameters: {
     layout: 'centered',
   },
   decorators: [
     (Story) => (
-      <div className="h-[640px] w-[320px] overflow-auto border border-border bg-background">
+      <div className="h-[640px] w-[320px] border border-border bg-background">
         <Story />
       </div>
     ),
   ],
-} satisfies Meta<typeof RepoRootFileTree>;
+} satisfies Meta<typeof FileTreeStory>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const RepoRoot: Story = {};
+export const RepoRoot: Story = {
+  args: { paths: repoRootPaths },
+};
+
+// Scroll this one: only a viewport-sized window of rows is ever mounted.
+export const LargeVirtualizedTree: Story = {
+  args: { paths: largeRepoPaths },
+};

--- a/packages/components/tests/file-tree-virtual-rows.test.tsx
+++ b/packages/components/tests/file-tree-virtual-rows.test.tsx
@@ -1,0 +1,208 @@
+// @vitest-environment jsdom
+
+// Regression coverage for the file-tree virtualization perf bugs: an empty
+// virtual range must never fall back to mounting every visible row, the
+// scrollport must get measured once it is actually attached, and icon component
+// identity must survive a tree rebuild so row memoization can hold.
+
+import { act, createElement, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FileTreeProviderView } from '../src/components/sessions/components/file-tree-view';
+import {
+  createFileIconComponent,
+  createFolderIconComponent,
+} from '../src/components/icons/file-icons';
+import type { FileWorkspaceProvider } from '../src/lib/file-workspace-provider';
+import { initI18n } from '../src/i18n';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const ROW_HEIGHT_PX = 22;
+const VIEWPORT_HEIGHT_PX = 220;
+const OVERSCAN = 12;
+const FILE_COUNT = 400;
+
+// jsdom reports every element as 0x0, so the virtualizer would measure an empty
+// viewport forever. Give the ScrollArea viewport a real height the way the
+// browser would. `viewportHeightPx` is per-test so we can also reproduce the
+// scrollport that measures 0, which is what produced the empty virtual range.
+let viewportHeightPx = VIEWPORT_HEIGHT_PX;
+
+function installLayoutStubs(): void {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get(this: HTMLElement) {
+      return this.hasAttribute('data-radix-scroll-area-viewport') ? viewportHeightPx : 0;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get: () => 320,
+  });
+}
+
+function createReadyProvider(paths: readonly string[]): FileWorkspaceProvider {
+  return {
+    kind: 'code-collab',
+    getState: () => ({ kind: 'code-collab', ready: true, sourceState: 'live-readonly' }),
+    listFiles: async () =>
+      paths.map((path) => ({ path, kind: 'text' as const, sourceState: 'live-readonly' as const })),
+  } as unknown as FileWorkspaceProvider;
+}
+
+describe('VirtualFileTree row mounting', () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  beforeEach(async () => {
+    await initI18n('en');
+    viewportHeightPx = VIEWPORT_HEIGHT_PX;
+    installLayoutStubs();
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    root = null;
+    container?.remove();
+    container = null;
+    vi.unstubAllGlobals();
+  });
+
+  async function render(node: ReactNode): Promise<HTMLDivElement> {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(node);
+    });
+    return container;
+  }
+
+  function countRows(host: HTMLElement): number {
+    return host.querySelectorAll('[role="treeitem"]').length;
+  }
+
+  it('mounts only a viewport-sized window of rows instead of the whole tree', async () => {
+    // Flat root-level files, so every file is a visible row with no expansion.
+    const paths = Array.from({ length: FILE_COUNT }, (_, index) => `file-${index}.ts`);
+    const host = await render(
+      createElement(FileTreeProviderView, {
+        fileProvider: createReadyProvider(paths),
+        fileProviderPending: false,
+        handleOpenFile: () => undefined,
+      })
+    );
+
+    const rowCount = countRows(host);
+    // The bug rendered all FILE_COUNT rows whenever the virtual range came back
+    // empty. Assert the real virtualization bound instead of "fewer than all".
+    const expectedCeiling = Math.ceil(VIEWPORT_HEIGHT_PX / ROW_HEIGHT_PX) + 2 * OVERSCAN + 2;
+    expect(rowCount).toBeGreaterThan(0);
+    expect(rowCount).toBeLessThanOrEqual(expectedCeiling);
+    expect(rowCount).toBeLessThan(FILE_COUNT);
+
+    // The spacer must carry the full scrollable height even though only a
+    // window is mounted, otherwise the scrollport can never resolve a range.
+    const tree = host.querySelector('[role="tree"]') as HTMLElement | null;
+    expect(tree?.style.height).toBe(`${FILE_COUNT * ROW_HEIGHT_PX}px`);
+  });
+
+  // The original bug: whenever the virtual range came back empty — a viewport
+  // that still measures 0 being the common cause — the component rendered the
+  // full `rows.map`, mounting the entire expanded tree at the exact moment
+  // virtualization was needed. An unresolved range must mount no rows and keep
+  // the spacer, so a later measure can still resolve one.
+  it('mounts no rows rather than the whole tree while the scrollport measures 0', async () => {
+    viewportHeightPx = 0;
+    const paths = Array.from({ length: FILE_COUNT }, (_, index) => `file-${index}.ts`);
+    const host = await render(
+      createElement(FileTreeProviderView, {
+        fileProvider: createReadyProvider(paths),
+        fileProviderPending: false,
+        handleOpenFile: () => undefined,
+      })
+    );
+
+    expect(countRows(host)).toBe(0);
+    const tree = host.querySelector('[role="tree"]') as HTMLElement | null;
+    expect(tree?.style.height).toBe(`${FILE_COUNT * ROW_HEIGHT_PX}px`);
+  });
+
+  // Scrolling must move the mounted window rather than grow it. This is the
+  // acceptance criterion the row memoization exists to serve: the committed row
+  // set stays viewport-sized for the whole gesture.
+  it('shifts the mounted window on scroll without growing it', async () => {
+    const paths = Array.from({ length: FILE_COUNT }, (_, index) => `file-${index}.ts`);
+    const host = await render(
+      createElement(FileTreeProviderView, {
+        fileProvider: createReadyProvider(paths),
+        fileProviderPending: false,
+        handleOpenFile: () => undefined,
+      })
+    );
+
+    const viewport = host.querySelector('[data-radix-scroll-area-viewport]') as HTMLElement;
+    const ceiling = Math.ceil(VIEWPORT_HEIGHT_PX / ROW_HEIGHT_PX) + 2 * OVERSCAN + 2;
+    const firstLabel = () => host.querySelector('[role="treeitem"] span')?.textContent;
+
+    expect(firstLabel()).toBe('file-0.ts');
+
+    for (const scrollTop of [ROW_HEIGHT_PX * 40, ROW_HEIGHT_PX * 120, ROW_HEIGHT_PX * 300]) {
+      viewport.scrollTop = scrollTop;
+      await act(async () => {
+        viewport.dispatchEvent(new Event('scroll'));
+      });
+      expect(countRows(host)).toBeLessThanOrEqual(ceiling);
+    }
+
+    // The window actually followed the scroll instead of staying pinned at the top.
+    expect(firstLabel()).not.toBe('file-0.ts');
+  });
+
+  it('renders every row without a spacer for a small tree', async () => {
+    const paths = Array.from({ length: 5 }, (_, index) => `file-${index}.ts`);
+    const host = await render(
+      createElement(FileTreeProviderView, {
+        fileProvider: createReadyProvider(paths),
+        fileProviderPending: false,
+        handleOpenFile: () => undefined,
+      })
+    );
+
+    expect(countRows(host)).toBe(5);
+    const tree = host.querySelector('[role="tree"]') as HTMLElement | null;
+    expect(tree?.style.height).toBe('');
+  });
+});
+
+describe('file icon component identity', () => {
+  // A fresh component type per call made React unmount and remount every icon
+  // whenever the parent rebuilt tree data for the same paths, which also
+  // defeated row memoization.
+  it('returns a stable component for repeated calls on the same path', () => {
+    expect(createFileIconComponent('src/index.ts')).toBe(createFileIconComponent('src/index.ts'));
+    expect(createFolderIconComponent('src/components')).toBe(
+      createFolderIconComponent('src/components')
+    );
+  });
+
+  it('shares one component across paths that resolve to the same icon', () => {
+    expect(createFileIconComponent('a/one.ts')).toBe(createFileIconComponent('b/two.ts'));
+  });
+
+  it('still distinguishes paths that resolve to different icons', () => {
+    expect(createFileIconComponent('src/index.ts')).not.toBe(createFileIconComponent('README.md'));
+  });
+});

--- a/packages/components/tests/file-tree-virtualization.test.ts
+++ b/packages/components/tests/file-tree-virtualization.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import type { TreeDataItem } from '../src/components/tree-view';
 import {
-  countTreeDataItems,
   flattenVisibleFileTreeRows,
   pruneExpandedFileTreeIds,
-  shouldVirtualizeFileTreeData,
   shouldVirtualizeVisibleFileTreeRows,
 } from '../src/lib/file-tree-virtualization';
 
@@ -25,12 +23,6 @@ const tree = [
 ] satisfies TreeDataItem[];
 
 describe('file tree virtualization helpers', () => {
-  it('counts nested tree items for virtualization threshold decisions', () => {
-    expect(countTreeDataItems(tree)).toBe(5);
-    expect(shouldVirtualizeFileTreeData(tree, 4)).toBe(true);
-    expect(shouldVirtualizeFileTreeData(tree, 5)).toBe(false);
-  });
-
   it('virtualizes based on visible row count after source selection', () => {
     expect(shouldVirtualizeVisibleFileTreeRows(50)).toBe(false);
     expect(shouldVirtualizeVisibleFileTreeRows(51)).toBe(true);
@@ -61,5 +53,34 @@ describe('file tree virtualization helpers', () => {
     expect([
       ...pruneExpandedFileTreeIds(new Set(['src', 'missing', 'src/index.ts']), tree),
     ]).toEqual(['src']);
+  });
+
+  // The result is fed straight to setState, and the file tree's source data churns
+  // by reference on every file-watcher tick. A fresh equal Set would schedule a
+  // render plus a re-flatten and a virtualizer pass for a no-op prune.
+  it('keeps the same Set reference when nothing was pruned', () => {
+    const expanded = new Set(['src', 'src/components']);
+    expect(pruneExpandedFileTreeIds(expanded, tree)).toBe(expanded);
+
+    // A rebuilt-but-equivalent tree still must not allocate.
+    const rebuilt = structuredClone(tree) as TreeDataItem[];
+    expect(pruneExpandedFileTreeIds(expanded, rebuilt)).toBe(expanded);
+  });
+
+  it('returns a new Set only when an id actually goes away', () => {
+    const expanded = new Set(['src', 'gone']);
+    const pruned = pruneExpandedFileTreeIds(expanded, tree);
+    expect(pruned).not.toBe(expanded);
+    expect([...pruned]).toEqual(['src']);
+  });
+
+  // Row objects are the memo boundary for virtual rows: scrolling must not
+  // re-flatten, and re-flattening the same inputs must stay cheap and stable.
+  it('reuses the underlying item objects it was given', () => {
+    const expanded = new Set(['src']);
+    const first = flattenVisibleFileTreeRows(tree, expanded);
+    const second = flattenVisibleFileTreeRows(tree, expanded);
+    expect(second.map((row) => row.item)).toEqual(first.map((row) => row.item));
+    expect(second[0]!.item).toBe(first[0]!.item);
   });
 });


### PR DESCRIPTION
**Risk: medium** — file tree interaction (expand/collapse, selection, scroll sync with `ScrollArea`) on every session Files surface and the project file browser. **Confidence: high** on the root cause and the row-count behavior, which are covered by tests each verified to fail without their fix. **Not verified:** the trace-level millisecond claims, which need a production Electron profile on a large repo.

Fixes loro-dev/lody#3339 (the issue lives in the private repo, so no auto-close keyword here).

## Root cause — verified, not assumed

The issue listed a plausible cause; I confirmed the mechanism with a probe test of React's ref attachment order:

```
["layout:null","passive:element"]
```

At the child's `useLayoutEffect` — **the exact pass where TanStack Virtual reads `getScrollElement()`** — the ancestor Radix `ScrollArea` viewport ref is still `null`. React attaches an ancestor host ref only *after* its descendants' layout effects run. So the first virtual range is **always** empty, not just occasionally.

The old code responded to that with:

```ts
if (!shouldVirtualizeRows || virtualItems.length === 0) {
  return rows.map(...) // full list
}
```

which mounted the entire expanded tree at precisely the moment virtualization was needed, then tore it down once a measure succeeded. A viewport that measures 0 kept it there permanently.

## Changes

- **P0 — no full-render fallback.** An unresolved range renders no rows and keeps the total-size spacer, so the scrollport retains the scrollable height a later measure needs. Added `measure()` on viewport attach plus a `ResizeObserver`, mirroring the existing `shared/option-selector.tsx` pattern.
- **P0 — `VirtualFileTreeRow` is `memo`'d.** The virtualizer re-renders the list every scroll frame, which re-ran every mounted row.
- **P0 — icon factories cache by resolved icon name.** A fresh component type per call remounted every icon whenever the parent rebuilt tree data for the same paths, which also defeated the row memo. Keying by icon name bounds the cache by the shipped SVG set rather than by repo file count.
- **P1 — `pruneExpandedFileTreeIds` returns its input Set** when nothing was pruned. File-watcher ticks churn `data` by reference; a fresh equal Set forced an extra render, re-flatten, and virtualizer pass per tick.
- **P1 — one renderer, one threshold.** Removed the tree-wide count (which included collapsed nodes) that swapped Radix `TreeView` in and out; the single gate now counts visible rows.
- **P2** — `renderMode` logs on transitions only, not on every scroll-driven range change. Documented why `w-full` already covers the absolute-row background case (it resolves against the positioned ancestor), so no style change was needed there.

## Verification

Each test was checked against the reintroduced bug rather than trusted for being green:

| Mutation | Result |
|---|---|
| Restore `virtualItems.length === 0` fallback | zero-height test fails — **400 rows mounted instead of 0** |
| Disable `measure()` only | 0 rows render — both halves are load-bearing |
| Un-cache icon factories | 2 identity tests fail |

18/18 pass across the three file-tree suites; `tsc --noEmit` clean.

## Two things to flag

1. `pnpm check:affected` exits 1, but all **26 failures across 8 files reproduce identically on a stashed clean tree** (Convex/platform mock issues in `settings-data-cache`, `useOrganization`, `workspace-target-router`, and others). Pre-existing and unrelated — none touch these files.
2. `pnpm format` reformatted 18 unrelated CLI/Electron files that were already unformatted at the merge-base; I reverted those to keep the diff surgical.

## Story fidelity

`FileTreeList.stories.tsx` claimed to mirror `FileTreeView`'s renderer while composing `TreeView` directly — this change made that false. It now renders the real `FileTreeProviderView` per the Storybook-fidelity invariant, and adds a 600-row story for the windowed path.

## Manual check still wanted

Electron session Files panel on a large repo: expand/collapse, selection, and fast scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)