### PR TITLE
fix(components): navigate after local project import [risk:low]

### DIFF
--- a/packages/components/src/components/loro-app-sidebar.tsx
+++ b/packages/components/src/components/loro-app-sidebar.tsx
@@ -47,6 +47,7 @@ import { taskQuickAddOpenAtom, taskQuickAddStatusAtom } from '@/atoms/tasks';
 import { lodyConnectionUiStateAtom } from '@/atoms/control-connection';
 import { localMachineIdAtom } from '@/atoms/local-probe';
 import { selectAndWriteLocalProject } from '@/lib/local-project-import';
+import { importSidebarLocalProject } from '@/components/sidebar-local-project-import';
 import { lodyPresenceNowMsAtom, lodyPresenceStatesAtom } from '@/atoms/presence';
 import {
   chatScopeAtom,
@@ -1306,22 +1307,38 @@ export function LoroAppSidebar({ className }: LoroAppSidebarProps) {
     [setLocalProjectCollapseState]
   );
 
+  const handleNavigateToProject = useCallback(
+    (machineId: MachineId, localProjectId: string) => {
+      if (!workspaceSlug) return;
+      closeMobileDrawer();
+      void router.navigate({
+        to: '/$workspaceName/chat',
+        params: { workspaceName: workspaceSlug },
+        search: { context: 'local' as const, machine: machineId, project: localProjectId },
+      });
+    },
+    [closeMobileDrawer, router, workspaceSlug]
+  );
+
   const handleImportLocalProject = useCallback(async () => {
     if (!isElectron || !runtime) return;
-    if (!window.api?.selectLocalProjectDirectory) {
-      return;
-    }
+    const selectDirectory = window.api?.selectLocalProjectDirectory;
+    if (!selectDirectory) return;
 
     try {
-      await selectAndWriteLocalProject({
-        runtime,
-        selectDirectory: window.api.selectLocalProjectDirectory,
-        timeoutMessage: t('localProjects.add.timeout', 'The machine did not respond in time.'),
+      await importSidebarLocalProject({
+        importProject: () =>
+          selectAndWriteLocalProject({
+            runtime,
+            selectDirectory,
+            timeoutMessage: t('localProjects.add.timeout', 'The machine did not respond in time.'),
+          }),
+        navigateToProject: handleNavigateToProject,
       });
     } catch (error) {
       toast.error(error instanceof Error ? error.message : String(error));
     }
-  }, [runtime, t]);
+  }, [handleNavigateToProject, runtime, t]);
 
   const handleConfirmRemoveLocalProject = useCallback(async () => {
     const pending = pendingLocalProjectRemoval;
@@ -1415,19 +1432,6 @@ export function LoroAppSidebar({ className }: LoroAppSidebarProps) {
     }
     return map;
   }, [localProjectSessionsByKey]);
-
-  const handleNavigateToProject = useCallback(
-    (machineId: MachineId, localProjectId: string) => {
-      if (!workspaceSlug) return;
-      closeMobileDrawer();
-      void router.navigate({
-        to: '/$workspaceName/chat',
-        params: { workspaceName: workspaceSlug },
-        search: { context: 'local' as const, machine: machineId, project: localProjectId },
-      });
-    },
-    [closeMobileDrawer, router, workspaceSlug]
-  );
 
   const handleNavigateToSession = useCallback(
     (sessionId: string) => {

--- a/packages/components/src/components/sidebar-local-project-import.ts
+++ b/packages/components/src/components/sidebar-local-project-import.ts
@@ -1,0 +1,14 @@
+import type { LocalProjectId, MachineId } from '@lody/shared';
+import type { selectAndWriteLocalProject } from '@/lib/local-project-import';
+
+type LocalProjectImportResult = Awaited<ReturnType<typeof selectAndWriteLocalProject>>;
+
+export async function importSidebarLocalProject(args: {
+  importProject: () => Promise<LocalProjectImportResult>;
+  navigateToProject: (machineId: MachineId, localProjectId: LocalProjectId) => void;
+}): Promise<void> {
+  const result = await args.importProject();
+  if (!result) return;
+
+  args.navigateToProject(result.machineId, result.localProjectId);
+}

--- a/packages/components/tests/sidebar-local-project-import.test.ts
+++ b/packages/components/tests/sidebar-local-project-import.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { LocalProjectId, MachineId } from '@lody/shared';
+import { importSidebarLocalProject } from '../src/components/sidebar-local-project-import';
+
+const machineId = 'machine-1' as MachineId;
+const localProjectId = 'project-1' as LocalProjectId;
+
+describe('importSidebarLocalProject', () => {
+  it.each(['added', 'existing'] as const)(
+    'navigates to a successfully %s local project',
+    async (status) => {
+      const navigateToProject = vi.fn();
+
+      await importSidebarLocalProject({
+        importProject: vi.fn(async () => ({
+          status,
+          machineId,
+          localProjectId,
+          name: 'lody',
+          rootPath: '/repo/lody',
+        })),
+        navigateToProject,
+      });
+
+      expect(navigateToProject).toHaveBeenCalledOnce();
+      expect(navigateToProject).toHaveBeenCalledWith(machineId, localProjectId);
+    }
+  );
+
+  it('does not navigate when directory selection is cancelled', async () => {
+    const navigateToProject = vi.fn();
+
+    await importSidebarLocalProject({
+      importProject: vi.fn(async () => null),
+      navigateToProject,
+    });
+
+    expect(navigateToProject).not.toHaveBeenCalled();
+  });
+
+  it('preserves the import error and does not navigate', async () => {
+    const navigateToProject = vi.fn();
+    const error = new Error('Unable to add local project');
+
+    await expect(
+      importSidebarLocalProject({
+        importProject: vi.fn(async () => {
+          throw error;
+        }),
+        navigateToProject,
+      })
+    ).rejects.toBe(error);
+    expect(navigateToProject).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- consume the local project import result from the sidebar
- navigate added and already-registered projects through the existing typed Chat Landing route
- leave cancellation and existing import error handling unchanged
- add deterministic coverage for added, existing, cancelled, and failed imports

## Root cause

The sidebar awaited selectAndWriteLocalProject but discarded its returned machineId and localProjectId, so a successful import left the user on the current page.

## Validation

- pnpm --filter @lody/components exec vitest run tests/sidebar-local-project-import.test.ts tests/local-project-import.test.ts
- pnpm --filter @lody/components typecheck
- pnpm check:quick
- pnpm check:affected was requested but is not defined in this public checkout root package.json