### PR TITLE
fix: resolve TODO comments in json-lines-parser and root route

### DIFF
--- a/apps/cli/src/utils/json-lines-parser.ts
+++ b/apps/cli/src/utils/json-lines-parser.ts
@@ -29,8 +29,10 @@ export class JsonLinesParser extends Transform {
           const parsed = JSON.parse(line);
           this.push(parsed);
         } catch {
-          // TODO: better parse error
-          // console.log("#### error", line);
+          this.emit(
+            'warning',
+            new Error(`Skipping malformed JSON line: ${line.slice(0, 200)}`)
+          );
         }
       }
     }

--- a/packages/components/src/routes/__root.tsx
+++ b/packages/components/src/routes/__root.tsx
@@ -81,6 +81,29 @@ export const Route = createRootRouteWithContext<RouterContext>()({
         name: 'viewport',
         content: 'width=device-width, initial-scale=1',
       },
+      {
+        title: 'Lody',
+      },
+      {
+        name: 'description',
+        content: 'Share coding agents with your team on phone and desktop.',
+      },
+      {
+         name: 'theme-color',
+         content: '#000000',
+      },
+      {
+        name: 'og:title',
+         content: 'Lody',
+      },
+      {
+        name: 'og:description',
+        content: 'Share coding agents with your team on phone and desktop.',
+      },
+      {
+        name: 'og:type',
+        content: 'website',
+      },
     ],
   }),
 });


### PR DESCRIPTION
## Summary

Resolve 2 TODO comments found in the codebase.

### Changes

**`apps/cli/src/utils/json-lines-parser.ts`**
- Replace silent `catch` block with `this.emit('warning', ...)` so malformed JSON lines are observable by consumers instead of being swallowed

**`packages/components/src/routes/__root.tsx`**
- Add `title`, `description`, `theme-color`, and Open Graph meta tags to the root route `head()` — previously only `charset` and `viewport` were set