### PR TITLE
fix(cli): accept frozen taskToolsEnabled in Operation target dispatch configs

### DIFF
--- a/apps/cli/src/orchestration/operation-store.test.ts
+++ b/apps/cli/src/orchestration/operation-store.test.ts
@@ -90,6 +90,42 @@ describe('LodyOperationStore', () => {
     }
   });
 
+  it('round-trips a frozen create dispatch config including the task tools gate', async () => {
+    const store = await makeStore();
+    try {
+      const accepted = store.accept({
+        ...baseInput(),
+        kind: 'session_create',
+        frozenContinuationConfig: {
+          agentConfigId: 'agent-1',
+          inputConfig: { cliType: 'builtin' as const, agentType: 'codex', chainDepth: 0 },
+          targetDispatchConfigs: [
+            {
+              modeId: 'default',
+              modelId: 'gpt-5',
+              configOptionValues: { fast: true },
+              taskToolsEnabled: false,
+              inheritSessionDefaults: false as const,
+            },
+          ],
+        },
+      });
+
+      expect(accepted.created).toBe(true);
+      expect(accepted.operation.frozenContinuationConfig.targetDispatchConfigs).toEqual([
+        {
+          modeId: 'default',
+          modelId: 'gpt-5',
+          configOptionValues: { fast: true },
+          taskToolsEnabled: false,
+          inheritSessionDefaults: false,
+        },
+      ]);
+    } finally {
+      store.close();
+    }
+  });
+
   it('rejects operation id reuse with different semantic input', async () => {
     const store = await makeStore();
     try {

--- a/apps/cli/src/orchestration/operation-store.ts
+++ b/apps/cli/src/orchestration/operation-store.ts
@@ -119,6 +119,7 @@ const FrozenConfigSchema = z
             modeId: z.string().optional(),
             modelId: z.string().optional(),
             configOptionValues: z.record(z.string(), z.union([z.string(), z.boolean()])).optional(),
+            taskToolsEnabled: z.boolean().optional(),
             inheritSessionDefaults: z.literal(false).optional(),
           })
           .strict()

--- a/packages/shared/src/session-orchestration.ts
+++ b/packages/shared/src/session-orchestration.ts
@@ -128,6 +128,11 @@ export type FrozenOperationContinuationConfig = {
     modeId?: string;
     modelId?: string;
     configOptionValues?: Record<string, string | boolean>;
+    /**
+     * Frozen capability gate for the built-in Lody Task MCP tools, carried
+     * from the driving Turn so recovery keeps the same tool surface.
+     */
+    taskToolsEnabled?: boolean;
     inheritSessionDefaults?: false;
   } | null>;
 };


### PR DESCRIPTION
## Problem

Every MCP `lody_session_create` / `lody_session_create_many` call fails locally with a Zod schema error:

```json
{ "code": "unrecognized_keys", "keys": ["taskToolsEnabled"], "path": ["targetDispatchConfigs", 0], "message": "Invalid input" }
```

This rejects the Operation at acceptance, before any session is materialized — so **all** MCP-driven session creation is broken, for Role-based and plain creates alike.

## Root cause

`resolveMcpSessionCreate` unconditionally freezes the driving Turn's `taskToolsEnabled` gate into the per-target dispatch config (`apps/cli/src/mcp/lody-mcp-server.ts`, both the Role and non-Role paths — the key is present even when the value is `false`). `validateSessionCreateOptions` preserves it, and `OperationStore.accept` stores it in `frozenContinuationConfig.targetDispatchConfigs`.

But `FrozenConfigSchema` in `apps/cli/src/orchestration/operation-store.ts` validates that frozen config with a `.strict()` object that was never extended when `taskToolsEnabled` was added to `ResolvedTurnDispatchConfig` — so strict parsing throws `unrecognized_keys` at `targetDispatchConfigs[0]`. TypeScript didn't catch the mismatch because the excess property check does not apply to already-typed variables.

## Fix

- Add `taskToolsEnabled: z.boolean().optional()` to the `targetDispatchConfigs` item schema in `FrozenConfigSchema`. The field must be **stored**, not stripped: daemon recovery replays the frozen dispatch config and the Task-MCP gate depends on it.
- Mirror the field in the shared `FrozenOperationContinuationConfig` type (`packages/shared/src/session-orchestration.ts`).
- Add an accept → read-back round-trip regression test in `operation-store.test.ts`.

## Verification

- `apps/cli`: `operation-store`, `lody-mcp-server`, and orchestration test files — 115 tests pass; `tsgo --noEmit` clean; oxlint clean on touched files.
- `packages/shared`: full suite (967 tests) passes; `tsgo --noEmit` clean.