### PR TITLE
fix: preserve tab rename during IME composition

### DIFF
--- a/packages/components/src/components/sessions/session-tab-bar.tsx
+++ b/packages/components/src/components/sessions/session-tab-bar.tsx
@@ -279,7 +279,8 @@ function TabContent({
           onChange={(e) => setEditDraft(e.target.value)}
           onBlur={commitRename}
           onKeyDown={(e) => {
-            if (e.key === 'Enter' && !isImeComposingKeyboardEvent(e)) commitRename();
+            if (isImeComposingKeyboardEvent(e)) return;
+            if (e.key === 'Enter') commitRename();
             if (e.key === 'Escape') cancelRename();
           }}
           className="w-full min-w-0 bg-transparent outline-hidden text-[13px]"

--- a/packages/components/src/components/sessions/session-tab-bar.tsx
+++ b/packages/components/src/components/sessions/session-tab-bar.tsx
@@ -28,6 +28,7 @@ import {
   useSortable,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { isImeComposingKeyboardEvent } from '@/lib/ime';
 import { type DraftSessionTab, getDraftTabLabel } from '@/lib/session-draft-tabs';
 import { TAB_PILL_ACTIVE_CLASS, TAB_PILL_INACTIVE_CLASS } from '@/components/shared/tab-pill-strip';
 import { AdaptiveTabStrip, AdaptiveTabStripItem } from './adaptive-tab-strip';
@@ -278,7 +279,7 @@ function TabContent({
           onChange={(e) => setEditDraft(e.target.value)}
           onBlur={commitRename}
           onKeyDown={(e) => {
-            if (e.key === 'Enter') commitRename();
+            if (e.key === 'Enter' && !isImeComposingKeyboardEvent(e)) commitRename();
             if (e.key === 'Escape') cancelRename();
           }}
           className="w-full min-w-0 bg-transparent outline-hidden text-[13px]"

--- a/packages/components/tests/session-tab-bar.test.tsx
+++ b/packages/components/tests/session-tab-bar.test.tsx
@@ -30,7 +30,7 @@ const childSession: SessionMeta = {
   title: 'Child session',
 };
 
-describe('SessionTabBar', () => {
+describe('SessionTabBar drag sources', () => {
   let root: Root;
   let container: HTMLDivElement;
 
@@ -46,10 +46,7 @@ describe('SessionTabBar', () => {
     vi.restoreAllMocks();
   });
 
-  async function renderTabBar(
-    childSessions: SessionMeta[],
-    onTabRename?: (sessionId: SessionId, title: string) => void
-  ) {
+  async function renderTabBar(childSessions: SessionMeta[]) {
     await act(async () => {
       root.render(
         <Provider store={createStore()}>
@@ -63,7 +60,6 @@ describe('SessionTabBar', () => {
               activeTabSessionId={parentSession.id}
               onTabSelect={vi.fn()}
               onNewTab={vi.fn()}
-              onTabRename={onTabRename}
             />
           </TooltipProvider>
         </Provider>
@@ -85,41 +81,5 @@ describe('SessionTabBar', () => {
     expect(container.querySelector<HTMLElement>('#session-tab-session-parent')?.draggable).toBe(
       true
     );
-  });
-
-  it('ignores Enter while the IME is composing an inline rename', async () => {
-    const onTabRename = vi.fn();
-    await renderTabBar([], onTabRename);
-
-    await act(async () => {
-      container
-        .querySelector<HTMLElement>('#session-tab-session-parent')
-        ?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
-    });
-
-    const input = container.querySelector<HTMLInputElement>('input');
-    expect(input).toBeInstanceOf(HTMLInputElement);
-
-    await act(async () => {
-      input?.dispatchEvent(
-        new KeyboardEvent('keydown', {
-          key: 'Enter',
-          bubbles: true,
-          cancelable: true,
-          isComposing: true,
-        })
-      );
-    });
-
-    expect(onTabRename).not.toHaveBeenCalled();
-    expect(container.querySelector('input')).toBe(input);
-
-    await act(async () => {
-      input?.dispatchEvent(
-        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
-      );
-    });
-
-    expect(onTabRename).toHaveBeenCalledWith(parentSession.id, parentSession.title);
   });
 });

--- a/packages/components/tests/session-tab-bar.test.tsx
+++ b/packages/components/tests/session-tab-bar.test.tsx
@@ -30,7 +30,7 @@ const childSession: SessionMeta = {
   title: 'Child session',
 };
 
-describe('SessionTabBar drag sources', () => {
+describe('SessionTabBar', () => {
   let root: Root;
   let container: HTMLDivElement;
 
@@ -46,7 +46,10 @@ describe('SessionTabBar drag sources', () => {
     vi.restoreAllMocks();
   });
 
-  async function renderTabBar(childSessions: SessionMeta[]) {
+  async function renderTabBar(
+    childSessions: SessionMeta[],
+    onTabRename?: (sessionId: SessionId, title: string) => void
+  ) {
     await act(async () => {
       root.render(
         <Provider store={createStore()}>
@@ -60,6 +63,7 @@ describe('SessionTabBar drag sources', () => {
               activeTabSessionId={parentSession.id}
               onTabSelect={vi.fn()}
               onNewTab={vi.fn()}
+              onTabRename={onTabRename}
             />
           </TooltipProvider>
         </Provider>
@@ -81,5 +85,41 @@ describe('SessionTabBar drag sources', () => {
     expect(container.querySelector<HTMLElement>('#session-tab-session-parent')?.draggable).toBe(
       true
     );
+  });
+
+  it('ignores Enter while the IME is composing an inline rename', async () => {
+    const onTabRename = vi.fn();
+    await renderTabBar([], onTabRename);
+
+    await act(async () => {
+      container
+        .querySelector<HTMLElement>('#session-tab-session-parent')
+        ?.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    });
+
+    const input = container.querySelector<HTMLInputElement>('input');
+    expect(input).toBeInstanceOf(HTMLInputElement);
+
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          bubbles: true,
+          cancelable: true,
+          isComposing: true,
+        })
+      );
+    });
+
+    expect(onTabRename).not.toHaveBeenCalled();
+    expect(container.querySelector('input')).toBe(input);
+
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(onTabRename).toHaveBeenCalledWith(parentSession.id, parentSession.title);
   });
 });


### PR DESCRIPTION
## Problem

Double-clicking a desktop chat session tab opens its inline rename input. During IME composition, Enter confirms a candidate and Escape dismisses the candidate UI or composition. The rename input treated those keys as submit and cancel actions, which could prematurely close the editor and potentially save an incomplete title.

## Summary

- ignore rename keyboard actions while an IME is composing
- preserve ordinary Enter submission and Escape cancellation by reusing the existing IME keyboard-event helper

## Testing

- existing `session-tab-bar.test.tsx` and `ime.test.ts` suites (14 tests)
- `corepack pnpm --filter @lody/components run typecheck`
- `corepack pnpm exec prettier --check packages/components/src/components/sessions/session-tab-bar.tsx`
- targeted type-aware oxlint on the changed production file (0 errors)

## Validation note

The root `pnpm lint` command also traversed the initialized, isolated `packages/acp-extension-kimi` submodule. Its standalone dependencies are not installed in this worktree, so that broad command reported unrelated missing-type and existing lint errors inside the submodule; the changed production file passes targeted type-aware lint.