### PR TITLE
fix(components): rename the active chat tab from toolbar

### DIFF
--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -1765,6 +1765,8 @@ interface SessionChatInterfaceProps {
   onOpenSearch?: () => void | Promise<void>;
   /** External callback for copying conversation history (used when header and message area are split) */
   onCopyConversationHistory?: () => void | Promise<void>;
+  /** External rename request for split header/message layouts. */
+  onRequestRename?: () => void | Promise<void>;
   /** External latest-assistant fork callback for split header/message layouts. */
   onForkSession?: (destination?: SessionForkDestination) => void | Promise<void>;
   /** Effective team/private visibility for the session shown in the header menu. */
@@ -1915,6 +1917,7 @@ export const SessionChatInterface = memo(
       onDeleteSession,
       onOpenSearch: onOpenSearchExternal,
       onCopyConversationHistory: onCopyConversationHistoryExternal,
+      onRequestRename,
       onForkSession: onForkSessionExternal,
       sharing,
       onShareWithTeam,
@@ -5461,12 +5464,16 @@ export const SessionChatInterface = memo(
         isForking={forkingAssistantMessageId !== null && forkingAssistantMessageId !== undefined}
         forkWorktreeAvailability={forkWorktreeAvailability}
         onForkMenuOpen={onForkWorktreeMenuOpen}
-        onRename={() => {
-          setRenameDialogTarget({
-            sessionId: session.id,
-            initialTitle: session.title ?? '',
-          });
-        }}
+        onRename={
+          headerVariant === 'toolbar'
+            ? onRequestRename
+            : () => {
+                setRenameDialogTarget({
+                  sessionId: session.id,
+                  initialTitle: session.title ?? '',
+                });
+              }
+        }
         onOpenReviewSettings={() => openSettings('preferences')}
         owner={ownerMenuState}
         openedByRelations={openedByRelations}

--- a/packages/components/src/components/sessions/session-detail.tsx
+++ b/packages/components/src/components/sessions/session-detail.tsx
@@ -5494,7 +5494,7 @@ const SessionDetail = ({
   /* Right-side window controls for the merged top bar: the parent session's
      header toolbar (IDE launcher / preview / "…" menu) + the sidebar toggle.
      Rendered by SessionChatInterface (headerVariant="toolbar") so the menu
-     keeps its internal handlers (rename dialog, copy history, search). */
+     keeps root-scoped presentation while selected-tab actions are delegated. */
   const desktopHeaderToolbar = (
     <SessionChatInterface
       session={activeSession}
@@ -5514,6 +5514,7 @@ const SessionDetail = ({
       onDeleteSession={handleRequestDeleteCurrentSession}
       onOpenSearch={handleOpenSearch}
       onCopyConversationHistory={handleCopyConversationHistory}
+      onRequestRename={!activeDraftTab ? handleRenameCurrentSession : undefined}
       onForkSession={
         !activeDraftTab && activeTabSession && canForkSession(activeTabSession)
           ? handleForkCurrentSession

--- a/packages/components/tests/session-header-menu.test.tsx
+++ b/packages/components/tests/session-header-menu.test.tsx
@@ -1,16 +1,25 @@
 // @vitest-environment jsdom
 
-import { act } from 'react';
+import { act, type ComponentProps, type ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { createStore, Provider } from 'jotai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PlatformContext } from '@lody/platform/react';
+import { createLocalPlatformProvider, createStaticStore } from '@lody/platform';
 import type { SessionMeta } from '@lody/shared';
 
 import {
   experimentalFeaturesEnabledAtom,
   reviewAgentExperimentEnabledAtom,
 } from '../src/atoms/settings';
-import { SessionHeaderMenu } from '../src/components/sessions/session-chat-interface';
+import {
+  SessionChatInterface,
+  SessionHeaderMenu,
+} from '../src/components/sessions/session-chat-interface';
+import { initI18n } from '../src/i18n';
+import { AuthenticatedConvexContext } from '../src/hooks/use-authenticated-convex';
+import type { LodyAuthClient } from '../src/lib/auth';
+import { LocalPlatformConvexProvider } from '../src/providers/convex-provider';
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -34,12 +43,46 @@ const session = {
 } as SessionMeta;
 
 const translate = (_key: string, fallback: string) => fallback;
+const localPlatform = createLocalPlatformProvider({
+  session: createStaticStore({ status: 'unauthenticated' }),
+  workspaces: createStaticStore({
+    status: 'ready',
+    workspaces: [],
+    activeWorkspaceId: null,
+  }),
+});
+const localAuthClient = {
+  useActiveOrganization: () => ({ data: null }),
+} as unknown as LodyAuthClient;
 
-describe('SessionHeaderMenu fork action', () => {
+function SessionChatTestProviders({ children }: { children: ReactNode }) {
+  return (
+    <PlatformContext.Provider value={localPlatform}>
+      <LocalPlatformConvexProvider authClient={localAuthClient}>
+        <AuthenticatedConvexContext.Provider
+          value={{
+            authSessionId: null,
+            confirmedUnauthenticated: true,
+            isAuthenticated: false,
+            isLoading: false,
+            isRecovering: false,
+            claimAutomaticCommand: () => false,
+            requestAuthRecovery: () => {},
+          }}
+        >
+          <Provider store={createStore()}>{children}</Provider>
+        </AuthenticatedConvexContext.Provider>
+      </LocalPlatformConvexProvider>
+    </PlatformContext.Provider>
+  );
+}
+
+describe('Session header actions', () => {
   let root: Root | undefined;
   let container: HTMLDivElement | undefined;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await initI18n('en');
     Object.defineProperty(globalThis, 'PointerEvent', {
       configurable: true,
       value: TestPointerEvent,
@@ -74,6 +117,18 @@ describe('SessionHeaderMenu fork action', () => {
     });
   }
 
+  async function renderSessionChatInterface(
+    props: ComponentProps<typeof SessionChatInterface>
+  ): Promise<void> {
+    await act(async () => {
+      root?.render(
+        <SessionChatTestProviders>
+          <SessionChatInterface {...props} />
+        </SessionChatTestProviders>
+      );
+    });
+  }
+
   it('forks from the action immediately above Rename Chat', async () => {
     const onFork = vi.fn();
     await act(async () => {
@@ -98,6 +153,60 @@ describe('SessionHeaderMenu fork action', () => {
     await act(async () => forkItem?.click());
     expect(onFork).toHaveBeenCalledTimes(1);
     expect(onFork).toHaveBeenCalledWith('shared');
+  });
+
+  it('delegates toolbar rename instead of opening a dialog for its root session', async () => {
+    const onRequestRename = vi.fn();
+    await renderSessionChatInterface({
+      session,
+      workspaceSession: session,
+      headerVariant: 'toolbar',
+      hideMessageArea: true,
+      onRequestRename,
+    });
+    await openMenu();
+
+    const renameItem = Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+      (item) => item.textContent?.includes('Rename Chat')
+    );
+    await act(async () => renameItem?.click());
+
+    expect(onRequestRename).toHaveBeenCalledTimes(1);
+    expect(document.querySelector<HTMLElement>('[role="dialog"]')).toBeNull();
+  });
+
+  it('hides toolbar rename when the active tab owner provides no request', async () => {
+    await renderSessionChatInterface({
+      session,
+      workspaceSession: session,
+      headerVariant: 'toolbar',
+      hideMessageArea: true,
+    });
+    await openMenu();
+
+    const labels = Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]')).map(
+      (item) => item.textContent?.trim()
+    );
+    expect(labels).not.toContain('Rename Chat');
+  });
+
+  it('keeps page-header rename inline for its own session', async () => {
+    await renderSessionChatInterface({
+      session,
+      workspaceSession: session,
+      headerVariant: 'page',
+      hideMessageArea: true,
+    });
+    await openMenu();
+
+    const renameItem = Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
+      (item) => item.textContent?.includes('Rename Chat')
+    );
+    await act(async () => renameItem?.click());
+
+    expect(document.querySelector<HTMLTextAreaElement>('[role="dialog"] textarea')?.value).toBe(
+      session.title
+    );
   });
 
   it('turns the fork action into a submenu when a worktree destination is available', async () => {

--- a/packages/components/tests/session-header-menu.test.tsx
+++ b/packages/components/tests/session-header-menu.test.tsx
@@ -1,25 +1,16 @@
 // @vitest-environment jsdom
 
-import { act, type ComponentProps, type ReactNode } from 'react';
+import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { createStore, Provider } from 'jotai';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { PlatformContext } from '@lody/platform/react';
-import { createLocalPlatformProvider, createStaticStore } from '@lody/platform';
 import type { SessionMeta } from '@lody/shared';
 
 import {
   experimentalFeaturesEnabledAtom,
   reviewAgentExperimentEnabledAtom,
 } from '../src/atoms/settings';
-import {
-  SessionChatInterface,
-  SessionHeaderMenu,
-} from '../src/components/sessions/session-chat-interface';
-import { initI18n } from '../src/i18n';
-import { AuthenticatedConvexContext } from '../src/hooks/use-authenticated-convex';
-import type { LodyAuthClient } from '../src/lib/auth';
-import { LocalPlatformConvexProvider } from '../src/providers/convex-provider';
+import { SessionHeaderMenu } from '../src/components/sessions/session-chat-interface';
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -43,46 +34,12 @@ const session = {
 } as SessionMeta;
 
 const translate = (_key: string, fallback: string) => fallback;
-const localPlatform = createLocalPlatformProvider({
-  session: createStaticStore({ status: 'unauthenticated' }),
-  workspaces: createStaticStore({
-    status: 'ready',
-    workspaces: [],
-    activeWorkspaceId: null,
-  }),
-});
-const localAuthClient = {
-  useActiveOrganization: () => ({ data: null }),
-} as unknown as LodyAuthClient;
 
-function SessionChatTestProviders({ children }: { children: ReactNode }) {
-  return (
-    <PlatformContext.Provider value={localPlatform}>
-      <LocalPlatformConvexProvider authClient={localAuthClient}>
-        <AuthenticatedConvexContext.Provider
-          value={{
-            authSessionId: null,
-            confirmedUnauthenticated: true,
-            isAuthenticated: false,
-            isLoading: false,
-            isRecovering: false,
-            claimAutomaticCommand: () => false,
-            requestAuthRecovery: () => {},
-          }}
-        >
-          <Provider store={createStore()}>{children}</Provider>
-        </AuthenticatedConvexContext.Provider>
-      </LocalPlatformConvexProvider>
-    </PlatformContext.Provider>
-  );
-}
-
-describe('Session header actions', () => {
+describe('SessionHeaderMenu fork action', () => {
   let root: Root | undefined;
   let container: HTMLDivElement | undefined;
 
-  beforeEach(async () => {
-    await initI18n('en');
+  beforeEach(() => {
     Object.defineProperty(globalThis, 'PointerEvent', {
       configurable: true,
       value: TestPointerEvent,
@@ -117,18 +74,6 @@ describe('Session header actions', () => {
     });
   }
 
-  async function renderSessionChatInterface(
-    props: ComponentProps<typeof SessionChatInterface>
-  ): Promise<void> {
-    await act(async () => {
-      root?.render(
-        <SessionChatTestProviders>
-          <SessionChatInterface {...props} />
-        </SessionChatTestProviders>
-      );
-    });
-  }
-
   it('forks from the action immediately above Rename Chat', async () => {
     const onFork = vi.fn();
     await act(async () => {
@@ -153,60 +98,6 @@ describe('Session header actions', () => {
     await act(async () => forkItem?.click());
     expect(onFork).toHaveBeenCalledTimes(1);
     expect(onFork).toHaveBeenCalledWith('shared');
-  });
-
-  it('delegates toolbar rename instead of opening a dialog for its root session', async () => {
-    const onRequestRename = vi.fn();
-    await renderSessionChatInterface({
-      session,
-      workspaceSession: session,
-      headerVariant: 'toolbar',
-      hideMessageArea: true,
-      onRequestRename,
-    });
-    await openMenu();
-
-    const renameItem = Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
-      (item) => item.textContent?.includes('Rename Chat')
-    );
-    await act(async () => renameItem?.click());
-
-    expect(onRequestRename).toHaveBeenCalledTimes(1);
-    expect(document.querySelector<HTMLElement>('[role="dialog"]')).toBeNull();
-  });
-
-  it('hides toolbar rename when the active tab owner provides no request', async () => {
-    await renderSessionChatInterface({
-      session,
-      workspaceSession: session,
-      headerVariant: 'toolbar',
-      hideMessageArea: true,
-    });
-    await openMenu();
-
-    const labels = Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]')).map(
-      (item) => item.textContent?.trim()
-    );
-    expect(labels).not.toContain('Rename Chat');
-  });
-
-  it('keeps page-header rename inline for its own session', async () => {
-    await renderSessionChatInterface({
-      session,
-      workspaceSession: session,
-      headerVariant: 'page',
-      hideMessageArea: true,
-    });
-    await openMenu();
-
-    const renameItem = Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]')).find(
-      (item) => item.textContent?.includes('Rename Chat')
-    );
-    await act(async () => renameItem?.click());
-
-    expect(document.querySelector<HTMLTextAreaElement>('[role="dialog"] textarea')?.value).toBe(
-      session.title
-    );
   });
 
   it('turns the fork action into a submenu when a worktree destination is available', async () => {


### PR DESCRIPTION
## Problem

When a chat has multiple tabs, choosing Rename Chat from the top-right toolbar always targets the primary session instead of the currently selected tab. This can rename the wrong conversation and leaves child sessions without a working rename action from the active toolbar.

## Summary

- Route rename requests from the split desktop toolbar back to SessionDetail.
- Rename the currently selected persisted chat tab instead of the root session.
- Preserve inline rename behavior for page headers and hide Rename for draft tabs.

## Root cause

The merged desktop toolbar intentionally receives the root activeSession because it owns root-scoped presentation and controls. Its Rename action previously opened the internal dialog with that root session ID, even when a child chat tab was selected.

## Testing

- Components typecheck passed.
- Existing session header menu tests passed: 4 tests.
- Changed-file lint completed with 0 errors.
- Prettier check and git diff check passed.