### PR TITLE
fix: initialize loro metadata monitoring

### DIFF
--- a/apps/cli/src/lib/loro/AGENTS.md
+++ b/apps/cli/src/lib/loro/AGENTS.md
@@ -12,6 +12,11 @@ down. Cost per call = one Streams subscription plus the doc's full initial sync.
 
 Rules:
 
+- Renderer metadata reaches the CLI by direct import into the repo's internal
+  meta Flock even when local mode has no registered transport. Keep the
+  `loro-repo` metadata live monitor enabled from repo initialization; deferring
+  it until transport join leaves `getDocMeta` stale and prevents the session
+  dispatch watcher from seeing `latestUserMsgId`.
 - Never open docs in a loop over `listAliveRoomIds` or any other workspace-wide
   enumeration. A long-lived workspace holds thousands of historical session
   rooms; opening them all stalls startup and floods the Streams backend.

--- a/packages/components/tests/doc-meta-subscription.test.ts
+++ b/packages/components/tests/doc-meta-subscription.test.ts
@@ -235,7 +235,9 @@ describe('docMetaSubscriptionAtom', () => {
     const machineId = 'machine-1' as MachineId;
     const docId = getMachineRoomId(machineId);
 
-    await repo.syncRunner.ensureMetaLiveMonitor();
+    // Electron local-first mode imports renderer metadata directly into the
+    // CLI repo's meta Flock while no cloud transport is registered. The repo
+    // must hydrate its metadata cache and emit watch events in that state.
     await importRemoteMeta(repo, remote, () => {
       remote.getMeta().put(['e', docId], true);
       remote.getMeta().put(['m', docId], { id: machineId, name: 'dev-box', lastSeen: 1 });
@@ -276,7 +278,6 @@ describe('docMetaSubscriptionAtom', () => {
     const machineId = 'machine-2' as MachineId;
     const docId = getMachineRoomId(machineId);
 
-    await repo.syncRunner.ensureMetaLiveMonitor();
     await importRemoteMeta(repo, remote, () => {
       remote.getMeta().put(['e', docId], true);
       remote.getMeta().put(['m', docId], { id: machineId, name: 'ci-box', lastSeen: 10 });

--- a/patches/loro-repo.patch
+++ b/patches/loro-repo.patch
@@ -1,0 +1,36 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index 1460c6b29d66d8e6e2c594e8aab02653d5c9fef4..627d4bb447c32b18843cfb76ea69772f3ff982d5 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -3527,6 +3527,7 @@ var LoroRepo = class LoroRepo {
+-	async ready() {
+-		if (this.metaPersister) {
+-			const version = this.metaFlock.version();
+-			this.metaPersister.start(version);
+-		}
+-	}
++	async ready() {
++		await this.syncRunner.ensureMetaLiveMonitor();
++		if (this.metaPersister) {
++			const version = this.metaFlock.version();
++			this.metaPersister.start(version);
++		}
++	}
+diff --git a/dist/index.js b/dist/index.js
+index 36afa6cc081db6f3d6b5073133cf9c8f209f92c2..7e2f66756d2d742b587f920a0dd0696973e48e02 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -3524,6 +3524,7 @@ var LoroRepo = class LoroRepo {
+-	async ready() {
+-		if (this.metaPersister) {
+-			const version = this.metaFlock.version();
+-			this.metaPersister.start(version);
+-		}
+-	}
++	async ready() {
++		await this.syncRunner.ensureMetaLiveMonitor();
++		if (this.metaPersister) {
++			const version = this.metaFlock.version();
++			this.metaPersister.start(version);
++		}
++	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ patchedDependencies:
   '@tanstack/router-generator@1.159.4':
     hash: 14fe630c2d7f306f8e60169e6a0116cf02de74368af213699cb449aeeecc663a
     path: patches/@tanstack__router-generator@1.159.4.patch
+  loro-repo@0.20.0:
+    hash: 74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357
+    path: patches/loro-repo.patch
   mdast-util-gfm-autolink-literal@2.0.1:
     hash: b03e2c531618296b99e716d479b68761f6ebc6c81dcd1e9359e80b71e6b5ee8e
     path: patches/mdast-util-gfm-autolink-literal@2.0.1.patch
@@ -349,7 +352,7 @@ importers:
         version: 2.2.1(loro-crdt@1.14.1)
       loro-repo:
         specifier: 'catalog:'
-        version: 0.20.0(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.3)(loro-crdt@1.14.1)
+        version: 0.20.0(patch_hash=74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357)(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.3)(loro-crdt@1.14.1)
       ora:
         specifier: ^8.2.0
         version: 8.2.0
@@ -1085,7 +1088,7 @@ importers:
         version: 2.2.1(loro-crdt@1.14.1)(loro-mirror@2.2.1(loro-crdt@1.14.1))(react@19.2.0)
       loro-repo:
         specifier: 'catalog:'
-        version: 0.20.0(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(loro-crdt@1.14.1)
+        version: 0.20.0(patch_hash=74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357)(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(loro-crdt@1.14.1)
       loro-websocket:
         specifier: 'catalog:'
         version: 0.6.2(@loro-dev/flock@4.4.4)(loro-crdt@1.14.1)
@@ -1405,7 +1408,7 @@ importers:
         version: 24.10.12
       loro-repo:
         specifier: 'catalog:'
-        version: 0.20.0(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(loro-crdt@1.14.1)
+        version: 0.20.0(patch_hash=74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357)(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(loro-crdt@1.14.1)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -21432,7 +21435,7 @@ snapshots:
 
   loro-protocol@0.3.0: {}
 
-  loro-repo@0.20.0(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(loro-crdt@1.14.1):
+  loro-repo@0.20.0(patch_hash=74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357)(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(loro-crdt@1.14.1):
     dependencies:
       '@loro-dev/flock-wasm': 0.4.3
       '@loro-dev/streams-crdt': 0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1)
@@ -21449,7 +21452,7 @@ snapshots:
       - utf-8-validate
       - yjs
 
-  loro-repo@0.20.0(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.3)(loro-crdt@1.14.1):
+  loro-repo@0.20.0(patch_hash=74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357)(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.3)(loro-crdt@1.14.1):
     dependencies:
       '@loro-dev/flock-wasm': 0.4.3
       '@loro-dev/streams-crdt': 0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -97,6 +97,7 @@ patchedDependencies:
   '@better-auth/electron@1.5.5': patches/@better-auth__electron@1.5.5.patch
   '@pierre/diffs@1.0.10': patches/@pierre__diffs@1.0.10.patch
   '@tanstack/router-generator@1.159.4': patches/@tanstack__router-generator@1.159.4.patch
+  loro-repo@0.20.0: patches/loro-repo.patch
   mdast-util-gfm-autolink-literal@2.0.1: patches/mdast-util-gfm-autolink-literal@2.0.1.patch
   react-photo-view@1.2.7: patches/react-photo-view@1.2.7.patch
   remend@1.3.0: patches/remend@1.3.0.patch


### PR DESCRIPTION
## Summary

- patch `loro-repo@0.20.0` so its metadata live monitor starts during repository initialization
- keep transport-free local meta imports hydrated in the repo metadata cache and visible to `repo.watch({ kinds: ['doc-metadata'] })`
- remove the regression tests' manual activation of the private sync runner and document the local dispatch invariant

## User impact

In the OSS Electron app, a locally sent message could appear in the conversation and remain durably persisted while the agent never started and no assistant reply arrived. Restarting the desktop app could recover the pending turn through the startup session scan, but that was only a temporary recovery: a later live message could become stuck again.

## Root cause

The OSS Electron composition starts the CLI repo without a registered transport and syncs renderer metadata through the local Loro data plane. The renderer's `latestUserMsgId` update reached the CLI's raw meta Flock, but `loro-repo` only started `ensureMetaLiveMonitor()` during metadata sync or an actual meta transport attachment. A pending transport-free meta room therefore never hydrated the derived metadata cache or emitted the event consumed by `SessionDispatchWatcher`.

Starting the existing idempotent monitor from `LoroRepo.ready()` closes that initialization gap without registering a transport or making a cloud request. Later cloud sync and transport attachment calls remain safe no-ops for monitor setup.

## Why a dependency patch

The published package metadata points to `loro-dev/loro-repo`, but that repository is currently unavailable to this contributor, and the public `loro-dev` repositories do not contain this package's source. There is therefore no accessible upstream target for a source PR today.

This change carries the smallest reproducible fix through pnpm's version-pinned `patchedDependencies`. When the upstream source becomes available and publishes the initialization fix, Lody should upgrade `loro-repo` and remove this patch.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run tests/doc-meta-subscription.test.ts` (7 passed)
- `pnpm exec vitest run tests/session-dispatch-watcher.test.ts` (36 passed)
- `pnpm exec oxlint --type-aware --quiet packages/components/tests/doc-meta-subscription.test.ts`
- `pnpm check:platform-boundaries`
- `pnpm check:public-boundary`
- `pnpm start:local` (desktop rebuilt and launched; a persisted pending turn was recovered and completed)

`pnpm check` completed the workspace typecheck, then stopped in the repository's existing lint baseline: 68 errors, primarily missing type definitions in the isolated `packages/acp-extension-kimi` submodule, plus an unrelated unused parameter in `packages/components/tests/session-file-content-view.test.tsx`.

This PR is intended as a minimal downstream fix while the package source is unavailable. If the maintainers prefer to address the issue through an upstream release or a different implementation, please feel free to close or supersede this PR.