### PR TITLE
fix: refine conversation outline hover timing

### DIFF
--- a/packages/components/src/components/ai-gui/conversation-outline-rail.tsx
+++ b/packages/components/src/components/ai-gui/conversation-outline-rail.tsx
@@ -66,13 +66,11 @@ import {
  */
 
 /**
- * Hovering must not flash a card while the pointer merely crosses the rail, but
- * a reader scanning several rounds should not wait each time. Same warm/grace
- * model as `session-info-hover-card.tsx`, with a shorter warmup: the ticks are
- * denser than sidebar rows, so the pointer settles on one deliberately.
+ * The rail uses a short hover-intent warmup so brushing across ticks does not
+ * flash cards, while the Popover's own presence animation supplies the visual
+ * transition once the pointer settles.
  */
-const HOVER_WARMUP_MS = 320;
-const HOVER_CLOSE_DELAY_MS = 140;
+const HOVER_WARMUP_MS = 200;
 const HOVER_WARM_WINDOW_MS = 2_500;
 
 export interface ConversationOutlineRailProps {
@@ -218,6 +216,8 @@ export function ConversationOutlineRail({
   const [pointerIndex, setPointerIndex] = useState(-1);
   /** One state, because the index and its anchor are never meaningful apart. */
   const [hoverCard, setHoverCard] = useState<{ index: number; element: HTMLElement } | null>(null);
+  /** Separate visibility from content so the close animation never fades an empty card. */
+  const [cardOpen, setCardOpen] = useState(false);
 
   const activeIndexRef = useLatestRef(activeIndex);
 
@@ -268,37 +268,17 @@ export function ConversationOutlineRail({
     return observeResizeOnAnimationFrame(strip, syncEdgeFade);
   }, [syncEdgeFade, tickCount]);
 
-  // Hover open/close timing. Refs, not state: these fire between renders and
-  // must not themselves cause one.
+  const cardOpenRef = useLatestRef(cardOpen);
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastClosedAtRef = useRef(0);
 
-  const clearTimers = useCallback(() => {
-    if (openTimerRef.current !== null) {
-      clearTimeout(openTimerRef.current);
-      openTimerRef.current = null;
-    }
-    if (closeTimerRef.current !== null) {
-      clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
-    }
+  const clearOpenTimer = useCallback(() => {
+    if (openTimerRef.current === null) return;
+    clearTimeout(openTimerRef.current);
+    openTimerRef.current = null;
   }, []);
 
-  useEffect(() => clearTimers, [clearTimers]);
-
-  const closeHoverCard = useCallback(() => {
-    setHoverCard((current) => {
-      if (current) lastClosedAtRef.current = Date.now();
-      return null;
-    });
-  }, []);
-
-  const openHoverCard = useCallback((index: number, element: HTMLElement) => {
-    setHoverCard({ index, element });
-  }, []);
-
-  const isCardOpenRef = useLatestRef(hoverCard !== null);
+  useEffect(() => clearOpenTimer, [clearOpenTimer]);
 
   const handlePointerOver = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {
@@ -311,35 +291,32 @@ export function ConversationOutlineRail({
       // Magnify immediately — this is direct manipulation and must not wait on
       // the card's warmup, or the rail would feel unresponsive to the cursor.
       setPointerIndex(index);
-
-      clearTimers();
-      // Read through a ref so this handler keeps one identity: it is bound to
-      // the list, and re-binding it every time a card opens or closes is churn
-      // for no behavioural gain.
+      clearOpenTimer();
       const isWarm =
-        isCardOpenRef.current || Date.now() - lastClosedAtRef.current < HOVER_WARM_WINDOW_MS;
+        cardOpenRef.current || Date.now() - lastClosedAtRef.current < HOVER_WARM_WINDOW_MS;
       if (isWarm) {
-        openHoverCard(index, element);
+        setHoverCard({ index, element });
+        setCardOpen(true);
         return;
       }
       openTimerRef.current = setTimeout(() => {
         openTimerRef.current = null;
-        openHoverCard(index, element);
+        setHoverCard({ index, element });
+        setCardOpen(true);
       }, HOVER_WARMUP_MS);
     },
-    [clearTimers, isCardOpenRef, openHoverCard]
+    [cardOpenRef, clearOpenTimer]
   );
 
   const handlePointerLeave = useCallback(() => {
-    // The swell collapses with the cursor; only the card gets a grace period,
-    // so it survives the pointer travelling from a tick onto the card itself.
+    // The swell collapses with the cursor. The card content stays in state until
+    // Radix finishes its own close animation, so the animation never fades an
+    // empty surface.
     setPointerIndex(-1);
-    clearTimers();
-    closeTimerRef.current = setTimeout(() => {
-      closeTimerRef.current = null;
-      closeHoverCard();
-    }, HOVER_CLOSE_DELAY_MS);
-  }, [clearTimers, closeHoverCard]);
+    clearOpenTimer();
+    if (cardOpenRef.current) lastClosedAtRef.current = Date.now();
+    setCardOpen(false);
+  }, [cardOpenRef, clearOpenTimer]);
 
   // Depends on the COUNT, not the array: the outline gets a new identity per
   // streamed delta, and this callback feeds the list's click/key handlers.
@@ -356,11 +333,12 @@ export function ConversationOutlineRail({
     (event: ReactMouseEvent<HTMLElement>) => {
       const index = readTickIndex(event.target);
       if (index === -1) return;
-      clearTimers();
-      closeHoverCard();
+      clearOpenTimer();
+      if (cardOpenRef.current) lastClosedAtRef.current = Date.now();
+      setCardOpen(false);
       jumpTo(index);
     },
-    [clearTimers, closeHoverCard, jumpTo]
+    [cardOpenRef, clearOpenTimer, jumpTo]
   );
 
   const focusTick = useCallback((index: number) => {
@@ -512,7 +490,7 @@ export function ConversationOutlineRail({
       {/* ONE popover for the whole rail, re-anchored to the hovered tick. A
           popover per tick would mount hundreds of Radix instances for a long
           session. */}
-      <Popover open={hoveredEntry !== null}>
+      <Popover open={cardOpen && hoveredEntry !== null}>
         <PopoverAnchor virtualRef={hoverCard ? { current: hoverCard.element } : undefined} />
         <PopoverContent
           side="right"
@@ -523,6 +501,15 @@ export function ConversationOutlineRail({
           onOpenAutoFocus={(event) => event.preventDefault()}
           onCloseAutoFocus={(event) => event.preventDefault()}
           className="pointer-events-none w-72 select-none p-3"
+          onAnimationEnd={(event) => {
+            if (
+              event.target === event.currentTarget &&
+              event.currentTarget.dataset.state === 'closed' &&
+              !cardOpenRef.current
+            ) {
+              setHoverCard(null);
+            }
+          }}
         >
           {hoveredEntry === null ? null : (
             <>

--- a/packages/components/src/components/ai-gui/view.tsx
+++ b/packages/components/src/components/ai-gui/view.tsx
@@ -1310,6 +1310,7 @@ export const SessionChatStreamView = forwardRef<
       scrollElement: scrollViewportElement,
       isSticky,
       scrollToBottom,
+      initialScrollRestored,
       handleScroll,
     } = useStickyScroll({
       sessionId,
@@ -1376,7 +1377,7 @@ export const SessionChatStreamView = forwardRef<
 
     const syncActiveOutlineIndex = useCallback(() => {
       const vlist = vlistRef.current;
-      if (!vlist || outlineAnchors.length === 0) {
+      if (!initialScrollRestored || !vlist || outlineAnchors.length === 0) {
         setActiveOutlineIndex(-1);
         return;
       }
@@ -1393,12 +1394,12 @@ export const SessionChatStreamView = forwardRef<
         isAtEnd
       );
       setActiveOutlineIndex(next);
-    }, [leadingRowCount, outlineAnchors]);
+    }, [initialScrollRestored, leadingRowCount, outlineAnchors]);
 
-    // Read the sync through a ref so this effect keys on the ELEMENT alone.
-    // Depending on the callback would re-run it — two `getBoundingClientRect`
-    // and an observer teardown/rebuild — on every streamed delta, which is
-    // exactly the forced layout the measurement comment above rules out.
+    // Read the sync through refs so this effect only re-runs when the viewport
+    // is bound or its one-time initial position restore completes. Depending on
+    // the callback would re-run it on every streamed delta, which is exactly the
+    // forced layout the measurement comment above rules out.
     const syncActiveOutlineIndexRef = useLatestRef(syncActiveOutlineIndex);
     const measureItemOffsetDeltaRef = useLatestRef(measureItemOffsetDelta);
     useEffect(() => {
@@ -1409,7 +1410,12 @@ export const SessionChatStreamView = forwardRef<
       };
       remeasure();
       return observeResizeOnAnimationFrame(scrollViewportElement, remeasure);
-    }, [measureItemOffsetDeltaRef, scrollViewportElement, syncActiveOutlineIndexRef]);
+    }, [
+      initialScrollRestored,
+      measureItemOffsetDeltaRef,
+      scrollViewportElement,
+      syncActiveOutlineIndexRef,
+    ]);
 
     /** How far a pending jump still is from its target, in item-offset space. */
     const outlineJumpDrift = useCallback(

--- a/packages/components/src/hooks/use-sticky-scroll.ts
+++ b/packages/components/src/hooks/use-sticky-scroll.ts
@@ -48,6 +48,8 @@ export interface UseStickyScrollResult {
   isSticky: boolean;
   /** Force-scroll to bottom and re-enable sticky mode. */
   scrollToBottom: () => void;
+  /** Whether the initial cached/end position has been applied to the virtualizer. */
+  initialScrollRestored: boolean;
   /** Pass to Virtua's onScroll prop. */
   handleScroll: (offset: number) => void;
 }
@@ -161,6 +163,7 @@ export function useStickyScroll({
   const scrollElementRef = useRef<HTMLDivElement | null>(null);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(null);
   const initialScrollRestoredRef = useRef(false);
+  const [initialScrollRestored, setInitialScrollRestored] = useState(false);
 
   const handleWheelUp = useCallback(
     (event: WheelEvent) => {
@@ -221,6 +224,7 @@ export function useStickyScroll({
         scrollToRealBottom();
       }
       initialScrollRestoredRef.current = true;
+      setInitialScrollRestored(true);
     });
   }, [itemCount, scrollToBottomWithLock, scrollToRealBottom, stopScroll, vlistRef]);
 
@@ -276,5 +280,12 @@ export function useStickyScroll({
     suppressAutoScrollRef,
   });
 
-  return { scrollRef: setScrollRef, scrollElement, isSticky, scrollToBottom, handleScroll };
+  return {
+    scrollRef: setScrollRef,
+    scrollElement,
+    isSticky,
+    scrollToBottom,
+    initialScrollRestored,
+    handleScroll,
+  };
 }

--- a/packages/components/tests/use-sticky-scroll.test.ts
+++ b/packages/components/tests/use-sticky-scroll.test.ts
@@ -300,6 +300,7 @@ describe('useStickyScroll Virtua adapter', () => {
       scrollElement: fixture.scrollElement,
       itemCount: 4,
     });
+    expect(latestResult?.initialScrollRestored).toBe(false);
     await act(async () => {
       await advanceAnimationFrames();
     });
@@ -307,6 +308,7 @@ describe('useStickyScroll Virtua adapter', () => {
     expect(vlist.scrollTo).toHaveBeenCalledWith(96);
     expect(fixture.getScrollTop()).toBe(96);
     expect(latestResult?.isSticky).toBe(false);
+    expect(latestResult?.initialScrollRestored).toBe(true);
   });
 
   it('unsticks after a real upward user scroll and does not auto-scroll on later content changes', async () => {


### PR DESCRIPTION
## Summary

- synchronize outline active-state calculation with initial scroll restoration
- keep the hover intent warmup at 200ms
- preserve hover-card content until the Popover close animation completes

## Validation

- `git diff --check` passed
- package typecheck and targeted tests were not runnable because this checkout has no installed dependencies and `corepack` is unavailable