### PR TITLE
fix(components): constrain message editor in narrow columns

### DIFF
--- a/packages/components/src/components/ai-gui/view.tsx
+++ b/packages/components/src/components/ai-gui/view.tsx
@@ -2632,13 +2632,19 @@ const UserMessageRowView = ({
                 unbreakable line, the content grows to its `sm:max-w-[800px]` cap, and being
                 right-aligned (`justify-end`) it overflows the column on the left. Chromium
                 honors overflow-wrap here so it doesn't repro there — hence "only sometimes". */}
-            <div className="relative w-fit min-w-0 max-w-full">
+            <div
+              className={cn(
+                'relative min-w-0 max-w-full',
+                isEditing ? 'w-full' : 'w-fit'
+              )}
+            >
               {showSendingSpinner && (
                 <Loader2 className="absolute bottom-[13px] right-full mr-1.5 h-4 w-4 animate-spin text-muted-foreground" />
               )}
               <div
                 className={cn(
-                  'w-fit min-w-0 max-w-full text-foreground',
+                  'min-w-0 max-w-full text-foreground',
+                  isEditing ? 'w-full' : 'w-fit',
                   hasWideContent ? 'min-w-[480px]' : '',
                   'sm:max-w-[800px]'
                 )}


### PR DESCRIPTION
## Summary

- use the available message-column width for both wrappers while editing
- preserve the existing fit-content message sizing outside edit mode
- keep the editor border and actions visible when a session side panel narrows the conversation

## Before / after

| Before | After |
| --- | --- |
| <img width="1152" height="746" alt="Message editor overflowing a narrow conversation column before the fix" src="https://github.com/user-attachments/assets/2f1cd3c0-b2fb-4e46-8eae-7ba3e1146082" /> | <img width="994" height="768" alt="Message editor contained within a narrower conversation column after the fix" src="https://github.com/user-attachments/assets/36988268-c156-4f77-9f8c-a67dfadaee44" /> |

## Validation

- `corepack pnpm --filter @lody/components typecheck`
- `corepack pnpm --filter @lody/components test` (380 files, 2727 tests)
- `git diff --check`
- manually verified in the local Electron app with HMR and the session side panel open

## Full check note

`corepack pnpm check` completed workspace typechecking, then stopped in lint on unrelated existing errors, including `packages/components/tests/session-file-content-view.test.tsx` and missing type definitions in the isolated Kimi workspace.