### PR TITLE
feat(components): unify workspace settings pages

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2884,6 +2884,7 @@
   "workspace.projects.delete": "Delete project",
   "workspace.projects.deleteConfirmTitle": "Remove project from Lody?",
   "workspace.projects.addProjectMenu": "Add project",
+  "workspace.projects.catalogTitle": "Available projects",
   "workspace.projects.settingsSubtitle": "Local folders and GitHub repositories available in this workspace.",
   "workspace.projects.githubProjectsTitle": "GitHub Projects",
   "workspace.projects.githubRepoNotAvailable": "This repo isn't available in the current workspace.",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -2884,6 +2884,7 @@
   "workspace.projects.delete": "删除项目",
   "workspace.projects.deleteConfirmTitle": "从 Lody 中删除项目？",
   "workspace.projects.addProjectMenu": "添加项目",
+  "workspace.projects.catalogTitle": "可用项目",
   "workspace.projects.settingsSubtitle": "当前工作区可用的本地文件夹和 GitHub 仓库。",
   "workspace.projects.githubProjectsTitle": "GitHub 项目",
   "workspace.projects.githubRepoNotAvailable": "此仓库在当前工作区不可用",

--- a/packages/components/src/components/settings/agent-roles-setting.tsx
+++ b/packages/components/src/components/settings/agent-roles-setting.tsx
@@ -36,7 +36,7 @@ import {
 import { Badge } from '@/ui/badge';
 import { Button } from '@/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/tooltip';
-import { settingContainerClass } from '.';
+import { SettingsEmptyState, SettingsPage } from './settings-page';
 import {
   AgentRoleEditorDialog,
   openAgentRoleEditorForCreate,
@@ -101,13 +101,11 @@ export function AgentRolesSetting() {
   };
 
   const addLabel = t('settings.agentRoles.add');
-
   return (
-    <div className={settingContainerClass}>
-      <p className="text-xs leading-snug text-muted-foreground">
-        {t('settings.agentRoles.description')}
-      </p>
-
+    <SettingsPage
+      title={t('settings.tabs.agentRoles')}
+      description={t('settings.agentRoles.description')}
+    >
       <section className="flex flex-col">
         <div className="flex items-center justify-between gap-2 pb-1 pt-0.5">
           <div className="flex min-w-0 items-center gap-2">
@@ -141,14 +139,16 @@ export function AgentRolesSetting() {
         </div>
 
         {roles.length === 0 ? (
-          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border/60 bg-card/30 px-6 py-8 text-center text-sm">
-            <UserRoundCog className="h-6 w-6 text-muted-foreground/70" aria-hidden="true" />
-            <p className="mt-2 text-muted-foreground">{t('settings.agentRoles.empty')}</p>
-            <Button size="sm" className="mt-3" onClick={openAdd}>
-              <Plus className="mr-1.5 h-3.5 w-3.5" />
-              {addLabel}
-            </Button>
-          </div>
+          <SettingsEmptyState
+            icon={<UserRoundCog aria-hidden="true" />}
+            message={t('settings.agentRoles.empty')}
+            action={
+              <Button size="sm" onClick={openAdd}>
+                <Plus className="mr-1.5 h-3.5 w-3.5" />
+                {addLabel}
+              </Button>
+            }
+          />
         ) : (
           <div className="space-y-3">
             {roleGroups.map((group) => (
@@ -216,7 +216,7 @@ export function AgentRolesSetting() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </div>
+    </SettingsPage>
   );
 }
 

--- a/packages/components/src/components/settings/desktop-settings-modal.tsx
+++ b/packages/components/src/components/settings/desktop-settings-modal.tsx
@@ -109,12 +109,12 @@ function SettingsModalBody() {
     { id: 'workspace', label: t('settings.sections.workspace', 'Workspace') },
     { id: 'other', label: t('settings.sections.misc', 'Other') },
   ];
-  // These tabs render their own in-content header (title + per-tab actions like
-  // "add project"), so we drop the chrome title to avoid showing it twice.
   const selfTitledTab =
-    resolvedActiveTab === 'projects' ||
     resolvedActiveTab === 'machines' ||
-    resolvedActiveTab === 'agents';
+    resolvedActiveTab === 'agents' ||
+    resolvedActiveTab === 'agent-roles' ||
+    resolvedActiveTab === 'mcp' ||
+    resolvedActiveTab === 'projects';
 
   return (
     <SettingsDataCacheProvider>
@@ -195,7 +195,7 @@ function SettingsModalBody() {
           )}
           <div className="min-h-0 flex-1">
             <ScrollArea className="h-full">
-              <div className={cn('px-6 pb-6', selfTitledTab ? 'pt-6' : 'pt-0')}>
+              <div className={cn('px-6 pb-6', resolvedActiveTab === 'machines' ? 'pt-6' : 'pt-0')}>
                 <div className="mx-auto max-w-5xl">
                   <SettingsTabContent tabId={resolvedActiveTab} />
                 </div>

--- a/packages/components/src/components/settings/index.tsx
+++ b/packages/components/src/components/settings/index.tsx
@@ -13,5 +13,4 @@ export { AboutSettingsComponent } from './about-setting';
 export { KeyboardShortcutsSetting } from './keyboard-shortcuts-setting';
 export { SettingsHeader } from './settings-header';
 export { SettingsCategoryList, SettingsCategoryGrid } from './settings-category-list';
-export const settingContainerClass =
-  'space-y-3 px-4 py-2 overflow-x-hidden md:mx-auto md:max-w-4xl md:px-2';
+export { settingContainerClass } from './settings-page';

--- a/packages/components/src/components/settings/machine-agent-settings.tsx
+++ b/packages/components/src/components/settings/machine-agent-settings.tsx
@@ -17,7 +17,7 @@ import {
   type SessionId,
   type WorkspaceId,
 } from '@lody/shared';
-import { ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
+import { Bot, ChevronDown, ChevronRight, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { activeWorkspaceRuntimeAtom, authTokenAtom, type WorkspaceRuntime } from '@/atoms/runtime';
 import { developerModeEnabledAtom } from '@/atoms/settings';
@@ -91,6 +91,7 @@ import {
   WorkspaceMachineExpandedSection,
   type WorkspaceMachineAccordionMeta,
 } from './workspace-machine-accordion';
+import { SettingsEmptyState, SettingsPage } from './settings-page';
 
 export type MachineAgentSettingsProps = {
   selectedMachineId: MachineId | null;
@@ -962,6 +963,10 @@ export function MachineAgentSettings({
 
   const showBanner = mode === 'agents' && migration.status === 'running';
   const hasMachines = machines.size > 0;
+  const agentsDescription = t(
+    'settings.categories.agents.description',
+    'AI agent configurations available in this workspace.'
+  );
 
   const banner = showBanner ? (
     <div className="flex items-center gap-2 rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
@@ -986,6 +991,28 @@ export function MachineAgentSettings({
         onInstallBinary={installBinary}
       />
     ) : null;
+
+  if (!isMobile && mode === 'agents' && isLoading && !hasMachines) {
+    return (
+      <SettingsPage title={t('settings.tabs.agents', 'Agents')} description={agentsDescription}>
+        <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          {t('workspace.machines.loadingVisibility', 'Loading machines')}
+        </div>
+      </SettingsPage>
+    );
+  }
+
+  if (!isMobile && mode === 'agents' && !hasMachines) {
+    return (
+      <SettingsPage title={t('settings.tabs.agents', 'Agents')} description={agentsDescription}>
+        <SettingsEmptyState
+          icon={<Bot aria-hidden="true" />}
+          message={t('workspace.machines.empty', 'No machines connected')}
+        />
+      </SettingsPage>
+    );
+  }
 
   if (isLoading && !hasMachines) {
     return (
@@ -1127,10 +1154,7 @@ export function MachineAgentSettings({
           'settings.categories.machines.description',
           'View workspace machines and manage the machines you own.'
         )
-      : t(
-          'settings.categories.agents.description',
-          'AI agent configurations available in this workspace.'
-        );
+      : agentsDescription;
 
   const header = (
     <div className="min-w-0">
@@ -1349,9 +1373,8 @@ export function MachineAgentSettings({
   }));
 
   return (
-    <div className="flex w-full min-w-0 flex-col gap-4">
+    <SettingsPage title={t('settings.tabs.agents', 'Agents')} description={subtitle}>
       {banner}
-      {header}
 
       <MachinePills
         pills={machinePills}
@@ -1380,7 +1403,7 @@ export function MachineAgentSettings({
       )}
       <ReviewPolicySection />
       {dialog}
-    </div>
+    </SettingsPage>
   );
 }
 

--- a/packages/components/src/components/settings/mcp-setting.tsx
+++ b/packages/components/src/components/settings/mcp-setting.tsx
@@ -33,7 +33,7 @@ import { Button } from '@/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/ui/dialog';
 import { Switch } from '@/ui/switch';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/tooltip';
-import { settingContainerClass } from '.';
+import { SettingsEmptyState, SettingsPage } from './settings-page';
 import { McpConnectionForm, type McpConnectionFormValue } from './mcp-connection-form';
 
 type EditorState = { mode: 'add' } | { mode: 'edit'; entry: WorkspaceMcpServerMeta };
@@ -124,11 +124,8 @@ export function McpSetting() {
   };
 
   const addLabel = t('settings.mcp.add');
-
   return (
-    <div className={settingContainerClass}>
-      <p className="text-xs leading-snug text-muted-foreground">{t('settings.mcp.description')}</p>
-
+    <SettingsPage title={t('settings.tabs.mcp')} description={t('settings.mcp.description')}>
       <section className="flex flex-col">
         <div className="flex items-center justify-between gap-2 pb-1 pt-0.5">
           <div className="flex min-w-0 items-center gap-2">
@@ -164,14 +161,16 @@ export function McpSetting() {
         </div>
 
         {servers.length === 0 ? (
-          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border/60 bg-card/30 px-6 py-8 text-center text-sm">
-            <Plug className="h-6 w-6 text-muted-foreground/70" aria-hidden="true" />
-            <p className="mt-2 text-muted-foreground">{t('settings.mcp.empty')}</p>
-            <Button size="sm" className="mt-3" onClick={() => openEditor({ mode: 'add' })}>
-              <Plus className="mr-1.5 h-3.5 w-3.5" />
-              {addLabel}
-            </Button>
-          </div>
+          <SettingsEmptyState
+            icon={<Plug aria-hidden="true" />}
+            message={t('settings.mcp.empty')}
+            action={
+              <Button size="sm" onClick={() => openEditor({ mode: 'add' })}>
+                <Plus className="mr-1.5 h-3.5 w-3.5" />
+                {addLabel}
+              </Button>
+            }
+          />
         ) : (
           <div className="space-y-2">
             {servers.map((server) => (
@@ -260,7 +259,7 @@ export function McpSetting() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </div>
+    </SettingsPage>
   );
 }
 

--- a/packages/components/src/components/settings/project-settings.tsx
+++ b/packages/components/src/components/settings/project-settings.tsx
@@ -74,7 +74,7 @@ import { toIntlLocale } from '@/lib/intl-locale';
 import { openExternalUrl } from '@/lib/native-browser';
 import { cn } from '@/lib/utils';
 import { MobileProjectSettings } from '@/components/mobile/mobile-project-settings';
-import { settingContainerClass } from '.';
+import { SettingsEmptyState, SettingsPage } from './settings-page';
 import { AgentIcon, getAgentDisplayName } from '@/components/icons/agent-icon';
 import { useSettingsDataCache } from './settings-data-cache';
 import { useGithubProjectWorktreeSaves } from '@/hooks/use-github-project-worktree-admin';
@@ -496,7 +496,7 @@ function ProjectSettingsDesktop({
       <ProjectAddMenu
         onAddLocalProject={onAddLocalProject}
         onAddGitHubProject={onAddGitHubProject}
-        className="h-8 w-8 shrink-0 bg-foreground/[0.06] text-foreground hover:bg-foreground/[0.1]"
+        className="h-7 w-7 shrink-0 text-muted-foreground hover:bg-muted/60 hover:text-foreground"
       />
     ) : null;
 
@@ -513,90 +513,99 @@ function ProjectSettingsDesktop({
   };
 
   return (
-    <div className={cn(settingContainerClass, 'md:max-w-6xl')}>
-      <div className="flex items-center justify-between gap-3">
-        <div className="min-w-0">
-          <h2 className="text-base font-semibold text-foreground">
-            {t('settings.tabs.projects', 'Projects')}
-          </h2>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            {t(
-              'workspace.projects.settingsSubtitle',
-              'Local folders and GitHub repositories available in this workspace.'
-            )}
-          </p>
-        </div>
-        {addProjectActions}
-      </div>
-
-      {isAnyLoading && totalCount === 0 ? (
-        <div className="flex items-center justify-center gap-2 px-3 py-10 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          {t('workspace.projects.loading', 'Loading projects')}
-        </div>
-      ) : totalCount === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-2 px-3 py-12 text-center">
-          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-muted/60">
-            <FolderOpen className="h-4 w-4 text-muted-foreground" />
-          </div>
-          <p className="text-sm text-muted-foreground">
-            {t('workspace.projects.empty', 'No projects yet')}
-          </p>
-        </div>
-      ) : (
-        <div className="flex flex-col gap-3">
-          <MachinePills
-            pills={pills}
-            selectedId={resolvedPillId}
-            onSelect={(id) => {
-              setSelectedPillId(id);
-              setSelectedProjectKey(null);
-            }}
-          />
-          <div className="flex h-[calc(90vh-16rem)] min-h-[400px] min-w-0">
-            <div className="scrollbar-pro w-[240px] shrink-0 overflow-y-auto border-r border-border/60 py-1 pr-2">
-              {isGithubPill
-                ? githubSections.map((section) => (
-                    <div key={section.owner} className="mb-2">
-                      <ProjectOwnerLabel owner={section.owner} />
-                      {section.rows.map((row) => (
-                        <ProjectMasterRow
-                          key={row.key}
-                          selected={selectedProject?.key === row.key}
-                          icon={<OwnerAvatar owner={section.owner} />}
-                          title={row.name}
-                          subtitle={row.repoFullName}
-                          onClick={() => setSelectedProjectKey(row.key)}
-                        />
-                      ))}
-                    </div>
-                  ))
-                : currentSelections.map((selection) =>
-                    selection.kind === 'local' ? (
-                      <ProjectMasterRow
-                        key={selection.key}
-                        selected={selectedProject?.key === selection.key}
-                        icon={<Folder className="h-3.5 w-3.5" />}
-                        title={selection.row.project.name}
-                        subtitle={selection.row.project.rootPath}
-                        onClick={() => setSelectedProjectKey(selection.key)}
-                      />
-                    ) : null
-                  )}
-            </div>
-            <div className="min-w-0 flex-1 overflow-hidden">
-              {selectedProject ? (
-                <ProjectDetailPane selection={selectedProject} {...detailHandlers} />
-              ) : (
-                <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
-                  {t('workspace.projects.selectPrompt', 'Select a project.')}
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
+    <SettingsPage
+      title={t('settings.tabs.projects', 'Projects')}
+      description={t(
+        'workspace.projects.settingsSubtitle',
+        'Local folders and GitHub repositories available in this workspace.'
       )}
-    </div>
+    >
+      <section className="flex flex-col">
+        <div className="flex items-center justify-between gap-2 pb-1 pt-0.5">
+          <div className="flex min-w-0 items-center gap-2">
+            <h3 className="text-xs font-semibold text-muted-foreground">
+              {t('workspace.projects.catalogTitle', 'Available projects')}
+            </h3>
+            {totalCount > 0 ? (
+              <span className="text-xs tabular-nums text-muted-foreground/70">{totalCount}</span>
+            ) : null}
+          </div>
+          {addProjectActions}
+        </div>
+        {isAnyLoading && totalCount === 0 ? (
+          <div className="flex items-center justify-center gap-2 px-3 py-10 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t('workspace.projects.loading', 'Loading projects')}
+          </div>
+        ) : totalCount === 0 ? (
+          <SettingsEmptyState
+            icon={<FolderOpen aria-hidden="true" />}
+            message={t('workspace.projects.empty', 'No projects yet')}
+            action={
+              <ProjectAddMenu
+                onAddLocalProject={onAddLocalProject}
+                onAddGitHubProject={onAddGitHubProject}
+                size="sm"
+                variant="default"
+                label={t('workspace.projects.addProjectMenu', 'Add project')}
+              />
+            }
+          />
+        ) : (
+          <div className="flex flex-col gap-3">
+            <MachinePills
+              pills={pills}
+              selectedId={resolvedPillId}
+              onSelect={(id) => {
+                setSelectedPillId(id);
+                setSelectedProjectKey(null);
+              }}
+            />
+            <div className="flex h-[calc(90vh-16rem)] min-h-[400px] min-w-0">
+              <div className="scrollbar-pro w-[240px] shrink-0 overflow-y-auto border-r border-border/60 py-1 pr-2">
+                {isGithubPill
+                  ? githubSections.map((section) => (
+                      <div key={section.owner} className="mb-2">
+                        <ProjectOwnerLabel owner={section.owner} />
+                        {section.rows.map((row) => (
+                          <ProjectMasterRow
+                            key={row.key}
+                            selected={selectedProject?.key === row.key}
+                            icon={<OwnerAvatar owner={section.owner} />}
+                            title={row.name}
+                            subtitle={row.repoFullName}
+                            onClick={() => setSelectedProjectKey(row.key)}
+                          />
+                        ))}
+                      </div>
+                    ))
+                  : currentSelections.map((selection) =>
+                      selection.kind === 'local' ? (
+                        <ProjectMasterRow
+                          key={selection.key}
+                          selected={selectedProject?.key === selection.key}
+                          icon={<Folder className="h-3.5 w-3.5" />}
+                          title={selection.row.project.name}
+                          subtitle={selection.row.project.rootPath}
+                          onClick={() => setSelectedProjectKey(selection.key)}
+                        />
+                      ) : null
+                    )}
+              </div>
+              <div className="min-w-0 flex-1 overflow-hidden">
+                {selectedProject ? (
+                  <ProjectDetailPane selection={selectedProject} {...detailHandlers} />
+                ) : (
+                  <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+                    {t('workspace.projects.selectPrompt', 'Select a project.')}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+    </SettingsPage>
   );
 }
 
@@ -664,12 +673,14 @@ function ProjectAddMenu({
   className,
   size,
   variant,
+  label,
 }: {
   readonly onAddLocalProject?: () => void;
   readonly onAddGitHubProject?: () => void;
   readonly className?: string;
   readonly size?: ButtonProps['size'];
   readonly variant?: ButtonProps['variant'];
+  readonly label?: string;
 }) {
   const { t } = useTranslation();
   return (
@@ -683,7 +694,8 @@ function ProjectAddMenu({
           aria-label={t('workspace.projects.addProjectMenu', 'Add project')}
           title={t('workspace.projects.addProjectMenu', 'Add project')}
         >
-          <Plus className="h-3.5 w-3.5" />
+          <Plus className={cn('h-3.5 w-3.5', label && 'mr-1.5')} />
+          {label}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-[220px]">

--- a/packages/components/src/components/settings/settings-page.tsx
+++ b/packages/components/src/components/settings/settings-page.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+
+export const settingContainerClass =
+  'space-y-3 px-4 py-2 overflow-x-hidden md:mx-auto md:max-w-4xl md:px-2';
+
+export function SettingsPage({
+  title,
+  description,
+  children,
+}: {
+  title: ReactNode;
+  description: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="overflow-x-hidden px-4 md:mx-auto md:max-w-4xl md:px-2">
+      <div className="hidden h-12 items-center md:flex">
+        <h2 className="text-xl font-semibold leading-none">{title}</h2>
+      </div>
+      <div className="flex min-h-8 items-center md:hidden">
+        <div className="min-w-0 text-xs leading-snug text-muted-foreground">{description}</div>
+      </div>
+      <div className="hidden min-h-8 items-center md:flex">
+        <div className="min-w-0 text-xs leading-snug text-muted-foreground">{description}</div>
+      </div>
+      <div className="space-y-3 pb-2 pt-3">{children}</div>
+    </div>
+  );
+}
+
+export function SettingsEmptyState({
+  icon,
+  message,
+  action,
+}: {
+  icon: ReactNode;
+  message: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex min-h-40 flex-col items-center justify-center rounded-lg border border-dashed border-border/60 bg-card/30 px-6 py-8 text-center text-sm">
+      <div className="text-muted-foreground/70 [&>svg]:h-6 [&>svg]:w-6">{icon}</div>
+      <p className="mt-2 text-muted-foreground">{message}</p>
+      {action ? <div className="mt-3">{action}</div> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- add shared settings page and empty-state primitives
- align Agents, Agent Roles, MCP, and Projects page headers and spacing
- improve the Projects catalog header and empty-state add action

## Validation

- `corepack pnpm --filter @lody/components typecheck`
- targeted type-aware oxlint on changed TS/TSX files (0 errors)
- `corepack pnpm lint:i18n`
- `git diff --check`