### PR TITLE
docs: fix clone directory in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ The repository uses Git submodules for ACP runtimes, so clone it recursively:
 
 ```bash
 git clone --recurse-submodules https://github.com/LodyAI/lody.git
-cd lody-oss
+cd lody
 ```
 
 For an existing checkout, initialise the submodules:


### PR DESCRIPTION
## Summary

- align the working-directory command with the default folder created by git clone
- make the new-contributor setup snippet copy-pasteable

## Validation

- git diff --check