### PR TITLE
fix(components): show latest usage weeks on compact calendars

### DIFF
--- a/packages/components/src/components/settings/usage-calendar-visualization.tsx
+++ b/packages/components/src/components/settings/usage-calendar-visualization.tsx
@@ -1248,6 +1248,12 @@ function UsageHeatmap({
   // Roving tabindex: the grid is one tab stop, arrow keys walk days and weeks.
   const [focusIndex, setFocusIndex] = useState(() => Math.max(0, todayIndex));
 
+  // Show the newest weeks initially without overriding later user scrolling.
+  useLayoutEffect(() => {
+    const scroller = scrollerRef.current;
+    if (scroller) scroller.scrollLeft = scroller.scrollWidth;
+  }, []);
+
   const cellLabel = useCallback(
     (cell: UsageCalendarCell) => {
       const date = formats.day.format(new Date(cell.dayStartMs));


### PR DESCRIPTION
## Summary

- initialize the usage heatmap at its right edge when the calendar overflows
- keep the most recent activity visible by default in the 30-day and all-time ranges
- apply the initial position only on mount so subsequent user scrolling is preserved

## Verification

- `pnpm --filter @lody/components typecheck`
- `pnpm --filter @lody/components exec vitest run tests/usage-calendar-model.test.ts` (9 tests)
- targeted Prettier and Oxlint checks on the changed component
- `git diff --check`
- verified the 30-day and all-time Storybook stories initialize at the right edge at 640px
- verified the calendar has no extra horizontal scrolling at 1280px