### PR TITLE
fix: align leftover package metadata with Apache-2.0 and LodyAI/Lody

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -37,7 +37,7 @@
     "remote-execution"
   ],
   "author": "Leon Zhao",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=22.14.0"
   },

--- a/apps/electron/electron-builder.yml
+++ b/apps/electron/electron-builder.yml
@@ -114,5 +114,5 @@ npmRebuild: false
 # during packaging also depends on this block being present.
 publish:
   provider: github
-  owner: loro-dev
-  repo: lody-oss
+  owner: LodyAI
+  repo: Lody

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -7,7 +7,7 @@
   "description": "Lody Desktop - Electron app",
   "main": "./out/main/index.js",
   "author": "LodyAI",
-  "homepage": "https://github.com/loro-dev/lody-oss",
+  "homepage": "https://github.com/LodyAI/Lody",
   "scripts": {
     "format": "prettier --write .",
     "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test src/main/reload-shortcut.test.mjs src/main/onboarding-launch-policy.test.mjs src/main/window-theme.test.mjs src/main/local-platform-snapshot.test.mjs src/main/ipc/ipc-channel-list.test.mjs src/main/services/local-path-launcher-core.test.mjs src/main/services/image-export-core.test.mjs src/main/services/public-browser-state.test.mjs src/main/services/app-updater-metadata.test.mjs src/main/services/loro-data-plane-relay.test.mjs src/renderer/renderer-csp.test.mjs src/renderer/src/auth-callback-transaction.test.mjs src/renderer/src/auth-query-generation.test.mjs src/renderer/src/renderer-error-reporting.test.mjs",

--- a/packages/code-review-helper/package.json
+++ b/packages/code-review-helper/package.json
@@ -81,5 +81,5 @@
     "vite-plugin-singlefile": "^2.3.0",
     "vitest": "^3.2.4"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/packages/code-review-viewer/package.json
+++ b/packages/code-review-viewer/package.json
@@ -3,7 +3,7 @@
   "version": "0.76.0",
   "description": "Self-contained single-file HTML viewer for Lody code reviews, fetched on demand by `lody review`.",
   "type": "module",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "files": [
     "standalone.html"
   ],

--- a/packages/ignore/package.json
+++ b/packages/ignore/package.json
@@ -25,5 +25,5 @@
     "typescript": "catalog:",
     "vitest": "^3.2.4"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/packages/turn-diff-store/package.json
+++ b/packages/turn-diff-store/package.json
@@ -38,5 +38,5 @@
     "typescript": "catalog:",
     "vitest": "^3.2.4"
   },
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/site-docs/components/site-footer.tsx
+++ b/site-docs/components/site-footer.tsx
@@ -9,7 +9,7 @@ import { founderCallUrl } from '@site/lib/founder-call';
 export type SiteFooterLocale = 'en' | 'zh';
 
 const X_HREF = 'https://x.com/lody_ai';
-const GITHUB_HREF = 'https://github.com/loro-dev/lody-oss';
+const GITHUB_HREF = 'https://github.com/LodyAI/Lody';
 
 const copy = {
   en: {

--- a/site-docs/scripts/generate-llms.mjs
+++ b/site-docs/scripts/generate-llms.mjs
@@ -163,7 +163,7 @@ ${blog.map(renderLink).join('\n')}
 
 ## External Links
 
-- [GitHub](https://github.com/loro-dev/lody-oss) - Open-source CLI and local desktop.
+- [GitHub](https://github.com/LodyAI/Lody) - Open-source CLI and local desktop.
 - [Discord](https://discord.gg/E8mZtMu38s) - Community and support.
 - [X](https://x.com/lody_ai) - Product updates.
 - [Loro](https://loro.dev) - Local-first technology used by Lody.


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

After `loro-dev/lody-oss` moved to `LodyAI/Lody`, packaging and npm metadata still advertised the old GitHub URL and MIT. The root `LICENSE`, GitHub license, and `CONTRIBUTING.md` are Apache-2.0, so the published `lody` package and Linux package metadata were wrong. #61.

## Summary

- Point Electron `homepage` at `https://github.com/LodyAI/Lody`.
- Set `license` to `Apache-2.0` on `lody`, `lody-code-review-viewer`, `@lody/turn-diff-store`, `@loro-dev/ignore`, and `@lody/code-review-helper`.
- Point the site footer, `llms` generator, and electron-builder GitHub publish target at `LodyAI/Lody`.
- Leave `@loro-dev/ignore` package name, `lody-oss` install identifiers, and historical/demo links unchanged.

Closes #61.

## Before / after

| Before | After |
| ------ | ----- |
| Electron homepage, site GitHub links, and updater publish target used `loro-dev/lody-oss` (404). Five packages declared MIT while the repo is Apache-2.0. | Public packaging and npm license fields match `LodyAI/Lody` and Apache-2.0. Workspace package names and local install IDs are unchanged. |

## Test plan

- Confirmed `https://github.com/loro-dev/lody-oss` returns 404 and `https://github.com/LodyAI/Lody` is Apache-2.0.
- Confirmed `npm view lody license` currently reports MIT (next publish will pick up `Apache-2.0`).
- `git grep` after the change: no remaining `"license": "MIT"` in workspace `package.json` files; remaining `loro-dev/lody-oss` strings are synthetic CLI fixtures only.
- Skipped `pnpm check` / `pnpm format`: ten one-line metadata edits, no runtime behavior.

## Agent handoff

<!-- agent-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `apps/electron/package.json` homepage, the five `license` fields named in #61, and `apps/electron/electron-builder.yml` publish `owner`/`repo`, which is baked into auto-update.
- **Decisions to challenge:** Treat MIT as leftover from the Apache-2.0 LICENSE commit; include the updater feed and public GitHub links, not only homepage; leave `@loro-dev/ignore` named as-is.
- **Plausible failures / evidence gaps:** Already-shipped desktops still read the old GitHub feed until they update; npm stays MIT until the next `lody` publish; no packaging dry-run was executed.

### Authoring context

- **User goal / directives:** N/A / redacted
- **Constraints / non-goals:** N/A / redacted
- **Risk-bearing decisions:** N/A / redacted
- **Destructive or irreversible behavior:** N/A / redacted
- **Deliberately not done or tested:** N/A / redacted
- **Unknowns / confidence:** N/A / redacted

### Sharing consent (author side)

Declining context sharing is respected, but it does not guarantee review. If withheld context prevents maintainers from assessing provenance, scope, or risk, they may decline the contribution or close the pull request.

- [ ] Author-side user explicitly allowed publishing the Authoring context above
- [x] Author-side user explicitly declined publishing Authoring context and understands that maintainers may decline or close the contribution; keep every field as `N/A` / redacted

<!-- agent-handoff:end -->
