### PR TITLE
fix: pin current Amp ACP adapter

### DIFF
--- a/apps/cli/tests/agent-setting.test.ts
+++ b/apps/cli/tests/agent-setting.test.ts
@@ -312,12 +312,12 @@ describe('resolveBuiltinACPSetting', () => {
     }
   });
 
-  it('refreshes metadata when a registry local command uses npx', () => {
+  it('pins the Amp ACP adapter version when launching through npx', () => {
     const resolved = resolveACPSetting({ cliType: 'registry', agentType: 'amp-acp' });
 
     expect(resolved.exec).toMatchObject({
       command: 'npx',
-      args: ['--prefer-offline', '-y', 'amp-acp'],
+      args: ['--prefer-offline', '-y', 'amp-acp@0.9.0'],
     });
   });
 

--- a/apps/cli/tests/history-session-catalog-client.test.ts
+++ b/apps/cli/tests/history-session-catalog-client.test.ts
@@ -260,6 +260,6 @@ describe('resolveHistoryACPProcessLaunch', () => {
     expect(historyLaunch.command).toBe(sessionLaunch.command);
     expect(historyLaunch.args).toEqual(sessionLaunch.args);
     expect(historyLaunch.command).toBe('npx');
-    expect(historyLaunch.args).toEqual(['--prefer-offline', '-y', 'amp-acp']);
+    expect(historyLaunch.args).toEqual(['--prefer-offline', '-y', 'amp-acp@0.9.0']);
   });
 });

--- a/packages/shared/src/acp/registry-generated.ts
+++ b/packages/shared/src/acp/registry-generated.ts
@@ -65,7 +65,7 @@ const REMOTE_REGISTRY_ACP_AGENTS: RegistryAcpAgent[] = [
         command: 'npx',
         args: [
           '-y',
-          'amp-acp'
+          'amp-acp@0.9.0'
         ],
         versionArgs: [
           '--version'

--- a/scripts/generate-acp-registry.mjs
+++ b/scripts/generate-acp-registry.mjs
@@ -12,6 +12,7 @@ const EXCLUDED_REMOTE_REGISTRY_AGENT_IDS = new Set([
   'grok-build',
 ]);
 const OFFICIAL_NPM_REGISTRY = 'https://registry.npmjs.org/';
+const AMP_ACP_VERSION = '0.9.0';
 const INTERACTIVE_CLAUDE_ACP_VERSION = '0.1.5';
 const INTERACTIVE_CLAUDE_REGISTRY_AGENT = {
   id: 'claude-p',
@@ -41,8 +42,9 @@ const INTERACTIVE_CLAUDE_REGISTRY_AGENT = {
 };
 const LOCAL_REGISTRY_AGENTS = {
   'amp-acp': {
+    version: AMP_ACP_VERSION,
     command: 'npx',
-    args: ['-y', 'amp-acp'],
+    args: ['-y', `amp-acp@${AMP_ACP_VERSION}`],
     versionArgs: ['--version'],
   },
   cursor: {
@@ -248,7 +250,7 @@ function normalizeLocalAgent(raw, id) {
   return {
     id,
     name: rawName || fallback.name,
-    version: rawVersion || fallback.version || 'local',
+    version: launcher.version || rawVersion || fallback.version || 'local',
     description:
       typeof rawRecord.description === 'string' ? rawRecord.description : fallback.description,
     icon: typeof rawRecord.icon === 'string' ? rawRecord.icon : fallback.icon,


### PR DESCRIPTION
Launch the registry Amp adapter by exact version so offline-first npx caching cannot keep serving the legacy Smart and Deep capability set. Keep generated registry metadata aligned with the pinned package and cover normal and history launches.

Model: GPT-5.6-Sol
Amp-Thread-ID: https://ampcode.com/threads/T-01a04209-48e6-765c-9d9c-5ca7d1c2698c

## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Lody identifies the Amp registry provider as `amp-acp` v0.9.0 but launches the unversioned package through `npx --prefer-offline`. Stale npm metadata can therefore keep resolving v0.8.1, which advertises the deprecated Smart and Deep choices instead of Amp’s current low, medium, high, and ultra modes.

## Summary

- Pin the Amp registry launcher and generated metadata to `amp-acp@0.9.0`.
- Prevent future registry generation from replacing the controlled Amp version with inconsistent remote metadata.
- Cover both normal ACP sessions and history-session launches.

## Before / after

| Before | After |
| ------ | ----- |
| `npx --prefer-offline -y amp-acp` could reuse a stale adapter | `npx --prefer-offline -y amp-acp@0.9.0` resolves an immutable adapter version |
| A stale adapter could advertise Smart and Deep | New probes advertise low, medium, high, and ultra through the existing generic ACP configuration UI |

## Test plan

- `pnpm --dir apps/cli exec vitest run tests/agent-setting.test.ts tests/history-session-catalog-client.test.ts` — 40 tests passed.
- Ran the registry generator in a scratch directory and verified it emitted `{"version":"0.9.0","package":"amp-acp@0.9.0"}`.
- `pnpm exec prettier --check scripts/generate-acp-registry.mjs apps/cli/tests/agent-setting.test.ts apps/cli/tests/history-session-catalog-client.test.ts` passed.
- `git diff --check` passed.
- An authenticated live Amp prompt was not run.

## Agent handoff

<!-- agent-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check `scripts/generate-acp-registry.mjs` and the generated Amp entry for one consistent exact version, then confirm both CLI launch paths retain `--prefer-offline` with that immutable package specification.
- **Decisions to challenge:** Decide whether a controlled exact pin is preferable to `@latest`; this change deliberately favors reproducible offline startup and explicit upgrades.
- **Plausible failures / evidence gaps:** Existing persisted Smart/Deep capability rows still require a normal runtime probe, and no authenticated live Amp prompt was executed.

### Authoring context

- **User goal / directives:** Update Lody’s stale Amp ACP integration to current modes, push the change on a feature branch, and submit it upstream without merging directly into `main`.
- **Constraints / non-goals:** Preserve Lody’s generic ACP capability UI and offline-first npx policy; do not add Amp-specific mode mappings or modify unrelated providers.
- **Risk-bearing decisions:** Pin `amp-acp` to v0.9.0 rather than use a moving online tag so the executable package and advertised source version cannot diverge.
- **Destructive or irreversible behavior:** None; the change only selects an exact adapter package and can be rolled back by changing the version constant.
- **Deliberately not done or tested:** Did not run a paid, authenticated Amp prompt; adapter metadata, package resolution, generator output, and launcher tests were verified instead.
- **Unknowns / confidence:** Confidence is high in launch determinism; users with persisted legacy capabilities may continue seeing them until the next provider refresh or ACP session probe.

### Sharing consent (author side)

- [x] Author-side user explicitly allowed publishing the Authoring context above
- [ ] Author-side user explicitly declined publishing Authoring context and understands that maintainers may decline or close the contribution; keep every field as `N/A` / redacted

<!-- agent-handoff:end -->