### PR TITLE
fix(components): warn about DeepSeek delegation model

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -418,6 +418,8 @@
   "chat.modeSelector.empty": "No modes available",
   "chat.modeSelector.permissionMode": "Permission mode",
   "chat.runConfig.buttonAriaLabel": "Run configuration",
+  "chat.runConfig.deepseek.delegationDiscussion": "Upstream discussion",
+  "chat.runConfig.deepseek.delegationWarning": "Due to a current DSH limitation, delegated subagents may use the session's creation-time model (DeepSeek-V4-Pro) instead of this model, which can cost more.",
   "chat.runConfig.fastLabel": "Fast",
   "chat.runConfig.grok.interaction.agent.description": "Use tools and make changes when needed",
   "chat.runConfig.grok.interaction.agent.label": "Agent",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -418,6 +418,8 @@
   "chat.modeSelector.empty": "暂无可用权限模式",
   "chat.modeSelector.permissionMode": "权限模式",
   "chat.runConfig.buttonAriaLabel": "运行设置",
+  "chat.runConfig.deepseek.delegationDiscussion": "上游讨论",
+  "chat.runConfig.deepseek.delegationWarning": "由于当前 DSH 的限制，委派的子智能体可能使用会话创建时的模型（DeepSeek-V4-Pro），而不是当前模型，因此可能产生更高费用。",
   "chat.runConfig.fastLabel": "快速",
   "chat.runConfig.grok.interaction.agent.description": "需要时使用工具并进行修改",
   "chat.runConfig.grok.interaction.agent.label": "Agent",

--- a/packages/components/src/components/mobile/mobile-run-config-sheet.tsx
+++ b/packages/components/src/components/mobile/mobile-run-config-sheet.tsx
@@ -18,12 +18,18 @@ import {
 } from '@/components/shared/acp-selector-options';
 import type { AcpSessionSelectOption } from '@/components/shared/acp-session-select';
 import type { AgentSelection } from '@/components/shared/agent-selector';
+import {
+  DEEPSEEK_DELEGATION_DISCUSSION_URL,
+  DeepSeekDelegationWarningContent,
+  shouldShowDeepSeekDelegationWarning,
+} from '@/components/shared/deepseek-delegation-warning';
 import { orderAcpConfigOptionSelectors } from '@/lib/acp-selector-order';
 import {
   AGENT_ROLE_UNAVAILABLE_REASON_KEYS,
   type ComposerAgentRoleItem,
 } from '@/lib/composer-agent-roles';
 import { shouldOfferOptionSearch } from '@/lib/fuzzy-option-filter';
+import { openExternalUrl } from '@/lib/native-browser';
 import { useKeyboardAwareSheet } from '@/hooks/use-keyboard-aware-scroll-into-view';
 import { cn } from '@/lib/utils';
 import { Drawer, DrawerContent, DrawerDescription, DrawerTitle } from '@/ui/drawer';
@@ -301,6 +307,7 @@ function MobileRunConfigSheetRows({
       value: opt.value,
       label: opt.label,
       searchText: opt.label,
+      description: opt.description,
       disabled: opt.disabled,
     }));
   }, [modelConfigSelector, modelOptions]);
@@ -317,6 +324,11 @@ function MobileRunConfigSheetRows({
     () => modelPickerOptions.find((opt) => opt.value === modelValue)?.label ?? modelValue,
     [modelPickerOptions, modelValue]
   );
+  const showDeepSeekDelegationWarning = shouldShowDeepSeekDelegationWarning({
+    cliType: selectedAgentConfig?.cliType,
+    agentType: selectedAgentConfig?.agentType,
+    modelId: modelValue,
+  });
 
   /* ── Provider-specific interaction mode (for example Grok Agent / Plan / Ask) ── */
   const interactionSelector = interactionModeSelectors[0];
@@ -558,6 +570,21 @@ function MobileRunConfigSheetRows({
             triggerContent={<span className="truncate">{modelLabel ?? modelRowLabel}</span>}
           />
         </RunConfigRow>
+      ) : null}
+
+      {showDeepSeekDelegationWarning ? (
+        <a
+          href={DEEPSEEK_DELEGATION_DISCUSSION_URL}
+          target="_blank"
+          rel="noreferrer"
+          onClick={(event) => {
+            event.preventDefault();
+            void openExternalUrl(DEEPSEEK_DELEGATION_DISCUSSION_URL);
+          }}
+          className="flex items-start gap-2 rounded-xl border border-status-warning/30 bg-status-warning/[0.08] px-3 py-2.5 active:bg-status-warning/[0.14]"
+        >
+          <DeepSeekDelegationWarningContent />
+        </a>
       ) : null}
 
       {interactionSelector && interactionOptions.length > 0 ? (

--- a/packages/components/src/components/sessions/AGENTS.md
+++ b/packages/components/src/components/sessions/AGENTS.md
@@ -301,6 +301,12 @@ Session conversation page chain:
   modes; provider interaction modes stay inside the run-config dropdown. Both
   are also used by the desktop chat landing; `DesktopRunConfigMenu` receives an
   explicit agent selection/machine scope rather than reading `SessionMeta`.
+  Builtin DeepSeek Harness sessions using a non-Pro model show the same linked
+  delegation-cost warning here and in `MobileRunConfigSheet`: until upstream DSH
+  fixes child-route inheritance, a delegated child may use the session's
+  creation-time DeepSeek-V4-Pro seed rather than the parent's visible model.
+  Keep the warning tied to that agent/model combination and its upstream
+  discussion rather than turning it into a global banner.
   Agent/Model/Reasoning option selection closes the dropdown and must not return
   keyboard focus to its trigger; Plan/Fast toggle rows intentionally stay open.
   Once the model list reaches `OPTION_SEARCH_MIN_OPTIONS`

--- a/packages/components/src/components/sessions/desktop-run-config-menu.tsx
+++ b/packages/components/src/components/sessions/desktop-run-config-menu.tsx
@@ -34,7 +34,13 @@ import {
 import type { AcpSessionSelectOption } from '@/components/shared/acp-session-select';
 import type { AgentSelection } from '@/components/shared/agent-selector';
 import { MenuOptionSearchList } from '@/components/shared/menu-option-search-list';
+import {
+  DEEPSEEK_DELEGATION_DISCUSSION_URL,
+  DeepSeekDelegationWarningContent,
+  shouldShowDeepSeekDelegationWarning,
+} from '@/components/shared/deepseek-delegation-warning';
 import { orderAcpConfigOptionSelectors } from '@/lib/acp-selector-order';
+import { openExternalUrl } from '@/lib/native-browser';
 import { resolvePermissionModeFace } from '@/lib/permission-mode-face';
 import {
   doesAgentRolePinPermissionMode,
@@ -467,6 +473,11 @@ export function DesktopRunConfigMenu({
         : null;
   const modelLabel =
     modelPickerOptions.find((opt) => opt.value === modelValue)?.label ?? modelValue;
+  const showDeepSeekDelegationWarning = shouldShowDeepSeekDelegationWarning({
+    cliType: selectedAgentConfig?.cliType ?? fallbackAgent?.cliType,
+    agentType: selectedAgentConfig?.agentType ?? fallbackAgent?.agentType,
+    modelId: modelValue,
+  });
   const handleModelSelect = (value: string) => {
     if (modelOptions.length > 0) {
       onModelChange?.(value);
@@ -826,6 +837,25 @@ export function DesktopRunConfigMenu({
               />
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+        ) : null}
+
+        {showDeepSeekDelegationWarning ? (
+          <DropdownMenuItem
+            asChild
+            className="mx-1 my-1 max-w-72 items-start gap-2 whitespace-normal border border-status-warning/30 bg-status-warning/[0.08] px-2.5 py-2 focus:bg-status-warning/[0.14]"
+          >
+            <a
+              href={DEEPSEEK_DELEGATION_DISCUSSION_URL}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(event) => {
+                event.preventDefault();
+                void openExternalUrl(DEEPSEEK_DELEGATION_DISCUSSION_URL);
+              }}
+            >
+              <DeepSeekDelegationWarningContent />
+            </a>
+          </DropdownMenuItem>
         ) : null}
 
         {interactionSelector ? (

--- a/packages/components/src/components/shared/deepseek-delegation-warning.tsx
+++ b/packages/components/src/components/shared/deepseek-delegation-warning.tsx
@@ -1,0 +1,44 @@
+import { ExternalLink, ShieldAlert } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { AgentConfigCliType, AgentType } from '@lody/shared';
+
+export const DEEPSEEK_DELEGATION_DISCUSSION_URL =
+  'https://github.com/deepseek-ai/deepseek-harness/discussions/4065';
+
+export function shouldShowDeepSeekDelegationWarning({
+  cliType,
+  agentType,
+  modelId,
+}: {
+  cliType: AgentConfigCliType | null | undefined;
+  agentType: AgentType | null | undefined;
+  modelId: string | null | undefined;
+}): boolean {
+  return (
+    cliType === 'builtin' &&
+    agentType === 'deepseek' &&
+    modelId != null &&
+    modelId !== 'deepseek-v4-pro'
+  );
+}
+
+/** Shared contents for the linked warning rendered by desktop and mobile run config. */
+export function DeepSeekDelegationWarningContent() {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0 text-status-warning" aria-hidden="true" />
+      <span className="min-w-0 text-xs leading-snug text-foreground/90">
+        {t(
+          'chat.runConfig.deepseek.delegationWarning',
+          "Due to a current DSH limitation, delegated subagents may use the session's creation-time model (DeepSeek-V4-Pro) instead of this model, which can cost more."
+        )}{' '}
+        <span className="inline-flex items-center gap-1 font-medium text-status-warning underline underline-offset-2">
+          {t('chat.runConfig.deepseek.delegationDiscussion', 'Upstream discussion')}
+          <ExternalLink className="h-3 w-3 shrink-0" aria-hidden="true" />
+        </span>
+      </span>
+    </>
+  );
+}

--- a/packages/components/src/stories/DesktopRunConfigMenu.stories.tsx
+++ b/packages/components/src/stories/DesktopRunConfigMenu.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { Provider, createStore } from 'jotai';
 import { useMemo, useState } from 'react';
 import { fn } from 'storybook/test';
+import { createLocalPlatformProvider, createStaticStore } from '@lody/platform';
+import { PlatformContext } from '@lody/platform/react';
 import {
   type AgentConfigId,
   type AgentConfigMeta,
@@ -31,6 +33,21 @@ import type { AcpSessionSelectOption } from '@/components/shared/acp-session-sel
 const machineId = 'machine-storybook' as MachineId;
 const codexId = 'agent-codex' as AgentConfigId;
 const grokId = 'agent-grok' as AgentConfigId;
+const deepseekId = 'agent-deepseek' as AgentConfigId;
+
+const storyPlatform = createLocalPlatformProvider({
+  session: createStaticStore({
+    status: 'authenticated',
+    user: { id: 'user-storybook-run-config', name: 'Storybook user' },
+  }),
+  workspaces: createStaticStore({
+    status: 'ready',
+    workspaces: [
+      { id: 'workspace-storybook', name: 'Storybook Workspace', slug: null, role: 'owner' },
+    ],
+    activeWorkspaceId: 'workspace-storybook',
+  }),
+});
 
 const agents: AgentConfigMeta[] = [
   {
@@ -58,6 +75,15 @@ const agents: AgentConfigMeta[] = [
     description: 'Official Grok runtime through the Lody compatibility adapter',
     cliType: 'builtin',
     agentType: 'grok',
+    env: {},
+  },
+  {
+    id: deepseekId,
+    machineId,
+    name: 'DeepSeek Harness',
+    description: 'Built-in DeepSeek Harness runtime',
+    cliType: 'builtin',
+    agentType: 'deepseek',
     env: {},
   },
 ];
@@ -282,6 +308,46 @@ function GrokConfigShell() {
   );
 }
 
+function DeepSeekWarningShell() {
+  const store = useMemo(() => {
+    const next = createStore();
+    next.set(
+      agentConfigMetaCacheAtom,
+      Object.fromEntries(agents.map((agent) => [getAgentConfigRoomId(agent.id), agent]))
+    );
+    return next;
+  }, []);
+  const [model, setModel] = useState<string | null>('deepseek-v4-flash');
+
+  return (
+    <Provider store={store}>
+      <div className="flex min-h-dvh items-end bg-background p-8">
+        <div className="mb-6 flex w-full max-w-3xl items-center gap-2 rounded-xl bg-input/90 px-4 py-3">
+          <DesktopRunConfigMenu
+            agentSelection={{ agentId: deepseekId, machineId }}
+            availableAgentConfigs={agents}
+            agentLocked
+            modelOptions={[
+              {
+                value: 'deepseek-v4-flash',
+                label: 'DeepSeek-V4-Flash',
+                description: 'Faster DeepSeek Harness coding model.',
+              },
+              {
+                value: 'deepseek-v4-pro',
+                label: 'DeepSeek-V4-Pro',
+                description: 'More capable DeepSeek Harness coding model.',
+              },
+            ]}
+            selectedModelId={model}
+            onModelChange={setModel}
+          />
+        </div>
+      </div>
+    </Provider>
+  );
+}
+
 function EmptyMachineScopeShell() {
   return (
     <div className="flex min-h-dvh items-center justify-center bg-background p-8">
@@ -295,6 +361,13 @@ const meta = {
   component: StoryShell,
   parameters: { layout: 'fullscreen' },
   globals: { theme: 'dark' },
+  decorators: [
+    (Story) => (
+      <PlatformContext.Provider value={storyPlatform}>
+        <Story />
+      </PlatformContext.Provider>
+    ),
+  ],
   tags: ['autodocs'],
 } satisfies Meta<typeof StoryShell>;
 
@@ -306,6 +379,10 @@ export const EmptyConversationAgentPickable: Story = { args: { isEmptyConversati
 export const GrokInteractionAndPermission: Story = {
   args: { isEmptyConversation: false },
   render: () => <GrokConfigShell />,
+};
+export const DeepSeekDelegationWarning: Story = {
+  args: { isEmptyConversation: false },
+  render: () => <DeepSeekWarningShell />,
 };
 export const MachineScope: Story = {
   args: { isEmptyConversation: true },

--- a/packages/components/src/stories/MobileRunConfigSheet.stories.tsx
+++ b/packages/components/src/stories/MobileRunConfigSheet.stories.tsx
@@ -36,6 +36,7 @@ const codexSessionId = 'session-codex' as SessionId;
 const claudeSessionId = 'session-claude' as SessionId;
 const codexId = 'agent-codex' as AgentConfigId;
 const claudeId = 'agent-claude' as AgentConfigId;
+const deepseekId = 'agent-deepseek' as AgentConfigId;
 
 const agents: AgentConfigMeta[] = [
   {
@@ -54,6 +55,15 @@ const agents: AgentConfigMeta[] = [
     description: 'Claude Code',
     cliType: 'builtin',
     agentType: 'claude',
+    env: {},
+  },
+  {
+    id: deepseekId,
+    machineId,
+    name: 'DeepSeek Harness',
+    description: 'Built-in DeepSeek Harness runtime',
+    cliType: 'builtin',
+    agentType: 'deepseek',
     env: {},
   },
 ];
@@ -76,6 +86,14 @@ const claudeSession: SessionMeta = {
   title: 'Claude session',
   agentType: 'claude',
   agentConfigId: claudeId,
+};
+
+const deepseekSession: SessionMeta = {
+  ...codexSession,
+  id: 'session-deepseek' as SessionId,
+  title: 'DeepSeek session',
+  agentType: 'deepseek',
+  agentConfigId: deepseekId,
 };
 
 const codexModelOptions: AcpSessionSelectOption[] = [
@@ -245,6 +263,25 @@ export const Codex: Story = {
 
 export const Claude: Story = {
   args: { session: claudeSession, modelOptions: claudeModelOptions, selectors: claudeSelectors },
+};
+
+export const DeepSeekDelegationWarning: Story = {
+  args: {
+    session: deepseekSession,
+    modelOptions: [
+      {
+        value: 'deepseek-v4-flash',
+        label: 'DeepSeek-V4-Flash',
+        description: 'Faster DeepSeek Harness coding model.',
+      },
+      {
+        value: 'deepseek-v4-pro',
+        label: 'DeepSeek-V4-Pro',
+        description: 'More capable DeepSeek Harness coding model.',
+      },
+    ],
+    selectors: codexSelectors,
+  },
 };
 
 /**

--- a/packages/components/tests/composer-model-search.test.tsx
+++ b/packages/components/tests/composer-model-search.test.tsx
@@ -36,6 +36,16 @@ const agentConfig: AgentConfigMeta = {
   agentType: 'codex',
   env: {},
 };
+const deepseekAgentConfig: AgentConfigMeta = {
+  ...agentConfig,
+  id: 'config-deepseek' as AgentConfigId,
+  name: 'DeepSeek Harness',
+  agentType: 'deepseek',
+};
+const deepseekModels = [
+  { value: 'deepseek-v4-flash', label: 'DeepSeek-V4-Flash' },
+  { value: 'deepseek-v4-pro', label: 'DeepSeek-V4-Pro' },
+];
 
 /* A provider that publishes far more models than a list can be scanned for —
    the case the search field exists for. */
@@ -203,6 +213,56 @@ describe('composer model picker search', () => {
     expect(rows()).toHaveLength(fewModels.length);
   });
 
+  it('links the upstream delegation warning for a builtin DeepSeek non-Pro model', async () => {
+    await act(async () => {
+      root?.render(
+        createElement(DesktopRunConfigMenu, {
+          ...desktopProps,
+          agentSelection: { agentId: deepseekAgentConfig.id, machineId },
+          availableAgentConfigs: [deepseekAgentConfig],
+          modelOptions: deepseekModels,
+          selectedModelId: 'deepseek-v4-flash',
+        })
+      );
+    });
+    await act(async () => {
+      container
+        ?.querySelector('button[aria-label="Run configuration"]')
+        ?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }));
+    });
+
+    const warning = document.querySelector<HTMLAnchorElement>(
+      'a[href="https://github.com/deepseek-ai/deepseek-harness/discussions/4065"]'
+    );
+    expect(warning?.textContent).toContain('delegated subagents may use');
+    expect(warning?.textContent).toContain('Upstream discussion');
+  });
+
+  it('does not warn when the builtin DeepSeek session already uses Pro', async () => {
+    await act(async () => {
+      root?.render(
+        createElement(DesktopRunConfigMenu, {
+          ...desktopProps,
+          agentSelection: { agentId: deepseekAgentConfig.id, machineId },
+          availableAgentConfigs: [deepseekAgentConfig],
+          modelOptions: deepseekModels,
+          selectedModelId: 'deepseek-v4-pro',
+        })
+      );
+    });
+    await act(async () => {
+      container
+        ?.querySelector('button[aria-label="Run configuration"]')
+        ?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }));
+    });
+
+    expect(
+      document.querySelector(
+        'a[href="https://github.com/deepseek-ai/deepseek-harness/discussions/4065"]'
+      )
+    ).toBeNull();
+  });
+
   /* ── Mobile: the same rule inside the run-config sheet ── */
 
   type SheetProps = ComponentProps<typeof MobileRunConfigSheet>;
@@ -293,5 +353,32 @@ describe('composer model picker search', () => {
       selectedModelId: fewModels[0]?.value ?? null,
     });
     expect(search).toBeNull();
+  });
+
+  it('shows the linked DeepSeek delegation warning in the mobile sheet', async () => {
+    const store = createStore();
+    store.set(agentConfigMetaCacheAtom, {
+      [getAgentConfigRoomId(deepseekAgentConfig.id)]: deepseekAgentConfig,
+    });
+    await act(async () => {
+      root?.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(MobileRunConfigSheet, {
+            ...mobileProps,
+            agentSelection: { agentId: deepseekAgentConfig.id, machineId },
+            modelOptions: deepseekModels,
+            selectedModelId: 'deepseek-v4-flash',
+          })
+        )
+      );
+    });
+
+    const warning = document.querySelector<HTMLAnchorElement>(
+      'a[href="https://github.com/deepseek-ai/deepseek-harness/discussions/4065"]'
+    );
+    expect(warning?.textContent).toContain('delegated subagents may use');
+    expect(warning?.textContent).toContain('Upstream discussion');
   });
 });

--- a/site-docs/content/docs/en/(core-concepts)/agents.mdx
+++ b/site-docs/content/docs/en/(core-concepts)/agents.mdx
@@ -48,6 +48,12 @@ Lody includes **DeepSeek Harness** as a built-in ACP provider. Create an Agent C
 DeepSeek Harness, and paste a DeepSeek API token. Lody stores it as `DEEPSEEK_API_KEY`; you do not
 need to install the standalone `dsh` command.
 
+> **Known delegation limitation:** When a session uses a model other than DeepSeek-V4-Pro,
+> delegated subagents may still use the session's creation-time DeepSeek-V4-Pro seed instead of the
+> model shown for the parent session, which can increase usage costs. Follow the
+> [upstream DSH discussion](https://github.com/deepseek-ai/deepseek-harness/discussions/4065) for the
+> inheritance fix.
+
 Lody follows the standard `DSH_HOME` location, so a separately installed `dsh` may share the same
 `~/.dsh/sessions` root. Harness requires one compression format per root. Lody uses upstream's
 `zstd` default for empty or compressed roots and preserves `none` for an existing raw-only root. If

--- a/site-docs/content/docs/zh/(core-concepts)/agents.mdx
+++ b/site-docs/content/docs/zh/(core-concepts)/agents.mdx
@@ -43,6 +43,10 @@ Lody 内置 **DeepSeek Harness** ACP Provider。新建 Agent Config、选择 Dee
 DeepSeek API Token 即可；Lody 会将其保存为 `DEEPSEEK_API_KEY`，无需另外安装 standalone
 `dsh` 命令。
 
+> **已知的委派限制：** 当会话使用 DeepSeek-V4-Pro 以外的模型时，委派的子智能体可能仍会使用
+> 会话创建时写入的 DeepSeek-V4-Pro，而不是父会话界面显示的模型，因而可能产生更高费用。继承
+> 行为的修复进展请关注 [DSH 上游讨论](https://github.com/deepseek-ai/deepseek-harness/discussions/4065)。
+
 Lody 遵循标准的 `DSH_HOME` 路径，因此单独安装的 `dsh` 可能与 Lody 共用
 `~/.dsh/sessions`。Harness 要求一个 session root 只能使用一种压缩格式：对于空 root 或已有
 压缩工件的 root，Lody 使用上游默认的 `zstd`；对于仅包含旧版未压缩工件的 root，Lody 继续使用


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

DeepSeek Harness delegated subagents can currently use the session creation-time DeepSeek-V4-Pro seed even when the parent session displays a less expensive model. Lody cannot correct the upstream routing behavior yet, but users need a visible cost warning and a path to the upstream discussion. Addresses the warning and documentation request in #58 without closing the upstream-blocked issue.

## Summary

- Show a linked warning in desktop and mobile run configuration for builtin DeepSeek Harness sessions using a non-Pro model.
- Link the warning and English/Chinese documentation to https://github.com/deepseek-ai/deepseek-harness/discussions/4065.
- Add focused stories and tests, including the no-warning Pro case.

## Before / after

| Before | After |
| ------ | ----- |
| Selecting a non-Pro DeepSeek model gave no indication that delegated children could use Pro. | Desktop and mobile show a localized cost warning linked to the upstream discussion; Pro sessions remain unchanged. |

## Test plan

- `pnpm --filter @lody/components exec vitest run tests/composer-model-search.test.tsx` — 15 tests passed.
- `pnpm --filter @lody/components typecheck` — passed.
- `pnpm --filter @lody/site-docs typecheck` — passed.
- `pnpm lint:i18n` — passed.
- Targeted `oxlint` for the six changed TS/TSX files — passed with zero warnings and errors.
- `git diff --check` — passed.
- Root `pnpm lint:fast` was attempted but remains blocked by the pre-existing unused `args` parameter in `packages/components/tests/session-file-content-view.test.tsx:1410`.

## Agent handoff

<!-- agent-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the DeepSeek predicate and desktop/mobile link behavior in the shared warning component and run-config surfaces.
- **Decisions to challenge:** Confirm that limiting the warning to builtin DeepSeek non-Pro models is the right scope while the upstream issue remains unresolved.
- **Plausible failures / evidence gaps:** The focused component tests and Storybook interaction passed, but the full suite was not rerun because root lint has an unrelated pre-existing failure.

### Authoring context

- **User goal / directives:** Add the warning proposed in issue #58, link its description to the upstream discussion, implement it first, and provide a screenshot.
- **Constraints / non-goals:** Do not attempt to repair DeepSeek Harness child-route inheritance in Lody or close the upstream-blocked issue.
- **Risk-bearing decisions:** Render the warning only for builtin DeepSeek Harness with an explicitly selected model other than DeepSeek-V4-Pro, and make the warning card itself an external link.
- **Destructive or irreversible behavior:** None; temporary screenshot artifacts were removed after the screenshot was uploaded to the author-side conversation.
- **Deliberately not done or tested:** No upstream runtime workaround was added; the full root check was not completed because of the unrelated existing lint error described above.
- **Unknowns / confidence:** High confidence in the UI predicate and link behavior; the remaining uncertainty is when upstream DSH will fix model inheritance.

### Sharing consent (author side)

Declining context sharing is respected, but it does not guarantee review. If withheld context prevents maintainers from assessing provenance, scope, or risk, they may decline the contribution or close the pull request.

- [x] Author-side user explicitly allowed publishing the Authoring context above
- [ ] Author-side user explicitly declined publishing Authoring context and understands that maintainers may decline or close the contribution; keep every field as `N/A` / redacted

<!-- agent-handoff:end -->