### PR TITLE
feat(components): show running state on collapsed projects

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -48,6 +48,9 @@ mobile surfaces.
 - `AgentActivityIndicator` animations stay CSS-only and compositor-friendly
   (`transform`/`opacity`). Do not restore canvas frame loops, React animation
   state, or timers; keep the Storybook Playwright render budgets passing.
+- Local-project sidebar rows aggregate fresh live activity across their Sessions and child Tabs.
+  Include pinned Sessions, and keep that status in its own slot so collapsing a project never
+  hides active work or replaces the folder/disclosure affordance.
 - `ZoomableImageViewer` is the one image viewer, and it presents per surface:
   full-bleed on touch, a lightbox on desktop (inset photo, translucent mask, a
   top bar that clears the native window controls). Inset the photo with a

--- a/packages/components/src/components/loro-app-sidebar.tsx
+++ b/packages/components/src/components/loro-app-sidebar.tsx
@@ -117,6 +117,7 @@ import {
   buildChildSessionsByParent,
   buildSessionListRows,
   buildSidebarOpenerRowResolver,
+  getEffectiveProjectActivitySummary,
   getEffectiveSessionActivitySummary,
   getEffectiveLatestMessageAt,
   getLatestPullRequestInfo,
@@ -146,6 +147,7 @@ import { writePreferredWorkspaceSlug } from '@/lib/workspace';
 import {
   SessionOpenedByTreeRow,
   SessionPrIcon,
+  SessionRowIndicator,
   SessionRowAuthorAvatar,
   SessionRowLeadingSlot,
   SessionRowWorktreeIndicator,
@@ -681,6 +683,8 @@ export type LocalProjectItemProps = {
   canNavigateProject: boolean;
   collapsed: boolean;
   isSelected: boolean;
+  /** All project Sessions, including pinned rows rendered in the separate top section. */
+  activitySessionsForProject?: SessionMeta[];
   sessionsForProject: SessionMeta[];
   /**
    * Map of parent session id -> non-archived child sessions. Used to roll up
@@ -748,6 +752,7 @@ export const LocalProjectItem = memo(function LocalProjectItem({
   canNavigateProject,
   collapsed,
   isSelected,
+  activitySessionsForProject,
   sessionsForProject,
   childSessionsByParent,
   liveSessionStatuses,
@@ -797,13 +802,25 @@ export const LocalProjectItem = memo(function LocalProjectItem({
     [childSessionsByParent, collapsedOpenedBySessionIds, resolveOpenerRowId, sessionsForProject]
   );
   const showTreeGutter = hasOpenedByTreeNesting(sessionNodes);
+  const projectActivity = useMemo(
+    () =>
+      getEffectiveProjectActivitySummary(
+        activitySessionsForProject ?? sessionsForProject,
+        childSessionsByParent,
+        liveSessionStatuses
+      ),
+    [activitySessionsForProject, childSessionsByParent, liveSessionStatuses, sessionsForProject]
+  );
   const trimmedMachineName =
     typeof machineName === 'string' && machineName.trim() ? machineName.trim() : null;
-  const ariaLabel = formattedPath
-    ? trimmedMachineName
-      ? `${project.name} · ${trimmedMachineName} · ${formattedPath}`
-      : `${project.name} · ${formattedPath}`
-    : project.name;
+  const projectActivityLabel = projectActivity.isWaitingPermission
+    ? t('sessions.status.requestPermission', 'Request Permission')
+    : projectActivity.isWorking
+      ? t('sessions.status.running', 'Running')
+      : null;
+  const ariaLabel = [project.name, trimmedMachineName, formattedPath, projectActivityLabel]
+    .filter(Boolean)
+    .join(' · ');
   const showSelectedState = isSelected && !isMobile;
   const handleNavigate = useCallback(() => {
     if (!canNavigateProject) return;
@@ -875,6 +892,21 @@ export const LocalProjectItem = memo(function LocalProjectItem({
               </button>
               <span className="min-w-0 flex-1 truncate text-left">{project.name}</span>
 
+              {projectActivity.isWorking ? (
+                <span
+                  data-sidebar-project-activity={
+                    projectActivity.isWaitingPermission ? 'requestPermission' : 'running'
+                  }
+                  className="flex h-5 w-5 shrink-0 items-center justify-center"
+                  aria-hidden="true"
+                >
+                  <SessionRowIndicator
+                    isWaitingPermission={projectActivity.isWaitingPermission}
+                    isWorking
+                  />
+                </span>
+              ) : null}
+
               {canRemoveProject ? (
                 <div className="relative h-5 w-5 shrink-0">
                   <button
@@ -904,9 +936,10 @@ export const LocalProjectItem = memo(function LocalProjectItem({
               ) : null}
             </div>
           </TooltipTrigger>
-          {formattedPath || trimmedMachineName ? (
+          {formattedPath || trimmedMachineName || projectActivityLabel ? (
             <TooltipContent side="right" align="start" className="max-w-[420px] break-all">
               <div className="flex flex-col gap-0.5 text-xs">
+                {projectActivityLabel ? <span>{projectActivityLabel}</span> : null}
                 {trimmedMachineName ? (
                   <span className="text-muted-foreground">{trimmedMachineName}</span>
                 ) : null}
@@ -1901,6 +1934,9 @@ export function LoroAppSidebar({ className }: LoroAppSidebarProps) {
                         canNavigateProject={section.canNavigateProject}
                         collapsed={collapsed}
                         isSelected={isSelected}
+                        activitySessionsForProject={
+                          localProjectSessionsByKey.get(projectKey) ?? sessionsForProject
+                        }
                         sessionsForProject={sessionsForProject}
                         childSessionsByParent={childSessionsByParent}
                         liveSessionStatuses={liveSessionStatuses}

--- a/packages/components/src/components/sessions/session-list-rows.ts
+++ b/packages/components/src/components/sessions/session-list-rows.ts
@@ -229,6 +229,34 @@ export function getEffectiveSessionActivitySummary(
   };
 }
 
+export type EffectiveProjectActivitySummary = Pick<
+  EffectiveSessionActivitySummary,
+  'isWorking' | 'isWaitingPermission'
+>;
+
+/** Aggregate live activity for a local-project sidebar row. */
+export function getEffectiveProjectActivitySummary(
+  sessions: SessionMeta[],
+  childSessionsByParent?: Map<string, SessionMeta[]>,
+  liveSessionStatuses?: ReadonlyMap<string, SessionStatus>
+): EffectiveProjectActivitySummary {
+  let isWorking = false;
+
+  for (const session of sessions) {
+    const activity = getEffectiveSessionActivitySummary(
+      session,
+      childSessionsByParent,
+      liveSessionStatuses
+    );
+    if (activity.isWaitingPermission) {
+      return { isWorking: true, isWaitingPermission: true };
+    }
+    isWorking ||= activity.isWorking;
+  }
+
+  return { isWorking, isWaitingPermission: false };
+}
+
 type LatestPullRequestInfo = {
   url: string | null;
   number: number | null;

--- a/packages/components/src/components/sidebar-row-shared.tsx
+++ b/packages/components/src/components/sidebar-row-shared.tsx
@@ -119,7 +119,7 @@ function MaskedPrCiIcon({
  * unless it is working / unread — but the slot is always reserved so the ⋯ menu
  * button can reveal there on hover without shifting the row.
  */
-function SessionRowIndicator({
+export function SessionRowIndicator({
   isWaitingPermission,
   isWorking,
   hasUnreadMessages,

--- a/packages/components/src/stories/LoroSidebar.stories.tsx
+++ b/packages/components/src/stories/LoroSidebar.stories.tsx
@@ -34,7 +34,9 @@ import type {
 } from '@lody/shared';
 
 const NOW = Date.now();
-const EMPTY_LIVE_SESSION_STATUSES = new Map<string, SessionStatus>();
+const DEMO_LIVE_SESSION_STATUSES = new Map<string, SessionStatus>([
+  ['local-sess-worktree', { type: 'running' }],
+]);
 
 const codexHistoryProvider = {
   cliType: 'builtin',
@@ -814,8 +816,8 @@ const demoProjects: LocalProjectMeta[] = [
 
 // A couple of local-project sessions so the single-line local row is exercised:
 // one running inside a worktree (shows the FolderTree mode icon) and one plain
-// local session (no mode icon). Live status is empty in the story, so the leading
-// status slot stays empty here.
+// local session (no mode icon). The first session stays live so the collapsed
+// project row demonstrates its aggregate running indicator.
 const demoLocalSessions: SessionMeta[] = [
   {
     id: 'local-sess-worktree' as SessionId,
@@ -999,7 +1001,7 @@ function ProductionLikeTopContent({
                       project.id === ('proj-lody' as LocalProjectId) ? demoLocalSessions : []
                     }
                     childSessionsByParent={new Map()}
-                    liveSessionStatuses={EMPTY_LIVE_SESSION_STATUSES}
+                    liveSessionStatuses={DEMO_LIVE_SESSION_STATUSES}
                     formattedPath={project.rootPath}
                     defaultSessionTitle="Untitled"
                     selectedSessionId={null}
@@ -1052,7 +1054,7 @@ function ProductionLikeTopContent({
                   isSelected={false}
                   sessionsForProject={[] as SessionMeta[]}
                   childSessionsByParent={new Map()}
-                  liveSessionStatuses={EMPTY_LIVE_SESSION_STATUSES}
+                  liveSessionStatuses={DEMO_LIVE_SESSION_STATUSES}
                   formattedPath={project.rootPath}
                   defaultSessionTitle="Untitled"
                   selectedSessionId={null}

--- a/packages/components/tests/session-list-rows.test.ts
+++ b/packages/components/tests/session-list-rows.test.ts
@@ -6,6 +6,7 @@ import {
   buildChildSessionsByParent,
   buildSessionListRows,
   getEffectiveLatestMessageAt,
+  getEffectiveProjectActivitySummary,
   getEffectiveSessionActivitySummary,
 } from '../src/components/sessions/session-list-rows';
 
@@ -276,6 +277,50 @@ describe('getEffectiveSessionActivitySummary child-status aggregation', () => {
       isWaitingPermission: false,
       hasUnreadMessages: false,
       latestMessageAt: parent.lastMessageAt,
+    });
+  });
+});
+
+describe('getEffectiveProjectActivitySummary', () => {
+  test('reports running when any project session has live activity', () => {
+    const idleSession = makeSession({ id: 'idle' });
+    const runningSession = makeSession({ id: 'running' });
+    const liveSessionStatuses = new Map<string, SessionStatus>([
+      [runningSession.id, { type: 'running' }],
+    ]);
+
+    expect(
+      getEffectiveProjectActivitySummary(
+        [idleSession, runningSession],
+        new Map(),
+        liveSessionStatuses
+      )
+    ).toEqual({ isWorking: true, isWaitingPermission: false });
+  });
+
+  test('gives child-tab permission activity precedence over running', () => {
+    const runningSession = makeSession({ id: 'running' });
+    const child = makeSession({
+      id: 'permission-child',
+      parentSessionId: runningSession.id,
+    });
+    const children = buildChildSessionsByParent([runningSession, child]);
+    const liveSessionStatuses = new Map<string, SessionStatus>([
+      [runningSession.id, { type: 'running' }],
+      [child.id, { type: 'requestPermission' }],
+    ]);
+
+    expect(
+      getEffectiveProjectActivitySummary([runningSession], children, liveSessionStatuses)
+    ).toEqual({ isWorking: true, isWaitingPermission: true });
+  });
+
+  test('ignores durable status without live presence', () => {
+    const session = makeSession({ id: 'stale', status: { type: 'running' } });
+
+    expect(getEffectiveProjectActivitySummary([session])).toEqual({
+      isWorking: false,
+      isWaitingPermission: false,
     });
   });
 });


### PR DESCRIPTION
## Summary
- aggregate fresh live activity across local-project Sessions and child Tabs
- keep the folder/disclosure affordance and show the running/permission indicator in a fixed project-row slot
- include pinned Sessions and add unit/Storybook coverage

## Validation
- `corepack pnpm --filter @lody/components exec vitest run tests/session-list-rows.test.ts`
- `corepack pnpm --filter @lody/components typecheck`
- targeted Oxlint
- `corepack pnpm check:public-boundary`