### PR TITLE
fix: preserve PR body enforcement outcome

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -30,3 +30,6 @@
 - Workflows triggered by `pull_request_target` have a write-capable token. They
   must never check out the pull request head or execute files supplied by the
   pull request. Read scripts and configuration from the base commit only.
+- PR-body comments require pull-request write permission. Treat comment creation,
+  updates, and cleanup as best-effort feedback; the checker result alone decides
+  whether the enforcement job passes or fails.

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: pr-body-${{ github.event.pull_request.number }}
@@ -48,6 +48,7 @@ jobs:
 
       - name: Notify author on format failure
         if: steps.validate.outputs.code != '0'
+        continue-on-error: true
         uses: actions/github-script@v7
         env:
           FINDINGS_FILE: ${{ runner.temp }}/pr-body-check.txt
@@ -102,6 +103,7 @@ jobs:
 
       - name: Clear format failure comment on success
         if: steps.validate.outputs.code == '0'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -122,5 +124,5 @@ jobs:
             }
 
       - name: Fail when the body is invalid
-        if: steps.validate.outputs.code != '0'
+        if: always() && steps.validate.outputs.code != '0'
         run: exit 1


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

An invalid external PR correctly failed body validation, but the notification step received a 403 while commenting and masked the intended enforcement step. The failure path needs the same effective PR permissions as the working scope-label workflow, and feedback delivery must not decide the policy result.

## Summary

- Grant the PR body workflow `pull-requests: write` so it can create, update, and remove its marker comment on pull requests.
- Treat notification and cleanup as best-effort feedback.
- Run the final invalid-body failure under `always()` so checker output remains the source of truth even when feedback fails.
- Record the permission and outcome-separation invariant in `.github/AGENTS.md`.

## Before / after

| Before | After |
| ------ | ----- |
| A comment API 403 stopped the job before the explicit enforcement step, obscuring the real invalid-body result. | Comment management has the required PR permission and cannot mask or override the checker result. |

## Test plan

- Actionlint for all workflows
- Prettier for the changed workflow and guidance
- Run the checker against merged PR #63 and confirm its Agent body passes
- `pnpm check:public-boundary`
- `git diff --check`

## Agent handoff

<!-- agent-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Verify the added PR write scope is necessary and remains safe with trusted-base checkout; confirm feedback failures cannot change the checker outcome.
- **Decisions to challenge:** Challenge retaining both Issues and Pull requests write permissions, using best-effort comment steps, and applying `always()` only to the final enforcement step.
- **Plausible failures / evidence gaps:** GitHub may still reject fork-PR comments due to a higher-level policy; broader PR permission becomes dangerous if future edits execute fork code; live comment recovery cannot be exercised before merge.

### Authoring context

- **User goal / directives:** Diagnose the Actions failure and open a new formal PR that fixes the confirmed PR-body workflow problem.
- **Constraints / non-goals:** Preserve external PR enforcement, never execute fork code with the write-capable token, and keep this fix separate from the already merged contribution automation PR.
- **Risk-bearing decisions:** Expand Pull requests from read to write and make comment management best-effort while checker output exclusively controls enforcement.
- **Destructive or irreversible behavior:** The workflow may create, update, or delete only its own marker comment; no product or user data changes.
- **Deliberately not done or tested:** No repository Actions settings or action versions were changed; a live invalid fork PR cannot validate comment creation until this workflow reaches the default branch.
- **Unknowns / confidence:** Static workflow, formatting, public-boundary, and real-body regressions pass; the working label workflow with the same write scopes supports the permission diagnosis.

### Sharing consent (author side)

Declining context sharing is respected, but it does not guarantee review. If withheld context prevents maintainers from assessing provenance, scope, or risk, they may decline the contribution or close the pull request.

- [x] Author-side user explicitly allowed publishing the Authoring context above
- [ ] Author-side user explicitly declined publishing Authoring context and understands that maintainers may decline or close the contribution; keep every field as `N/A` / redacted

<!-- agent-handoff:end -->