### PR TITLE
fix(cli): detect the active Windows code page

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-09-windows-console-code-page-detection.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-windows-console-code-page-detection.md
@@ -1,0 +1,47 @@
+# Detect the active Windows console code page from a trusted utility
+
+Status: implemented
+Translation: pending
+PR: https://github.com/LodyAI/Lody/pull/70
+
+## Abstract
+
+Windows console programs can encode output with the active OEM code page, which is
+independent of locale environment variables. The CLI now resolves the kernel-owned
+SystemRoot link to `chcp.com`, runs that read-only utility directly with bounded
+resources, and uses the reported supported encoding before locale fallback. The
+synchronous probe is cached to avoid repeated startup work, while transient failures
+retry later and never replace a last known good value.
+
+## Decision and boundaries
+
+Probe only when invalid UTF-8 output needs the Windows fallback. Resolve
+`\\?\GLOBALROOT\SystemRoot\System32\chcp.com` with `realpathSync.native` so
+`SystemRoot`, `WINDIR`, `ComSpec`, `PATH`, and the working directory cannot select
+an executable. Run without a shell, with a two-second timeout and 64 KiB output cap.
+Accept only a successful, parseable code page supported by `iconv-lite`; map Windows
+aliases 65001 and 54936 to UTF-8 and GB18030.
+
+Cache successful detection for five minutes. A failed refresh retains the last known
+good encoding and retries after 30 seconds; without one, decoding uses the existing
+locale fallback. Non-Windows behavior and forced encodings remain unchanged.
+
+## Alternatives and trade-offs
+
+Locale-only inference was rejected because locale and console configuration can
+disagree. Resolving `cmd.exe` or `chcp.com` through environment variables was rejected
+because the CLI can inherit attacker-controlled paths. A registry probe or native
+addon would avoid a subprocess but adds platform-specific dependencies and failure
+surfaces for a fallback used only after UTF-8 validation fails.
+
+The synchronous probe can pause the first affected decode if Windows is unhealthy.
+Bounding and caching that work keeps the common UTF-8 path free of subprocesses while
+retaining deterministic recovery from transient failures.
+
+## Evidence and limits
+
+Focused tests exercise localized raw output, UTF-8 and GB18030 aliases, unsupported
+and malformed output, unresolvable system paths, hostile environment paths, locale
+precedence, cache expiry, retry, and last-known-good retention. A live CP936 Windows
+probe and Chinese round trip have succeeded. Local testing does not cover every
+localized Windows message resource or unusual console host.

--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -39,6 +39,9 @@ Root `AGENTS.md` applies; this file adds CLI context. Build, PR-poller, and adap
   only and never authorize PID killing.
 - Read context/terminal-output-lifecycle.md before changing ACP terminal notification handling or
   history compaction.
+- Windows non-UTF-8 child output uses the active console code page from the trusted system
+  utility, then falls back to locale inference; never select that utility from caller-controlled
+  environment paths. See the [code-page decision](../../.agents/notes/implemented/bug-fix/2026-09-09-windows-console-code-page-detection.md).
 
 ## Cross-entry agent contracts
 

--- a/apps/cli/src/utils/encoding.test.ts
+++ b/apps/cli/src/utils/encoding.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { win32 as pathWin32 } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import iconv from 'iconv-lite';
 import {
   decodeBuffer,
@@ -8,14 +11,64 @@ import {
   setLocaleForTesting,
 } from './encoding';
 
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+}));
+
+const mockedSpawnSync = vi.mocked(spawnSync);
+const WINDOWS_CHCP_GLOBAL_ROOT_PATH = '\\\\?\\GLOBALROOT\\SystemRoot\\System32\\chcp.com';
+const WINDOWS_CHCP_RESOLVED_PATH = 'C:\\Windows\\System32\\chcp.com';
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+const environmentVariables = [
+  'LC_ALL',
+  'LC_CTYPE',
+  'LANG',
+  'LOCALE',
+  'SystemRoot',
+  'WINDIR',
+  'ComSpec',
+] as const;
+const originalLocaleEnvironment = Object.fromEntries(
+  environmentVariables.map((name) => [name, process.env[name]])
+) as Record<(typeof environmentVariables)[number], string | undefined>;
+
+function setChcpResult(stdout: Buffer, status = 0): void {
+  mockedSpawnSync.mockReturnValue({
+    pid: 1,
+    output: [null, stdout, Buffer.alloc(0)],
+    stdout,
+    stderr: Buffer.alloc(0),
+    status,
+    signal: null,
+  } as never);
+}
+
 describe('encoding utilities', () => {
   beforeEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' });
+    vi.spyOn(realpathSync, 'native').mockReturnValue(WINDOWS_CHCP_RESOLVED_PATH);
+    mockedSpawnSync.mockReset();
+    setChcpResult(Buffer.alloc(0), 1);
+
     // Reset cached values before each test
     setWindowsOemCodePageForTesting(null);
     setLocaleForTesting(null);
   });
 
   afterEach(() => {
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+    }
+    for (const name of environmentVariables) {
+      const value = originalLocaleEnvironment[name];
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+    vi.restoreAllMocks();
+
     // Clean up after each test
     setWindowsOemCodePageForTesting(null);
     setLocaleForTesting(null);
@@ -97,16 +150,12 @@ describe('encoding utilities', () => {
       expect(decodeBuffer(gbkBuffer, 'gbk')).toBe('你好');
     });
 
-    it('should handle GBK encoded Chinese on Windows', () => {
-      // Simulate Windows environment
-      const originalPlatform = process.platform;
-
-      // We can't easily mock process.platform, so we test the forceEncoding path
+    it('should decode GBK output through the detected Windows code page', () => {
+      setChcpResult(Buffer.from('Active code page: 936\r\n'));
       const gbkBuffer = iconv.encode('测试中文输出', 'gbk');
-      expect(decodeBuffer(gbkBuffer, 'gbk')).toBe('测试中文输出');
 
-      // Restore
-      Object.defineProperty(process, 'platform', { value: originalPlatform });
+      expect(decodeBuffer(gbkBuffer)).toBe('测试中文输出');
+      expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
     });
 
     it('should decode CP936 (GBK) correctly with forceEncoding', () => {
@@ -126,9 +175,235 @@ describe('encoding utilities', () => {
       const cp949Buffer = iconv.encode(text, 'cp949');
       expect(decodeBuffer(cp949Buffer, 'cp949')).toBe(text);
     });
+
+    it('should keep invalid UTF-8 on the UTF-8 path outside Windows', () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' });
+      const buffer = iconv.encode('你好', 'cp936');
+
+      expect(decodeBuffer(buffer)).toBe(buffer.toString('utf8'));
+      expect(realpathSync.native).not.toHaveBeenCalled();
+      expect(mockedSpawnSync).not.toHaveBeenCalled();
+    });
   });
 
   describe('getWindowsOemCodePage', () => {
+    it('should detect the active code page from localized chcp output', () => {
+      setLocaleForTesting('ja-JP');
+      setChcpResult(
+        Buffer.concat([
+          Buffer.from([0x8b, 0x43, 0x83, 0x52, 0x81, 0x5b, 0x83, 0x68]),
+          Buffer.from(': 936\r\n'),
+        ])
+      );
+
+      expect(getWindowsOemCodePage()).toBe('cp936');
+      expect(realpathSync.native).toHaveBeenCalledWith(WINDOWS_CHCP_GLOBAL_ROOT_PATH);
+      expect(mockedSpawnSync).toHaveBeenCalledWith(
+        WINDOWS_CHCP_RESOLVED_PATH,
+        [],
+        expect.objectContaining({
+          encoding: null,
+          windowsHide: true,
+          timeout: 2_000,
+          maxBuffer: 64 * 1024,
+        })
+      );
+    });
+
+    it('should map code page 65001 to utf8', () => {
+      setChcpResult(Buffer.from('Active code page: 65001\r\n'));
+
+      expect(getWindowsOemCodePage()).toBe('utf8');
+    });
+
+    it('should map Windows code page 54936 to gb18030 and decode its output', () => {
+      setChcpResult(Buffer.from('Active code page: 54936\r\n'));
+      const text = '𠀀';
+      const buffer = iconv.encode(text, 'gb18030');
+
+      expect(isValidUtf8(buffer)).toBe(false);
+      expect(getWindowsOemCodePage()).toBe('gb18030');
+      expect(decodeBuffer(buffer)).toBe(text);
+    });
+
+    it('should skip the probe when the system code-page utility cannot be resolved', () => {
+      vi.mocked(realpathSync.native).mockImplementation(() => {
+        throw new Error('system utility unavailable');
+      });
+      setLocaleForTesting('ja-JP');
+      setChcpResult(Buffer.from('Active code page: 936\r\n'));
+
+      expect(getWindowsOemCodePage()).toBe('cp932');
+      expect(mockedSpawnSync).not.toHaveBeenCalled();
+    });
+
+    it('should not execute a command processor selected entirely by environment variables', () => {
+      const attackerControlledRoot = 'D:\\Payload';
+      process.env.SystemRoot = attackerControlledRoot;
+      process.env.WINDIR = attackerControlledRoot;
+      process.env.ComSpec = pathWin32.join(attackerControlledRoot, 'System32', 'cmd.exe');
+      setChcpResult(Buffer.from('Active code page: 936\r\n'));
+
+      expect(getWindowsOemCodePage()).toBe('cp936');
+      expect(realpathSync.native).toHaveBeenCalledWith(WINDOWS_CHCP_GLOBAL_ROOT_PATH);
+      expect(mockedSpawnSync).toHaveBeenCalledWith(
+        WINDOWS_CHCP_RESOLVED_PATH,
+        [],
+        expect.any(Object)
+      );
+      expect(mockedSpawnSync).not.toHaveBeenCalledWith(
+        pathWin32.join(attackerControlledRoot, 'System32', 'cmd.exe'),
+        expect.any(Array),
+        expect.any(Object)
+      );
+    });
+
+    it('should ignore unsupported chcp values and fall back to the locale', () => {
+      setChcpResult(Buffer.from('Active code page: 99999\r\n'));
+      setLocaleForTesting('zh-SG');
+
+      expect(getWindowsOemCodePage()).toBe('cp936');
+    });
+
+    it('should ignore malformed chcp output and fall back to the locale', () => {
+      setChcpResult(Buffer.from('chcp failed with diagnostic 1252\r\n'));
+      setLocaleForTesting('zh-SG');
+
+      expect(getWindowsOemCodePage()).toBe('cp936');
+    });
+
+    it.each([
+      {
+        name: 'LC_CTYPE over LANG',
+        environment: { LC_ALL: '', LC_CTYPE: 'ja_JP.UTF-8', LANG: 'zh_CN.UTF-8' },
+        expected: 'cp932',
+      },
+      {
+        name: 'LANG over LOCALE',
+        environment: { LC_ALL: '', LC_CTYPE: '', LANG: 'zh_CN.UTF-8', LOCALE: 'ru_RU.UTF-8' },
+        expected: 'cp936',
+      },
+      {
+        name: 'LOCALE over Intl',
+        environment: { LC_ALL: '', LC_CTYPE: '', LANG: '', LOCALE: 'ru_RU.UTF-8' },
+        expected: 'cp866',
+      },
+    ])('should prefer $name', ({ environment, expected }) => {
+      Object.assign(process.env, environment);
+      vi.spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions').mockReturnValue({
+        locale: 'zh-SG',
+        calendar: 'gregory',
+        numberingSystem: 'latn',
+        timeZone: 'Asia/Singapore',
+      });
+
+      expect(getWindowsOemCodePage()).toBe(expected);
+    });
+
+    it('should prefer LC_ALL over other locale environment variables', () => {
+      process.env.LC_ALL = 'zh_CN.UTF-8';
+      process.env.LC_CTYPE = 'ja_JP.UTF-8';
+      process.env.LANG = 'en_US.UTF-8';
+      process.env.LOCALE = 'ru_RU.UTF-8';
+
+      expect(getWindowsOemCodePage()).toBe('cp936');
+    });
+
+    it('should fall back to the Intl locale when environment locales are unusable', () => {
+      process.env.LC_ALL = '';
+      process.env.LC_CTYPE = '';
+      process.env.LANG = 'C.UTF-8';
+      process.env.LOCALE = '';
+      vi.spyOn(Intl.DateTimeFormat.prototype, 'resolvedOptions').mockReturnValue({
+        locale: 'zh-SG',
+        calendar: 'gregory',
+        numberingSystem: 'latn',
+        timeZone: 'Asia/Singapore',
+      });
+
+      expect(getWindowsOemCodePage()).toBe('cp936');
+    });
+
+    it('should map traditional Chinese BCP 47 locales to cp950', () => {
+      process.env.LC_ALL = 'zh-Hant-HK.UTF-8';
+
+      expect(getWindowsOemCodePage()).toBe('cp950');
+    });
+
+    it.each([
+      ['ja', 'cp932'],
+      ['ja-Jpan-JP', 'cp932'],
+      ['ko', 'cp949'],
+      ['ru', 'cp866'],
+    ])('should resolve language-level locale %s to %s', (locale, expected) => {
+      setLocaleForTesting(locale);
+
+      expect(getWindowsOemCodePage()).toBe(expected);
+    });
+
+    it('should probe the active code page only once', () => {
+      setChcpResult(Buffer.from('Active code page: 936\r\n'));
+
+      expect(getWindowsOemCodePage()).toBe('cp936');
+      setChcpResult(Buffer.from('Active code page: 932\r\n'));
+      expect(getWindowsOemCodePage()).toBe('cp936');
+      expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry a failed probe after a bounded delay', () => {
+      const now = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      setLocaleForTesting('ja-JP');
+
+      expect(getWindowsOemCodePage()).toBe('cp932');
+      expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
+
+      setChcpResult(Buffer.from('Active code page: 936\r\n'));
+      now.mockReturnValue(30_999);
+      expect(getWindowsOemCodePage()).toBe('cp932');
+      expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
+
+      now.mockReturnValue(31_000);
+      expect(getWindowsOemCodePage()).toBe('cp936');
+      expect(mockedSpawnSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('should refresh a successful probe after its cache expires', () => {
+      const now = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      setChcpResult(Buffer.from('Active code page: 936\r\n'));
+
+      expect(getWindowsOemCodePage()).toBe('cp936');
+      setChcpResult(Buffer.from('Active code page: 932\r\n'));
+
+      now.mockReturnValue(300_999);
+      expect(getWindowsOemCodePage()).toBe('cp936');
+      expect(mockedSpawnSync).toHaveBeenCalledTimes(1);
+
+      now.mockReturnValue(301_000);
+      expect(getWindowsOemCodePage()).toBe('cp932');
+      expect(mockedSpawnSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('should retain the last successful code page when a refresh fails', () => {
+      const now = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+      setLocaleForTesting('ja-JP');
+      setChcpResult(Buffer.from('Active code page: 936\r\n'));
+
+      expect(getWindowsOemCodePage()).toBe('cp936');
+
+      setChcpResult(Buffer.alloc(0), 1);
+      now.mockReturnValue(301_000);
+      expect(getWindowsOemCodePage()).toBe('cp936');
+
+      now.mockReturnValue(330_999);
+      expect(getWindowsOemCodePage()).toBe('cp936');
+      expect(mockedSpawnSync).toHaveBeenCalledTimes(2);
+
+      setChcpResult(Buffer.from('Active code page: 932\r\n'));
+      now.mockReturnValue(331_000);
+      expect(getWindowsOemCodePage()).toBe('cp932');
+      expect(mockedSpawnSync).toHaveBeenCalledTimes(3);
+    });
+
     it('should return cp936 for zh-CN locale', () => {
       setLocaleForTesting('zh-CN');
       setWindowsOemCodePageForTesting(null); // Reset to force re-detection

--- a/apps/cli/src/utils/encoding.ts
+++ b/apps/cli/src/utils/encoding.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
 import iconv from 'iconv-lite';
 
 /**
@@ -42,11 +44,43 @@ const WINDOWS_OEM_CODE_PAGES: Record<string, string> = {
   'vi-VN': 'cp1258', // Vietnamese
 };
 
+const WINDOWS_OEM_CODE_PAGES_BY_LANGUAGE: Readonly<Record<string, string>> = {
+  ar: 'cp720',
+  bg: 'cp866',
+  cs: 'cp852',
+  de: 'cp850',
+  en: 'cp437',
+  es: 'cp850',
+  fr: 'cp850',
+  he: 'cp862',
+  hu: 'cp852',
+  it: 'cp850',
+  ja: 'cp932',
+  ko: 'cp949',
+  pl: 'cp852',
+  pt: 'cp850',
+  ro: 'cp852',
+  ru: 'cp866',
+  th: 'cp874',
+  tr: 'cp857',
+  uk: 'cp866',
+  vi: 'cp1258',
+};
+
 /**
  * Default OEM code page when locale cannot be determined.
  * CP437 is the original IBM PC code page.
  */
 const DEFAULT_OEM_CODE_PAGE = 'cp437';
+const CHCP_TIMEOUT_MS = 2_000;
+const CHCP_MAX_BUFFER_BYTES = 64 * 1024;
+const CHCP_RETRY_DELAY_MS = 30_000;
+const CHCP_SUCCESS_CACHE_MS = 5 * 60_000;
+const WINDOWS_CHCP_GLOBAL_ROOT_PATH = '\\\\?\\GLOBALROOT\\SystemRoot\\System32\\chcp.com';
+const WINDOWS_CODE_PAGE_ALIASES: Readonly<Record<number, string>> = {
+  54936: 'gb18030',
+  65001: 'utf8',
+};
 
 /**
  * Cached system locale (detected once at startup).
@@ -57,52 +91,144 @@ let cachedLocale: string | null = null;
  * Cached OEM code page for the current system.
  */
 let cachedOemCodePage: string | null = null;
+let cachedOemCodePageExpiresAt = 0;
+let nextOemCodePageProbeAt = 0;
 
 /**
- * Detects the system locale from environment variables.
- *
- * On Windows, the locale can be determined from:
- * - LANG environment variable (if set by user)
- * - LC_ALL environment variable
- * - LOCALE environment variable
- * - PowerShell's $PSCulture (not directly accessible)
- *
- * Falls back to 'en-US' if no locale can be detected.
+ * Converts environment-style locale values to canonical BCP 47 tags.
+ */
+function normalizeLocale(value: string | undefined): Intl.Locale | null {
+  const trimmed = value?.trim();
+  if (trimmed === undefined || trimmed.length === 0 || /^(?:C|POSIX)(?:[.@]|$)/i.test(trimmed)) {
+    return null;
+  }
+
+  const languageTag = trimmed.split(/[.@]/, 1)[0]?.replaceAll('_', '-');
+  if (languageTag === undefined || languageTag.length === 0) {
+    return null;
+  }
+
+  try {
+    return new Intl.Locale(languageTag);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Detects the system locale from standard locale variables, then Intl.
  */
 function detectSystemLocale(): string {
   if (cachedLocale !== null) {
     return cachedLocale;
   }
 
-  // Check common environment variables for locale
-  const envLocale =
-    process.env.LANG || process.env.LC_ALL || process.env.LC_CTYPE || process.env.LOCALE;
+  const candidates = [
+    process.env.LC_ALL,
+    process.env.LC_CTYPE,
+    process.env.LANG,
+    process.env.LOCALE,
+  ];
 
-  if (envLocale) {
-    // Parse locale string (e.g., "zh_CN.UTF-8" -> "zh-CN")
-    const match = envLocale.match(/^([a-z]{2})[-_]([A-Z]{2})/i);
-    if (match && match[1] && match[2]) {
-      cachedLocale = `${match[1].toLowerCase()}-${match[2].toUpperCase()}`;
+  try {
+    candidates.push(Intl.DateTimeFormat().resolvedOptions().locale);
+  } catch {
+    // Intl may be unavailable in a reduced Node.js build.
+  }
+
+  for (const candidate of candidates) {
+    const locale = normalizeLocale(candidate);
+    if (locale) {
+      cachedLocale = locale.toString();
       return cachedLocale;
     }
   }
 
-  // On Windows without LANG set, try to infer from other indicators
-  // This is a best-effort approach
-  if (process.platform === 'win32') {
-    // Check if running in a Chinese environment (common case)
-    // Windows sets some environment variables that can hint at the locale
-    const systemRoot = process.env.SystemRoot || '';
-    if (systemRoot.includes('\\Windows')) {
-      // Default to Chinese for now if on Windows without explicit locale
-      // This could be improved by checking registry or using native APIs
-      // For now, we'll use a safe default
-    }
-  }
-
-  // Default fallback
   cachedLocale = 'en-US';
   return cachedLocale;
+}
+
+/**
+ * Resolves a locale to a known Windows OEM code page.
+ */
+function resolveLocaleCodePage(localeName: string): string {
+  const locale = normalizeLocale(localeName);
+  if (!locale) {
+    return DEFAULT_OEM_CODE_PAGE;
+  }
+
+  const exactMatch = WINDOWS_OEM_CODE_PAGES[locale.baseName];
+  if (exactMatch !== undefined) {
+    return exactMatch;
+  }
+
+  if (locale.language === 'zh') {
+    return locale.script === 'Hant' || ['TW', 'HK', 'MO'].includes(locale.region ?? '')
+      ? 'cp950'
+      : 'cp936';
+  }
+
+  return WINDOWS_OEM_CODE_PAGES_BY_LANGUAGE[locale.language] ?? DEFAULT_OEM_CODE_PAGE;
+}
+
+/**
+ * Parses the final code-page-shaped number from localized chcp output.
+ */
+function parseChcpCodePage(output: Buffer): number | null {
+  const value = /^[^\r\n]*:\s*(\d{3,5})\s*$/.exec(output.toString('latin1'))?.[1];
+  if (value === undefined) {
+    return null;
+  }
+
+  const codePage = Number.parseInt(value, 10);
+  return Number.isSafeInteger(codePage) ? codePage : null;
+}
+
+function resolveWindowsCodePageUtility(): string | null {
+  try {
+    // GLOBALROOT reaches the kernel-owned SystemRoot link without trusting
+    // caller-controlled SystemRoot, WINDIR, ComSpec, PATH, or the working directory.
+    return realpathSync.native(WINDOWS_CHCP_GLOBAL_ROOT_PATH);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Probes the system chcp.com utility for the console's active code page.
+ */
+function probeWindowsOemCodePage(): string | null {
+  try {
+    const codePageUtility = resolveWindowsCodePageUtility();
+    if (codePageUtility === null) {
+      return null;
+    }
+
+    const result = spawnSync(codePageUtility, [], {
+      encoding: null,
+      windowsHide: true,
+      timeout: CHCP_TIMEOUT_MS,
+      maxBuffer: CHCP_MAX_BUFFER_BYTES,
+    });
+
+    if (result.error || result.status !== 0 || !Buffer.isBuffer(result.stdout)) {
+      return null;
+    }
+
+    const codePage = parseChcpCodePage(result.stdout);
+    if (codePage === null) {
+      return null;
+    }
+    const alias = WINDOWS_CODE_PAGE_ALIASES[codePage];
+    if (alias !== undefined) {
+      return iconv.encodingExists(alias) ? alias : null;
+    }
+
+    const encoding = `cp${codePage}`;
+    return iconv.encodingExists(encoding) ? encoding : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -113,13 +239,29 @@ function detectSystemLocale(): string {
  * used by GUI applications.
  */
 export function getWindowsOemCodePage(): string {
-  if (cachedOemCodePage !== null) {
+  const now = Date.now();
+  if (cachedOemCodePage !== null && now < cachedOemCodePageExpiresAt) {
     return cachedOemCodePage;
   }
 
-  const locale = detectSystemLocale();
-  cachedOemCodePage = WINDOWS_OEM_CODE_PAGES[locale] || DEFAULT_OEM_CODE_PAGE;
-  return cachedOemCodePage;
+  if (process.platform === 'win32') {
+    if (now >= nextOemCodePageProbeAt) {
+      const detectedCodePage = probeWindowsOemCodePage();
+      if (detectedCodePage !== null) {
+        cachedOemCodePage = detectedCodePage;
+        cachedOemCodePageExpiresAt = now + CHCP_SUCCESS_CACHE_MS;
+        return cachedOemCodePage;
+      }
+      nextOemCodePageProbeAt = now + CHCP_RETRY_DELAY_MS;
+    }
+
+    if (cachedOemCodePage !== null) {
+      return cachedOemCodePage;
+    }
+  }
+
+  cachedOemCodePage = null;
+  return resolveLocaleCodePage(detectSystemLocale());
 }
 
 /**
@@ -218,7 +360,7 @@ export function decodeBuffer(buffer: Buffer, forceEncoding?: string): string {
   }
 
   // If a specific encoding is forced, use it
-  if (forceEncoding) {
+  if (forceEncoding !== undefined && forceEncoding.length > 0) {
     return iconv.decode(buffer, forceEncoding);
   }
 
@@ -244,6 +386,8 @@ export function decodeBuffer(buffer: Buffer, forceEncoding?: string): string {
  */
 export function setWindowsOemCodePageForTesting(codePage: string | null): void {
   cachedOemCodePage = codePage;
+  cachedOemCodePageExpiresAt = codePage === null ? 0 : Number.POSITIVE_INFINITY;
+  nextOemCodePageProbeAt = 0;
 }
 
 /**


### PR DESCRIPTION
## Related issue

Closes #115

## Problem / pressure

Windows child processes can emit bytes in the active console OEM code page. Locale variables do not necessarily describe that code page, so the existing locale-only fallback can decode terminal or command output incorrectly. The probe must also avoid selecting an executable through caller-controlled environment paths.

## Summary

- Resolve the kernel-owned `\\?\GLOBALROOT\SystemRoot\System32\chcp.com` path and execute that read-only utility directly, without a shell.
- Bound the probe by time and output size, validate the reported code page through `iconv-lite`, and map Windows aliases such as 65001 and 54936.
- Cache successful detection, retry transient failures without discarding a last-known-good value, and preserve locale fallback when probing cannot provide a supported encoding.
- Cover localized output, hostile environment paths, malformed or unsupported results, cache and retry behavior, CP936/GB18030 decoding, forced encodings, and non-Windows behavior.
- Record the trust and fallback decision in the repository Agent Note system.

## Visual explanation

```mermaid
flowchart TD
  A[Child-process bytes] --> B{Valid UTF-8?}
  B -- Yes --> C[Decode as UTF-8]
  B -- No, forced encoding --> D[Decode with forced encoding]
  B -- No, Windows auto mode --> E[Resolve trusted GLOBALROOT chcp.com]
  E --> F{Bounded probe returns supported code page?}
  F -- Yes --> G[Cache code page and decode]
  F -- No --> H[Infer encoding from locale precedence]
  B -- No, non-Windows auto mode --> H
  G --> I[Return decoded output]
  H --> I
  D --> I
```

The common valid UTF-8 path does not start a subprocess. Caller-controlled `SystemRoot`, `WINDIR`, `ComSpec`, `PATH`, and working-directory values cannot select the probed executable.

## Before / after

| Before | After |
| ------ | ----- |
| Invalid UTF-8 output used a locale guess that could disagree with the active Windows console code page. | Windows auto-detection first queries the active code page through a trusted, bounded probe, then falls back to locale inference if needed. |
| A transient probe failure had no prior-good state to retain. | Successful results are cached; failed refreshes retain the last known good encoding and retry later. |

## Test plan

- `corepack pnpm --dir apps/cli exec vitest run src/utils/encoding.test.ts tests/terminal-manager.test.ts` (48/48 passed)
- `corepack pnpm --dir apps/cli typecheck` (passed)
- Type-aware Oxlint on the changed source and test files (0 warnings, 0 errors)
- Prettier check on the changed source, test, guidance, and Agent Note files (passed)
- `corepack pnpm check:quick` (passed; repository lint reported 10,528 warnings and 0 errors, and all boundary/i18n checks passed)
- Live Windows probe returned `cp936`; the CP936 Chinese decoding round trip passed
- `git diff --check` (passed)
- Full `corepack pnpm check` reached `test:scripts` after typecheck and lint, then stopped because 3 unchanged documentation tests could not create Windows symlinks (`EPERM`); the same three failures reproduced on the other rebased branch
- `corepack pnpm docs check` recognizes the new Agent Note but remains non-green on this Windows checkout because tracked `CLAUDE.md` symlinks are scanned as documents

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Inspect trusted executable resolution, raw localized `chcp` parsing, encoding aliases, cache/retry state, and the final decoding integration in `apps/cli/src/utils/encoding.ts` and its tests.
- **Decisions to challenge:** Confirm that direct `GLOBALROOT` resolution, a synchronous two-second/64-KiB probe, five-minute success caching, and 30-second retry timing are appropriate Windows boundaries.
- **Plausible failures / evidence gaps:** Windows variants beyond the live CP936 host and mocked localized prefixes were not directly available; the full repository suite is blocked locally by Windows symlink privileges.

### Authoring context

- **User goal / directives:** Correct Windows child-output decoding through a focused, test-backed change that follows the current community contribution policy.
- **Constraints / non-goals:** Do not change global console state, public APIs, forced-encoding behavior, non-Windows behavior, or unrelated Windows tests.
- **Risk-bearing decisions:** Trust only the kernel-owned SystemRoot alias, execute without a shell, cap probe resources, validate support before use, and retain a last-known-good result across transient refresh failures.
- **Destructive or irreversible behavior:** The probe is read-only, does not change the active code page, and does not modify user data or process-wide environment state.
- **Deliberately not done or tested:** No native addon or registry dependency was introduced, and every localized Windows message resource was not directly exercised.
- **Unknowns / confidence:** Focused behavior, security boundaries, and live CP936 detection are covered; residual risk is limited to unusual Windows installations where the trusted alias cannot be resolved, which follows the tested locale fallback.

### Original user prompt

<details>
<summary>Show original prompt</summary>

````text
Inspect the Lody repository for concrete correctness and compatibility problems. Do not assume that code changes are required. First establish whether each suspected issue is reproducible, supported by repository evidence, and materially affects users.

Follow this process:

## Discovery

Investigate two potential compatibility problems:

1. Windows terminal output may be decoded using an encoding inferred from the system locale rather than the console's active code page. Determine whether this can corrupt child-process output in non-UTF-8 environments such as CP936 and CP950.

2. The workspace may permit Node.js versions below the actual minimum required by the CLI's SQLite functionality. Determine whether Node.js 22.0-22.13 can satisfy the declared requirements but fail when the CLI loads `node:sqlite`.

Inspect the current implementation, package metadata, tests, documentation, upstream state, related issues, and ongoing changes. Record reproducible evidence before proposing modifications.

## Review

For Windows encoding:

- Trace how the decoding charset is selected and where decoded output is consumed.
- Verify whether the active console code page can differ from locale-derived assumptions.
- Examine valid UTF-8 behavior, forced encodings, localized `chcp` output, unsupported code pages, command failures, timeouts, caching, and fallback behavior.
- Preserve existing correct behavior and public interfaces.

For the Node.js runtime requirement:

- Determine the exact minimum Node.js version from the runtime APIs actually used by the CLI.
- Compare root and package-level declarations, development runtime metadata, documentation, and tests.
- Check for related ongoing work to avoid redundant or conflicting changes.

## Ideas

Prefer narrowly scoped, conservative fixes over broad refactoring.

For Windows encoding, consider detecting the active console code page once, parsing its numeric value independently of localized text, accepting it only when supported by the decoder, and retaining a deterministic locale-based fallback. Any system command should have bounded execution time and output size.

For the Node.js requirement, consider aligning the workspace runtime floor with the first version that safely supports the CLI's SQLite functionality, then add a regression check to prevent the declarations from drifting again.

Keep the two concerns independent. Do not include unrelated package naming, licensing, repository metadata, or architectural changes.

## Decision

Before modifying files, report:

- whether each suspected defect is confirmed;
- the observable user impact;
- the relevant code and version evidence;
- the alternatives considered;
- the smallest defensible fix;
- regression risks and required tests.

Implement changes only for confirmed defects. Add focused regression coverage, run the relevant type checks and repository validation, and review the final diff for compatibility regressions. Clearly distinguish newly introduced failures from existing baseline failures, and do not expose private paths, credentials, or unrelated conversation history.
````

</details>
### Shared conversation

Status: unavailable
Reason: Codex cannot publish a scoped Lody-only link from this multi-project conversation without exposing unrelated private context.
<!-- context-handoff:end -->
