### PR TITLE
fix(electron): block untrusted main-window navigation

### DIFF
--- a/apps/electron/src/main/window.ts
+++ b/apps/electron/src/main/window.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, dialog, nativeTheme, shell } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import {
   consumePendingDeepLink,
   getMainWindow,
@@ -155,6 +156,34 @@ function loadRendererTarget(window: BrowserWindow, target: ReloadTarget): Promis
     return window.loadURL(target.url)
   }
   return window.loadFile(target.filePath, target.hash ? { hash: target.hash } : undefined)
+}
+
+function isTrustedNavigation(url: string, targets: readonly ReloadTarget[]): boolean {
+  if (!URL.canParse(url)) return false
+
+  const candidate = new URL(url)
+  candidate.hash = ''
+  candidate.search = ''
+  return targets.some((target) => {
+    if (target.type === 'url') return candidate.origin === new URL(target.url).origin
+    return candidate.href === pathToFileURL(target.filePath).href
+  })
+}
+
+function installNavigationGuard(window: BrowserWindow, targets: readonly ReloadTarget[]): void {
+  const preventUntrustedNavigation = (event: { url: string; preventDefault: () => void }): void => {
+    if (isTrustedNavigation(event.url, targets)) return
+
+    event.preventDefault()
+    const externalUrl = normalizeExternalHttpUrl(event.url)
+    if (externalUrl) {
+      void shell.openExternal(externalUrl)
+    }
+    console.warn('[Electron] Blocked main window navigation', { url: event.url })
+  }
+
+  window.webContents.on('will-navigate', preventUntrustedNavigation)
+  window.webContents.on('will-redirect', preventUntrustedNavigation)
 }
 
 async function showUnresponsiveDialog(window: BrowserWindow): Promise<void> {
@@ -328,6 +357,7 @@ export function createMainWindow(options: CreateMainWindowOptions): BrowserWindo
   trackMainWindowState(window)
   const mainTarget = resolveMainRendererTarget(options.initialPath)
   const recoveryTarget = resolveRecoveryTarget()
+  installNavigationGuard(window, [mainTarget, recoveryTarget])
   setReloadTarget(window, mainTarget)
   attachMainWindowDiagnostics(window, recoveryTarget)
 


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

The privileged Electron main window could navigate to a remote document while retaining its preload bridge, allowing remote content to reach high-privilege IPC and ultimately execute local commands.

## Summary

Restrict top-level main-window navigations and redirects to the existing application and recovery renderer targets. Blocked HTTP(S) destinations are opened in the system browser.

## Before / after

| Before | After |
| ------ | ----- |
| Remote content could replace the main renderer and retain privileged preload access. | The main window prevents untrusted navigation before commit and keeps only application-owned targets. |

## Test plan

- Ran Electron main/preload TypeScript checking successfully.
- Ran the existing Electron test suite: 43 tests passed.
- Ran `git diff --check` successfully.

## Agent handoff

<!-- agent-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Inspect `apps/electron/src/main/window.ts`, especially URL normalization and both navigation event handlers.
- **Decisions to challenge:** Confirm same-origin development navigation and exact packaged-file matching are the intended trust boundaries.
- **Plausible failures / evidence gaps:** No dedicated navigation test or manual packaged Electron smoke test was added; verification used type checking and the existing suite.

### Authoring context

- **User goal / directives:** Fix remote navigation retaining privileged Electron IPC, use an isolated worktree, keep names concise, and create a PR.
- **Constraints / non-goals:** Keep the change narrow; do not add test files, documentation changes, preload changes, or broad IPC refactors.
- **Risk-bearing decisions:** Reuse the resolved application and recovery targets as the allowlist, compare development targets by origin, and open blocked HTTP(S) URLs externally.
- **Destructive or irreversible behavior:** None; the change only prevents unsafe navigation and redirects HTTP(S) destinations to the system browser.
- **Deliberately not done or tested:** No new `.mjs` test and no manual packaged-app smoke test, per the requested narrow scope.
- **Unknowns / confidence:** High confidence in Electron 39 event typing and existing test coverage; packaged navigation behavior was not exercised manually.

### Sharing consent (author side)

- [x] Author-side user explicitly allowed publishing the Authoring context above
- [ ] Author-side user explicitly declined publishing Authoring context and understands that maintainers may decline or close the contribution; keep every field as `N/A` / redacted

<!-- agent-handoff:end -->