### PR TITLE
fix(electron): detect available session path launchers

### DIFF
--- a/apps/electron/src/main/ipc/services/app-ipc.ts
+++ b/apps/electron/src/main/ipc/services/app-ipc.ts
@@ -4,6 +4,7 @@ import {
   GLOBAL_SHORTCUT_DEFAULTS,
   IPC_PUSH_CHANNELS,
   LaunchLocalPathInputSchema,
+  PathLauncherProbeSchema,
   type NativeThemeSource,
   type RendererFatalErrorReport,
   type SetGlobalShortcutInput,
@@ -11,7 +12,7 @@ import {
 } from '@lody/shared/electron-ipc'
 import { getIpcServiceDeps } from '../ipc-service-deps'
 import { setMenuLanguage } from '../../menu'
-import { launchLocalPath } from '../../services/local-path-launcher-service'
+import { hasPathLauncher, launchLocalPath } from '../../services/local-path-launcher-service'
 import { parseWindowBadge } from '../../services/window-badge-service'
 import {
   findWindow,
@@ -212,6 +213,25 @@ export class AppIpc extends IpcService {
       return { launched: false as const, error: 'invalid_payload' }
     }
     return await launchLocalPath(parsed.data)
+  }
+
+  @IpcMethod()
+  async probePathLaunchers(payload: unknown) {
+    const parsed = PathLauncherProbeSchema.safeParse(payload)
+    if (!parsed.success) {
+      return { availableIds: [] }
+    }
+    const availability = await Promise.all(
+      parsed.data.launchers.map(async ({ launcherId, input }) => ({
+        launcherId,
+        available: await hasPathLauncher(input)
+      }))
+    )
+    return {
+      availableIds: availability
+        .filter(({ available }) => available)
+        .map(({ launcherId }) => launcherId)
+    }
   }
 
   @IpcMethod()

--- a/apps/electron/src/main/services/local-path-launcher-core.test.mjs
+++ b/apps/electron/src/main/services/local-path-launcher-core.test.mjs
@@ -1,6 +1,60 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { launchCommandPathWithFallback } from './local-path-launcher-core.ts'
+import { launchCommandPathWithFallback, probePathLauncher } from './local-path-launcher-core.ts'
+
+void test('reports a launcher available when any command candidate exists', async () => {
+  const checked = []
+  const available = await probePathLauncher(
+    {
+      kind: 'command',
+      command: { command: 'cursor' },
+      fallbackCommands: [{ command: '/Applications/Cursor.app/cursor' }],
+      targetPath: '/Users/me/project'
+    },
+    async ({ command }) => {
+      checked.push(command)
+      return command.startsWith('/Applications/')
+    },
+    async () => false
+  )
+
+  assert.equal(available, true)
+  assert.deepEqual(checked, ['cursor', '/Applications/Cursor.app/cursor'])
+})
+
+void test('uses a registered protocol after command candidates are unavailable', async () => {
+  let checkedProtocol = null
+  const available = await probePathLauncher(
+    {
+      kind: 'command',
+      command: { command: 'code' },
+      fallbackUrl: 'vscode://file/Users/me/project',
+      targetPath: '/Users/me/project'
+    },
+    async () => false,
+    async (url) => {
+      checkedProtocol = url
+      return true
+    }
+  )
+
+  assert.equal(available, true)
+  assert.equal(checkedProtocol, 'vscode://file/Users/me/project')
+})
+
+void test('reports a URL launcher unavailable when its protocol is not registered', async () => {
+  const available = await probePathLauncher(
+    {
+      kind: 'url',
+      url: 'warp://action/new_tab?path=%2Ftmp',
+      targetPath: '/tmp'
+    },
+    async () => true,
+    async () => false
+  )
+
+  assert.equal(available, false)
+})
 
 void test('opens the deeplink after every command candidate fails', async () => {
   const attempts = []

--- a/apps/electron/src/main/services/local-path-launcher-core.ts
+++ b/apps/electron/src/main/services/local-path-launcher-core.ts
@@ -6,6 +6,26 @@ import type {
 
 type CommandLaunchInput = Extract<LaunchLocalPathInput, { kind: 'command' }>
 
+export async function probePathLauncher(
+  input: LaunchLocalPathInput,
+  commandAvailable: (command: LocalPathCommandSpec) => Promise<boolean>,
+  protocolAvailable: (url: string) => Promise<boolean>
+): Promise<boolean> {
+  if (input.kind === 'url') {
+    return protocolAvailable(input.url)
+  }
+
+  const availabilityChecks = [commandAvailable(input.command)]
+  if (input.fallbackCommands) {
+    for (const command of input.fallbackCommands) {
+      availabilityChecks.push(commandAvailable(command))
+    }
+  }
+  const commandAvailability = await Promise.all(availabilityChecks)
+  if (commandAvailability.some(Boolean)) return true
+  return input.fallbackUrl ? protocolAvailable(input.fallbackUrl) : false
+}
+
 export async function launchCommandPathWithFallback(
   input: CommandLaunchInput,
   launchCommand: (command: LocalPathCommandSpec) => Promise<LaunchLocalPathResult>,

--- a/apps/electron/src/main/services/local-path-launcher-service.ts
+++ b/apps/electron/src/main/services/local-path-launcher-service.ts
@@ -1,4 +1,7 @@
-import { shell } from 'electron'
+import { constants as fsConstants } from 'node:fs'
+import { access, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { app, shell } from 'electron'
 import { spawn } from 'node:child_process'
 import type {
   LaunchLocalPathInput,
@@ -6,8 +9,11 @@ import type {
   LocalPathCommandSpec
 } from '@lody/shared/electron-ipc'
 import { formatUnknownError } from '../utils'
-import { launchCommandPathWithFallback } from './local-path-launcher-core'
+import { launchCommandPathWithFallback, probePathLauncher } from './local-path-launcher-core'
 import { getUserShellEnvCached, shouldUseWindowsShell } from './shell-env'
+
+const PROBE_CACHE_MS = 5 * 60 * 1000
+const probeCache = new Map<string, { available: boolean; checkedAt: number }>()
 
 // Editors launch via their CLI first. VS Code falls back to its protocol handler
 // when no CLI candidate is available; Warp always launches through its protocol.
@@ -23,6 +29,96 @@ function normalizeAllowedLocalLaunchUrl(value: string): string | null {
   } catch {
     return null
   }
+}
+
+async function hasPath(filePath: string): Promise<boolean> {
+  return stat(filePath).then(
+    async (info) => {
+      if (!info.isFile()) return false
+      return access(
+        filePath,
+        process.platform === 'win32' ? fsConstants.F_OK : fsConstants.X_OK
+      ).then(
+        () => true,
+        () => false
+      )
+    },
+    () => false
+  )
+}
+
+async function hasMacApp(name: string): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const child = spawn('/usr/bin/open', ['-Ra', name], {
+      shell: false,
+      stdio: 'ignore'
+    })
+    child.once('error', () => resolve(false))
+    child.once('close', (code) => resolve(code === 0))
+  })
+}
+
+async function hasCommand(command: string, args?: readonly string[]): Promise<boolean> {
+  const applicationName =
+    process.platform === 'darwin' && path.basename(command) === 'open' && args && args[0] === '-a'
+      ? args[1]
+      : undefined
+  const cacheKey = `command:${command}:${applicationName ? applicationName : ''}`
+  const cached = probeCache.get(cacheKey)
+  if (cached && Date.now() - cached.checkedAt < PROBE_CACHE_MS) {
+    return cached.available
+  }
+
+  let available = false
+  // `/usr/bin/open` exists on every Mac, but `open -a Foo` is launchable only
+  // when Foo is installed. This also covers custom launchers using that idiom.
+  if (applicationName) {
+    available = await hasMacApp(applicationName)
+  } else if (path.isAbsolute(command) || command.includes('/') || command.includes('\\')) {
+    available = await hasPath(command)
+  } else {
+    const shellEnv = await getUserShellEnvCached()
+    const env = shellEnv ? { ...process.env, ...shellEnv } : process.env
+    const pathValue = env.PATH ? env.PATH : ''
+    const pathEntries = pathValue.split(path.delimiter).filter(Boolean)
+    const extensions =
+      process.platform === 'win32'
+        ? (env.PATHEXT ? env.PATHEXT : '.COM;.EXE;.BAT;.CMD').split(';').filter(Boolean)
+        : ['']
+    const commandHasExtension = process.platform === 'win32' && path.extname(command) !== ''
+    const candidates = pathEntries.flatMap((entry) =>
+      commandHasExtension
+        ? [path.join(entry, command)]
+        : extensions.map((extension) => path.join(entry, `${command}${extension}`))
+    )
+    available = (await Promise.all(candidates.map(hasPath))).some(Boolean)
+  }
+
+  probeCache.set(cacheKey, { available, checkedAt: Date.now() })
+  return available
+}
+
+async function hasProtocol(urlValue: string): Promise<boolean> {
+  if (!URL.canParse(urlValue)) return false
+  const protocol = new URL(urlValue).protocol
+
+  const cacheKey = `protocol:${protocol}`
+  const cached = probeCache.get(cacheKey)
+  if (cached && Date.now() - cached.checkedAt < PROBE_CACHE_MS) {
+    return cached.available
+  }
+
+  const available = app.getApplicationNameForProtocol(`${protocol}//`).length > 0
+  probeCache.set(cacheKey, { available, checkedAt: Date.now() })
+  return available
+}
+
+export function hasPathLauncher(input: LaunchLocalPathInput): Promise<boolean> {
+  return probePathLauncher(
+    input,
+    (candidate) => hasCommand(candidate.command, candidate.args),
+    hasProtocol
+  )
 }
 
 async function canResolveWindowsShellCommand(

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -153,6 +153,7 @@ import { getAppShareUrl } from '@/lib/app-location';
 import { resolveSessionOpenInIdePathTarget } from '@/lib/session-open-in-ide-path';
 import {
   buildPathLauncherLaunchInput,
+  buildPathLauncherProbes,
   getAvailablePathLauncherOptions,
   getPathLauncherId,
   PATH_LAUNCHER_PREFERENCE_CHANGED_EVENT,
@@ -5173,8 +5174,6 @@ export const SessionChatInterface = memo(
     );
     const openInIdePath = openInIdeTarget?.path ?? null;
     const openInIdePathSource = openInIdeTarget?.source ?? null;
-    const shouldShowOpenInIdeButton = Boolean(openInIdePath);
-
     const resolveOpenInIdePath = useCallback(async (): Promise<string | null> => {
       return openInIdePath;
     }, [openInIdePath]);
@@ -5206,7 +5205,7 @@ export const SessionChatInterface = memo(
       typeof window !== 'undefined' && window.__LODY_ELECTRON__ === true;
     const electronPathLauncherPlatform =
       typeof window !== 'undefined' ? window.__LODY_PLATFORM__?.os : undefined;
-    const pathLauncherOptions = useMemo(
+    const launcherCandidates = useMemo(
       () =>
         getAvailablePathLauncherOptions({
           customLaunchers: pathLauncherPreference.customLaunchers,
@@ -5219,6 +5218,54 @@ export const SessionChatInterface = memo(
         pathLauncherPreference.customLaunchers,
       ]
     );
+    const [availableLauncherIds, setAvailableLauncherIds] = useState(new Set<string>());
+    useEffect(() => {
+      if (!isElectronRendererForPathLaunch || !openInIdePath) {
+        setAvailableLauncherIds(new Set());
+        return undefined;
+      }
+      const services = getIpcServices();
+      if (!services) return undefined;
+
+      let cancelled = false;
+      const launchers = buildPathLauncherProbes(
+        launcherCandidates,
+        openInIdePath,
+        electronPathLauncherPlatform
+      );
+      void services.app
+        .probePathLaunchers({
+          launchers,
+        })
+        .then(
+          (result) => {
+            if (!cancelled) {
+              setAvailableLauncherIds(new Set(result.availableIds));
+            }
+          },
+          () => {
+            // A failed probe must not advertise launchers whose presence could
+            // not be established.
+            if (!cancelled) setAvailableLauncherIds(new Set());
+          }
+        );
+      return () => {
+        cancelled = true;
+      };
+    }, [
+      launcherCandidates,
+      electronPathLauncherPlatform,
+      isElectronRendererForPathLaunch,
+      openInIdePath,
+    ]);
+    const pathLauncherOptions = useMemo(
+      () =>
+        launcherCandidates.filter((launcher) =>
+          availableLauncherIds.has(getPathLauncherId(launcher))
+        ),
+      [availableLauncherIds, launcherCandidates]
+    );
+    const shouldShowOpenInIdeButton = Boolean(openInIdePath) && pathLauncherOptions.length > 0;
     const selectedPathLauncher = useMemo(
       () =>
         resolveSelectedPathLauncher(pathLauncherPreference.selectedLauncherId, pathLauncherOptions),

--- a/packages/components/src/lib/session-path-launchers.ts
+++ b/packages/components/src/lib/session-path-launchers.ts
@@ -449,3 +449,23 @@ export function buildPathLauncherLaunchInput(
 
   throw new Error(`Path launcher ${launcher.id} cannot build a launch request`);
 }
+
+export function buildPathLauncherProbes(
+  launchers: readonly PathLauncherOption[],
+  targetPath: string,
+  platform?: string | null
+): Array<{ launcherId: string; input: LaunchLocalPathInput }> {
+  const checks: Array<{ launcherId: string; input: LaunchLocalPathInput }> = [];
+  for (const launcher of launchers) {
+    if (
+      launcher.kind === 'custom' &&
+      !validateCustomPathLauncherCommandTemplate(launcher.commandTemplate).ok
+    )
+      continue;
+    checks.push({
+      launcherId: getPathLauncherId(launcher),
+      input: buildPathLauncherLaunchInput(launcher, targetPath, platform),
+    });
+  }
+  return checks;
+}

--- a/packages/components/tests/session-path-launchers.test.ts
+++ b/packages/components/tests/session-path-launchers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { pathLauncherPreferenceSchema } from '../src/lib/local-storage-cache';
 import {
   buildPathLauncherLaunchInput,
+  buildPathLauncherProbes,
   buildVSCodePathLauncherFallbackUrl,
   getAvailablePathLauncherOptions,
   getCustomPathLauncherOptionId,
@@ -112,6 +113,23 @@ describe('custom path launcher command templates', () => {
       targetPath: '/Users/me/My Project',
       label: 'Code Insiders',
     });
+  });
+
+  it('skips invalid stored custom launchers during availability checks', () => {
+    expect(
+      buildPathLauncherProbes(
+        [
+          {
+            id: 'broken',
+            kind: 'custom',
+            launcherId: getCustomPathLauncherOptionId('broken'),
+            label: 'Broken',
+            commandTemplate: 'broken-without-a-path',
+          },
+        ],
+        '/Users/me/project'
+      )
+    ).toEqual([]);
   });
 });
 

--- a/packages/shared/src/electron-ipc.ts
+++ b/packages/shared/src/electron-ipc.ts
@@ -163,6 +163,21 @@ export const LaunchLocalPathInputSchema = z.discriminatedUnion('kind', [
 
 export type LaunchLocalPathInput = z.infer<typeof LaunchLocalPathInputSchema>;
 
+export const PathLauncherProbeSchema = z
+  .object({
+    launchers: z
+      .array(
+        z
+          .object({
+            launcherId: z.string().trim().min(1).max(200),
+            input: LaunchLocalPathInputSchema,
+          })
+          .strict()
+      )
+      .max(30),
+  })
+  .strict();
+
 export type LaunchLocalPathResult =
   | {
       launched: true;


### PR DESCRIPTION
## Related issue

Fix https://github.com/LodyAI/Lody/issues/138

## Problem / pressure

The Session header advertised every platform-compatible path launcher, even when the corresponding editor or URL protocol was not installed on the local machine. Selecting one then failed only after the user tried to launch it.

## Summary

- Add a validated Electron IPC probe for path-launcher availability.
- Resolve command candidates through the user's cached shell `PATH`, platform executable rules, known absolute fallbacks, macOS application lookup, and registered URL protocols.
- Filter the Session header launcher button and menu to the launcher IDs confirmed by the main process.
- Keep invalid stored custom launcher templates out of probe requests.

## Before / after

| Before | After |
| :--: | :--: |
| Shows all supported editors, even if they are not installed. | Shows only editors installed on this machine. |
| <img width="120" alt="Before: all supported editors are shown" src="https://github.com/user-attachments/assets/8e106e23-76f4-43f8-b84a-7dbfa224e59e" /> | <img width="120" alt="After: only installed editors are shown" src="https://github.com/user-attachments/assets/49d2bf6c-7a39-4197-aecc-7568b3cb57c1" /> |

## Test plan

- `node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test src/main/services/local-path-launcher-core.test.mjs` — 5 tests passed.
- Electron package test run reached 45 passing tests; the unrelated Loro data-plane test could not start because this worktree lacked the linked `zod` dependency.
- The focused components test could not start because this worktree lacked its linked Vitest module.
- No further tests were run after the final diff-only review, per the author-side user's instruction.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the probe boundary in `app-ipc.ts`, cross-platform command discovery in `local-path-launcher-service.ts`, and filtering lifecycle in `session-chat-interface.tsx`.
- **Decisions to challenge:** Verify that a five-minute per-command/protocol cache is the right balance for multiple mounted Session surfaces.
- **Plausible failures / evidence gaps:** Windows and Linux discovery paths were reviewed but not exercised on those operating systems, and the components test runner was unavailable in the worktree.

### Authoring context

- **User goal / directives:** Make the Session header dynamically show only locally available editors and keep the uncommitted change small and necessary.
- **Constraints / non-goals:** Do not broaden launcher behavior, add cloud dependencies, or retain temporary file moves and duplicate tests.
- **Risk-bearing decisions:** Availability is determined in Electron main from commands, fallbacks, macOS application lookup, and registered URL protocols, then cached for five minutes.
- **Destructive or irreversible behavior:** The change only probes local availability and filters UI options; it performs no destructive or irreversible action.
- **Deliberately not done or tested:** No further tests were run after the author-side user requested diff-only review; Windows and Linux runtime probing was not exercised.
- **Unknowns / confidence:** Confidence is high in the IPC and filtering flow; residual risk is platform-specific command and protocol discovery behavior.

<!-- context-handoff:end -->
