### PR TITLE
fix: preserve skill mentions for custom agents

### DIFF
--- a/packages/components/src/components/mentions/AGENTS.md
+++ b/packages/components/src/components/mentions/AGENTS.md
@@ -20,7 +20,9 @@ Product-level mention sources built on `src/ui/mention`.
   each filtered by the provider's `getRegisteredGlobalSkillDirs` /
   `getRegisteredSystemSkillDirs`. `~/.agents/skills` is a provider-specific
   alias, not a universal fallback: only providers with verified support register
-  it. The scanner handles flat `~/<agent>/skills/<skill>/SKILL.md` and catalog
+  it. An unregistered agent type has no mention-directory whitelist and may use
+  every scanned skill; a registered type with no directories keeps an explicit
+  empty whitelist. The scanner handles flat `~/<agent>/skills/<skill>/SKILL.md` and catalog
   `~/<agent>/skills/<category>/<skill>/SKILL.md`; paths outside the provider's
   registered roots (e.g. plugin caches) appear only once their dirs are added.
 - Before send, known `$` skill tokens are expanded in prompt text to

--- a/packages/components/src/components/mentions/mention-skill-source.tsx
+++ b/packages/components/src/components/mentions/mention-skill-source.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useAtomValue } from 'jotai';
 import {
+  ACP_SKILL_DIRS_BY_AGENT_TYPE,
   compareProjectSkillScope,
   getRegisteredGlobalSkillDirs,
   getRegisteredSkillDirs,
@@ -167,6 +168,9 @@ export function getAllowedSkillMentionDirs(
   skillAgent: { cliType?: AgentConfigCliType; agentType?: string } | undefined
 ): ReadonlySet<string> | null {
   if (!skillAgent?.cliType || !skillAgent.agentType) {
+    return null;
+  }
+  if (!(skillAgent.agentType in ACP_SKILL_DIRS_BY_AGENT_TYPE)) {
     return null;
   }
   const agent = { cliType: skillAgent.cliType, agentType: skillAgent.agentType };

--- a/packages/components/tests/mention-skill-source.test.ts
+++ b/packages/components/tests/mention-skill-source.test.ts
@@ -3,6 +3,7 @@ import { applyTextRewrites, type ProjectSkill, type ProjectSkillGroup } from '@l
 import {
   buildSkillMentionItems,
   buildSkillMentionRewrites,
+  getAllowedSkillMentionDirs,
   getSkillMentionToken,
   hydrateSkillMentionsFromText,
   mergeMentionSkillState,
@@ -197,6 +198,43 @@ describe('selectSkillMentionCandidates', () => {
   });
 });
 
+describe('getAllowedSkillMentionDirs', () => {
+  it.each(['custom-1234', 'unknown-agent'])(
+    'does not restrict scanned skills for unregistered agent type %s',
+    (agentType) => {
+      expect(getAllowedSkillMentionDirs({ cliType: 'custom', agentType })).toBeNull();
+    }
+  );
+
+  it('returns the registered project and global directories for a known agent', () => {
+    expect(getAllowedSkillMentionDirs({ cliType: 'claude', agentType: 'claude-code' })).toEqual(
+      new Set(['.claude/skills', '~/.claude/skills'])
+    );
+  });
+
+  it('preserves an explicitly registered empty directory set', () => {
+    expect(getAllowedSkillMentionDirs({ cliType: 'deepagents', agentType: 'deepagents' })).toEqual(
+      new Set()
+    );
+  });
+
+  it('keeps scanned candidates for a custom agent', () => {
+    const items = buildSkillMentionItems(GROUPS);
+    const allowedDirs = getAllowedSkillMentionDirs({
+      cliType: 'custom',
+      agentType: 'custom-1234',
+    });
+
+    expect(selectSkillMentionCandidates(items, '', allowedDirs).map((item) => item.token)).toEqual([
+      'claude-only',
+      'code-review',
+      'deep-research',
+      'global-only',
+      'qwen-only',
+    ]);
+  });
+});
+
 describe('hydrateSkillMentionsFromText', () => {
   it('rebuilds ranges for known $tokens only', () => {
     const known = new Set(['code-review', 'deep-research']);
@@ -219,11 +257,7 @@ describe('buildSkillMentionRewrites', () => {
   });
 
   it('expands global skill tokens to absolute skill paths when present', () => {
-    const result = expandInText(
-      'run $global-only',
-      items,
-      new Set(['~/.claude/skills'])
-    );
+    const result = expandInText('run $global-only', items, new Set(['~/.claude/skills']));
 
     expect(result).toBe(
       'run use /global-only [Skill Path](/home/user/.claude/skills/global-only/SKILL.md)'
@@ -231,11 +265,7 @@ describe('buildSkillMentionRewrites', () => {
   });
 
   it('uses the selected provider directories before resolving duplicate tokens', () => {
-    const result = expandInText(
-      'run $code-review',
-      items,
-      new Set(['.claude/skills'])
-    );
+    const result = expandInText('run $code-review', items, new Set(['.claude/skills']));
 
     expect(result).toBe('run use /code-review [Skill Path](.claude/skills/code-review/SKILL.md)');
   });


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Custom command configurations receive generated `custom-<uuid>` agent types that are not registered in `ACP_SKILL_DIRS_BY_AGENT_TYPE`. The skill mention source converted that missing mapping into an empty `Set`, which is truthy and therefore filtered every scanned `$` skill candidate out of the menu.

## Summary

- Return `null` from `getAllowedSkillMentionDirs` when the selected agent type is not registered, preserving the existing meaning of `null` as no whitelist restriction.
- Keep registered agents on the existing directory aggregation path, including explicit empty mappings such as `deepagents`.
- Add regression coverage for custom and unknown agents, known directory mappings, explicit empty mappings, and candidate preservation.
- Document the registered-versus-unregistered whitelist contract near the mention source.

## Before / after

| Before | After |
| ------ | ----- |
| Custom and unknown agents received a truthy empty whitelist, so all scanned skill candidates were removed. | Custom and unknown agents have no whitelist restriction and retain all scanned candidates. |
| Registered empty mappings and missing mappings were indistinguishable. | Registered empty mappings remain explicit empty whitelists while missing mappings return `null`. |

## Test plan

- Red regression run on the pre-fix implementation: `@lody/components` suite reported the three new assertions failing while 2,735 existing tests passed.
- `corepack pnpm --filter @lody/components exec vitest run tests/mention-skill-source.test.ts` — 23 tests passed.
- `corepack pnpm --filter @lody/components test` — 382 files and 2,738 tests passed.
- `corepack pnpm --filter @lody/components typecheck` — passed.
- `corepack pnpm exec oxlint --quiet packages/components/src/components/mentions/mention-skill-source.tsx packages/components/tests/mention-skill-source.test.ts` — no warnings or errors.
- Prettier check and `git diff --check` — passed.

## Agent handoff

<!-- agent-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the registered-agent membership guard in `mention-skill-source.tsx` and the custom/known/explicit-empty cases in `mention-skill-source.test.ts`.
- **Decisions to challenge:** Confirm that `null` correctly means no mention-directory restriction for unregistered agents while a registered empty mapping remains restrictive.
- **Plausible failures / evidence gaps:** The pure selector and full component suite were exercised, but the packaged Electron UI was not launched for an interactive `$` menu smoke test.

### Authoring context

- **User goal / directives:** Fix empty `$` skill candidates for custom commands, add focused tests, commit the change, fork the repository, and open an upstream pull request.
- **Constraints / non-goals:** Keep the change in the mention source, import the shared agent directory registry, preserve known-agent and explicit-empty semantics, and avoid redundant fallback logic or unrelated refactoring.
- **Risk-bearing decisions:** Unregistered agent types may use every skill already scanned by Lody instead of being constrained by a provider directory whitelist.
- **Destructive or irreversible behavior:** None; the change only affects candidate filtering and documentation.
- **Deliberately not done or tested:** No packaged Electron build or interactive UI smoke test was run because the behavior is covered at the pure selection boundary and by the complete component suite.
- **Unknowns / confidence:** High confidence in the filtering fix; residual risk is limited to integration behavior outside the tested component paths.

### Sharing consent (author side)

- [x] Author-side user explicitly allowed publishing the Authoring context above
- [ ] Author-side user explicitly declined publishing Authoring context and understands that maintainers may decline or close the contribution; keep every field as `N/A` / redacted

<!-- agent-handoff:end -->
