### PR TITLE
fix(components): use registered local Machine RPC bridge

### DIFF
--- a/packages/components/src/providers/workspace-machine-rpc-facade.ts
+++ b/packages/components/src/providers/workspace-machine-rpc-facade.ts
@@ -94,14 +94,8 @@ const toCodeCollabTransportError = (error: unknown): CodeCollabV2Error => ({
   retryable: true,
 });
 
-const getLocalMachineRpcSender = (): LocalMachineRpcSender | null => {
-  if (typeof window === 'undefined') return null;
-  const api = (window as unknown as { readonly api?: { readonly sendLocalMachineRpc?: unknown } })
-    .api;
-  return typeof api?.sendLocalMachineRpc === 'function'
-    ? (api.sendLocalMachineRpc as LocalMachineRpcSender)
-    : null;
-};
+const getLocalMachineRpcSender = (): LocalMachineRpcSender | undefined =>
+  getIpcServices()?.machineRpc.send;
 
 export function createWorkspaceMachineRpcFacade(deps: WorkspaceMachineRpcFacadeDeps) {
   const { workspaceId, targetRouter, getMachineRpcClient } = deps;

--- a/packages/components/tests/workspace-machine-rpc-facade.test.ts
+++ b/packages/components/tests/workspace-machine-rpc-facade.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
 
 describe('createWorkspaceMachineRpcFacade', () => {
   it('uses the local-only IPC preview method without creating a cloud client', async () => {
-    const sendLocalMachineRpc = vi.fn(async () => ({
+    const invoke = vi.fn(async () => ({
       ok: true as const,
       result: {
         status: 'ok' as const,
@@ -30,7 +30,7 @@ describe('createWorkspaceMachineRpcFacade', () => {
     }));
     vi.stubGlobal('window', {
       __LODY_ELECTRON__: true,
-      api: { sendLocalMachineRpc },
+      ipc: { invoke },
     });
     const getMachineRpcClient = vi.fn();
     const facade = createWorkspaceMachineRpcFacade({
@@ -48,7 +48,8 @@ describe('createWorkspaceMachineRpcFacade', () => {
         path: '/Users/me/Documents/notes.md',
       })
     ).resolves.toMatchObject({ status: 'ok', external: true, readonly: true });
-    expect(sendLocalMachineRpc).toHaveBeenCalledWith(
+    expect(invoke).toHaveBeenCalledWith(
+      'machineRpc.send',
       expect.objectContaining({
         machineId: localMachineId,
         workspaceId,
@@ -60,10 +61,10 @@ describe('createWorkspaceMachineRpcFacade', () => {
   });
 
   it('does not fall back to a cloud preview while Electron local routing is unresolved', async () => {
-    const sendLocalMachineRpc = vi.fn();
+    const invoke = vi.fn();
     vi.stubGlobal('window', {
       __LODY_ELECTRON__: true,
-      api: { sendLocalMachineRpc },
+      ipc: { invoke },
     });
     const getMachineRpcClient = vi.fn();
     const facade = createWorkspaceMachineRpcFacade({
@@ -80,12 +81,12 @@ describe('createWorkspaceMachineRpcFacade', () => {
     await expect(
       facade.requestFilePreview(localMachineId, { sessionId, path: '/tmp/local.txt' })
     ).resolves.toMatchObject({ status: 'error', code: 'transient_io' });
-    expect(sendLocalMachineRpc).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
     expect(getMachineRpcClient).not.toHaveBeenCalled();
   });
 
   it('uses the local bridge for a file-index snapshot without creating a cloud client', async () => {
-    const sendLocalMachineRpc = vi.fn(async () => ({
+    const invoke = vi.fn(async () => ({
       ok: true as const,
       result: {
         status: 'ok' as const,
@@ -96,7 +97,7 @@ describe('createWorkspaceMachineRpcFacade', () => {
     }));
     vi.stubGlobal('window', {
       __LODY_ELECTRON__: true,
-      api: { sendLocalMachineRpc },
+      ipc: { invoke },
     });
     const getMachineRpcClient = vi.fn();
     const facade = createWorkspaceMachineRpcFacade({
@@ -118,7 +119,8 @@ describe('createWorkspaceMachineRpcFacade', () => {
       status: 'ok',
       fileIndex: { 'src/local.ts': { kind: 'file' } },
     });
-    expect(sendLocalMachineRpc).toHaveBeenCalledWith(
+    expect(invoke).toHaveBeenCalledWith(
+      'machineRpc.send',
       expect.objectContaining({
         machineId: localMachineId,
         workspaceId,
@@ -131,7 +133,7 @@ describe('createWorkspaceMachineRpcFacade', () => {
   });
 
   it('uses the local bridge without creating a cloud client for the local machine', async () => {
-    const sendLocalMachineRpc = vi.fn(async () => ({
+    const invoke = vi.fn(async () => ({
       ok: true as const,
       result: {
         type: 'session/cancel_response' as const,
@@ -141,7 +143,7 @@ describe('createWorkspaceMachineRpcFacade', () => {
     }));
     vi.stubGlobal('window', {
       __LODY_ELECTRON__: true,
-      api: { sendLocalMachineRpc },
+      ipc: { invoke },
     });
     const getMachineRpcClient = vi.fn();
     const facade = createWorkspaceMachineRpcFacade({
@@ -160,7 +162,8 @@ describe('createWorkspaceMachineRpcFacade', () => {
         success: true,
       }
     );
-    expect(sendLocalMachineRpc).toHaveBeenCalledWith(
+    expect(invoke).toHaveBeenCalledWith(
+      'machineRpc.send',
       expect.objectContaining({
         machineId: localMachineId,
         workspaceId,
@@ -171,10 +174,10 @@ describe('createWorkspaceMachineRpcFacade', () => {
   });
 
   it('uses the cloud Machine RPC client for a remote machine', async () => {
-    const sendLocalMachineRpc = vi.fn();
+    const invoke = vi.fn();
     vi.stubGlobal('window', {
       __LODY_ELECTRON__: true,
-      api: { sendLocalMachineRpc },
+      ipc: { invoke },
     });
     const requestSessionCancel = vi.fn(async () => ({
       type: 'session/cancel_response' as const,
@@ -204,6 +207,6 @@ describe('createWorkspaceMachineRpcFacade', () => {
       turnId: 'turn-1',
       timeoutMs: 2_000,
     });
-    expect(sendLocalMachineRpc).not.toHaveBeenCalled();
+    expect(invoke).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Electron's preload migration removed the legacy `window.api.sendLocalMachineRpc` bridge and replaced it with the typed `window.ipc` bridge, but `workspace-machine-rpc-facade` still looked up the removed API. As a result, local Machine RPC requests made through that facade reported the bridge as unavailable instead of reaching Electron's registered `machineRpc.send` service.

This directly affects the session's Project Files surface. Its file provider loads the local file index through `requestLocalCodeCollabFileIndex` and loads a selected file's contents through `requestFilePreview`; both methods use the same stale local Machine RPC sender. The most visible symptom is that selecting a project file opens the preview without any content.

Other file-preview providers and paths may remain healthy, but they are not the path shown in the before/after screenshots.

## User-visible call chain

Opening a file from Project Files follows this path:

`Project Files selection`
→ `useCodeCollabSessionFileProvider.previewFile`
→ `runtime.requestFilePreview`
→ `workspace-machine-rpc-facade.requestFilePreview`
→ `getIpcServices().machineRpc.send`
→ `window.ipc.invoke('machineRpc.send', request)`
→ `MachineRpcIpc.send`
→ `CliService.sendLocalMachineRpc`
→ daemon `file/preview-local`

Before this fix, the chain stopped in `workspace-machine-rpc-facade` because `window.api.sendLocalMachineRpc` no longer existed. The preview request therefore never reached Electron or the local daemon.

The Project Files index follows the same transport path via `runtime.requestLocalCodeCollabFileIndex` and the `code-collab/get-file-index` Machine RPC method.

## Summary

- Route local Machine RPC through Electron's registered `machineRpc.send` service and typed `window.ipc.invoke` bridge.
- Restore Project Files index and selected-file content requests that depend on the facade.
- Update the facade tests to exercise the real `window.ipc.invoke` bridge contract.

## Before / after

| Before | After |
| ------ | ----- |
| <img width="260" alt="Before: selecting a file in Project Files opens a preview with no content because local Machine RPC is unavailable" src="https://github.com/user-attachments/assets/221681dc-8f2f-44c2-af7d-2a6d68ffff66" /> | <img width="260" alt="After: the selected Project Files file loads after local Machine RPC is restored" src="https://github.com/user-attachments/assets/ae739977-35ff-4fcf-97de-744d404c5692" /> |

## Regression origin

[`e8d8748`](https://github.com/LodyAI/Lody/commit/e8d874834dc4118ea85cd6451abc63ad48dffaed) migrated Electron preload from `window.api` to `window.ipc`, but `workspace-machine-rpc-facade` and its tests retained the removed `window.api.sendLocalMachineRpc` bridge.

## Test plan

- `workspace-machine-rpc-facade.test.ts`: 5 tests passed.
- Components TypeScript check passed.
- `git diff --check` passed.

## Agent handoff

<!-- agent-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Verify that `workspace-machine-rpc-facade.ts` resolves the existing registered `machineRpc.send` service without changing local-versus-cloud routing.
- **Decisions to challenge:** Confirm that the facade should consume the shared typed Electron IPC proxy rather than recreate a preload bridge contract.
- **Plausible failures / evidence gaps:** Focused tests cover local preview, file-index, session control, unresolved local routing, and remote routing; no full Electron end-to-end run was performed.

### Authoring context

- **User goal / directives:** Keep the PR atomic and repair only the stale local Machine RPC bridge.
- **Constraints / non-goals:** Do not include ACP/file-path provenance changes; preserve the two uploaded images at a compact size; do not use browser or computer-control tooling.
- **Risk-bearing decisions:** Reuse the registered typed Electron IPC service while preserving the existing no-cloud-fallback behavior for unresolved local routes.
- **Destructive or irreversible behavior:** None; no user data or persistent format changes are involved.
- **Deliberately not done or tested:** ACP/file-path handling was restored to `main`; no full Electron end-to-end run was performed.
- **Unknowns / confidence:** High confidence in the bridge contract and focused coverage; desktop integration outside the facade was not re-exercised.

### Sharing consent (author side)

- [x] Author-side user explicitly allowed publishing the Authoring context above
- [ ] Author-side user explicitly declined publishing Authoring context and understands that maintainers may decline or close the contribution; keep every field as `N/A` / redacted

<!-- agent-handoff:end -->
