### PR TITLE
fix(components): preserve heatmap cell rings

### DIFF
--- a/packages/components/src/components/settings/usage-calendar-visualization.tsx
+++ b/packages/components/src/components/settings/usage-calendar-visualization.tsx
@@ -1390,7 +1390,7 @@ function UsageHeatmap({
 
         <div ref={scrollerRef} className="scrollbar-pro min-w-0 flex-1 overflow-x-auto pb-1">
           <div
-            className="min-w-[var(--usage-heatmap-min-track-width)] @[672px]:min-w-0"
+            className="min-w-[var(--usage-heatmap-min-track-width)] px-0.5 @[672px]:min-w-0"
             style={
               {
                 '--usage-heatmap-min-track-width': `${HEATMAP_MIN_TRACK_WIDTH}px`,


### PR DESCRIPTION
## Summary
- reserve one pixel on each side of the heatmap track for external cell rings
- keep the calendar grid and month labels aligned while preventing clipped edge borders

## Verification
- `git diff --check`