### PR TITLE
fix(components): avoid waking skyline scrollbar

### DIFF
--- a/packages/components/src/components/settings/usage-calendar-visualization.tsx
+++ b/packages/components/src/components/settings/usage-calendar-visualization.tsx
@@ -1248,12 +1248,6 @@ function UsageHeatmap({
   // Roving tabindex: the grid is one tab stop, arrow keys walk days and weeks.
   const [focusIndex, setFocusIndex] = useState(() => Math.max(0, todayIndex));
 
-  // Show the newest weeks initially without overriding later user scrolling.
-  useLayoutEffect(() => {
-    const scroller = scrollerRef.current;
-    if (scroller) scroller.scrollLeft = scroller.scrollWidth;
-  }, []);
-
   const cellLabel = useCallback(
     (cell: UsageCalendarCell) => {
       const date = formats.day.format(new Date(cell.dayStartMs));
@@ -1388,8 +1382,16 @@ function UsageHeatmap({
           })}
         </div>
 
-        <div ref={scrollerRef} className="scrollbar-pro min-w-0 flex-1 overflow-x-auto pb-1">
+        {/* RTL gives an overflowing calendar a native right-edge origin without
+            programmatic scrolling, so mounting it does not reveal an overlay
+            scrollbar. Restore LTR on the content to preserve chronological order. */}
+        <div
+          ref={scrollerRef}
+          dir="rtl"
+          className="scrollbar-pro min-w-0 flex-1 overflow-x-auto pb-1"
+        >
           <div
+            dir="ltr"
             className="min-w-[var(--usage-heatmap-min-track-width)] px-0.5 @[672px]:min-w-0"
             style={
               {


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

The usage skyline programmatically moved its horizontal scroller to the newest week during mount. On overlay-scrollbar platforms, that initial scroll operation revealed the scrollbar before the user interacted with the calendar.

## Summary

- Use the horizontal scroller native RTL origin to start at the newest weeks without assigning scrollLeft during mount.
- Restore LTR direction on the calendar content so chronology, labels, and interaction order remain unchanged.
- Keep native horizontal scrolling and the existing selected-day scroll synchronization intact.

## Before / after

| Before | After |
| ------ | ----- |
| A mount-time layout effect assigned scrollLeft and could wake the overlay scrollbar. | Native layout starts at the right edge with no initial scroll event; user scrolling still works normally. |

## Test plan

- `prettier --check packages/components/src/components/settings/usage-calendar-visualization.tsx` passed using the matching installed toolchain from another worktree with an identical package manifest and lockfile.
- `oxlint --quiet packages/components/src/components/settings/usage-calendar-visualization.tsx` passed with 0 warnings and 0 errors.
- `git diff --check` passed.
- A local Chrome behavior probe confirmed the RTL scroller starts at the right edge with 0 scroll events, then changes scrollLeft and emits a scroll event after simulated user input.
- Full package typecheck and Vitest were not run because this checkout has no node_modules; repository guidance prohibits a nested install in this embedded workspace.

## Agent handoff

<!-- agent-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Review `UsageHeatmap` in `usage-calendar-visualization.tsx`, especially right-edge initialization and retained selected-day anchor synchronization.
- **Decisions to challenge:** Confirm that an RTL scroller with an LTR content child is preferable to stateful scrollbar suppression for supported browser surfaces.
- **Plausible failures / evidence gaps:** Full component tests and cross-browser visual checks were unavailable; RTL scroll coordinates differ across engines, though this code no longer reads their value.

### Authoring context

- **User goal / directives:** Prevent the skyline scrollbar from appearing because of initial positioning while preserving scrollbar feedback after user scrolling.
- **Constraints / non-goals:** Avoid adding state or new lifecycle work and do not alter the chronological presentation or later user interaction.
- **Risk-bearing decisions:** The implementation relies on the browser native RTL scroll origin and resets the content subtree to LTR.
- **Destructive or irreversible behavior:** None.
- **Deliberately not done or tested:** No stateful scrollbar visibility controller was added; full typecheck, Vitest, and multi-browser visual testing were not run because dependencies are absent in this checkout.
- **Unknowns / confidence:** High confidence in Chromium behavior; residual risk is browser-specific RTL scrollbar presentation on other supported engines.

### Sharing consent (author side)

- [x] Author-side user explicitly allowed publishing the Authoring context above
- [ ] Author-side user explicitly declined publishing Authoring context and understands that maintainers may decline or close the contribution; keep every field as `N/A` / redacted

<!-- agent-handoff:end -->