### PR TITLE
fix: retain undelivered marker on new messages

### DIFF
--- a/apps/cli/src/session/AGENTS.md
+++ b/apps/cli/src/session/AGENTS.md
@@ -42,10 +42,8 @@ delegation proofs or a shared-machine gate without a new product and security de
   "not delivered" label for that exact entry from the marker plus its non-terminal
   status (no CLI repair write, no schema change), and recovery is a fresh send:
   the row's "not delivered" label opens a confirmation dialog that re-sends the
-  SAME content as a brand-new message (new turn id) through the ordinary
-  producer path, whose ordinary dispatch write clears the marker as a side
-  effect; the resend also supersedes the abandoned entry to `canceled` so the
-  stale pending copy can never dispatch once the marker is gone. The watcher
+  SAME content as a brand-new message (new turn id). The renderer retains the
+  marker and supersedes the abandoned entry to `canceled`. The watcher
   must not publish or clear
   session active presence; `../lib/loro/session-active-presence.ts` is the only owner
   for start/phase/heartbeat/clear. Owned-session startup/meta bootstrap scans may contain

--- a/apps/cli/src/session/session-dispatch-watcher.ts
+++ b/apps/cli/src/session/session-dispatch-watcher.ts
@@ -343,13 +343,9 @@ const isConfigOptionValueRecord = (
  * renderer derives a visible "not delivered" label for it from the marker plus
  * its non-terminal status (no CLI repair write, no schema change). Recovery is
  * a fresh send — the row's "not delivered" label opens a confirmation dialog
- * that re-sends the same content as a brand-new message (new turn id) through
- * the ordinary producer path, whose ordinary dispatch write clears the marker
- * as a side effect; the resend also supersedes the abandoned entry to
- * `canceled` so the stale pending copy can never dispatch once the marker is
- * gone. That is preferred over an unbounded silent wait, repeated recovery
- * loops, or resurrecting a message the user may already have resent as a new
- * turn.
+ * that re-sends the same content as a brand-new message (new turn id). The
+ * renderer retains the marker and supersedes the abandoned entry to
+ * `canceled`.
  *
  * Sessions without an explicit activation signal stay metadata-only. History is
  * a turn-selection source after activation, not a startup activation index.

--- a/packages/components/src/components/ai-gui/AGENTS.md
+++ b/packages/components/src/components/ai-gui/AGENTS.md
@@ -121,7 +121,7 @@ work) and a hover preview.
 - A user entry marked by `SessionMeta.lastMissingHistoryUserMsgId` renders the
   terminal "Not delivered" label. That label is the only recovery entry: its
   dialog resends the same content as a new ordinary message, then marks the old
-  entry `canceled`; the producer clears the marker. Never automatically dispatch
-  or revive the old turn.
+  entry `canceled` while retaining the marker as a tombstone. Never automatically
+  dispatch or revive the old turn.
 - Attachment and mobile image-preview invariants live in
   [session-files-rendering.md](session-files-rendering.md).

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -3896,11 +3896,7 @@ export const SessionChatInterface = memo(
       async (userTurnId: string, inputBlocks: SessionInputBlock[]): Promise<boolean> => {
         const accepted = await handleSendMessage(inputBlocks);
         if (accepted) {
-          // Supersede the abandoned delivery attempt. The ordinary send clears
-          // the missing-history marker, and without a terminal status the stale
-          // pending entry would become dispatchable again (duplicating the just
-          // resent content). 'canceled' is the truthful terminal state and also
-          // hides the row's not-delivered label independent of the marker.
+          // The marker stays as a tombstone; terminalize the abandoned entry.
           try {
             await updateHistoryEntry(userTurnId, (entry) => ({
               ...entry,

--- a/packages/components/src/hooks/use-session-actions.ts
+++ b/packages/components/src/hooks/use-session-actions.ts
@@ -851,7 +851,6 @@ export function useSessionActions(): SessionActions {
       try {
         await runtime.writer.upsertDocMeta(roomId, {
           latestUserMsgId: userTurnId,
-          lastMissingHistoryUserMsgId: undefined,
         } as Partial<SessionMeta>);
       } catch (error) {
         // The RPC fast path may already have delivered this turn to the CLI; a

--- a/packages/components/tests/use-session-actions.test.ts
+++ b/packages/components/tests/use-session-actions.test.ts
@@ -484,10 +484,9 @@ describe('useSessionActions', () => {
     });
     await vi.waitFor(() => expect(requestSessionDispatchTurn).toHaveBeenCalledTimes(1));
 
-    expect(upsertDocMeta).toHaveBeenCalledWith(
-      getSessionRoomId(sessionId),
-      expect.objectContaining({ latestUserMsgId: userTurnId })
-    );
+    expect(upsertDocMeta).toHaveBeenCalledWith(getSessionRoomId(sessionId), {
+      latestUserMsgId: userTurnId,
+    });
     expect(setState).not.toHaveBeenCalled();
     expect(waitUntilSynced).toHaveBeenCalledTimes(1);
 


### PR DESCRIPTION
## Related issue

Fix #47

## Problem / pressure

PR #74 made `lastMissingHistoryUserMsgId` a permanent negative acknowledgement for an undelivered turn, but missed the ordinary new-message path:

1. Message A times out waiting for history and is blocked by the marker.
2. A's history entry later reaches the CLI with `status: pending`.
3. The user sends a different message B instead of resending A.
4. The renderer points `latestUserMsgId` at B but also clears A's marker.
5. The dispatcher scans pending history from oldest to newest and selects A before B.

This can execute a message the UI already presented as not delivered.

## Summary

- Preserve the existing missing-history marker when the renderer publishes a different new turn.
- Keep the marker-specific resend flow responsible for terminalizing the abandoned entry.
- Tighten the renderer metadata-write test so clearing the marker fails the assertion.
- Correct the nearby comments and contributor invariants that described the old behavior.
- Rebase the change onto the latest `main` and resolve the contributor-invariant conflict.

## Before / after

| Before | After |
| ------ | ----- |
| Sending B cleared A's marker, making late `pending` A dispatchable again. | Sending B changes only `latestUserMsgId`; A remains excluded and B dispatches normally. |

## Test plan

- `packages/components/node_modules/.bin/vitest run tests/use-session-actions.test.ts tests/resend-undelivered-dialog.test.tsx tests/undelivered-user-turn.test.ts` — 34 tests passed after rebasing.
- `apps/cli/node_modules/.bin/vitest run src/session/session-dispatch-logic.test.ts tests/session-dispatch-watcher.test.ts` — 50 tests passed after rebasing.
- CLI and Components `tsgo --noEmit` passed before the rebase.
- Type-aware lint completed with 0 errors on the changed TypeScript files before the rebase.
- Prettier check passed before the rebase; `git diff --check` passed after conflict resolution.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Verify the metadata patch in `use-session-actions.ts` preserves an existing marker while moving `latestUserMsgId` to B.
- **Decisions to challenge:** Confirm retaining A's exact-ID tombstone is preferable to implicitly canceling A when the user sends unrelated B.
- **Plausible failures / evidence gaps:** The fix is intentionally scoped to renderer sends; CLI commands and internal dispatch producers were not changed.

### Authoring context

- **User goal / directives:** Fix the PR #74 gap where sending B can revive an older not-delivered A, keep the change minimal, and explain the reproduction chain in the PR.
- **Constraints / non-goals:** Do not redesign dispatch state, broaden unrelated producer behavior, include dependency-store artifacts, or expose conversation transcripts.
- **Risk-bearing decisions:** Retain the exact-ID marker across unrelated renderer sends so A remains excluded while B still activates dispatch.
- **Destructive or irreversible behavior:** The product change does not migrate or delete persisted data; the PR branch was rebased onto current `main` to resolve conflicts.
- **Deliberately not done or tested:** Full repository CI was not rerun locally after the rebase; the affected Components and CLI suites were rerun instead.
- **Unknowns / confidence:** Confidence is high for the reported renderer path; equivalent behavior in non-renderer producers remains outside this PR's scope.

<!-- context-handoff:end -->
