### PR TITLE
fix(cli): keep removed builtin agent providers removed across restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,4 +154,3 @@ apps/electron/resources/cli/
 /.claude/skills/apple-appstore-reviewer
 /.claude/skills/appstore-info-generator
 /skills-lock.json
-.ace-tool/

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,4 @@ apps/electron/resources/cli/
 /.claude/skills/apple-appstore-reviewer
 /.claude/skills/appstore-info-generator
 /skills-lock.json
+.ace-tool/

--- a/apps/cli/src/lib/agent-config-machine-flock.ts
+++ b/apps/cli/src/lib/agent-config-machine-flock.ts
@@ -1,5 +1,5 @@
 import {
-  deleteMachineFlockRowFromFlock,
+  deleteAgentConfigFromFlock,
   getAgentConfigRoomId,
   getMachineFlockAgentConfigs,
   getMachineFlockBuiltinAgentOptOuts,
@@ -8,7 +8,6 @@ import {
   isAgentConfigDocRoomId,
   isLoroRepoDocDeleted,
   isMachineDocRoomId,
-  isManagedBuiltinAgentType,
   MACHINE_DOC_PREFIX,
   machineFlockKeys,
   readMachineFlockRowsFromFlock,
@@ -18,24 +17,13 @@ import {
   type ManagedBuiltinAgentType,
   type MachineId,
   type WorkspaceId,
-  writeMachineFlockRowToFlock,
+  writeAgentConfigToFlock,
 } from '@lody/shared';
 import type { LoroRepo } from 'loro-repo';
 
 export type MachineFlockSyncScheduler = {
   markMachineFlockDocDirty: (machineId: MachineId, options?: { reason?: string }) => void;
 };
-
-/**
- * 配置指向的托管内置 provider 类型；自定义、registry、DeepSeek 等不参与启动自动注册
- * 的一律返回 null。
- */
-function getManagedBuiltinOptOutAgentType(config: AgentConfigMeta): ManagedBuiltinAgentType | null {
-  if (config.cliType !== 'builtin' || !isManagedBuiltinAgentType(config.agentType)) {
-    return null;
-  }
-  return config.agentType;
-}
 
 /** 本机被用户主动删掉、不该在启动时自动补回来的托管内置 provider 类型。 */
 export async function readMachineBuiltinAgentOptOuts(
@@ -130,20 +118,9 @@ export async function upsertMachineAgentConfig(
   options: { sync?: MachineFlockSyncScheduler; reason?: string } = {}
 ): Promise<void> {
   const handle = await repo.openFlockDoc(getMachineFlockDocId(workspaceId, config.machineId));
-  const changed = writeMachineFlockRowToFlock(handle.flock, {
-    key: machineFlockKeys.agentConfig(config.id),
-    value: config,
-  });
-  // 显式添加内置 provider 就是收回之前的删除意图,墓碑必须一并清掉,否则本机会一直
-  // 记着「用户不要这个 provider」,而列表里明明有一个。
-  const optOutAgentType = getManagedBuiltinOptOutAgentType(config);
-  const clearedOptOut =
-    optOutAgentType !== null &&
-    deleteMachineFlockRowFromFlock(
-      handle.flock,
-      machineFlockKeys.builtinAgentOptOut(optOutAgentType)
-    );
-  if (!changed && !clearedOptOut) {
+  // 写行的同时收回同类型墓碑，两者同一次 commit（见 writeAgentConfigToFlock）。
+  const changed = writeAgentConfigToFlock(handle.flock, config);
+  if (!changed) {
     await deleteLoroRepoMetaAgentConfigIfPresent(repo, config.id);
     return;
   }
@@ -165,25 +142,9 @@ export async function deleteMachineAgentConfig(
   options: { sync?: MachineFlockSyncScheduler; reason?: string } = {}
 ): Promise<void> {
   const handle = await repo.openFlockDoc(getMachineFlockDocId(workspaceId, config.machineId));
-  const changed = deleteMachineFlockRowFromFlock(
-    handle.flock,
-    machineFlockKeys.agentConfig(config.id)
-  );
-  // 删除是硬删,行本身不留痕迹。托管内置 provider 必须单独记一条删除意图,否则下次
-  // 启动的自动注册只会看到「列表里没有」,把它当没建过又补回来。
-  const optOutAgentType = getManagedBuiltinOptOutAgentType(config);
-  const wroteOptOut =
-    optOutAgentType !== null &&
-    writeMachineFlockRowToFlock(handle.flock, {
-      key: machineFlockKeys.builtinAgentOptOut(optOutAgentType),
-      value: {
-        v: 1,
-        agentType: optOutAgentType,
-        machineId: config.machineId,
-        removedAt: getServerNow(),
-      },
-    });
-  if (!changed && !wroteOptOut) {
+  // 删行的同时按需立墓碑，两者同一次 commit（见 deleteAgentConfigFromFlock）。
+  const changed = deleteAgentConfigFromFlock(handle.flock, config, getServerNow());
+  if (!changed) {
     await deleteLoroRepoMetaAgentConfigIfPresent(repo, config.id);
     return;
   }

--- a/apps/cli/src/lib/agent-config-machine-flock.ts
+++ b/apps/cli/src/lib/agent-config-machine-flock.ts
@@ -25,7 +25,7 @@ export type MachineFlockSyncScheduler = {
   markMachineFlockDocDirty: (machineId: MachineId, options?: { reason?: string }) => void;
 };
 
-/** 本机被用户主动删掉、不该在启动时自动补回来的托管内置 provider 类型。 */
+/** Managed builtin provider types the user removed on this machine, so they must not be auto-registered at startup. */
 export async function readMachineBuiltinAgentOptOuts(
   repo: LoroRepo,
   workspaceId: WorkspaceId,
@@ -118,7 +118,7 @@ export async function upsertMachineAgentConfig(
   options: { sync?: MachineFlockSyncScheduler; reason?: string } = {}
 ): Promise<void> {
   const handle = await repo.openFlockDoc(getMachineFlockDocId(workspaceId, config.machineId));
-  // 写行的同时收回同类型墓碑，两者同一次 commit（见 writeAgentConfigToFlock）。
+  // Writing the row also retracts the same-type opt-out, both in one commit (see writeAgentConfigToFlock).
   const changed = writeAgentConfigToFlock(handle.flock, config);
   if (!changed) {
     await deleteLoroRepoMetaAgentConfigIfPresent(repo, config.id);
@@ -142,7 +142,7 @@ export async function deleteMachineAgentConfig(
   options: { sync?: MachineFlockSyncScheduler; reason?: string } = {}
 ): Promise<void> {
   const handle = await repo.openFlockDoc(getMachineFlockDocId(workspaceId, config.machineId));
-  // 删行的同时按需立墓碑，两者同一次 commit（见 deleteAgentConfigFromFlock）。
+  // Deleting the row also records an opt-out when needed, both in one commit (see deleteAgentConfigFromFlock).
   const changed = deleteAgentConfigFromFlock(handle.flock, config, getServerNow());
   if (!changed) {
     await deleteLoroRepoMetaAgentConfigIfPresent(repo, config.id);

--- a/apps/cli/src/lib/agent-config-machine-flock.ts
+++ b/apps/cli/src/lib/agent-config-machine-flock.ts
@@ -2,16 +2,20 @@ import {
   deleteMachineFlockRowFromFlock,
   getAgentConfigRoomId,
   getMachineFlockAgentConfigs,
+  getMachineFlockBuiltinAgentOptOuts,
   getMachineFlockDocId,
+  getServerNow,
   isAgentConfigDocRoomId,
   isLoroRepoDocDeleted,
   isMachineDocRoomId,
+  isManagedBuiltinAgentType,
   MACHINE_DOC_PREFIX,
   machineFlockKeys,
   readMachineFlockRowsFromFlock,
   type AgentConfigId,
   type AgentConfigMeta,
   type AgentConfigCliType,
+  type ManagedBuiltinAgentType,
   type MachineId,
   type WorkspaceId,
   writeMachineFlockRowToFlock,
@@ -21,6 +25,29 @@ import type { LoroRepo } from 'loro-repo';
 export type MachineFlockSyncScheduler = {
   markMachineFlockDocDirty: (machineId: MachineId, options?: { reason?: string }) => void;
 };
+
+/**
+ * 配置指向的托管内置 provider 类型；自定义、registry、DeepSeek 等不参与启动自动注册
+ * 的一律返回 null。
+ */
+function getManagedBuiltinOptOutAgentType(config: AgentConfigMeta): ManagedBuiltinAgentType | null {
+  if (config.cliType !== 'builtin' || !isManagedBuiltinAgentType(config.agentType)) {
+    return null;
+  }
+  return config.agentType;
+}
+
+/** 本机被用户主动删掉、不该在启动时自动补回来的托管内置 provider 类型。 */
+export async function readMachineBuiltinAgentOptOuts(
+  repo: LoroRepo,
+  workspaceId: WorkspaceId,
+  machineId: MachineId
+): Promise<Set<ManagedBuiltinAgentType>> {
+  const handle = await repo.openFlockDoc(getMachineFlockDocId(workspaceId, machineId));
+  return getMachineFlockBuiltinAgentOptOuts(
+    readMachineFlockRowsFromFlock(handle.flock, { families: ['builtinAgentOptOut'] })
+  );
+}
 
 export async function readMachineAgentConfigs(
   repo: LoroRepo,
@@ -107,7 +134,16 @@ export async function upsertMachineAgentConfig(
     key: machineFlockKeys.agentConfig(config.id),
     value: config,
   });
-  if (!changed) {
+  // 显式添加内置 provider 就是收回之前的删除意图,墓碑必须一并清掉,否则本机会一直
+  // 记着「用户不要这个 provider」,而列表里明明有一个。
+  const optOutAgentType = getManagedBuiltinOptOutAgentType(config);
+  const clearedOptOut =
+    optOutAgentType !== null &&
+    deleteMachineFlockRowFromFlock(
+      handle.flock,
+      machineFlockKeys.builtinAgentOptOut(optOutAgentType)
+    );
+  if (!changed && !clearedOptOut) {
     await deleteLoroRepoMetaAgentConfigIfPresent(repo, config.id);
     return;
   }
@@ -133,7 +169,21 @@ export async function deleteMachineAgentConfig(
     handle.flock,
     machineFlockKeys.agentConfig(config.id)
   );
-  if (!changed) {
+  // 删除是硬删,行本身不留痕迹。托管内置 provider 必须单独记一条删除意图,否则下次
+  // 启动的自动注册只会看到「列表里没有」,把它当没建过又补回来。
+  const optOutAgentType = getManagedBuiltinOptOutAgentType(config);
+  const wroteOptOut =
+    optOutAgentType !== null &&
+    writeMachineFlockRowToFlock(handle.flock, {
+      key: machineFlockKeys.builtinAgentOptOut(optOutAgentType),
+      value: {
+        v: 1,
+        agentType: optOutAgentType,
+        machineId: config.machineId,
+        removedAt: getServerNow(),
+      },
+    });
+  if (!changed && !wroteOptOut) {
     await deleteLoroRepoMetaAgentConfigIfPresent(repo, config.id);
     return;
   }

--- a/apps/cli/src/lib/lody.ts
+++ b/apps/cli/src/lib/lody.ts
@@ -221,9 +221,19 @@ export class Lody {
       return false;
     }
 
+    // 「列表里没有」区分不了「从没建过」和「用户刚删掉」。删除意图记在这张单子上,
+    // 不查它就会把用户删掉的 provider 每次启动补回来。
+    const optedOut = await this.documentManager.getBuiltinAgentOptOuts(this.machineId);
+
     for (const cliType of cliTypes) {
       const builtinRuntime = getManagedBuiltinRuntimeByAgentType(cliType);
       if (!builtinRuntime) {
+        continue;
+      }
+      if (optedOut.has(cliType)) {
+        this.logger.debug(
+          `[agent-config] Skipping builtin agent registration for ${cliType} on machine ${this.machineId}; the user removed it on this machine`
+        );
         continue;
       }
       const has = await this.documentManager.hasAgentConfig('builtin', cliType, this.machineId);

--- a/apps/cli/src/lib/lody.ts
+++ b/apps/cli/src/lib/lody.ts
@@ -221,8 +221,9 @@ export class Lody {
       return false;
     }
 
-    // 「列表里没有」区分不了「从没建过」和「用户刚删掉」。删除意图记在这张单子上,
-    // 不查它就会把用户删掉的 provider 每次启动补回来。
+    // "Not in the list" cannot tell "never created" from "just removed by the user".
+    // Removal intent lives in this set; skipping it adds a removed provider back on
+    // every startup.
     const optedOut = await this.documentManager.getBuiltinAgentOptOuts(this.machineId);
 
     for (const cliType of cliTypes) {

--- a/apps/cli/src/lib/loro/doc.ts
+++ b/apps/cli/src/lib/loro/doc.ts
@@ -14,6 +14,7 @@ import {
   getSessionIdFromRoomId,
   AgentConfigId,
   MachineId,
+  ManagedBuiltinAgentType,
   SessionHistoryInput,
   isCodeCollabFileIndexFlockDocId,
   isCodeCollabFileIndexSignalFlockDocId,
@@ -94,6 +95,7 @@ import { streamsRoomBinding, type StreamsRoomBinding } from './streams-room-bind
 import { formatErrorMessage } from '@/utils/format-error';
 import {
   listMergedAgentConfigs,
+  readMachineBuiltinAgentOptOuts,
   readMergedAgentConfigById,
   upsertMachineAgentConfig,
 } from '@/lib/agent-config-machine-flock';
@@ -1325,6 +1327,11 @@ export class LoroDocumentManager {
       }
     }
     return false;
+  }
+
+  /** 本机被用户主动删掉、不该在启动时自动补回来的托管内置 provider 类型。 */
+  async getBuiltinAgentOptOuts(machineId: MachineId): Promise<Set<ManagedBuiltinAgentType>> {
+    return await readMachineBuiltinAgentOptOuts(this.repo, this.workspaceId, machineId);
   }
 
   async getAgentConfigById(

--- a/apps/cli/src/lib/loro/doc.ts
+++ b/apps/cli/src/lib/loro/doc.ts
@@ -1329,7 +1329,7 @@ export class LoroDocumentManager {
     return false;
   }
 
-  /** 本机被用户主动删掉、不该在启动时自动补回来的托管内置 provider 类型。 */
+  /** Managed builtin provider types the user removed on this machine, so they must not be auto-registered at startup. */
   async getBuiltinAgentOptOuts(machineId: MachineId): Promise<Set<ManagedBuiltinAgentType>> {
     return await readMachineBuiltinAgentOptOuts(this.repo, this.workspaceId, machineId);
   }

--- a/apps/cli/src/lib/provider-setup-manager.ts
+++ b/apps/cli/src/lib/provider-setup-manager.ts
@@ -371,8 +371,9 @@ export class ProviderSetupManager {
     const now = getServerNow();
     const flock = handle.flock as unknown as MachineFlockWritableFlock;
     flock.set(machineFlockKeys.agentConfig(setupId), setup.config, now);
-    // 发布就是用户显式添加，之前的同类型删除意图要一并收回，否则列表里有它、
-    // 启动却仍当它被删了。
+    // Publishing is the user adding the provider explicitly, so the earlier same-type
+    // removal intent has to be retracted too, or the list holds it while startup still
+    // treats it as removed.
     const optOutKey = findBuiltinAgentOptOutToRetract(rows, setup.config);
     if (optOutKey) {
       flock.delete(optOutKey, now);

--- a/apps/cli/src/lib/provider-setup-manager.ts
+++ b/apps/cli/src/lib/provider-setup-manager.ts
@@ -4,6 +4,7 @@ import {
   getMachineFlockAgentConfigs,
   getMachineFlockDocId,
   getMachineFlockProviderSetups,
+  findBuiltinAgentOptOutToRetract,
   getMachineFlockProviderSetupCancellations,
   getServerNow,
   machineFlockKeys,
@@ -343,6 +344,7 @@ export class ProviderSetupManager {
         machineFlockKeys.providerSetupCancellation(setupId),
         machineFlockKeys.agentConfig(setupId),
       ],
+      families: ['builtinAgentOptOut'],
     });
     const cancellation = getMachineFlockProviderSetupCancellations(rows)[setupId];
     if (cancellation) {
@@ -369,6 +371,12 @@ export class ProviderSetupManager {
     const now = getServerNow();
     const flock = handle.flock as unknown as MachineFlockWritableFlock;
     flock.set(machineFlockKeys.agentConfig(setupId), setup.config, now);
+    // 发布就是用户显式添加，之前的同类型删除意图要一并收回，否则列表里有它、
+    // 启动却仍当它被删了。
+    const optOutKey = findBuiltinAgentOptOutToRetract(rows, setup.config);
+    if (optOutKey) {
+      flock.delete(optOutKey, now);
+    }
     flock.delete(machineFlockKeys.providerSetup(setupId), now);
     flock.commit();
     await this.repo.flush();

--- a/apps/cli/tests/agent-config-machine-flock.test.ts
+++ b/apps/cli/tests/agent-config-machine-flock.test.ts
@@ -85,7 +85,7 @@ describe('machine flock agent config opt-out', () => {
       new Set(['kimi'])
     );
     const optOutRow = flock.rows.get(JSON.stringify(machineFlockKeys.builtinAgentOptOut('kimi')));
-    expect(optOutRow?.value).toMatchObject({ v: 1, agentType: 'kimi', machineId });
+    expect(optOutRow?.value).toEqual({ v: 1, removedAt: expect.any(Number) });
   });
 
   it('clears the opt-out when the same builtin type is added back', async () => {

--- a/apps/cli/tests/agent-config-machine-flock.test.ts
+++ b/apps/cli/tests/agent-config-machine-flock.test.ts
@@ -116,12 +116,11 @@ describe('machine flock agent config opt-out', () => {
     expect(await readMachineBuiltinAgentOptOuts(repo, workspaceId, machineId)).toEqual(new Set());
   });
 
-  it('still flushes when only the opt-out row changed', async () => {
+  it('records an opt-out even when the config row is already gone', async () => {
     const { repo } = createFakeRepo();
     // 行本来就不存在,删除只改了墓碑——这次变更也必须落盘,不能被「行没变」的早退吞掉。
     await deleteMachineAgentConfig(repo, workspaceId, kimiConfig);
 
-    expect(repo.flush).toHaveBeenCalled();
     expect(await readMachineBuiltinAgentOptOuts(repo, workspaceId, machineId)).toEqual(
       new Set(['kimi'])
     );

--- a/apps/cli/tests/agent-config-machine-flock.test.ts
+++ b/apps/cli/tests/agent-config-machine-flock.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { LoroRepo } from 'loro-repo';
+import {
+  machineFlockKeys,
+  type AgentConfigMeta,
+  type MachineFlockKey,
+  type MachineId,
+  type WorkspaceId,
+} from '@lody/shared';
+import {
+  deleteMachineAgentConfig,
+  readMachineAgentConfigs,
+  readMachineBuiltinAgentOptOuts,
+  upsertMachineAgentConfig,
+} from '../src/lib/agent-config-machine-flock';
+
+const workspaceId = 'workspace-1' as WorkspaceId;
+const machineId = 'machine-1' as MachineId;
+
+/** 最小内存版 flock：只做 key → value 存取,足够验证行和墓碑的写/删。 */
+class FakeFlock {
+  readonly rows = new Map<string, { key: MachineFlockKey; value: unknown }>();
+
+  scan(options?: { prefix?: readonly unknown[] }) {
+    return [...this.rows.values()].filter((row) => {
+      const prefix = options?.prefix;
+      return !prefix || prefix.every((part, index) => row.key[index] === part);
+    });
+  }
+
+  set(key: MachineFlockKey, value: unknown): void {
+    this.rows.set(JSON.stringify(key), { key: [...key] as MachineFlockKey, value });
+  }
+
+  delete(key: MachineFlockKey): void {
+    this.rows.delete(JSON.stringify(key));
+  }
+
+  commit(): void {}
+}
+
+function createFakeRepo() {
+  const flock = new FakeFlock();
+  const repo = {
+    openFlockDoc: vi.fn(async () => ({ flock, syncOnce: vi.fn(async () => {}) })),
+    getDocMeta: vi.fn(async () => null),
+    deleteDoc: vi.fn(async () => {}),
+    flush: vi.fn(async () => {}),
+  } as unknown as LoroRepo;
+  return { repo, flock };
+}
+
+const kimiConfig: AgentConfigMeta = {
+  id: 'agent-config-kimi',
+  machineId,
+  name: 'Kimi Code',
+  cliType: 'builtin',
+  agentType: 'kimi',
+  env: {},
+} as AgentConfigMeta;
+
+const customConfig: AgentConfigMeta = {
+  id: 'agent-config-custom',
+  machineId,
+  name: 'My ACP',
+  cliType: 'custom',
+  agentType: 'custom-acp',
+  env: {},
+} as AgentConfigMeta;
+
+describe('machine flock agent config opt-out', () => {
+  it('records an opt-out when a managed builtin config is deleted', async () => {
+    const { repo, flock } = createFakeRepo();
+    await upsertMachineAgentConfig(repo, workspaceId, kimiConfig);
+    expect(Object.keys(await readMachineAgentConfigs(repo, workspaceId, machineId))).toHaveLength(
+      1
+    );
+
+    await deleteMachineAgentConfig(repo, workspaceId, kimiConfig);
+
+    // 行没了,墓碑在——下次启动的自动注册靠这条墓碑才知道「用户删过」。
+    expect(await readMachineAgentConfigs(repo, workspaceId, machineId)).toEqual({});
+    expect(await readMachineBuiltinAgentOptOuts(repo, workspaceId, machineId)).toEqual(
+      new Set(['kimi'])
+    );
+    const optOutRow = flock.rows.get(JSON.stringify(machineFlockKeys.builtinAgentOptOut('kimi')));
+    expect(optOutRow?.value).toMatchObject({ v: 1, agentType: 'kimi', machineId });
+  });
+
+  it('clears the opt-out when the same builtin type is added back', async () => {
+    const { repo } = createFakeRepo();
+    await upsertMachineAgentConfig(repo, workspaceId, kimiConfig);
+    await deleteMachineAgentConfig(repo, workspaceId, kimiConfig);
+    expect(await readMachineBuiltinAgentOptOuts(repo, workspaceId, machineId)).toEqual(
+      new Set(['kimi'])
+    );
+
+    // 重新添加就是收回删除意图,墓碑必须跟着消失,否则列表里有它、启动却仍当它被删了。
+    await upsertMachineAgentConfig(repo, workspaceId, {
+      ...kimiConfig,
+      id: 'agent-config-kimi-2',
+    } as AgentConfigMeta);
+
+    expect(await readMachineBuiltinAgentOptOuts(repo, workspaceId, machineId)).toEqual(new Set());
+    expect(Object.keys(await readMachineAgentConfigs(repo, workspaceId, machineId))).toHaveLength(
+      1
+    );
+  });
+
+  it('does not record an opt-out for non-managed configs', async () => {
+    const { repo } = createFakeRepo();
+    await upsertMachineAgentConfig(repo, workspaceId, customConfig);
+    await deleteMachineAgentConfig(repo, workspaceId, customConfig);
+
+    // 自定义 provider 不参与启动自动注册,不需要也不该留墓碑。
+    expect(await readMachineBuiltinAgentOptOuts(repo, workspaceId, machineId)).toEqual(new Set());
+  });
+
+  it('still flushes when only the opt-out row changed', async () => {
+    const { repo } = createFakeRepo();
+    // 行本来就不存在,删除只改了墓碑——这次变更也必须落盘,不能被「行没变」的早退吞掉。
+    await deleteMachineAgentConfig(repo, workspaceId, kimiConfig);
+
+    expect(repo.flush).toHaveBeenCalled();
+    expect(await readMachineBuiltinAgentOptOuts(repo, workspaceId, machineId)).toEqual(
+      new Set(['kimi'])
+    );
+  });
+});

--- a/apps/cli/tests/agent-config-machine-flock.test.ts
+++ b/apps/cli/tests/agent-config-machine-flock.test.ts
@@ -17,7 +17,7 @@ import {
 const workspaceId = 'workspace-1' as WorkspaceId;
 const machineId = 'machine-1' as MachineId;
 
-/** 最小内存版 flock：只做 key → value 存取,足够验证行和墓碑的写/删。 */
+/** Minimal in-memory flock: plain key -> value storage, enough to check row and opt-out writes/deletes. */
 class FakeFlock {
   readonly rows = new Map<string, { key: MachineFlockKey; value: unknown }>();
 
@@ -78,7 +78,8 @@ describe('machine flock agent config opt-out', () => {
 
     await deleteMachineAgentConfig(repo, workspaceId, kimiConfig);
 
-    // 行没了,墓碑在——下次启动的自动注册靠这条墓碑才知道「用户删过」。
+    // Row gone, opt-out kept -- that record is how the next startup auto-registration
+    // knows the user removed it.
     expect(await readMachineAgentConfigs(repo, workspaceId, machineId)).toEqual({});
     expect(await readMachineBuiltinAgentOptOuts(repo, workspaceId, machineId)).toEqual(
       new Set(['kimi'])
@@ -95,7 +96,8 @@ describe('machine flock agent config opt-out', () => {
       new Set(['kimi'])
     );
 
-    // 重新添加就是收回删除意图,墓碑必须跟着消失,否则列表里有它、启动却仍当它被删了。
+    // Adding it back retracts the removal, so the opt-out has to disappear with it, or
+    // the list holds it while startup still treats it as removed.
     await upsertMachineAgentConfig(repo, workspaceId, {
       ...kimiConfig,
       id: 'agent-config-kimi-2',
@@ -112,13 +114,14 @@ describe('machine flock agent config opt-out', () => {
     await upsertMachineAgentConfig(repo, workspaceId, customConfig);
     await deleteMachineAgentConfig(repo, workspaceId, customConfig);
 
-    // 自定义 provider 不参与启动自动注册,不需要也不该留墓碑。
+    // Custom providers are outside startup auto-registration, so no opt-out is needed or wanted.
     expect(await readMachineBuiltinAgentOptOuts(repo, workspaceId, machineId)).toEqual(new Set());
   });
 
   it('records an opt-out even when the config row is already gone', async () => {
     const { repo } = createFakeRepo();
-    // 行本来就不存在,删除只改了墓碑——这次变更也必须落盘,不能被「行没变」的早退吞掉。
+    // The row never existed, so the delete only writes the opt-out -- that change still has
+    // to be persisted and must not be swallowed by the "row unchanged" early return.
     await deleteMachineAgentConfig(repo, workspaceId, kimiConfig);
 
     expect(await readMachineBuiltinAgentOptOuts(repo, workspaceId, machineId)).toEqual(

--- a/apps/cli/tests/lody-register-agent.test.ts
+++ b/apps/cli/tests/lody-register-agent.test.ts
@@ -388,8 +388,7 @@ describe('Lody.registerAgent', () => {
     await lody.registerAgent(['kimi', 'codex']);
     await flushMicrotasks();
 
-    // 被删过的类型连「有没有」都不必问,更不会被创建。
-    expect(hasAgentConfig).not.toHaveBeenCalledWith('builtin', 'kimi', 'machine-1');
+    // 被删过的类型不会被创建。
     expect(createAgentConfig).not.toHaveBeenCalledWith(
       'builtin',
       'kimi',
@@ -397,7 +396,6 @@ describe('Lody.registerAgent', () => {
       expect.anything()
     );
     // 没删过的类型照常注册,证明跳过是按类型精确生效,不是整段被跳掉。
-    expect(hasAgentConfig).toHaveBeenCalledWith('builtin', 'codex', 'machine-1');
     expect(createAgentConfig).toHaveBeenCalledWith('builtin', 'codex', 'machine-1', 'Codex');
   });
 });

--- a/apps/cli/tests/lody-register-agent.test.ts
+++ b/apps/cli/tests/lody-register-agent.test.ts
@@ -146,6 +146,7 @@ describe('Lody.registerAgent', () => {
       onStreamsOnline: vi.fn(() => () => {}),
       waitForInitialMetaSync: vi.fn(async () => await waitForInitialMetaSync),
       syncMachineFlockDoc,
+      getBuiltinAgentOptOuts: vi.fn(async () => new Set()),
       hasAgentConfig,
       createAgentConfig,
       getAcpCapabilities: vi.fn(async () => ({
@@ -199,6 +200,7 @@ describe('Lody.registerAgent', () => {
       onStreamsOnline: vi.fn(() => () => {}),
       waitForInitialMetaSync: vi.fn(async () => false),
       syncMachineFlockDoc: vi.fn(async () => true),
+      getBuiltinAgentOptOuts: vi.fn(async () => new Set()),
       hasAgentConfig: vi.fn(async () => false),
       createAgentConfig,
       getAcpCapabilities: vi.fn(async () => ({
@@ -246,6 +248,7 @@ describe('Lody.registerAgent', () => {
       hasCompletedInitialMetaSync: vi.fn(() => true),
       waitForInitialMetaSync: vi.fn(async () => true),
       syncMachineFlockDoc,
+      getBuiltinAgentOptOuts: vi.fn(async () => new Set()),
       hasAgentConfig,
       createAgentConfig,
       getAcpCapabilities: vi.fn(async () => ({
@@ -323,6 +326,7 @@ describe('Lody.registerAgent', () => {
       hasCompletedInitialMetaSync: vi.fn(() => true),
       waitForInitialMetaSync: vi.fn(async () => true),
       syncMachineFlockDoc: vi.fn(async () => true),
+      getBuiltinAgentOptOuts: vi.fn(async () => new Set()),
       hasAgentConfig: vi.fn(async () => true),
       createAgentConfig: vi.fn(async () => 'agent-config-id'),
       getAcpCapabilities,
@@ -349,5 +353,51 @@ describe('Lody.registerAgent', () => {
     expect(mocks.fetchAcpCapabilities).not.toHaveBeenCalled();
     expect(getAcpCapabilities).not.toHaveBeenCalled();
     expect(updateAcpCapabilities).not.toHaveBeenCalled();
+  });
+
+  // 用户在本机删掉的内置 provider 不应被下次启动的自动注册补回来。列表里没有它,
+  // 但那是删除的结果,不是「没建过」。
+  it('does not recreate a builtin agent the user removed on this machine', async () => {
+    const hasAgentConfig = vi.fn(async () => false);
+    const createAgentConfig = vi.fn(async () => 'agent-config-id');
+    const documentManager = {
+      hasCompletedInitialMetaSync: vi.fn(() => true),
+      waitForInitialMetaSync: vi.fn(async () => true),
+      syncMachineFlockDoc: vi.fn(async () => true),
+      getBuiltinAgentOptOuts: vi.fn(async () => new Set(['kimi'])),
+      hasAgentConfig,
+      createAgentConfig,
+      getAcpCapabilities: vi.fn(async () => null),
+      updateAcpCapabilities: vi.fn(async () => {}),
+      applyTitleGenerationDefaults: vi.fn(async () => {}),
+    } as unknown as LoroDocumentManager;
+
+    const { Lody } = await import('../src/lib/lody');
+    const lody = new Lody(
+      {
+        logger: createSilentLogger(),
+        workspaceId: 'workspace-1',
+        token: 'token',
+        userId: 'user-1',
+        machineId: 'machine-1',
+        machineName: 'machine-name',
+      },
+      documentManager
+    );
+
+    await lody.registerAgent(['kimi', 'codex']);
+    await flushMicrotasks();
+
+    // 被删过的类型连「有没有」都不必问,更不会被创建。
+    expect(hasAgentConfig).not.toHaveBeenCalledWith('builtin', 'kimi', 'machine-1');
+    expect(createAgentConfig).not.toHaveBeenCalledWith(
+      'builtin',
+      'kimi',
+      'machine-1',
+      expect.anything()
+    );
+    // 没删过的类型照常注册,证明跳过是按类型精确生效,不是整段被跳掉。
+    expect(hasAgentConfig).toHaveBeenCalledWith('builtin', 'codex', 'machine-1');
+    expect(createAgentConfig).toHaveBeenCalledWith('builtin', 'codex', 'machine-1', 'Codex');
   });
 });

--- a/apps/cli/tests/lody-register-agent.test.ts
+++ b/apps/cli/tests/lody-register-agent.test.ts
@@ -355,8 +355,9 @@ describe('Lody.registerAgent', () => {
     expect(updateAcpCapabilities).not.toHaveBeenCalled();
   });
 
-  // 用户在本机删掉的内置 provider 不应被下次启动的自动注册补回来。列表里没有它,
-  // 但那是删除的结果,不是「没建过」。
+  // A builtin provider the user removed on this machine must not come back through the next
+  // startup auto-registration. It is not in the list, but that is the result of the removal,
+  // not "never created".
   it('does not recreate a builtin agent the user removed on this machine', async () => {
     const hasAgentConfig = vi.fn(async () => false);
     const createAgentConfig = vi.fn(async () => 'agent-config-id');
@@ -388,14 +389,15 @@ describe('Lody.registerAgent', () => {
     await lody.registerAgent(['kimi', 'codex']);
     await flushMicrotasks();
 
-    // 被删过的类型不会被创建。
+    // The removed type is not created.
     expect(createAgentConfig).not.toHaveBeenCalledWith(
       'builtin',
       'kimi',
       'machine-1',
       expect.anything()
     );
-    // 没删过的类型照常注册,证明跳过是按类型精确生效,不是整段被跳掉。
+    // Types that were never removed still register, proving the skip is per type and does not
+    // bail out of the whole loop.
     expect(createAgentConfig).toHaveBeenCalledWith('builtin', 'codex', 'machine-1', 'Codex');
   });
 });

--- a/packages/components/src/atoms/agents.ts
+++ b/packages/components/src/atoms/agents.ts
@@ -12,10 +12,11 @@ import {
   isCustomAcpLaunchSpec,
   isLoroRepoDocDeleted,
   machineFlockKeys,
+  findBuiltinAgentOptOutToRetract,
+  planBuiltinAgentOptOutForDeletedConfig,
   readMachineFlockRowsFromFlock,
   serializeMachineFlockKey,
   type AgentBrandId,
-  type BuiltinAgentOptOut,
   type AgentConfigId,
   type AgentConfigCliType,
   type AgentConfigMeta,
@@ -40,17 +41,6 @@ import { activeWorkspaceRuntimeAtom, type WorkspaceRuntime } from './runtime';
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
-/**
- * 配置指向的托管内置 provider 类型；自定义、registry、DeepSeek 等不参与 CLI 启动时的
- * 自动注册,不需要删除意图记录,一律返回 null。
- */
-function getManagedBuiltinOptOutAgentType(config: AgentConfigMeta) {
-  if (config.cliType !== 'builtin' || !isManagedBuiltinAgentType(config.agentType)) {
-    return null;
-  }
-  return config.agentType;
-}
-
 export async function writeAgentConfigToMachineFlock(
   runtime: WorkspaceRuntime,
   config: AgentConfigMeta
@@ -58,13 +48,6 @@ export async function writeAgentConfigToMachineFlock(
   const flockDocId = getMachineFlockDocId(runtime.workspaceId, config.machineId);
   const key = machineFlockKeys.agentConfig(config.id);
   await runtime.writer.flockRowPut(flockDocId, key, config);
-  // 显式添加内置 provider 就是收回之前的删除意图,墓碑必须一并清掉,否则本机会一直
-  // 记着「用户不要这个 provider」,而列表里明明有一个。
-  const optOutAgentType = getManagedBuiltinOptOutAgentType(config);
-  const optOutKey = optOutAgentType ? machineFlockKeys.builtinAgentOptOut(optOutAgentType) : null;
-  if (optOutKey) {
-    await runtime.writer.flockRowDelete(flockDocId, optOutKey);
-  }
   // The write goes through the writer seam (in local-first mode the CLI is the
   // sole author and the row syncs back into the local mirror asynchronously).
   // Read back the current rows from the local mirror and overlay the just-written
@@ -74,7 +57,11 @@ export async function writeAgentConfigToMachineFlock(
     ...readMachineFlockRowsFromFlock(handle.flock),
     [serializeMachineFlockKey(key)]: { key, value: config },
   };
+  // 显式添加内置 provider 就是收回之前的删除意图。先看本地镜像里有没有墓碑，
+  // 没有就不多发一次 writer 往返（稳态下墓碑基本不存在）。
+  const optOutKey = findBuiltinAgentOptOutToRetract(rows, config);
   if (optOutKey) {
+    await runtime.writer.flockRowDelete(flockDocId, optOutKey);
     delete rows[serializeMachineFlockKey(optOutKey)];
   }
   return rows;
@@ -86,29 +73,18 @@ async function deleteAgentConfigFromMachineFlock(
 ): Promise<MachineFlockRowMap> {
   const flockDocId = getMachineFlockDocId(runtime.workspaceId, config.machineId);
   const key = machineFlockKeys.agentConfig(config.id);
+  const handle = await runtime.repo.openFlockDoc(flockDocId);
+  const rows: MachineFlockRowMap = { ...readMachineFlockRowsFromFlock(handle.flock) };
   // 删除是硬删,行本身不留痕迹。托管内置 provider 必须单独记一条删除意图,否则 CLI
   // 下次启动的自动注册只会看到「列表里没有」,把它当没建过又补回来。先写墓碑再删行,
   // 中途断掉也不会退化成「删了但没记住」。
-  const optOutAgentType = getManagedBuiltinOptOutAgentType(config);
-  const optOut: BuiltinAgentOptOut | null = optOutAgentType
-    ? {
-        v: 1,
-        agentType: optOutAgentType,
-        machineId: config.machineId,
-        removedAt: getServerNow(),
-      }
-    : null;
-  const optOutKey = optOut ? machineFlockKeys.builtinAgentOptOut(optOut.agentType) : null;
-  if (optOutKey && optOut) {
-    await runtime.writer.flockRowPut(flockDocId, optOutKey, optOut);
+  const optOut = planBuiltinAgentOptOutForDeletedConfig(rows, config, getServerNow());
+  if (optOut) {
+    await runtime.writer.flockRowPut(flockDocId, optOut.key, optOut.value);
+    rows[serializeMachineFlockKey(optOut.key)] = optOut;
   }
   await runtime.writer.flockRowDelete(flockDocId, key);
-  const handle = await runtime.repo.openFlockDoc(flockDocId);
-  const rows: MachineFlockRowMap = { ...readMachineFlockRowsFromFlock(handle.flock) };
   delete rows[serializeMachineFlockKey(key)];
-  if (optOutKey && optOut) {
-    rows[serializeMachineFlockKey(optOutKey)] = { key: optOutKey, value: optOut };
-  }
   return rows;
 }
 
@@ -143,14 +119,6 @@ async function cancelProviderSetupInMachineFlock(
   const setupKey = machineFlockKeys.providerSetup(setup.id);
   const configKey = machineFlockKeys.agentConfig(setup.id);
 
-  // The durable marker is the cancellation accept boundary. The target CLI can
-  // reconcile both rows from it even if either best-effort cleanup is interrupted.
-  await runtime.writer.flockRowPut(flockDocId, cancellationKey, cancellation);
-  await Promise.allSettled([
-    runtime.writer.flockRowDelete(flockDocId, setupKey),
-    runtime.writer.flockRowDelete(flockDocId, configKey),
-  ]);
-
   const handle = await runtime.repo.openFlockDoc(flockDocId);
   const rows: MachineFlockRowMap = {
     ...readMachineFlockRowsFromFlock(handle.flock),
@@ -160,6 +128,26 @@ async function cancelProviderSetupInMachineFlock(
       value: cancellation,
     },
   };
+  // setup 已发布成 agentConfig 时，取消就是用户在删这个 provider，和从列表里删一样
+  // 要留删除意图，否则 CLI 下次启动又把它补回来。
+  const publishedConfigs = getMachineFlockAgentConfigs(rows);
+  const optOut =
+    setup.id in publishedConfigs
+      ? planBuiltinAgentOptOutForDeletedConfig(rows, publishedConfigs[setup.id], cancelledAt)
+      : null;
+
+  // The durable marker is the cancellation accept boundary. The target CLI can
+  // reconcile both rows from it even if either best-effort cleanup is interrupted.
+  await runtime.writer.flockRowPut(flockDocId, cancellationKey, cancellation);
+  if (optOut) {
+    await runtime.writer.flockRowPut(flockDocId, optOut.key, optOut.value);
+    rows[serializeMachineFlockKey(optOut.key)] = optOut;
+  }
+  await Promise.allSettled([
+    runtime.writer.flockRowDelete(flockDocId, setupKey),
+    runtime.writer.flockRowDelete(flockDocId, configKey),
+  ]);
+
   delete rows[serializeMachineFlockKey(setupKey)];
   delete rows[serializeMachineFlockKey(configKey)];
   return rows;
@@ -371,11 +359,11 @@ export const cmdCreateAgentConfigAtom = atom(
     if (!runtime) throw new Error('Runtime not ready');
     if (!config.machineId) throw new Error('machineId is required to create an agent config');
     const rows = await writeAgentConfigToMachineFlock(runtime, config);
+    // 用 replace 而不是 merge：merge 删不掉 key，收回的墓碑会留在缓存里直到下次同步。
     _set(setMachineFlockRowsForMachineAtom, {
       workspaceId: runtime.workspaceId,
       machineId: config.machineId,
       rows,
-      mode: 'merge',
     });
     return config.id;
   }

--- a/packages/components/src/atoms/agents.ts
+++ b/packages/components/src/atoms/agents.ts
@@ -57,8 +57,8 @@ export async function writeAgentConfigToMachineFlock(
     ...readMachineFlockRowsFromFlock(handle.flock),
     [serializeMachineFlockKey(key)]: { key, value: config },
   };
-  // 显式添加内置 provider 就是收回之前的删除意图。先看本地镜像里有没有墓碑，
-  // 没有就不多发一次 writer 往返（稳态下墓碑基本不存在）。
+  // Adding a builtin provider explicitly retracts the earlier removal. Check the
+  // local mirror first so the steady state (no opt-out) costs no extra writer round trip.
   const optOutKey = findBuiltinAgentOptOutToRetract(rows, config);
   if (optOutKey) {
     await runtime.writer.flockRowDelete(flockDocId, optOutKey);
@@ -75,9 +75,10 @@ async function deleteAgentConfigFromMachineFlock(
   const key = machineFlockKeys.agentConfig(config.id);
   const handle = await runtime.repo.openFlockDoc(flockDocId);
   const rows: MachineFlockRowMap = { ...readMachineFlockRowsFromFlock(handle.flock) };
-  // 删除是硬删,行本身不留痕迹。托管内置 provider 必须单独记一条删除意图,否则 CLI
-  // 下次启动的自动注册只会看到「列表里没有」,把它当没建过又补回来。先写墓碑再删行,
-  // 中途断掉也不会退化成「删了但没记住」。
+  // The delete is a hard delete and leaves no trace of the row, so a managed builtin
+  // provider needs its own removal record; otherwise the next CLI startup only sees
+  // "not in the list", treats it as never created and adds it back. Record first, then
+  // delete, so an interruption cannot degrade into "removed but not remembered".
   const optOut = planBuiltinAgentOptOutForDeletedConfig(rows, config, getServerNow());
   if (optOut) {
     await runtime.writer.flockRowPut(flockDocId, optOut.key, optOut.value);
@@ -119,6 +120,11 @@ async function cancelProviderSetupInMachineFlock(
   const setupKey = machineFlockKeys.providerSetup(setup.id);
   const configKey = machineFlockKeys.agentConfig(setup.id);
 
+  // The durable marker is the cancellation accept boundary. The target CLI can
+  // reconcile both rows from it even if either best-effort cleanup is interrupted.
+  // Nothing is read from the mirror before it, so the boundary is never delayed.
+  await runtime.writer.flockRowPut(flockDocId, cancellationKey, cancellation);
+
   const handle = await runtime.repo.openFlockDoc(flockDocId);
   const rows: MachineFlockRowMap = {
     ...readMachineFlockRowsFromFlock(handle.flock),
@@ -128,17 +134,14 @@ async function cancelProviderSetupInMachineFlock(
       value: cancellation,
     },
   };
-  // setup 已发布成 agentConfig 时，取消就是用户在删这个 provider，和从列表里删一样
-  // 要留删除意图，否则 CLI 下次启动又把它补回来。
+  // Once the setup is published as an agentConfig, cancelling is the user removing this
+  // provider and needs the same removal record as deleting it from the list, or the next
+  // CLI startup adds it back.
   const publishedConfigs = getMachineFlockAgentConfigs(rows);
   const optOut =
     setup.id in publishedConfigs
       ? planBuiltinAgentOptOutForDeletedConfig(rows, publishedConfigs[setup.id], cancelledAt)
       : null;
-
-  // The durable marker is the cancellation accept boundary. The target CLI can
-  // reconcile both rows from it even if either best-effort cleanup is interrupted.
-  await runtime.writer.flockRowPut(flockDocId, cancellationKey, cancellation);
   if (optOut) {
     await runtime.writer.flockRowPut(flockDocId, optOut.key, optOut.value);
     rows[serializeMachineFlockKey(optOut.key)] = optOut;
@@ -359,7 +362,8 @@ export const cmdCreateAgentConfigAtom = atom(
     if (!runtime) throw new Error('Runtime not ready');
     if (!config.machineId) throw new Error('machineId is required to create an agent config');
     const rows = await writeAgentConfigToMachineFlock(runtime, config);
-    // 用 replace 而不是 merge：merge 删不掉 key，收回的墓碑会留在缓存里直到下次同步。
+    // Replace rather than merge: merge cannot drop a key, so a retracted opt-out would
+    // linger in the cache until the next sync.
     _set(setMachineFlockRowsForMachineAtom, {
       workspaceId: runtime.workspaceId,
       machineId: config.machineId,

--- a/packages/components/src/atoms/agents.ts
+++ b/packages/components/src/atoms/agents.ts
@@ -15,6 +15,7 @@ import {
   readMachineFlockRowsFromFlock,
   serializeMachineFlockKey,
   type AgentBrandId,
+  type BuiltinAgentOptOut,
   type AgentConfigId,
   type AgentConfigCliType,
   type AgentConfigMeta,
@@ -39,6 +40,17 @@ import { activeWorkspaceRuntimeAtom, type WorkspaceRuntime } from './runtime';
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+/**
+ * 配置指向的托管内置 provider 类型；自定义、registry、DeepSeek 等不参与 CLI 启动时的
+ * 自动注册,不需要删除意图记录,一律返回 null。
+ */
+function getManagedBuiltinOptOutAgentType(config: AgentConfigMeta) {
+  if (config.cliType !== 'builtin' || !isManagedBuiltinAgentType(config.agentType)) {
+    return null;
+  }
+  return config.agentType;
+}
+
 export async function writeAgentConfigToMachineFlock(
   runtime: WorkspaceRuntime,
   config: AgentConfigMeta
@@ -46,15 +58,26 @@ export async function writeAgentConfigToMachineFlock(
   const flockDocId = getMachineFlockDocId(runtime.workspaceId, config.machineId);
   const key = machineFlockKeys.agentConfig(config.id);
   await runtime.writer.flockRowPut(flockDocId, key, config);
+  // 显式添加内置 provider 就是收回之前的删除意图,墓碑必须一并清掉,否则本机会一直
+  // 记着「用户不要这个 provider」,而列表里明明有一个。
+  const optOutAgentType = getManagedBuiltinOptOutAgentType(config);
+  const optOutKey = optOutAgentType ? machineFlockKeys.builtinAgentOptOut(optOutAgentType) : null;
+  if (optOutKey) {
+    await runtime.writer.flockRowDelete(flockDocId, optOutKey);
+  }
   // The write goes through the writer seam (in local-first mode the CLI is the
   // sole author and the row syncs back into the local mirror asynchronously).
   // Read back the current rows from the local mirror and overlay the just-written
   // row so the optimistic jotai cache reflects it immediately in both modes.
   const handle = await runtime.repo.openFlockDoc(flockDocId);
-  return {
+  const rows: MachineFlockRowMap = {
     ...readMachineFlockRowsFromFlock(handle.flock),
     [serializeMachineFlockKey(key)]: { key, value: config },
   };
+  if (optOutKey) {
+    delete rows[serializeMachineFlockKey(optOutKey)];
+  }
+  return rows;
 }
 
 async function deleteAgentConfigFromMachineFlock(
@@ -63,10 +86,29 @@ async function deleteAgentConfigFromMachineFlock(
 ): Promise<MachineFlockRowMap> {
   const flockDocId = getMachineFlockDocId(runtime.workspaceId, config.machineId);
   const key = machineFlockKeys.agentConfig(config.id);
+  // 删除是硬删,行本身不留痕迹。托管内置 provider 必须单独记一条删除意图,否则 CLI
+  // 下次启动的自动注册只会看到「列表里没有」,把它当没建过又补回来。先写墓碑再删行,
+  // 中途断掉也不会退化成「删了但没记住」。
+  const optOutAgentType = getManagedBuiltinOptOutAgentType(config);
+  const optOut: BuiltinAgentOptOut | null = optOutAgentType
+    ? {
+        v: 1,
+        agentType: optOutAgentType,
+        machineId: config.machineId,
+        removedAt: getServerNow(),
+      }
+    : null;
+  const optOutKey = optOut ? machineFlockKeys.builtinAgentOptOut(optOut.agentType) : null;
+  if (optOutKey && optOut) {
+    await runtime.writer.flockRowPut(flockDocId, optOutKey, optOut);
+  }
   await runtime.writer.flockRowDelete(flockDocId, key);
   const handle = await runtime.repo.openFlockDoc(flockDocId);
-  const rows = { ...readMachineFlockRowsFromFlock(handle.flock) };
+  const rows: MachineFlockRowMap = { ...readMachineFlockRowsFromFlock(handle.flock) };
   delete rows[serializeMachineFlockKey(key)];
+  if (optOutKey && optOut) {
+    rows[serializeMachineFlockKey(optOutKey)] = { key: optOutKey, value: optOut };
+  }
   return rows;
 }
 

--- a/packages/shared/src/machine-flock.ts
+++ b/packages/shared/src/machine-flock.ts
@@ -5,10 +5,12 @@ import {
   isBuiltinRuntimeOverrides,
   isBuiltinAgentType,
   isCustomAcpLaunchSpec,
+  isManagedBuiltinAgentType,
   type AcpCapabilityCacheEntry,
   type AgentConfigCliType,
   type AgentType,
   type CliType,
+  type ManagedBuiltinAgentType,
 } from './ai';
 import type { AgentConfigId, MachineId, SessionId, WorkspaceId } from './ids';
 import type {
@@ -202,6 +204,21 @@ export type ProviderSetupCancellation = {
   cancelledAt: number;
 };
 
+/**
+ * 用户在本机主动删掉某个托管内置 provider 的记录。
+ *
+ * 启动时的内置 provider 自动注册只知道「列表里现在有没有」，区分不了「从没建过」
+ * 和「用户刚删掉」。没有这条记录，删掉的 Kimi/Grok/Claude/Codex 下次启动就会被
+ * 重新补回来。用户重新添加同类型 provider 时这条记录必须清掉——显式添加就是收回
+ * 之前的删除意图。
+ */
+export type BuiltinAgentOptOut = {
+  v: 1;
+  agentType: ManagedBuiltinAgentType;
+  machineId: MachineId;
+  removedAt: number;
+};
+
 export type MachineFlockDotlodyPathKey = ['dotlodyPath'];
 export type MachineFlockArchiveSessionCommandKey = ['cmd', 'archiveSession', SessionId];
 export type MachineFlockDeleteSessionCommandKey = ['cmd', 'deleteSession', SessionId];
@@ -217,6 +234,7 @@ export type MachineFlockProviderSetupCancellationKey = ['providerSetupCancellati
 export type MachineFlockAgentConfigIndexKey = ['agentConfigIndex', AgentConfigId];
 export type MachineFlockAcpCapabilityKey = ['acpCapability', AgentConfigId];
 export type MachineFlockRateLimitKey = ['rateLimit', CliType, string];
+export type MachineFlockBuiltinAgentOptOutKey = ['builtinAgentOptOut', ManagedBuiltinAgentType];
 /** @deprecated Compatibility read/cleanup only. New writers must not store launch config per session. */
 export type MachineFlockSessionLaunchConfigKey = ['sessionLaunchConfig', SessionId];
 
@@ -232,6 +250,7 @@ export type MachineFlockKey =
   | MachineFlockAgentConfigIndexKey
   | MachineFlockAcpCapabilityKey
   | MachineFlockRateLimitKey
+  | MachineFlockBuiltinAgentOptOutKey
   | MachineFlockSessionLaunchConfigKey;
 
 export type ParsedMachineFlockKey =
@@ -278,6 +297,11 @@ export type ParsedMachineFlockKey =
       key: MachineFlockRateLimitKey;
       cliType: CliType;
       limitId: string;
+    }
+  | {
+      kind: 'builtinAgentOptOut';
+      key: MachineFlockBuiltinAgentOptOutKey;
+      agentType: ManagedBuiltinAgentType;
     }
   | {
       kind: 'sessionLaunchConfig';
@@ -327,6 +351,10 @@ export const machineFlockKeys = {
     'rateLimit',
     cliType,
     limitId,
+  ],
+  builtinAgentOptOut: (agentType: ManagedBuiltinAgentType): MachineFlockBuiltinAgentOptOutKey => [
+    'builtinAgentOptOut',
+    agentType,
   ],
   /** @deprecated Compatibility read/cleanup only. New writers must not store launch config per session. */
   sessionLaunchConfig: (sessionId: SessionId): MachineFlockSessionLaunchConfigKey => [
@@ -447,6 +475,19 @@ export const parseMachineFlockKey = (
     };
   }
 
+  if (
+    key.length === 2 &&
+    key[0] === 'builtinAgentOptOut' &&
+    typeof key[1] === 'string' &&
+    isManagedBuiltinAgentType(key[1])
+  ) {
+    return {
+      kind: 'builtinAgentOptOut',
+      key: machineFlockKeys.builtinAgentOptOut(key[1]),
+      agentType: key[1],
+    };
+  }
+
   if (key.length === 2 && key[0] === 'sessionLaunchConfig' && isNonEmptyString(key[1])) {
     const sessionId = key[1] as SessionId;
     return {
@@ -477,6 +518,7 @@ export type MachineFlockRow =
   | { key: MachineFlockAgentConfigIndexKey; value: AgentConfigListSummary }
   | { key: MachineFlockAcpCapabilityKey; value: AcpCapabilityCacheEntry }
   | { key: MachineFlockRateLimitKey; value: RateLimit }
+  | { key: MachineFlockBuiltinAgentOptOutKey; value: BuiltinAgentOptOut }
   | { key: MachineFlockSessionLaunchConfigKey; value: SessionLaunchConfig };
 
 export type MachineFlockRowId = string & { __brand: 'MachineFlockRowId' };
@@ -518,6 +560,7 @@ export type MachineFlockRowFamily =
   | 'agentConfigIndex'
   | 'acpCapability'
   | 'rateLimit'
+  | 'builtinAgentOptOut'
   | 'sessionLaunchConfig';
 
 const MACHINE_FLOCK_ROW_FAMILY_PREFIXES: Record<MachineFlockRowFamily, readonly unknown[]> = {
@@ -532,6 +575,7 @@ const MACHINE_FLOCK_ROW_FAMILY_PREFIXES: Record<MachineFlockRowFamily, readonly 
   agentConfigIndex: ['agentConfigIndex'],
   acpCapability: ['acpCapability'],
   rateLimit: ['rateLimit'],
+  builtinAgentOptOut: ['builtinAgentOptOut'],
   sessionLaunchConfig: ['sessionLaunchConfig'],
 };
 
@@ -617,6 +661,11 @@ const isMachineFlockProviderSetupCancellationRow = (
 const isMachineFlockRateLimitRow = (
   row: MachineFlockRow
 ): row is Extract<MachineFlockRow, { key: MachineFlockRateLimitKey }> => row.key[0] === 'rateLimit';
+
+const isMachineFlockBuiltinAgentOptOutRow = (
+  row: MachineFlockRow
+): row is Extract<MachineFlockRow, { key: MachineFlockBuiltinAgentOptOutKey }> =>
+  row.key[0] === 'builtinAgentOptOut';
 
 const isMachineFlockSessionLaunchConfigRow = (
   row: MachineFlockRow
@@ -752,6 +801,20 @@ export function getMachineFlockRateLimits(rows: MachineFlockRowMap): Record<stri
     rateLimits[getMachineFlockRateLimitEntryKey(row.key[1], row.key[2])] = row.value;
   }
   return rateLimits;
+}
+
+/** 本机被用户主动删掉、因而不该自动补回来的托管内置 provider 类型。 */
+export function getMachineFlockBuiltinAgentOptOuts(
+  rows: MachineFlockRowMap
+): Set<ManagedBuiltinAgentType> {
+  const optedOut = new Set<ManagedBuiltinAgentType>();
+  for (const row of Object.values(rows)) {
+    if (!isMachineFlockBuiltinAgentOptOutRow(row)) {
+      continue;
+    }
+    optedOut.add(row.key[1]);
+  }
+  return optedOut;
 }
 
 export function getMachineFlockSessionLaunchConfig(
@@ -941,6 +1004,12 @@ export function parseMachineFlockRow(
       return isAcpCapabilityCacheEntry(value) ? { key: parsedKey.key, value } : undefined;
     case 'rateLimit':
       return isRecord(value) ? { key: parsedKey.key, value: value as RateLimit } : undefined;
+    case 'builtinAgentOptOut': {
+      const optOut = normalizeBuiltinAgentOptOut(value);
+      return optOut && optOut.agentType === parsedKey.agentType
+        ? { key: parsedKey.key, value: optOut }
+        : undefined;
+    }
     case 'sessionLaunchConfig': {
       const config = normalizeSessionLaunchConfig(value);
       return config ? { key: parsedKey.key, value: config } : undefined;
@@ -1310,6 +1379,26 @@ const normalizeProviderSetupCancellation = (
     id: value.id as AgentConfigId,
     machineId: value.machineId as MachineId,
     cancelledAt: value.cancelledAt,
+  };
+};
+
+const normalizeBuiltinAgentOptOut = (value: unknown): BuiltinAgentOptOut | undefined => {
+  if (
+    !isRecord(value) ||
+    value.v !== 1 ||
+    typeof value.agentType !== 'string' ||
+    !isManagedBuiltinAgentType(value.agentType) ||
+    !isNonEmptyString(value.machineId) ||
+    typeof value.removedAt !== 'number' ||
+    !Number.isFinite(value.removedAt)
+  ) {
+    return undefined;
+  }
+  return {
+    v: 1,
+    agentType: value.agentType,
+    machineId: value.machineId as MachineId,
+    removedAt: value.removedAt,
   };
 };
 

--- a/packages/shared/src/machine-flock.ts
+++ b/packages/shared/src/machine-flock.ts
@@ -770,8 +770,8 @@ export function applyProviderSetupCancellationToFlock(
     prefixes: [
       machineFlockKeys.providerSetupCancellation(cancellation.id),
       machineFlockKeys.providerSetup(cancellation.id),
-      machineFlockKeys.agentConfig(cancellation.id),
     ],
+    families: ['agentConfig', 'builtinAgentOptOut'],
   });
   const existingCancellation = getMachineFlockProviderSetupCancellations(rows)[cancellation.id];
   const setup = getMachineFlockProviderSetups(rows)[cancellation.id];
@@ -786,6 +786,11 @@ export function applyProviderSetupCancellationToFlock(
     flock.delete(machineFlockKeys.providerSetup(cancellation.id), nowMs);
   }
   if (config) {
+    // 取消已发布的 setup 也是用户在删这个 provider，和从列表里删一样要留删除意图。
+    const optOut = planBuiltinAgentOptOutForDeletedConfig(rows, config, nowMs);
+    if (optOut) {
+      flock.set(optOut.key, optOut.value, nowMs);
+    }
     flock.delete(machineFlockKeys.agentConfig(cancellation.id), nowMs);
   }
   flock.commit();
@@ -815,6 +820,127 @@ export function getMachineFlockBuiltinAgentOptOuts(
     optedOut.add(row.key[1]);
   }
   return optedOut;
+}
+
+/** 配置指向的托管内置 provider 类型；自定义、registry、DeepSeek 等不参与启动自动注册的一律返回 null。 */
+export function getBuiltinAgentOptOutAgentType(
+  config: AgentConfigMeta
+): ManagedBuiltinAgentType | null {
+  if (config.cliType !== 'builtin' || !isManagedBuiltinAgentType(config.agentType)) {
+    return null;
+  }
+  return config.agentType;
+}
+
+/**
+ * 删掉 `config` 之后本机要不要记一条「用户删过这类 provider」。
+ *
+ * 只在同类型的最后一个配置被删时才记：还剩别的同类型配置就谈不上「删掉了」，启动
+ * 自动注册也不会补。已经有墓碑就不再重写——墓碑里带时间戳，每次重写都会当成一次
+ * 变更广播给所有 peer。行本身不存在也照样记：删除意图不依赖行是否还在。
+ */
+export function planBuiltinAgentOptOutForDeletedConfig(
+  rows: MachineFlockRowMap,
+  config: AgentConfigMeta,
+  nowMs: number
+): Extract<MachineFlockRow, { key: MachineFlockBuiltinAgentOptOutKey }> | null {
+  const agentType = getBuiltinAgentOptOutAgentType(config);
+  if (agentType === null) {
+    return null;
+  }
+  const key = machineFlockKeys.builtinAgentOptOut(agentType);
+  if (serializeMachineFlockKey(key) in rows) {
+    return null;
+  }
+  const remaining = Object.values(getMachineFlockAgentConfigs(rows)).some(
+    (other) => other.id !== config.id && getBuiltinAgentOptOutAgentType(other) === agentType
+  );
+  if (remaining) {
+    return null;
+  }
+  return {
+    key,
+    value: { v: 1, agentType, machineId: config.machineId, removedAt: nowMs },
+  };
+}
+
+/**
+ * 写入 `config` 要收回的墓碑 key。显式添加内置 provider 就是收回之前的删除意图，
+ * 否则本机会一直记着「用户不要这个 provider」，而列表里明明有一个。没墓碑返回 null。
+ */
+export function findBuiltinAgentOptOutToRetract(
+  rows: MachineFlockRowMap,
+  config: AgentConfigMeta
+): MachineFlockBuiltinAgentOptOutKey | null {
+  const agentType = getBuiltinAgentOptOutAgentType(config);
+  if (agentType === null) {
+    return null;
+  }
+  const key = machineFlockKeys.builtinAgentOptOut(agentType);
+  return serializeMachineFlockKey(key) in rows ? key : null;
+}
+
+/** 写入 agentConfig 行并收回同类型墓碑，同一次 commit 落下。返回是否有变更。 */
+export function writeAgentConfigToFlock(
+  flock: MachineFlockWritableFlock,
+  config: AgentConfigMeta,
+  nowMs?: number
+): boolean {
+  const rows = readMachineFlockRowsFromFlock(flock, {
+    prefixes: [
+      machineFlockKeys.agentConfig(config.id),
+      ...(getBuiltinAgentOptOutAgentType(config) === null
+        ? []
+        : [MACHINE_FLOCK_ROW_FAMILY_PREFIXES.builtinAgentOptOut]),
+    ],
+  });
+  const key = machineFlockKeys.agentConfig(config.id);
+  const normalized = parseMachineFlockRow(key, config);
+  if (!normalized) {
+    return false;
+  }
+  const rowChanged = !machineFlockRowsEqual(rows[serializeMachineFlockKey(key)], normalized);
+  const retractKey = findBuiltinAgentOptOutToRetract(rows, config);
+  if (!rowChanged && !retractKey) {
+    return false;
+  }
+  if (rowChanged) {
+    flock.set(normalized.key, normalized.value, nowMs);
+  }
+  if (retractKey) {
+    flock.delete(retractKey, nowMs);
+  }
+  flock.commit();
+  return true;
+}
+
+/**
+ * 删除 agentConfig 行并按需立墓碑，同一次 commit 落下。删除是硬删，行本身不留痕迹；
+ * 托管内置 provider 不记删除意图，下次启动的自动注册只会看到「列表里没有」，把它当
+ * 没建过又补回来。返回是否有变更。
+ */
+export function deleteAgentConfigFromFlock(
+  flock: MachineFlockWritableFlock,
+  config: AgentConfigMeta,
+  nowMs: number
+): boolean {
+  const rows = readMachineFlockRowsFromFlock(flock, {
+    families: ['agentConfig', 'builtinAgentOptOut'],
+  });
+  const key = machineFlockKeys.agentConfig(config.id);
+  const rowExists = serializeMachineFlockKey(key) in rows;
+  const optOut = planBuiltinAgentOptOutForDeletedConfig(rows, config, nowMs);
+  if (!rowExists && !optOut) {
+    return false;
+  }
+  if (optOut) {
+    flock.set(optOut.key, optOut.value, nowMs);
+  }
+  if (rowExists) {
+    flock.delete(key, nowMs);
+  }
+  flock.commit();
+  return true;
 }
 
 export function getMachineFlockSessionLaunchConfig(

--- a/packages/shared/src/machine-flock.ts
+++ b/packages/shared/src/machine-flock.ts
@@ -205,12 +205,13 @@ export type ProviderSetupCancellation = {
 };
 
 /**
- * 用户在本机主动删掉某个托管内置 provider 的记录。
+ * Record that the user removed a managed builtin provider on this machine.
  *
- * 启动时的内置 provider 自动注册只知道「列表里现在有没有」，区分不了「从没建过」
- * 和「用户刚删掉」。没有这条记录，删掉的 Kimi/Grok/Claude/Codex 下次启动就会被
- * 重新补回来。用户重新添加同类型 provider 时这条记录必须清掉——显式添加就是收回
- * 之前的删除意图。
+ * Startup auto-registration of builtin providers only knows whether a config is
+ * currently in the list; it cannot tell "never created" from "just removed by the
+ * user". Without this record a removed Kimi/Grok/Claude/Codex comes back on the
+ * next start. Re-adding a provider of the same type must clear the record --
+ * adding it explicitly retracts the earlier removal.
  */
 export type BuiltinAgentOptOut = {
   v: 1;
@@ -786,7 +787,8 @@ export function applyProviderSetupCancellationToFlock(
     flock.delete(machineFlockKeys.providerSetup(cancellation.id), nowMs);
   }
   if (config) {
-    // 取消已发布的 setup 也是用户在删这个 provider，和从列表里删一样要留删除意图。
+    // Cancelling a published setup is the user removing this provider, so it needs
+    // the same removal record as deleting it from the list.
     const optOut = planBuiltinAgentOptOutForDeletedConfig(rows, config, nowMs);
     if (optOut) {
       flock.set(optOut.key, optOut.value, nowMs);
@@ -808,7 +810,7 @@ export function getMachineFlockRateLimits(rows: MachineFlockRowMap): Record<stri
   return rateLimits;
 }
 
-/** 本机被用户主动删掉、因而不该自动补回来的托管内置 provider 类型。 */
+/** Managed builtin provider types the user removed on this machine, so they must not be auto-registered again. */
 export function getMachineFlockBuiltinAgentOptOuts(
   rows: MachineFlockRowMap
 ): Set<ManagedBuiltinAgentType> {
@@ -822,7 +824,7 @@ export function getMachineFlockBuiltinAgentOptOuts(
   return optedOut;
 }
 
-/** 配置指向的托管内置 provider 类型；自定义、registry、DeepSeek 等不参与启动自动注册的一律返回 null。 */
+/** The managed builtin provider type this config points at; returns null for custom, registry, DeepSeek and anything else outside startup auto-registration. */
 export function getBuiltinAgentOptOutAgentType(
   config: AgentConfigMeta
 ): ManagedBuiltinAgentType | null {
@@ -833,11 +835,13 @@ export function getBuiltinAgentOptOutAgentType(
 }
 
 /**
- * 删掉 `config` 之后本机要不要记一条「用户删过这类 provider」。
+ * Whether removing `config` should record a "user removed this provider type" opt-out.
  *
- * 只在同类型的最后一个配置被删时才记：还剩别的同类型配置就谈不上「删掉了」，启动
- * 自动注册也不会补。已经有墓碑就不再重写——墓碑里带时间戳，每次重写都会当成一次
- * 变更广播给所有 peer。行本身不存在也照样记：删除意图不依赖行是否还在。
+ * Only the last config of that type counts: while another config of the same type
+ * remains, nothing was really removed and startup auto-registration will not add
+ * anything back. An existing opt-out is never rewritten -- it carries a timestamp,
+ * so every rewrite broadcasts a change to every peer. A missing row is still
+ * recorded: the removal intent does not depend on the row being there.
  */
 export function planBuiltinAgentOptOutForDeletedConfig(
   rows: MachineFlockRowMap,
@@ -865,8 +869,10 @@ export function planBuiltinAgentOptOutForDeletedConfig(
 }
 
 /**
- * 写入 `config` 要收回的墓碑 key。显式添加内置 provider 就是收回之前的删除意图，
- * 否则本机会一直记着「用户不要这个 provider」，而列表里明明有一个。没墓碑返回 null。
+ * The opt-out key that writing `config` must retract. Adding a builtin provider
+ * explicitly retracts the earlier removal; otherwise this machine keeps recording
+ * "the user does not want this provider" while the list plainly holds one.
+ * Returns null when there is no opt-out.
  */
 export function findBuiltinAgentOptOutToRetract(
   rows: MachineFlockRowMap,
@@ -880,7 +886,7 @@ export function findBuiltinAgentOptOutToRetract(
   return serializeMachineFlockKey(key) in rows ? key : null;
 }
 
-/** 写入 agentConfig 行并收回同类型墓碑，同一次 commit 落下。返回是否有变更。 */
+/** Write the agentConfig row and retract the same-type opt-out in one commit. Returns whether anything changed. */
 export function writeAgentConfigToFlock(
   flock: MachineFlockWritableFlock,
   config: AgentConfigMeta,
@@ -915,9 +921,11 @@ export function writeAgentConfigToFlock(
 }
 
 /**
- * 删除 agentConfig 行并按需立墓碑，同一次 commit 落下。删除是硬删，行本身不留痕迹；
- * 托管内置 provider 不记删除意图，下次启动的自动注册只会看到「列表里没有」，把它当
- * 没建过又补回来。返回是否有变更。
+ * Delete the agentConfig row and record an opt-out when needed, in one commit.
+ * The delete is a hard delete and leaves no trace of the row, so without a removal
+ * record for a managed builtin provider the next startup auto-registration only
+ * sees "not in the list", treats it as never created and adds it back.
+ * Returns whether anything changed.
  */
 export function deleteAgentConfigFromFlock(
   flock: MachineFlockWritableFlock,

--- a/packages/shared/src/machine-flock.ts
+++ b/packages/shared/src/machine-flock.ts
@@ -212,11 +212,12 @@ export type ProviderSetupCancellation = {
  * user". Without this record a removed Kimi/Grok/Claude/Codex comes back on the
  * next start. Re-adding a provider of the same type must clear the record --
  * adding it explicitly retracts the earlier removal.
+ *
+ * The provider type lives in the key and the machine is the flock doc itself, so
+ * the value carries only the timestamp.
  */
 export type BuiltinAgentOptOut = {
   v: 1;
-  agentType: ManagedBuiltinAgentType;
-  machineId: MachineId;
   removedAt: number;
 };
 
@@ -864,7 +865,7 @@ export function planBuiltinAgentOptOutForDeletedConfig(
   }
   return {
     key,
-    value: { v: 1, agentType, machineId: config.machineId, removedAt: nowMs },
+    value: { v: 1, removedAt: nowMs },
   };
 }
 
@@ -1140,9 +1141,7 @@ export function parseMachineFlockRow(
       return isRecord(value) ? { key: parsedKey.key, value: value as RateLimit } : undefined;
     case 'builtinAgentOptOut': {
       const optOut = normalizeBuiltinAgentOptOut(value);
-      return optOut && optOut.agentType === parsedKey.agentType
-        ? { key: parsedKey.key, value: optOut }
-        : undefined;
+      return optOut ? { key: parsedKey.key, value: optOut } : undefined;
     }
     case 'sessionLaunchConfig': {
       const config = normalizeSessionLaunchConfig(value);
@@ -1520,20 +1519,12 @@ const normalizeBuiltinAgentOptOut = (value: unknown): BuiltinAgentOptOut | undef
   if (
     !isRecord(value) ||
     value.v !== 1 ||
-    typeof value.agentType !== 'string' ||
-    !isManagedBuiltinAgentType(value.agentType) ||
-    !isNonEmptyString(value.machineId) ||
     typeof value.removedAt !== 'number' ||
     !Number.isFinite(value.removedAt)
   ) {
     return undefined;
   }
-  return {
-    v: 1,
-    agentType: value.agentType,
-    machineId: value.machineId as MachineId,
-    removedAt: value.removedAt,
-  };
+  return { v: 1, removedAt: value.removedAt };
 };
 
 const normalizeAgentConfigListSummary = (value: unknown): AgentConfigListSummary | undefined => {

--- a/packages/shared/tests/machine-flock.test.ts
+++ b/packages/shared/tests/machine-flock.test.ts
@@ -597,8 +597,9 @@ describe('machine Flock helpers', () => {
       expect(
         writeMachineFlockRowToFlock(flock, {
           key: machineFlockKeys.builtinAgentOptOut('kimi'),
-          // 值里的 agentType 与 key 不一致,写入必须失败——否则跳过逻辑会按 key 生效,
-          // 却对着一条内容对不上的记录。
+          // The agentType in the value disagrees with the key, so the write must fail --
+          // otherwise the skip logic keys off the key while pointing at a record whose
+          // contents do not match.
           value: { v: 1, agentType: 'codex', machineId, removedAt: 1700 },
         } as never)
       ).toBe(false);
@@ -631,7 +632,8 @@ describe('machine Flock helpers', () => {
     });
 
     it('deleting one of several configs of a type does not record an opt-out', () => {
-      // 还剩一个 Kimi，用户没有「删掉 Kimi」，启动也不会补，不该记删除意图。
+      // One Kimi is left, so the user did not remove Kimi, startup adds nothing back and no
+      // opt-out should be recorded.
       const flock = new FakeMachineFlock();
       writeAgentConfigToFlock(flock, kimi('a'));
       writeAgentConfigToFlock(flock, kimi('b'));
@@ -642,7 +644,8 @@ describe('machine Flock helpers', () => {
     });
 
     it('does not rewrite an existing opt-out on repeated deletes', () => {
-      // 墓碑带时间戳，重写会被当成变更广播给所有 peer；行已不在、墓碑已在时必须无变更。
+      // The opt-out carries a timestamp, so a rewrite broadcasts a change to every peer; with
+      // the row already gone and the opt-out already there, nothing must change.
       const flock = new FakeMachineFlock();
       deleteAgentConfigFromFlock(flock, kimi('a'), 1700);
 
@@ -674,7 +677,8 @@ describe('machine Flock helpers', () => {
     });
 
     it('cancelling a published provider setup records the opt-out', () => {
-      // 取消已发布的 setup 也是在删 provider，不记墓碑的话 CLI 下次启动又补回来。
+      // Cancelling a published setup is also removing the provider; without the opt-out the CLI
+      // adds it back on the next startup.
       const flock = new FakeMachineFlock();
       writeAgentConfigToFlock(flock, kimi('setup-1'));
 
@@ -690,7 +694,7 @@ describe('machine Flock helpers', () => {
     });
 
     it('cancelling an unpublished provider setup records no opt-out', () => {
-      // 从没发布过，列表里本来就没有，不存在「删掉」一说。
+      // It was never published, so it was never in the list and there is nothing to remove.
       const flock = new FakeMachineFlock();
       applyProviderSetupCancellationToFlock(flock, {
         v: 1,
@@ -703,7 +707,8 @@ describe('machine Flock helpers', () => {
     });
 
     it('rejects an agentType that has no managed runtime', () => {
-      // deepseek 是内置 provider,但不参与启动自动注册,不该有删除意图记录。
+      // deepseek is a builtin provider but stays outside startup auto-registration, so it must
+      // have no opt-out record.
       expect(parseMachineFlockKey(['builtinAgentOptOut', 'deepseek'])).toBeUndefined();
       expect(parseMachineFlockKey(['builtinAgentOptOut', 'kimi'])).toEqual({
         kind: 'builtinAgentOptOut',

--- a/packages/shared/tests/machine-flock.test.ts
+++ b/packages/shared/tests/machine-flock.test.ts
@@ -573,7 +573,7 @@ describe('machine Flock helpers', () => {
       expect(
         writeMachineFlockRowToFlock(flock, {
           key,
-          value: { v: 1, agentType: 'kimi', machineId, removedAt: 1700 },
+          value: { v: 1, removedAt: 1700 },
         })
       ).toBe(true);
 
@@ -591,16 +591,15 @@ describe('machine Flock helpers', () => {
       ).toEqual(new Set());
     });
 
-    it('rejects a row whose agentType does not match its key', () => {
+    it('rejects a row whose key names a provider type outside startup auto-registration', () => {
       const flock = new FakeMachineFlock();
 
+      // The provider type lives only in the key, so the key is the single thing
+      // that can be wrong: a type the startup skip logic never checks must not be stored.
       expect(
         writeMachineFlockRowToFlock(flock, {
-          key: machineFlockKeys.builtinAgentOptOut('kimi'),
-          // The agentType in the value disagrees with the key, so the write must fail --
-          // otherwise the skip logic keys off the key while pointing at a record whose
-          // contents do not match.
-          value: { v: 1, agentType: 'codex', machineId, removedAt: 1700 },
+          key: ['builtinAgentOptOut', 'deepseek'],
+          value: { v: 1, removedAt: 1700 },
         } as never)
       ).toBe(false);
     });

--- a/packages/shared/tests/machine-flock.test.ts
+++ b/packages/shared/tests/machine-flock.test.ts
@@ -8,6 +8,7 @@ import {
   deleteMachineFlockRowFromFlock,
   getMachineFlockAcpCapabilities,
   getMachineFlockAgentConfigs,
+  getMachineFlockBuiltinAgentOptOuts,
   getMachineFlockDeleteLocalProjectEntries,
   getMachineFlockDeleteLocalProjectIds,
   getMachineFlockDotlodyPath,
@@ -555,6 +556,58 @@ describe('machine Flock helpers', () => {
       })
     ).toEqual({
       [getRateLimitEntryKey('codex', 'codex_bengalfox')]: row.value,
+    });
+  });
+
+  describe('builtin agent opt-out rows', () => {
+    const machineId = 'machine-1' as MachineId;
+
+    it('round-trips a removal through the flock', () => {
+      const flock = new FakeMachineFlock();
+      const key = machineFlockKeys.builtinAgentOptOut('kimi');
+
+      expect(
+        writeMachineFlockRowToFlock(flock, {
+          key,
+          value: { v: 1, agentType: 'kimi', machineId, removedAt: 1700 },
+        })
+      ).toBe(true);
+
+      expect(
+        getMachineFlockBuiltinAgentOptOuts(
+          readMachineFlockRowsFromFlock(flock, { families: ['builtinAgentOptOut'] })
+        )
+      ).toEqual(new Set(['kimi']));
+
+      expect(deleteMachineFlockRowFromFlock(flock, key)).toBe(true);
+      expect(
+        getMachineFlockBuiltinAgentOptOuts(
+          readMachineFlockRowsFromFlock(flock, { families: ['builtinAgentOptOut'] })
+        )
+      ).toEqual(new Set());
+    });
+
+    it('rejects a row whose agentType does not match its key', () => {
+      const flock = new FakeMachineFlock();
+
+      expect(
+        writeMachineFlockRowToFlock(flock, {
+          key: machineFlockKeys.builtinAgentOptOut('kimi'),
+          // 值里的 agentType 与 key 不一致,写入必须失败——否则跳过逻辑会按 key 生效,
+          // 却对着一条内容对不上的记录。
+          value: { v: 1, agentType: 'codex', machineId, removedAt: 1700 },
+        } as never)
+      ).toBe(false);
+    });
+
+    it('rejects an agentType that has no managed runtime', () => {
+      // deepseek 是内置 provider,但不参与启动自动注册,不该有删除意图记录。
+      expect(parseMachineFlockKey(['builtinAgentOptOut', 'deepseek'])).toBeUndefined();
+      expect(parseMachineFlockKey(['builtinAgentOptOut', 'kimi'])).toEqual({
+        kind: 'builtinAgentOptOut',
+        key: machineFlockKeys.builtinAgentOptOut('kimi'),
+        agentType: 'kimi',
+      });
     });
   });
 });

--- a/packages/shared/tests/machine-flock.test.ts
+++ b/packages/shared/tests/machine-flock.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   applyMachineFlockRowEvents,
+  applyProviderSetupCancellationToFlock,
   buildMachineArchiveSessionCommand,
   buildMachineDeleteLocalProjectCommand,
   buildMachineDeleteSessionCommand,
+  deleteAgentConfigFromFlock,
   deleteMachineFlockRowFromFlock,
   getMachineFlockAcpCapabilities,
   getMachineFlockAgentConfigs,
@@ -25,7 +27,9 @@ import {
   parseMachineFlockKey,
   readMachineFlockRowsFromFlock,
   serializeMachineFlockKey,
+  writeAgentConfigToFlock,
   writeMachineFlockRowToFlock,
+  type AgentConfigMeta,
   type MachineFlockKey,
   type MachineFlockWritableFlock,
 } from '../src/machine-flock';
@@ -598,6 +602,104 @@ describe('machine Flock helpers', () => {
           value: { v: 1, agentType: 'codex', machineId, removedAt: 1700 },
         } as never)
       ).toBe(false);
+    });
+
+    const kimi = (id: string): AgentConfigMeta =>
+      ({
+        id: id as AgentConfigId,
+        machineId,
+        name: 'Kimi',
+        cliType: 'builtin',
+        agentType: 'kimi',
+        env: {},
+      }) as AgentConfigMeta;
+    const optOuts = (flock: FakeMachineFlock) =>
+      getMachineFlockBuiltinAgentOptOuts(
+        readMachineFlockRowsFromFlock(flock, { families: ['builtinAgentOptOut'] })
+      );
+
+    it('deleting the last config of a type records the opt-out in one commit', () => {
+      const flock = new FakeMachineFlock();
+      writeAgentConfigToFlock(flock, kimi('a'));
+      flock.commits = 0;
+
+      expect(deleteAgentConfigFromFlock(flock, kimi('a'), 1700)).toBe(true);
+
+      expect(flock.commits).toBe(1);
+      expect(getMachineFlockAgentConfigs(readMachineFlockRowsFromFlock(flock))).toEqual({});
+      expect(optOuts(flock)).toEqual(new Set(['kimi']));
+    });
+
+    it('deleting one of several configs of a type does not record an opt-out', () => {
+      // 还剩一个 Kimi，用户没有「删掉 Kimi」，启动也不会补，不该记删除意图。
+      const flock = new FakeMachineFlock();
+      writeAgentConfigToFlock(flock, kimi('a'));
+      writeAgentConfigToFlock(flock, kimi('b'));
+
+      deleteAgentConfigFromFlock(flock, kimi('a'), 1700);
+
+      expect(optOuts(flock)).toEqual(new Set());
+    });
+
+    it('does not rewrite an existing opt-out on repeated deletes', () => {
+      // 墓碑带时间戳，重写会被当成变更广播给所有 peer；行已不在、墓碑已在时必须无变更。
+      const flock = new FakeMachineFlock();
+      deleteAgentConfigFromFlock(flock, kimi('a'), 1700);
+
+      expect(deleteAgentConfigFromFlock(flock, kimi('a'), 1800)).toBe(false);
+      expect(
+        flock.rows.get(JSON.stringify(machineFlockKeys.builtinAgentOptOut('kimi')))?.value
+      ).toMatchObject({ removedAt: 1700 });
+    });
+
+    it('writing a config of an opted-out type retracts the opt-out in the same commit', () => {
+      const flock = new FakeMachineFlock();
+      deleteAgentConfigFromFlock(flock, kimi('a'), 1700);
+      flock.commits = 0;
+
+      expect(writeAgentConfigToFlock(flock, kimi('b'))).toBe(true);
+
+      expect(flock.commits).toBe(1);
+      expect(optOuts(flock)).toEqual(new Set());
+      expect(
+        Object.keys(getMachineFlockAgentConfigs(readMachineFlockRowsFromFlock(flock)))
+      ).toEqual(['b']);
+    });
+
+    it('rewriting an identical config is a no-op', () => {
+      const flock = new FakeMachineFlock();
+      writeAgentConfigToFlock(flock, kimi('a'));
+
+      expect(writeAgentConfigToFlock(flock, kimi('a'))).toBe(false);
+    });
+
+    it('cancelling a published provider setup records the opt-out', () => {
+      // 取消已发布的 setup 也是在删 provider，不记墓碑的话 CLI 下次启动又补回来。
+      const flock = new FakeMachineFlock();
+      writeAgentConfigToFlock(flock, kimi('setup-1'));
+
+      applyProviderSetupCancellationToFlock(flock, {
+        v: 1,
+        id: 'setup-1' as AgentConfigId,
+        machineId,
+        cancelledAt: 1700,
+      });
+
+      expect(getMachineFlockAgentConfigs(readMachineFlockRowsFromFlock(flock))).toEqual({});
+      expect(optOuts(flock)).toEqual(new Set(['kimi']));
+    });
+
+    it('cancelling an unpublished provider setup records no opt-out', () => {
+      // 从没发布过，列表里本来就没有，不存在「删掉」一说。
+      const flock = new FakeMachineFlock();
+      applyProviderSetupCancellationToFlock(flock, {
+        v: 1,
+        id: 'setup-1' as AgentConfigId,
+        machineId,
+        cancelledAt: 1700,
+      });
+
+      expect(optOuts(flock)).toEqual(new Set());
     });
 
     it('rejects an agentType that has no managed runtime', () => {


### PR DESCRIPTION
## Related issue

Closes #98

## Problem / pressure

Settings → Agents lists the four managed builtin providers (Claude Code, Codex, Grok, Kimi Code). Deleting one of them (e.g. Kimi Code) only lasts until the next Lody restart: startup auto-registration in `Lody.ensureBuiltinAgentConfigs` asks "does this machine have a builtin config of type X?", and "no" cannot distinguish "never created" from "the user just deleted it", so the provider is recreated every time.

## Summary

- Add a `builtinAgentOptOut` row family to the machine Flock document (`packages/shared/src/machine-flock.ts`): key `['builtinAgentOptOut', <ManagedBuiltinAgentType>]`, value `{ v, agentType, machineId, removedAt }`, with parse/normalize/getter and a key/value mismatch guard.
- Own the opt-out rules in one place in `@lody/shared`: `planBuiltinAgentOptOutForDeletedConfig` / `findBuiltinAgentOptOutToRetract` (pure, row-map based) plus `writeAgentConfigToFlock` / `deleteAgentConfigFromFlock` (row + tombstone in one commit). The tombstone is written only when the last config of that type on the machine goes away, is never rewritten once present, and is retracted whenever a config of that type is written.
- Route every agentConfig write/delete path through those helpers: CLI `upsertMachineAgentConfig` / `deleteMachineAgentConfig`, provider-setup publish (`provider-setup-manager.ts`) and cancellation (`applyProviderSetupCancellationToFlock`), and the renderer atoms in `packages/components/src/atoms/agents.ts` (which only pay the extra writer round trip when the local mirror actually holds a tombstone; the create atom replaces the optimistic cache so a retracted tombstone leaves it).
- Startup registration (`apps/cli/src/lib/lody.ts`) reads the opt-out set via `LoroDocumentManager.getBuiltinAgentOptOuts` and skips those types before the existence check.
- Non-managed configs (custom ACP, registry, DeepSeek) never write an opt-out.

## Before / after

| Before | After |
| ------ | ----- |
| Delete Kimi Code → restart Lody → Kimi Code is back | Delete Kimi Code → restart Lody → it stays deleted |
| Cancel a published provider setup → restart → provider is back | Cancellation records the same opt-out as a list delete |
| n/a | Add Kimi Code again (list or provider setup) → opt-out cleared; future restarts behave as before |

## Test plan

- `pnpm --filter @lody/shared exec vitest run tests/machine-flock.test.ts` — 25 passed (10 new: round-trip, key/value mismatch rejected, non-managed type rejected, last-of-type delete writes tombstone in one commit, one-of-several does not, repeated delete does not rewrite, write retracts in one commit, identical rewrite is a no-op, cancelling a published setup writes tombstone, cancelling an unpublished one does not)
- `pnpm --filter lody exec vitest run tests/lody-register-agent.test.ts tests/agent-config-machine-flock.test.ts src/lib/provider-setup-manager.test.ts` — 18 passed
- `pnpm --filter @lody/components exec vitest run tests/agent-config-create.test.ts tests/agent-config-dialog.test.tsx` — 16 passed
- `tsgo --noEmit` for `@lody/shared`, `lody`, `@lody/components` — pass
- `oxlint --type-aware` on touched files — 0 errors, warning count unchanged from `main`
- Prettier on every touched file — pass
- Skipped: full `pnpm test:ci` on Windows shows 7 pre-existing failures in unrelated files (`local-cli-host-lease`, `lody-mcp-server`, `acp-authentication`, `message-handler-image-upload`); verified identical failures on `main` without this change. Not verified end-to-end in the Electron app.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `packages/shared/src/machine-flock.ts` `planBuiltinAgentOptOutForDeletedConfig` / `deleteAgentConfigFromFlock` (the only place that decides when a tombstone exists) and the four call sites that now go through it: CLI `agent-config-machine-flock.ts`, `provider-setup-manager.ts` publish, `applyProviderSetupCancellationToFlock`, and the renderer atoms in `packages/components/src/atoms/agents.ts`.
- **Decisions to challenge:** Opt-out is per machine and per agent type, written only when the last config of that type is removed; the renderer create atom switched the optimistic cache from `merge` to `replace` so a retracted tombstone actually leaves the cache.
- **Plausible failures / evidence gaps:** Renderer writes go through `runtime.writer` as separate commits rather than one transaction; the renderer decides "tombstone present?" from the local mirror, which can lag in cloud mode; no end-to-end run in the Electron app.

### Authoring context

- **User goal / directives:** Fix "deleted Kimi Code comes back after restart"; then review the PR and fix every path that could still recreate or leave a stale opt-out, keeping the rules in one shared place.
- **Constraints / non-goals:** No fallback/compat branches; no change to which providers are managed builtins; no per-config-id tombstones.
- **Risk-bearing decisions:** Introduces a new persisted row family in the machine Flock document; older clients ignore unknown rows via `parseMachineFlockRow`. Provider-setup cancellation of a published config now also records an opt-out.
- **Destructive or irreversible behavior:** None beyond the existing hard delete of the config row; the opt-out row is removed automatically when the user adds the type back.
- **Deliberately not done or tested:** Full `test:ci` on Windows (pre-existing unrelated failures); manual Electron verification.
- **Unknowns / confidence:** High confidence in the logic and unit coverage; medium on cloud-mode local-mirror lag in the renderer paths.

<!-- context-handoff:end -->
