### PR TITLE
fix: stop advertising ⌘L on web composer

### DIFF
--- a/packages/components/src/lib/commands/shortcuts.ts
+++ b/packages/components/src/lib/commands/shortcuts.ts
@@ -62,7 +62,9 @@ export const COMMAND_SHORTCUTS: Record<ShortcutCommandId, CommandKeybindings> = 
   'sidebar.toggle': ['$mod+b'],
   'session.toggleCurrentPinned': ['$mod+Alt+p'],
   'session.searchCurrent': [electron('$mod+f'), web('$mod+Alt+f')],
-  'session.focusInput': ['$mod+l'],
+  // Desktop ⌘L focuses the composer. On web the browser owns ⌘L (Open Location),
+  // so leave it unbound — the hint chip follows the resolved binding.
+  'session.focusInput': [electron('$mod+l')],
   'session.toggleExplorerSidebar': ['$mod+Alt+b'],
   'session.copyCurrentBranch': ['Alt+Shift+b'],
   'session.copyUrl': ['Alt+Shift+c'],

--- a/packages/components/tests/commands-built-ins.test.ts
+++ b/packages/components/tests/commands-built-ins.test.ts
@@ -21,7 +21,7 @@ describe('built-in commands', () => {
     expect(commands.get('session.archiveCurrent')?.title).toBe('Archive Current Chat');
     expect(commands.getDefaultKeybindingsFor('session.archiveCurrent')).toEqual(['$mod+Alt+a']);
     expect(commands.getDefaultKeybindingsFor('session.searchCurrent')).toEqual(['$mod+Alt+f']);
-    expect(commands.getDefaultKeybindingsFor('session.focusInput')).toEqual(['$mod+l']);
+    expect(commands.getDefaultKeybindingsFor('session.focusInput')).toEqual([]);
     expect(commands.getDefaultKeybindingsFor('session.nextTab')).toEqual([]);
     expect(commands.getDefaultKeybindingsFor('session.previousVisible')).toEqual([]);
     // ⌥N works on web too (always a new tab there); ⌘[/⌘] back/forward and the terminal
@@ -47,6 +47,7 @@ describe('built-in commands', () => {
     registerBuiltInCommands();
 
     expect(commands.getDefaultKeybindingsFor('session.searchCurrent')).toEqual(['$mod+f']);
+    expect(commands.getDefaultKeybindingsFor('session.focusInput')).toEqual(['$mod+l']);
     expect(commands.getDefaultKeybindingsFor('session.nextTab')).toEqual(['$mod+Shift+.']);
     expect(commands.getDefaultKeybindingsFor('session.previousTab')).toEqual(['$mod+Shift+,']);
     expect(commands.getDefaultKeybindingsFor('session.previousVisible')).toEqual(['$mod+Shift+[']);


### PR DESCRIPTION
## Author type

- [ ] I am an Agent (check this if an LLM agent authored this PR)
- [x] I am a human

## Problem / pressure

On web, the empty composer shows ⌘L for focusing the input. That chord is already Open Location in Safari and Chrome, so the chip teaches a shortcut that never works.

## Summary

`session.focusInput` is desktop-only now. Web has no default, so the hint chip hides. Didn't pick another chord — Safari uses ⌘⌥L for downloads.

## Test plan

- web built-in command test: `session.focusInput` unbound
- electron test: still `$mod+l`

Closes #90
