### PR TITLE
fix: tolerate synced doc root keys written by newer peers

### DIFF
--- a/apps/cli/src/lib/loro/AGENTS.md
+++ b/apps/cli/src/lib/loro/AGENTS.md
@@ -2,6 +2,14 @@
 
 `CLAUDE.md` is a symlink to this file. Edit `AGENTS.md` only.
 
+## Mirrors over synced docs tolerate unknown root keys
+
+Every `new Mirror(...)` over a doc that syncs between clients must pass
+`ignoreUnknownProperties: true`. Peers on a newer schema write root keys this
+build does not declare; without the flag loro-mirror rejects the entire state
+with `Unknown property: <key>`, so the older client can never write to that doc
+again. Contract test: `packages/shared/tests/session-doc-forward-compat.test.ts`.
+
 ## Opening a doc pulls its stream
 
 `LoroDocumentManager.getOrCreateSessionDoc()` is not a cheap read.

--- a/apps/cli/src/lib/loro/doc.ts
+++ b/apps/cli/src/lib/loro/doc.ts
@@ -1693,6 +1693,8 @@ export class SessionDocument implements LoroDocument<SessionDocMeta, SessionMeta
     this.mirror = new Mirror({
       doc: handle.doc,
       schema: sessionDocSchema,
+      // Tolerate root keys written by peers running a newer schema version.
+      ignoreUnknownProperties: true,
       // Type assertion needed because InferInputType makes plan required even though
       // schema defines it as required: false. At runtime, plan is optional on history entries.
       initialState: merged as unknown as ConstructorParameters<typeof Mirror>[0]['initialState'],

--- a/apps/cli/src/lib/task-doc.ts
+++ b/apps/cli/src/lib/task-doc.ts
@@ -98,6 +98,8 @@ const withTaskMirror = async <T>(
   const mirror = new Mirror({
     doc: handle.doc as LoroDoc,
     schema: taskDocSchema,
+    // Tolerate root keys written by peers running a newer schema version.
+    ignoreUnknownProperties: true,
     // Only creation seeds the containers. Every other path must see an absent
     // document as absent: seeding here would make `readTask` answer with a
     // placeholder meta instead of null, and TASK_NOT_FOUND would stop existing.

--- a/packages/components/src/providers/AGENTS.md
+++ b/packages/components/src/providers/AGENTS.md
@@ -2,6 +2,14 @@
 
 `CLAUDE.md` is a symlink to this file. Parent `AGENTS.md` files also apply.
 
+## Mirrors over synced docs tolerate unknown root keys
+
+Every `new Mirror(...)` over a doc that syncs between clients must pass
+`ignoreUnknownProperties: true`. Peers on a newer schema write root keys this
+build does not declare; without the flag loro-mirror rejects the entire state
+with `Unknown property: <key>`, so the older client can never write to that doc
+again. Contract test: `packages/shared/tests/session-doc-forward-compat.test.ts`.
+
 ## Streams connection cardinality
 
 - Capability discovery and refresh must reuse the workspace runtime's existing Machine

--- a/packages/components/src/providers/create-workspace-runtime.ts
+++ b/packages/components/src/providers/create-workspace-runtime.ts
@@ -3611,6 +3611,8 @@ export async function createWorkspaceRuntime(deps: RuntimeDeps): Promise<Workspa
     const mirror = new Mirror({
       doc: persistedDoc.doc as LoroDoc,
       schema: sessionDocSchema,
+      // Tolerate root keys written by peers running a newer schema version.
+      ignoreUnknownProperties: true,
       // Plan is now stored per-turn on history entries, not at root level
       initialState: { session: { id: sessionId }, history: [] },
       debug: false,
@@ -3807,6 +3809,8 @@ export async function createWorkspaceRuntime(deps: RuntimeDeps): Promise<Workspa
     const mirror = new Mirror({
       doc: persistedDoc.doc as LoroDoc,
       schema: previewVisualCommentDocSchema,
+      // Tolerate root keys written by peers running a newer schema version.
+      ignoreUnknownProperties: true,
       initialState: { meta: { sessionId }, turns: {} },
       debug: false,
     });
@@ -3895,6 +3899,8 @@ export async function createWorkspaceRuntime(deps: RuntimeDeps): Promise<Workspa
     const mirror = new Mirror({
       doc: persistedDoc.doc as LoroDoc,
       schema: taskDocSchema,
+      // Tolerate root keys written by peers running a newer schema version.
+      ignoreUnknownProperties: true,
       initialState: {
         meta: {
           taskId,

--- a/packages/shared/src/preview-comment-schema.ts
+++ b/packages/shared/src/preview-comment-schema.ts
@@ -89,6 +89,7 @@ export const previewVisualCommentTurnSchema = schema.LoroMap({
   comments: schema.LoroList(previewVisualCommentSchema, (item: { id: string }) => item.id),
 });
 
+/** Root schema for a preview visual comment doc; see `sessionDocSchema` on adding root fields. */
 export const previewVisualCommentDocSchema = schema({
   meta: schema.LoroMap({
     sessionId: schema.String<SessionId>(),

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -980,6 +980,19 @@ const sessionForkOperationDocSchema = schema.LoroMap(
   { required: false }
 );
 
+/**
+ * Root schema for a session doc.
+ *
+ * Synced docs outlive the builds that write them: a client on a newer schema
+ * can add a root key that older clients do not declare. Adding an optional
+ * root field is therefore safe, but only because every Mirror over a synced
+ * doc is constructed with `ignoreUnknownProperties` — without it loro-mirror
+ * rejects the whole state with `Unknown property: <key>` and the older client
+ * can never write to that doc again. Removing or repurposing an existing root
+ * field is still a breaking change.
+ *
+ * See `packages/shared/tests/session-doc-forward-compat.test.ts`.
+ */
 export const sessionDocSchema = schema({
   session: sessionSchema,
   history: schema.LoroList(sessionHistorySchema, (item) => item.id),

--- a/packages/shared/src/task-schema.ts
+++ b/packages/shared/src/task-schema.ts
@@ -87,6 +87,7 @@ export const taskTimelineEntrySchema = schema.LoroMap({
   activityData: schema.Any({ required: false }),
 });
 
+/** Root schema for a task doc; see `sessionDocSchema` on adding root fields. */
 export const taskDocSchema = schema({
   meta: taskMetaSchema,
   body: schema.LoroText(),

--- a/packages/shared/tests/mirror-construction-sites.test.ts
+++ b/packages/shared/tests/mirror-construction-sites.test.ts
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `ignoreUnknownProperties` is passed per construction site, so a behavioural
+ * test over one Mirror cannot prove the invariant holds — a new store that
+ * forgets the option still passes `session-doc-forward-compat`.
+ */
+
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
+const searchRoots = ['apps/cli/src', 'packages/components/src'];
+
+function productionSources(dir: string): string[] {
+  return readdirSync(dir, { recursive: true, withFileTypes: true })
+    .filter((e) => e.isFile() && /(?<!\.test)\.tsx?$/.test(e.name))
+    .map((e) => join(e.parentPath, e.name));
+}
+
+describe('Mirror construction sites', () => {
+  it('always opt into tolerating unknown root keys', () => {
+    const missing: string[] = [];
+    let sites = 0;
+
+    for (const root of searchRoots) {
+      for (const file of productionSources(join(repoRoot, root))) {
+        const source = readFileSync(file, 'utf8');
+        for (
+          let at = source.indexOf('new Mirror(');
+          at !== -1;
+          at = source.indexOf('new Mirror(', at + 1)
+        ) {
+          sites++;
+          // Options are top level in the call, so the first `});` ends it.
+          if (source.slice(at, source.indexOf('});', at)).includes('ignoreUnknownProperties'))
+            continue;
+          missing.push(`${file.slice(repoRoot.length)}:${source.slice(0, at).split('\n').length}`);
+        }
+      }
+    }
+
+    expect(missing).toEqual([]);
+    // A scan that silently matched nothing would pass forever.
+    expect(sites).toBeGreaterThan(0);
+  });
+});

--- a/packages/shared/tests/session-doc-forward-compat.test.ts
+++ b/packages/shared/tests/session-doc-forward-compat.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { Loro } from 'loro-crdt';
+import { Mirror, schema } from 'loro-mirror';
+
+import { sessionDocSchema } from '../src/schema';
+import type { SessionId } from '../src/ai';
+
+/**
+ * Session docs are shared between clients built against different schema
+ * versions. A peer on a newer build writes root keys this build does not
+ * declare (`forkOperation` was the first one to reach production), so every
+ * Mirror over a session doc must be constructed with
+ * `ignoreUnknownProperties`. Without it, loro-mirror rejects the whole state
+ * with `State validation failed: Unknown property: <key>` and the older client
+ * can never write to that session again.
+ */
+
+const sessionId = 'session-forward-compat' as SessionId;
+
+/** A future build's schema: today's schema plus one undeclared root container. */
+const futureDocSchema = schema({
+  ...sessionDocSchema.definition,
+  futureFeature: schema.LoroMap({
+    id: schema.String(),
+    state: schema.String(),
+  }),
+});
+
+function createFutureDocSnapshot(): Uint8Array {
+  const doc = new Loro();
+  const mirror = new Mirror({ doc, schema: futureDocSchema });
+  mirror.setState((state) => ({
+    ...state,
+    session: { id: sessionId },
+    history: [],
+    futureFeature: { id: 'op-1', state: 'preparing' },
+  }));
+  return doc.export({ mode: 'snapshot' });
+}
+
+function createSessionMirror(doc: Loro) {
+  return new Mirror({
+    doc,
+    schema: sessionDocSchema,
+    ignoreUnknownProperties: true,
+    initialState: { session: { id: sessionId }, history: [] },
+  });
+}
+
+describe('session doc forward compatibility', () => {
+  it('keeps writing after a newer peer adds an undeclared root key', () => {
+    const doc = new Loro();
+    const mirror = createSessionMirror(doc);
+
+    // The crashing path in production: the mirror is already open when the
+    // newer peer's update arrives, so the unknown key enters state via events.
+    doc.import(createFutureDocSnapshot());
+
+    expect(() => {
+      mirror.setState((state) => {
+        state.session.title = 'renamed by the older client';
+      });
+    }).not.toThrow();
+
+    expect(doc.toJSON().futureFeature).toEqual({ id: 'op-1', state: 'preparing' });
+  });
+
+  it('preserves the undeclared root key through a full-state update', () => {
+    const doc = new Loro();
+    const mirror = createSessionMirror(doc);
+    doc.import(createFutureDocSnapshot());
+
+    mirror.setState((state) => ({ ...state, session: { ...state.session, title: 'rebuilt' } }));
+
+    expect(doc.toJSON().futureFeature).toEqual({ id: 'op-1', state: 'preparing' });
+  });
+
+  it('does not lose concurrent edits made by the newer peer', () => {
+    const snapshot = createFutureDocSnapshot();
+
+    const olderDoc = new Loro();
+    const olderMirror = createSessionMirror(olderDoc);
+    olderDoc.import(snapshot);
+
+    const newerDoc = new Loro();
+    newerDoc.import(snapshot);
+    const newerMirror = new Mirror({ doc: newerDoc, schema: futureDocSchema });
+
+    olderMirror.setState((state) => {
+      state.session.title = 'edited by the older client';
+    });
+    newerMirror.setState((state) => {
+      state.futureFeature.state = 'failed';
+    });
+
+    olderDoc.import(newerDoc.export({ mode: 'update', from: olderDoc.version() }));
+    newerDoc.import(olderDoc.export({ mode: 'update', from: newerDoc.version() }));
+
+    expect(newerMirror.getState().futureFeature).toEqual({ id: 'op-1', state: 'failed' });
+    expect(newerMirror.getState().session.title).toBe('edited by the older client');
+    expect(olderDoc.toJSON().futureFeature).toEqual({ id: 'op-1', state: 'failed' });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,14 +79,14 @@ catalogs:
       specifier: ^1.14.1
       version: 1.14.1
     loro-mirror:
-      specifier: 2.2.1
-      version: 2.2.1
+      specifier: 2.3.0
+      version: 2.3.0
     loro-mirror-jotai:
-      specifier: 2.2.1
-      version: 2.2.1
+      specifier: 2.3.0
+      version: 2.3.0
     loro-mirror-react:
-      specifier: 2.2.1
-      version: 2.2.1
+      specifier: 2.3.0
+      version: 2.3.0
     loro-repo:
       specifier: ^0.20.0
       version: 0.20.0
@@ -349,7 +349,7 @@ importers:
         version: link:../../packages/code-review-viewer
       loro-mirror:
         specifier: 'catalog:'
-        version: 2.2.1(loro-crdt@1.14.1)
+        version: 2.3.0(loro-crdt@1.14.1)
       loro-repo:
         specifier: 'catalog:'
         version: 0.20.0(patch_hash=74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357)(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.3)(loro-crdt@1.14.1)
@@ -1082,13 +1082,13 @@ importers:
         version: 1.14.1
       loro-mirror:
         specifier: 'catalog:'
-        version: 2.2.1(loro-crdt@1.14.1)
+        version: 2.3.0(loro-crdt@1.14.1)
       loro-mirror-jotai:
         specifier: 'catalog:'
-        version: 2.2.1(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.14.1)(loro-mirror@2.2.1(loro-crdt@1.14.1))
+        version: 2.3.0(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.14.1)(loro-mirror@2.3.0(loro-crdt@1.14.1))
       loro-mirror-react:
         specifier: 'catalog:'
-        version: 2.2.1(loro-crdt@1.14.1)(loro-mirror@2.2.1(loro-crdt@1.14.1))(react@19.2.0)
+        version: 2.3.0(loro-crdt@1.14.1)(loro-mirror@2.3.0(loro-crdt@1.14.1))(react@19.2.0)
       loro-repo:
         specifier: 'catalog:'
         version: 0.20.0(patch_hash=74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357)(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.14.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(loro-crdt@1.14.1)
@@ -1398,7 +1398,7 @@ importers:
         version: 1.14.1
       loro-mirror:
         specifier: 'catalog:'
-        version: 2.2.1(loro-crdt@1.14.1)
+        version: 2.3.0(loro-crdt@1.14.1)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -9179,22 +9179,22 @@ packages:
   loro-crdt@1.14.1:
     resolution: {integrity: sha512-1BQ7neoQeJdCbD8gxlLHsy8tqCLYIJGrXSZic4s3t7toIsiFfks8Z0nGWvuEWr5miZ7giJx19x5ffkBaw+g9KQ==}
 
-  loro-mirror-jotai@2.2.1:
-    resolution: {integrity: sha512-iixmVFMtVKz6p2N+WcveeYk6BWeYYllTb+k7vdKCFf5nvADkN735ljHRLfP1AOUvVrmm2RxwE0P78XCoJX2/ZQ==}
+  loro-mirror-jotai@2.3.0:
+    resolution: {integrity: sha512-bgdBCheEML8oqsqEnpCVLQGHrkNwZzd2BsCq8lezhwC8cef7ugBv6hKzy7HenPqiMq+n+cng82D0Y+nJ5zwhRA==}
     peerDependencies:
       jotai: ^2.0.0
       loro-crdt: ^1.13.3
-      loro-mirror: 2.2.1
+      loro-mirror: 2.3.0
 
-  loro-mirror-react@2.2.1:
-    resolution: {integrity: sha512-Bw1OKLwk9xRVeyDPt7+JOtZyEx+1mEkfCyRyGGc06YVs5HGYnGKRiDys+TxO3Kj302RT12rTtN+RbwYQpiEsxg==}
+  loro-mirror-react@2.3.0:
+    resolution: {integrity: sha512-fX4qU/ykiFx2zxZVgiUO5GKqk6nqrmu7dfogHtd9a4D0SK2TqG0Sqyc3DUbxjX2gbj2xYgFVAr+rUpjwAEij1Q==}
     peerDependencies:
       loro-crdt: ^1.13.3
-      loro-mirror: 2.2.1
+      loro-mirror: 2.3.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  loro-mirror@2.2.1:
-    resolution: {integrity: sha512-wOeNqNTSdFS7S6z0j+GWlRUtgRwMG/vAS0U0MJ3egZZlJUw4tIpmQoUQ2lEtjzdddBzZBfTR33YphE+ZIXY6LA==}
+  loro-mirror@2.3.0:
+    resolution: {integrity: sha512-CVoxuh4D+JSkYQrJyIXfqnbnYnIwVFlCoRcNc1XSdWRshJZQ7tymnb5rT6AQ+XuDZHyIua0HVHjpEvHkGCTm9A==}
     peerDependencies:
       loro-crdt: ^1.13.3
 
@@ -21422,19 +21422,19 @@ snapshots:
 
   loro-crdt@1.14.1: {}
 
-  loro-mirror-jotai@2.2.1(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.14.1)(loro-mirror@2.2.1(loro-crdt@1.14.1)):
+  loro-mirror-jotai@2.3.0(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.14.1)(loro-mirror@2.3.0(loro-crdt@1.14.1)):
     dependencies:
       jotai: 2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0)
       loro-crdt: 1.14.1
-      loro-mirror: 2.2.1(loro-crdt@1.14.1)
+      loro-mirror: 2.3.0(loro-crdt@1.14.1)
 
-  loro-mirror-react@2.2.1(loro-crdt@1.14.1)(loro-mirror@2.2.1(loro-crdt@1.14.1))(react@19.2.0):
+  loro-mirror-react@2.3.0(loro-crdt@1.14.1)(loro-mirror@2.3.0(loro-crdt@1.14.1))(react@19.2.0):
     dependencies:
       loro-crdt: 1.14.1
-      loro-mirror: 2.2.1(loro-crdt@1.14.1)
+      loro-mirror: 2.3.0(loro-crdt@1.14.1)
       react: 19.2.0
 
-  loro-mirror@2.2.1(loro-crdt@1.14.1):
+  loro-mirror@2.3.0(loro-crdt@1.14.1):
     dependencies:
       immer: 10.2.0
       loro-crdt: 1.14.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,9 +36,9 @@ catalog:
   jotai: ^2.16.0
   loro-adaptors: ^0.6.1
   loro-crdt: ^1.14.1
-  loro-mirror: 2.2.1
-  loro-mirror-jotai: 2.2.1
-  loro-mirror-react: 2.2.1
+  loro-mirror: 2.3.0
+  loro-mirror-jotai: 2.3.0
+  loro-mirror-react: 2.3.0
   loro-protocol: ^0.3.0
   loro-repo: ^0.20.0
   loro-websocket: ^0.6.2


### PR DESCRIPTION
## Related issue

https://github.com/LodyAI/Lody/issues/103

## Problem / pressure

An older client is permanently blocked from writing a synced doc once a newer client adds a root key its compiled schema does not declare. `forkOperation` was the first such key to reach production: the symptom is `State validation failed: Unknown property: forkOperation`, thrown from **any** later `setState` — marking history read, touching the message queue, anything — not just fork-related writes.

The key is legitimate in the doc; it is only "unknown" relative to the older build's schema. Every future root field carries the same hazard, so the fix has to be forward compatibility in the mirror, not a one-off for `forkOperation`. Until then the only remedy is forcing every client to upgrade in lockstep, which a CRDT sync plane cannot guarantee.

## Summary

Bumps the loro-mirror catalog to 2.3.0 and passes its new opt-in `ignoreUnknownProperties` at all five Mirror construction sites over synced docs: `apps/cli/src/lib/loro/doc.ts` (session), `apps/cli/src/lib/task-doc.ts` (task), and the session / preview-visual-comment / task stores in `packages/components/src/providers/create-workspace-runtime.ts`.

The option mirrors undeclared root keys into state instead of rejecting them, on both the initial-snapshot and the incremental-event read path. Nothing else changes: with the option off, 2.3.0 behaves exactly as 2.2.1.

Also records the invariant where it is actionable — a doc comment on the three synced root schemas, and a section in the two nearest `AGENTS.md` files.

## Before / after

| Before | After |
| ------ | ----- |
| A newer peer writes an undeclared root key; the older client's next `setState` throws `Unknown property: <key>` and every subsequent write to that doc fails until the client is upgraded. | The undeclared key is mirrored into state, validation skips it, and writes continue normally. |
| Adding a root field to a synced schema is a lockstep-upgrade change. | Adding an optional root field is backward safe by construction. |
| The undeclared key's fate under write-back was unverified. | Verified: it round-trips untouched, keeping container identity and CRDT merge history; concurrent edits from the newer peer converge. |
| No test covered cross-version schema drift. | Two tests: behavioural forward compatibility, plus a source scan pinning every construction site. |

## Test plan

- `pnpm --filter @lody/shared test` — 88 files, 972 tests green, including both new suites.
- `npx vitest run src/lib/loro src/lib/task-doc.test.ts src/lib/task-body-edit.test.ts` in `apps/cli` — 97 tests green.
- `pnpm --filter lody typecheck` and `pnpm --filter @lody/components typecheck` — clean.
- Both new tests were verified to fail when the change is undone. Removing `ignoreUnknownProperties` from the test's Mirror turns all three forward-compat cases red with the production message; removing it from `task-doc.ts` makes the source scan report `apps/cli/src/lib/task-doc.ts:98` exactly.
- Behaviour verified directly against the published 2.3.0 build, not just from its docs: with the flag **off** it still reproduces the original crash, so the option is required rather than incidental.
- `pnpm install --frozen-lockfile` passes on the committed lockfile.
- **Skipped:** full `pnpm check` / repo-wide test run, and any Electron or site-docs suite — untouched by this change. No manual multi-version client run against a live workspace; cross-version behaviour is covered by the in-memory two-schema tests instead.

## Notes for reviewers

2.3.0 adds one full `toNormalizedJson(doc)` walk in `buildRootStateSnapshot`. It runs at Mirror construction and on the rare non-incremental `setState` fallback, not per event; measured on a large session doc (6000 history entries) construction is ~11–20% slower. With the flag on, root-level `validateSchema` also bypasses its memo cache — recursive child calls do not forward the option, so per-subtree memoisation is unaffected.

2.3.0 also carries two unrelated internal changes that apply regardless of the flag: `CID_PLACEHOLDER_PREFIX` is now NUL-delimited (collision hardening, never persisted), and one `new Array(n)` became `Array.from({length: n})` with identical output.

The lockfile diff is deliberately restricted to the loro-mirror entries. A full regeneration also drifts unrelated peer resolutions (`@types/node` in storybook/vite contexts, better-auth peer hashes); the committed lockfile passes `--frozen-lockfile`.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** The five `new Mirror(` sites — confirm none is missed, since a missed one stays invisible until a future root field ships; and `packages/shared/tests/mirror-construction-sites.test.ts`, whose source scan is the only thing enforcing that.
- **Decisions to challenge:** Applying the flag to task and preview-comment docs rather than only the session doc; recording the invariant in schema doc comments plus two `AGENTS.md` instead of one place; restricting the lockfile diff to loro-mirror hunks instead of committing a full regeneration.
- **Plausible failures / evidence gaps:** State is the source of truth for write-back, so any future updater that rebuilds root state without spreading unknown keys is a data-loss shape — no current call site does this and nothing pins it. Mirror construction is ~11–20% slower on large session docs, measured on one doc shape only. No live multi-version client test was run.

### Authoring context

- **User goal / directives:** Diagnose why `Unknown property: forkOperation` reaches users, then fix it properly. An earlier upstream patch that changed loro-mirror's default read and write paths was rejected in favour of an opt-in configuration, so default behaviour and delete semantics stay untouched; that PR was closed and this change consumes the resulting opt-in release.
- **Constraints / non-goals:** No change to loro-mirror default behaviour. Do not move the `lody-oss` pointer in the paired private-repo PR. Keep the dependency-bump diff scoped. Not in scope: cleaning up existing `forkOperation` residue in live docs, and any client-version handshake or `minReadVersion` scheme, which was discussed and deferred.
- **Risk-bearing decisions:** Bumping the CRDT mirroring library used by every synced doc; enabling the flag on task and preview-comment docs, not just the session doc; hand-filtering the lockfile diff to loro-mirror hunks; accepting the measured Mirror-construction slowdown as the price of forward compatibility.
- **Destructive or irreversible behavior:** None. No migration, no data rewrite, no cleanup of existing docs. Fully revertable by dropping the option and pinning 2.2.1; docs written by a newer peer stay readable either way, because the option only affects how keys are mirrored, never what is stored.
- **Deliberately not done or tested:** No repo-wide `pnpm check`, since unrelated packages are untouched. No live multi-version client run. Existing `forkOperation` residue is left to the CLI's own fork-recovery path. The bare, message-less `Error` that loro-mirror raises when a root key is removed from state was left upstream — it predates 2.3.0 and no Lody call site reaches it.
- **Unknowns / confidence:** High confidence in correctness. Two adversarial review passes ran; both findings they produced were real and are fixed here — a missed fifth Mirror site, and a lockfile regenerated against the wrong submodule baseline. Residual risk is the perf cost on very large session docs and the latent full-root-rebuild shape noted above.

<!-- context-handoff:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
