### PR TITLE
fix(components): keep conversation outline page-centred

### DIFF
--- a/packages/components/src/components/ai-gui/AGENTS.md
+++ b/packages/components/src/components/ai-gui/AGENTS.md
@@ -111,10 +111,13 @@ context/message-flow.md.
     position likewise comes from Virtua's index math (`getItemOffset` +
     `resolveActiveOutlineIndex`), and the active round is the LAST one whose
     anchor is above the viewport top, so it stays set through a long turn.
-  - **It is an overlay SIBLING of the scroll viewport**, next to the top fade and
-    the scroll-to-latest button. Not a Virtua row (it would scroll away), and not
-    a child of the viewport either — `use-sticky-scroll.ts` takes the content
-    element from that div's `firstElementChild`.
+  - **It is a page-level overlay, portalled outside the shrinking message area.**
+    It is never a Virtua row (it would scroll away) or a child of the viewport
+    (`use-sticky-scroll.ts` takes the content element from that div's
+    `firstElementChild`). Its portal root is the full session page so the rail
+    stays vertically centred when the composer changes height; do not replace
+    that with a composer-height measurement or `position: fixed`, which breaks
+    split conversation panes.
   - **Reader position must not re-render the tick list.** It never enters the
     list's props: the active round is painted by one absolutely-positioned bar
     (fixed pitch, pure arithmetic, no measurement) and `aria-current` is synced

--- a/packages/components/src/components/ai-gui/conversation-outline-rail.tsx
+++ b/packages/components/src/components/ai-gui/conversation-outline-rail.tsx
@@ -10,6 +10,7 @@ import {
   type MouseEvent as ReactMouseEvent,
   type FocusEvent as ReactFocusEvent,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { Popover, PopoverAnchor, PopoverContent } from '@/ui/popover';
@@ -45,10 +46,10 @@ import {
  * neighbours taper off along a normal distribution, so the tick under the
  * cursor is unmistakable while the rail still reads as one continuous shape.
  *
- * **Where this mounts matters.** It is an absolutely-positioned OVERLAY sibling
- * of the conversation scroll viewport (alongside the top fade and the
- * scroll-to-latest button), never a row inside the Virtua list — a row would
- * scroll away, and the rail has to stay put.
+ * **Where this mounts matters.** It is an absolutely-positioned overlay of the
+ * whole conversation page, never a row inside the Virtua list — a row would
+ * scroll away. The page-level mount also keeps its centre stable when the
+ * composer changes height.
  *
  * **Two rendering rules keep it off the scroll hot path.** The conversation is
  * already a fragile render surface (see this folder's AGENTS.md), so:
@@ -79,6 +80,12 @@ export interface ConversationOutlineRailProps {
   activeIndex: number;
   /** Jump to the round at this index into `entries`. */
   onJumpToRound: (index: number) => void;
+  /**
+   * The full-page overlay that owns the rail's coordinate system. Omit this
+   * for standalone uses such as the component story, where the local pane is
+   * the intended coordinate system.
+   */
+  overlayRoot?: HTMLElement | null;
   className?: string;
 }
 
@@ -202,6 +209,7 @@ export function ConversationOutlineRail({
   entries,
   activeIndex,
   onJumpToRound,
+  overlayRoot = null,
   className,
 }: ConversationOutlineRailProps) {
   const { t } = useTranslation();
@@ -416,7 +424,7 @@ export function ConversationOutlineRail({
 
   if (tickCount < 2) return null;
 
-  return (
+  const rail = (
     <nav
       aria-label={t('sessions.outline.railLabel', 'Conversation outline')}
       // Low contrast at rest so the rail reads as a margin marker, not chrome;
@@ -528,6 +536,8 @@ export function ConversationOutlineRail({
       </Popover>
     </nav>
   );
+
+  return overlayRoot === null ? rail : createPortal(rail, overlayRoot);
 }
 
 export default ConversationOutlineRail;

--- a/packages/components/src/components/ai-gui/index.tsx
+++ b/packages/components/src/components/ai-gui/index.tsx
@@ -104,6 +104,8 @@ export interface SessionChatStreamProps {
   conversationFontSize?: ConversationFontSize;
   /** Skips one auto-follow caused by the session composer changing height. */
   skipNextViewportResizeAutoScrollRef?: MutableRefObject<boolean>;
+  /** Full-page overlay that keeps the conversation outline independent of composer height. */
+  outlineOverlayRoot?: HTMLElement | null;
   suppressStickyAutoScrollRef?: React.RefObject<boolean>;
 }
 
@@ -176,6 +178,7 @@ const SessionChatStreamImpl = forwardRef<SessionChatStreamHandle, SessionChatStr
       conversationFontSize = DEFAULT_CONVERSATION_FONT_SIZE,
       skipNextViewportResizeAutoScrollRef,
       suppressStickyAutoScrollRef,
+      outlineOverlayRoot,
     },
     ref
   ) => {
@@ -280,6 +283,7 @@ const SessionChatStreamImpl = forwardRef<SessionChatStreamHandle, SessionChatStr
         conversationFontSize={conversationFontSize}
         skipNextViewportResizeAutoScrollRef={skipNextViewportResizeAutoScrollRef}
         suppressStickyAutoScrollRef={suppressStickyAutoScrollRef}
+        outlineOverlayRoot={outlineOverlayRoot}
       />
     );
   }

--- a/packages/components/src/components/ai-gui/view.tsx
+++ b/packages/components/src/components/ai-gui/view.tsx
@@ -416,6 +416,8 @@ export interface SessionChatStreamViewProps {
   conversationFontSize?: ConversationFontSize;
   /** Skips one auto-follow caused by the session composer changing height. */
   skipNextViewportResizeAutoScrollRef?: MutableRefObject<boolean>;
+  /** Full-page overlay that keeps the conversation outline independent of composer height. */
+  outlineOverlayRoot?: HTMLElement | null;
   /**
    * When true, prevents sticky auto-scroll from fighting programmatic scrolls
    * (e.g. during search result navigation).
@@ -1163,6 +1165,7 @@ export const SessionChatStreamView = forwardRef<
       conversationFontSize = DEFAULT_CONVERSATION_FONT_SIZE,
       skipNextViewportResizeAutoScrollRef,
       suppressStickyAutoScrollRef,
+      outlineOverlayRoot,
     },
     ref
   ) => {
@@ -1723,16 +1726,18 @@ export const SessionChatStreamView = forwardRef<
             {!isMobile && isScrolledFromTop ? (
               <div className="pointer-events-none absolute inset-x-0 top-0 h-12 bg-gradient-to-b from-background to-transparent" />
             ) : null}
-            {/* Round outline. An overlay SIBLING of the scroll viewport, never a
-                Virtua row — and never a child of the viewport either, because
-                sticky scroll takes the content element from that div's
-                `firstElementChild`. Touch has no hover, so mobile is excluded
-                rather than shipped without its preview card. */}
+            {/* Round outline. Its visual layer portals to the full-page overlay
+                when supplied, so composer growth cannot move its centre. It is
+                never a Virtua row or a child of the viewport: sticky scroll
+                takes the content element from that div's `firstElementChild`.
+                Touch has no hover, so mobile is excluded rather than shipped
+                without its preview card. */}
             {isMobile ? null : (
               <ConversationOutlineRail
                 entries={outlineEntries}
                 activeIndex={activeOutlineIndex}
                 onJumpToRound={handleOutlineJump}
+                overlayRoot={outlineOverlayRoot}
               />
             )}
             {showScrollToLatest && !isSticky && (
@@ -2713,12 +2718,7 @@ const UserMessageRowView = ({
                 unbreakable line, the content grows to its `sm:max-w-[800px]` cap, and being
                 right-aligned (`justify-end`) it overflows the column on the left. Chromium
                 honors overflow-wrap here so it doesn't repro there — hence "only sometimes". */}
-            <div
-              className={cn(
-                'relative min-w-0 max-w-full',
-                isEditing ? 'w-full' : 'w-fit'
-              )}
-            >
+            <div className={cn('relative min-w-0 max-w-full', isEditing ? 'w-full' : 'w-fit')}>
               {showSendingSpinner && (
                 <Loader2 className="absolute bottom-[13px] right-full mr-1.5 h-4 w-4 animate-spin text-muted-foreground" />
               )}

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -2218,6 +2218,7 @@ export const SessionChatInterface = memo(
     const inputAreaRef = useRef<SessionChatInputAreaHandle>(null);
     const searchInputRef = useRef<HTMLInputElement>(null);
     const messageAreaRef = useRef<HTMLDivElement>(null);
+    const [outlineOverlayRoot, setOutlineOverlayRoot] = useState<HTMLDivElement | null>(null);
     const skipNextViewportResizeAutoScrollRef = useRef(false);
     const suppressStickyAutoScrollRef = useRef(false);
     const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -5530,6 +5531,12 @@ export const SessionChatInterface = memo(
           hideMessageArea={hideMessageArea}
           {...pageDropHandlers}
         >
+          {/* The outline must centre in the whole conversation page, not only
+              the flex area left after the composer takes its height. */}
+          <div
+            ref={setOutlineOverlayRoot}
+            className="pointer-events-none absolute inset-0 @container"
+          />
           {!shouldHideHeader &&
             (headerVariant === 'toolbar' ? (
               /* Compact toolbar for the merged desktop tab row: right-side
@@ -5669,6 +5676,7 @@ export const SessionChatInterface = memo(
                           conversationFontSize={conversationFontSize}
                           skipNextViewportResizeAutoScrollRef={skipNextViewportResizeAutoScrollRef}
                           suppressStickyAutoScrollRef={suppressStickyAutoScrollRef}
+                          outlineOverlayRoot={outlineOverlayRoot}
                         />
                       </MessageSendStatusContext.Provider>
                     </ErrorBoundary>

--- a/packages/components/src/stories/ConversationOutlineRail.stories.tsx
+++ b/packages/components/src/stories/ConversationOutlineRail.stories.tsx
@@ -116,6 +116,54 @@ export const OverflowingConversation: Story = {
   render: () => <RailFrame entries={longConversation} initialActiveIndex={90} />,
 };
 
+/**
+ * Mirrors a tall composer consuming the lower part of a conversation page.
+ * The rail used to be mounted in the shrinking message area, so it centres
+ * visibly too high here. This is retained as an explicit visual regression
+ * state; production passes the full-page overlay root instead.
+ */
+function ComposerHeightFrame({ pageLevelOverlay }: { pageLevelOverlay: boolean }) {
+  const [outlineOverlayRoot, setOutlineOverlayRoot] = useState<HTMLDivElement | null>(null);
+  const activeIndex = 44;
+  return (
+    <div className="@container relative flex h-[720px] w-full flex-col overflow-hidden bg-background">
+      {pageLevelOverlay ? (
+        <div
+          ref={setOutlineOverlayRoot}
+          className="pointer-events-none absolute inset-0 @container"
+        />
+      ) : null}
+      <div className="relative min-h-0 flex-1 overflow-hidden border-b border-border/70">
+        <div className="mx-auto h-full max-w-[46rem] px-4 py-6 text-sm text-muted-foreground">
+          The message viewport shrinks as the composer grows. The outline should remain centred in
+          the page, not in this remaining area.
+        </div>
+        <ConversationOutlineRail
+          entries={longConversation}
+          activeIndex={activeIndex}
+          onJumpToRound={() => {}}
+          overlayRoot={outlineOverlayRoot}
+        />
+      </div>
+      <div className="h-[260px] shrink-0 border-t border-border bg-muted/20 p-4">
+        <div className="mx-auto h-full max-w-[46rem] rounded-xl border border-border bg-background p-4 text-sm text-muted-foreground">
+          Tall composer
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const ComposerExpandedBefore: Story = {
+  args: { entries: [], activeIndex: -1, onJumpToRound: () => {} },
+  render: () => <ComposerHeightFrame pageLevelOverlay={false} />,
+};
+
+export const ComposerExpandedAfter: Story = {
+  args: { entries: [], activeIndex: -1, onJumpToRound: () => {} },
+  render: () => <ComposerHeightFrame pageLevelOverlay />,
+};
+
 /** A CJK title and a round the agent started, to check truncation and fallbacks. */
 export const MixedContent: Story = {
   args: { entries: [], activeIndex: 0, onJumpToRound: () => {} },


### PR DESCRIPTION
## Summary

- portal the conversation outline into the full conversation-page overlay
- keep the rail centred when a tall composer shrinks the message viewport
- add a visual regression story for the before/after layout

## Validation

- `git diff --check`
- `oxlint` on changed TypeScript/TSX files (existing warnings only)
- TypeScript/TSX parse check

Full package typecheck could not run because this worktree has no installed dependency links.