### PR TITLE
fix: route queued steering by ACP capability

### DIFF
--- a/apps/cli/src/agent/acp-capabilities.test.ts
+++ b/apps/cli/src/agent/acp-capabilities.test.ts
@@ -34,7 +34,9 @@ const createSilentLogger = (): Logger => ({
 function createSuccessfulStartupResult(sessionResponse?: Record<string, unknown>) {
   return {
     agentProcess: {} as never,
-    client: {} as never,
+    client: {
+      supportsAcknowledgedSteer: () => false,
+    } as never,
     acpSessionId: 'acp-session-1' as never,
     sessionResponse: sessionResponse ?? {
       sessionId: 'acp-session-1',
@@ -125,6 +127,18 @@ describe('fetchAcpCapabilities', () => {
       })
     );
     expect(result.availableCommands).toEqual([{ name: '/help', description: 'Help' }]);
+  });
+
+  it('preserves acknowledged steering support discovered from the live client', async () => {
+    const startupResult = createSuccessfulStartupResult();
+    startupResult.client = {
+      supportsAcknowledgedSteer: () => true,
+    } as never;
+    mocks.startLocalAcpAgent.mockResolvedValue(startupResult);
+
+    const result = await fetchAcpCapabilities('registry', 'steering-agent', createSilentLogger());
+
+    expect(result.acknowledgedSteer).toBe(true);
   });
 
   it('uses commands from NewSessionResponse and ignores command update notifications', async () => {

--- a/apps/cli/src/agent/acp-capabilities.ts
+++ b/apps/cli/src/agent/acp-capabilities.ts
@@ -91,6 +91,7 @@ export async function fetchAcpCapabilities(
     return {
       ...normalizeAcpSessionCapabilities(sessionResponse, {
         sessionFork: client.supportsSessionFork?.() === true,
+        acknowledgedSteer: client.supportsAcknowledgedSteer(),
       }),
       capabilitySourceVersion,
     };

--- a/apps/cli/src/agent/acp-capability-normalization.ts
+++ b/apps/cli/src/agent/acp-capability-normalization.ts
@@ -13,6 +13,7 @@ export type AcpCapabilitiesResult = {
   configOptions?: AcpConfigOptionSummary[];
   availableCommands?: AcpCommandSummary[];
   sessionFork: boolean;
+  acknowledgedSteer: boolean;
   modelReasoningEfforts?: Record<string, string[]>;
 };
 
@@ -150,7 +151,7 @@ type AcpSessionCapabilitiesResponse = {
 /** Extract cacheable capabilities from a real ACP new/load/resume session response. */
 export function normalizeAcpSessionCapabilities(
   sessionResponse: AcpSessionCapabilitiesResponse,
-  lifecycleCapabilities: { sessionFork?: boolean } = {}
+  lifecycleCapabilities: { sessionFork?: boolean; acknowledgedSteer?: boolean } = {}
 ): AcpCapabilitiesResult {
   const modes = (sessionResponse.modes?.availableModes ?? []).map((mode) => ({
     id: mode.id,
@@ -181,6 +182,7 @@ export function normalizeAcpSessionCapabilities(
     configOptions,
     availableCommands,
     sessionFork: lifecycleCapabilities.sessionFork === true,
+    acknowledgedSteer: lifecycleCapabilities.acknowledgedSteer === true,
     ...(modelReasoningEfforts ? { modelReasoningEfforts } : {}),
   };
 }

--- a/apps/cli/src/lib/loro/doc.ts
+++ b/apps/cli/src/lib/loro/doc.ts
@@ -1439,6 +1439,7 @@ export class LoroDocumentManager {
     sessionFork: boolean,
     sourceVersion: string,
     modelReasoningEfforts?: Record<string, string[]>,
+    acknowledgedSteer = false,
     options: { signal?: AbortSignal } = {}
   ): Promise<void> {
     options.signal?.throwIfAborted();
@@ -1458,6 +1459,7 @@ export class LoroDocumentManager {
       sessionFork,
       sourceVersion,
       modelReasoningEfforts,
+      acknowledgedSteer,
       options
     );
   }
@@ -2909,6 +2911,7 @@ const serializeAcpCapabilityWithoutFetchTime = (entry: AcpCapabilityCacheEntry):
     configOptions: entry.configOptions,
     availableCommands: entry.availableCommands,
     sessionFork: entry.sessionFork,
+    acknowledgedSteer: entry.acknowledgedSteer,
     sessionForkWorktree: entry.sessionForkWorktree,
   });
 
@@ -2993,6 +2996,7 @@ export class MachineDocument implements LoroDocument<{}, MachineMeta> {
     sessionFork: boolean,
     sourceVersion: string,
     modelReasoningEfforts?: Record<string, string[]>,
+    acknowledgedSteer = false,
     options: { signal?: AbortSignal } = {}
   ): Promise<void> {
     options.signal?.throwIfAborted();
@@ -3017,6 +3021,7 @@ export class MachineDocument implements LoroDocument<{}, MachineMeta> {
       configOptions: configOptions?.length ? configOptions : undefined,
       availableCommands: availableCommands?.length ? availableCommands : undefined,
       sessionFork,
+      acknowledgedSteer,
       sessionForkWorktree: sessionFork,
       modelReasoningEfforts:
         modelReasoningEfforts && Object.keys(modelReasoningEfforts).length > 0

--- a/apps/cli/src/lib/loro/machine-document-capabilities.test.ts
+++ b/apps/cli/src/lib/loro/machine-document-capabilities.test.ts
@@ -64,7 +64,9 @@ describe('MachineDocument ACP capabilities', () => {
         undefined,
         [{ name: '/help', description: 'Help' }],
         false,
-        'builtin:codex:test'
+        'builtin:codex:test',
+        undefined,
+        true
       );
 
     await write();
@@ -75,6 +77,7 @@ describe('MachineDocument ACP capabilities', () => {
     expect(flush).toHaveBeenCalledTimes(1);
     expect(markDirty).toHaveBeenCalledTimes(1);
     expect(syncOnce).not.toHaveBeenCalled();
+    expect([...flock.rows.values()][0]?.value).toMatchObject({ acknowledgedSteer: true });
   });
 
   it('does not write capabilities when cancelled while opening the Machine Flock', async () => {
@@ -115,6 +118,7 @@ describe('MachineDocument ACP capabilities', () => {
       false,
       'builtin:codex:test',
       undefined,
+      false,
       { signal: controller.signal }
     );
     await openStarted;

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -8263,6 +8263,7 @@ export class MessageHandler {
     configOptions?: AcpConfigOptionSummary[];
     availableCommands?: NonNullable<MachineAcpCapabilitiesRefreshResponse['availableCommands']>;
     sessionFork: boolean;
+    acknowledgedSteer: boolean;
     modelReasoningEfforts?: Record<string, string[]>;
     capabilitySourceVersion?: string;
   }> {

--- a/apps/cli/src/session/session-execution-service.ts
+++ b/apps/cli/src/session/session-execution-service.ts
@@ -493,6 +493,7 @@ export type SessionExecutionServiceDeps = {
     configOptions?: AcpConfigOptionSummary[];
     availableCommands?: AcpCommandSummary[];
     sessionFork: boolean;
+    acknowledgedSteer: boolean;
     modelReasoningEfforts?: Record<string, string[]>;
     capabilitySourceVersion?: string;
   }>;
@@ -4820,7 +4821,8 @@ export class SessionExecutionService {
         availableCommands,
         capabilities.sessionFork,
         sourceVersion,
-        capabilities.modelReasoningEfforts
+        capabilities.modelReasoningEfforts,
+        capabilities.acknowledgedSteer
       );
     })().catch((error: unknown) => {
       this.deps.logger.debug(
@@ -5035,6 +5037,7 @@ export class SessionExecutionService {
         configOptions,
         availableCommands,
         sessionFork,
+        acknowledgedSteer,
         modelReasoningEfforts,
         capabilitySourceVersion,
       } = await this.deps.fetchAcpCapabilities(
@@ -5073,6 +5076,7 @@ export class SessionExecutionService {
             runtimeOverrides: message.runtimeOverrides,
           }),
         modelReasoningEfforts,
+        acknowledgedSteer,
         { signal: options.signal }
       );
 

--- a/apps/cli/src/session/session.ts
+++ b/apps/cli/src/session/session.ts
@@ -657,6 +657,7 @@ export class Session extends EventEmitter<SessionEvents> implements ISession {
         acpSessionId = started.acpSessionId;
         acpCapabilities = normalizeAcpSessionCapabilities(started.sessionResponse, {
           sessionFork: started.client.supportsSessionFork(),
+          acknowledgedSteer: started.client.supportsAcknowledgedSteer(),
         });
       } catch (error) {
         // The agent process died before startup completed (the startup monitor

--- a/apps/cli/tests/acp-capability-normalization.test.ts
+++ b/apps/cli/tests/acp-capability-normalization.test.ts
@@ -108,4 +108,13 @@ describe('ACP capability normalization', () => {
     expect(capabilities.modelReasoningEfforts).toBeUndefined();
     expect(capabilities.models.map((model) => model.modelId)).toEqual(['opus', 'sonnet']);
   });
+
+  it('preserves acknowledged steering support discovered from the live client', () => {
+    const capabilities = normalizeAcpSessionCapabilities(
+      { modes: { availableModes: [] } },
+      { acknowledgedSteer: true }
+    );
+
+    expect(capabilities.acknowledgedSteer).toBe(true);
+  });
 });

--- a/apps/cli/tests/session-execution-service.test.ts
+++ b/apps/cli/tests/session-execution-service.test.ts
@@ -1932,6 +1932,7 @@ describe('SessionExecutionService', () => {
         ],
         availableCommands: [{ name: 'review', description: 'Review changes' }],
         sessionFork: false,
+        acknowledgedSteer: true,
       }),
       terminalManager: {} as unknown,
       getWorkdir: () => '/local/repo',
@@ -2025,7 +2026,8 @@ describe('SessionExecutionService', () => {
         expect.any(String),
         // Per-model reasoning efforts: absent for this agent, which publishes no
         // legacy `model[effort]` combination list.
-        undefined
+        undefined,
+        true
       )
     );
   });
@@ -5451,6 +5453,7 @@ describe('SessionExecutionService', () => {
       ],
       availableCommands: [{ name: 'review', description: 'Review changes' }],
       sessionFork: false,
+      acknowledgedSteer: true,
     }));
 
     const deps = createBaseDeps({
@@ -5506,6 +5509,7 @@ describe('SessionExecutionService', () => {
       'registry:codex:unknown',
       // Per-model reasoning efforts: this stub agent reports none.
       undefined,
+      true,
       { signal: expect.any(AbortSignal) }
     );
     expect(result).toEqual(

--- a/packages/components/src/components/sessions/AGENTS.md
+++ b/packages/components/src/components/sessions/AGENTS.md
@@ -289,6 +289,10 @@ Session conversation page chain:
   wide markdown, tool output, and user content own their nested horizontal scrollers
   and must never make the whole conversation pane pan sideways.
 - `session-chat-input-area.tsx` — composer; `message-queue-display.tsx` — queued turns.
+  A queued item's Steer action uses native acknowledged steering only when the
+  authoritative ACP capability cache advertises it. Never infer steering support
+  from built-in/custom config type or agent identity; unsupported and stale cache
+  entries retain the interrupt-and-send fallback.
   Child-tab suggestions are shared by draft and persisted child sessions through
   `child-tab-empty-state.tsx`; it uses the same `px-3` + `ConversationColumn` as
   the composer, so its right edge and max width must stay aligned automatically.

--- a/packages/components/src/components/sessions/message-queue/queued-message-steer.ts
+++ b/packages/components/src/components/sessions/message-queue/queued-message-steer.ts
@@ -1,10 +1,8 @@
-import type { SessionMeta } from '@lody/shared';
+import type { AcpCapabilityAuthority, AcpCapabilityCacheEntry } from '@lody/shared';
 
 export function shouldRequestNativeQueueSteer(
-  session: Pick<SessionMeta, 'cliType' | 'agentType'>
+  authority: AcpCapabilityAuthority,
+  capability: Pick<AcpCapabilityCacheEntry, 'acknowledgedSteer'> | undefined
 ): boolean {
-  return (
-    session.cliType === 'builtin' &&
-    (session.agentType === 'claude' || session.agentType === 'codex')
-  );
+  return authority === 'authoritative' && capability?.acknowledgedSteer === true;
 }

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -4939,7 +4939,13 @@ export const SessionChatInterface = memo(
       ]
     );
 
-    const shouldUseNativeQueueSteer = shouldRequestNativeQueueSteer(session);
+    const queueSteerCapability = session.agentConfigId
+      ? sessionMachine?.acpCapabilities?.[getAcpCapabilityCacheKey(session.agentConfigId)]
+      : undefined;
+    const shouldUseNativeQueueSteer = shouldRequestNativeQueueSteer(
+      capabilityAuthority,
+      queueSteerCapability
+    );
     const handleSteerQueuedMessage = useCallback(
       async (item: MessageQueueItem) => {
         if (shouldUseNativeQueueSteer) {

--- a/packages/components/tests/queued-message-steer.test.ts
+++ b/packages/components/tests/queued-message-steer.test.ts
@@ -3,13 +3,12 @@ import { shouldRequestNativeQueueSteer } from '../src/components/sessions/messag
 
 describe('shouldRequestNativeQueueSteer', () => {
   it.each([
-    [{ cliType: 'builtin', agentType: 'claude' }, true],
-    [{ cliType: 'builtin', agentType: 'codex' }, true],
-    [{ cliType: 'builtin', agentType: 'kimi' }, false],
-    [{ cliType: 'registry', agentType: 'claude' }, false],
-    [{ cliType: 'registry', agentType: 'gemini' }, false],
-    [{ cliType: 'custom', agentType: 'custom-agent' }, false],
-  ] as const)('routes %o to native steer: %s', (session, expected) => {
-    expect(shouldRequestNativeQueueSteer(session)).toBe(expected);
+    ['authoritative', { acknowledgedSteer: true }, true],
+    ['authoritative', { acknowledgedSteer: false }, false],
+    ['authoritative', undefined, false],
+    ['provisional', { acknowledgedSteer: true }, false],
+    ['unavailable', { acknowledgedSteer: true }, false],
+  ] as const)('routes %s capability %o to native steer: %s', (authority, capability, expected) => {
+    expect(shouldRequestNativeQueueSteer(authority, capability)).toBe(expected);
   });
 });

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -279,7 +279,7 @@ export type AcpCommandSummary = {
 };
 
 // Bump when cached ACP probes need to be invalidated across clients.
-export const ACP_CAPABILITY_CACHE_VERSION = 5;
+export const ACP_CAPABILITY_CACHE_VERSION = 6;
 
 export type AcpCapabilityAuthority = 'unavailable' | 'provisional' | 'authoritative';
 
@@ -311,6 +311,8 @@ export type AcpCapabilityCacheEntry = {
   availableCommands?: AcpCommandSummary[];
   /** True only when the runtime initialize response advertised `sessionCapabilities.fork`. */
   sessionFork?: boolean;
+  /** True only when the runtime advertised Lody's acknowledged steering extension. */
+  acknowledgedSteer?: boolean;
   /** True when this Lody machine supports durable asynchronous forks into a new worktree. */
   sessionForkWorktree?: boolean;
   fetchedAt: number;


### PR DESCRIPTION
## Related issue

https://github.com/LodyAI/Lody/issues/100

## Problem / pressure

The queued-message Steer action only used native acknowledged steering for built-in Claude and Codex sessions. Custom and registry ACP agents fell back to interrupt-and-send even when their runtime advertised acknowledged steering support.

## Summary

- Cache the acknowledged steering capability discovered from the live ACP client.
- Bump the ACP capability cache version so existing machines refresh entries that lack the new field.
- Route queued-message steering from the authoritative capability cache instead of CLI type or agent identity.
- Preserve interrupt-and-send for unsupported, provisional, or stale capability entries.

## Before / after

| Before | After |
| ------ | ----- |
| Native queue steering was hard-coded to built-in Claude and Codex sessions. | Any ACP agent with authoritative acknowledged steering support uses native queue steering. |
| Custom capable agents were cancelled and their queued message was dispatched as a new turn. | Custom capable agents receive the acknowledged steering request during the active turn. |

## Test plan

- `corepack pnpm --filter lody exec vitest run tests/acp-capability-normalization.test.ts src/lib/loro/machine-document-capabilities.test.ts tests/session-execution-service.test.ts` (76 tests passed)
- `corepack pnpm --filter @lody/components exec vitest run tests/queued-message-steer.test.ts` (5 tests passed)
- `corepack pnpm --filter lody typecheck`
- `corepack pnpm --filter @lody/components typecheck`
- Targeted Prettier check passed for all changed TypeScript/TSX files.
- Targeted type-aware Oxlint completed with 0 errors.
- Full repository `pnpm check` was not run; validation was scoped to the affected CLI, shared capability cache, and components paths.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Trace `AgentClient.supportsAcknowledgedSteer()` through normalization and Machine Flock persistence into `shouldRequestNativeQueueSteer`.
- **Decisions to challenge:** Confirm that only authoritative cache entries should enable native steering and stale or missing entries should retain interrupt-and-send.
- **Plausible failures / evidence gaps:** A newly active session depends on its capability entry reaching the renderer; full desktop interaction and full-repository checks were not run.

### Authoring context

- **User goal / directives:** Fix queued-message steering for a custom ACP agent that already advertises acknowledged steering support and submit the fix upstream.
- **Constraints / non-goals:** Keep unsupported-agent behavior unchanged and avoid agent-name or CLI-type allowlists.
- **Risk-bearing decisions:** The ACP capability cache version is bumped so old entries refresh rather than silently treating the absent field as unsupported.
- **Destructive or irreversible behavior:** None; the change only refreshes derived capability-cache entries and changes UI routing when support is authoritative.
- **Deliberately not done or tested:** No full desktop manual test and no full-repository `pnpm check`; targeted tests, typechecks, formatting, and lint were run.
- **Unknowns / confidence:** High confidence in capability propagation and routing; residual risk is timing before a refreshed capability entry reaches the renderer.

<!-- context-handoff:end -->
