### PR TITLE
fix: escape untrusted attachment names in prompt text

### DIFF
--- a/apps/cli/src/lib/session-file-attachments.test.ts
+++ b/apps/cli/src/lib/session-file-attachments.test.ts
@@ -11,6 +11,7 @@ import {
   buildUnavailableAttachmentPromptText,
   computeExcludeFileContent,
   ensureAttachmentsGitExcluded,
+  formatUntrustedFileNameForPrompt,
   resolveContainedUploadPath,
   sanitizeAttachmentFileName,
 } from './session-file-attachments';
@@ -112,6 +113,18 @@ describe('buildAttachmentPromptText', () => {
     });
     expect(text).toContain('application/octet-stream');
     expect(text).toContain('10 B');
+  });
+
+  it('escapes brackets and line breaks in the display name', () => {
+    expect(formatUntrustedFileNameForPrompt('notes].md')).toBe('notes\\].md');
+    const text = buildAttachmentPromptText({
+      fileName: 'line one\nline two.log',
+      sizeBytes: 12,
+      mimeType: 'text/plain',
+      relativePath: '.lody/attachments/a1b2c3d4-line two.log',
+    });
+    expect(text).toContain('line one line two.log');
+    expect(text).not.toContain('line one\nline two.log');
   });
 });
 

--- a/apps/cli/src/lib/session-file-attachments.ts
+++ b/apps/cli/src/lib/session-file-attachments.ts
@@ -198,6 +198,14 @@ const formatSizeForPrompt = (sizeBytes: number): string => {
  *
  * Pure and unit-testable.
  */
+/**
+ * Format an untrusted display name for prompt text.
+ * File names are caller-supplied and may contain brackets or line breaks.
+ */
+export const formatUntrustedFileNameForPrompt = (fileName: string): string => {
+  return fileName.replaceAll('\\', '\\\\').replaceAll(']', '\\]').replaceAll(/[\r\n]+/g, ' ');
+};
+
 export const buildAttachmentPromptText = (args: {
   fileName: string;
   sizeBytes: number;
@@ -206,7 +214,8 @@ export const buildAttachmentPromptText = (args: {
 }): string => {
   const size = formatSizeForPrompt(args.sizeBytes);
   const mime = args.mimeType.trim() || 'application/octet-stream';
-  return `[User sent a file: ${args.fileName} (${size}, ${mime})]\nSaved to: ${args.relativePath}`;
+  const fileName = formatUntrustedFileNameForPrompt(args.fileName);
+  return `[User sent a file: ${fileName} (${size}, ${mime})]\nSaved to: ${args.relativePath}`;
 };
 
 /** Prompt text for a file that could not be downloaded yet (e.g. r2 404). */
@@ -217,7 +226,8 @@ export const buildUnavailableAttachmentPromptText = (args: {
 }): string => {
   const size = formatSizeForPrompt(args.sizeBytes);
   const mime = args.mimeType.trim() || 'application/octet-stream';
-  return `[User sent a file: ${args.fileName} (${size}, ${mime})]\nThe file is not available yet and could not be downloaded; ask the user to resend it if you need its contents.`;
+  const fileName = formatUntrustedFileNameForPrompt(args.fileName);
+  return `[User sent a file: ${fileName} (${size}, ${mime})]\nThe file is not available yet and could not be downloaded; ask the user to resend it if you need its contents.`;
 };
 
 /**


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

Attachment display names are stored as unconstrained strings and interpolated into the text given to the agent (`[User sent a file: …]`). A name with `]` or a line break changes the shape of that sentence. Names are untrusted caller input (upload `File.name`, path basename). On-disk `sanitizeAttachmentFileName` already applies to the saved path only.

## Summary

`formatUntrustedFileNameForPrompt` escapes `]` and backslashes and collapses line breaks. Used by `buildAttachmentPromptText` and `buildUnavailableAttachmentPromptText`. Saved attachment paths are unchanged.

**Companion (required, other repo):** `ladydd/acp-extension-codex` `fix/escape-resource-link-filenames` (`32037d7`, against `LodyAI/acp-extension-codex`). That PR is the markdown-label half (`escapeMarkdownLinkLabel` in both `formatUriAsLink` implementations). ACP `resource_link.name` stays the raw display name **in this PR** so that adapter can escape it at the markdown boundary. Open that PR together with this one.

## Before / after

| Before | After |
| ------ | ----- |
| Display name copied into the prompt verbatim | `]` escaped; newlines flattened to spaces |
| `build.log` | Unchanged |

## Test plan

On this branch (`fix/escape-attachment-file-names` @ `fd0f1dc`), after `pnpm install` at the repo root:

```
corepack pnpm --filter lody exec vitest run src/lib/session-file-attachments.test.ts
```

Result: **22 passed**.

Skipped: full `apps/cli` suite; e2e.

## Agent handoff

<!-- agent-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `formatUntrustedFileNameForPrompt` and the two prompt builders in `session-file-attachments.ts`.
- **Decisions to challenge:** Escaping prompt text only; ACP `resource_link.name` is left as the raw display name for the adapter PR (`ladydd/acp-extension-codex` `fix/escape-resource-link-filenames` @ `32037d7`) to escape.
- **Plausible failures / evidence gaps:** Only the attachments unit file was run, not the full CLI suite.

### Authoring context

- **User goal / directives:** Keep attachment prompt lines stable when the display name has brackets or line breaks.
- **Constraints / non-goals:** Do not change on-disk `sanitizeAttachmentFileName`. Do not put file bytes in the prompt.
- **Risk-bearing decisions:** Prompt-visible name spelling for unusual characters.
- **Destructive or irreversible behavior:** None.
- **Deliberately not done or tested:** Full CLI suite.
- **Unknowns / confidence:** High for the unit cases; other prompt construction paths still pass the raw `fileName` into ACP `resource_link.name` for the adapter to escape.

### Sharing consent (author side)

Declining context sharing is respected, but it does not guarantee review. If withheld context prevents maintainers from assessing provenance, scope, or risk, they may decline the contribution or close the pull request.

- [x] Author-side user explicitly allowed publishing the Authoring context above
- [ ] Author-side user explicitly declined publishing Authoring context and understands that maintainers may decline or close the contribution; keep every field as `N/A` / redacted

<!-- agent-handoff:end -->
