### PR TITLE
fix: warn when a generated image cannot be attached

### DIFF
--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -1389,6 +1389,11 @@ export class MessageHandler {
         this.logger.debug(
           `[${sessionId}] Failed to upload Codex generated image (callId=${callId} path=${savedPath ?? 'none'}): ${formatErrorMessage(error)}`
         );
+        void this.recordAgentWarning(sessionId, {
+          message:
+            'Codex generated an image, but it could not be attached to the conversation.',
+          source: 'imageGeneration',
+        });
         if (isTerminal) {
           state.imageGenerationTurnIds.delete(callId);
         }

--- a/apps/cli/tests/message-handler-image-upload.test.ts
+++ b/apps/cli/tests/message-handler-image-upload.test.ts
@@ -331,6 +331,69 @@ describe('MessageHandler image upload flow', () => {
     expect(harness.sessionDoc.setLastMessageAt).toHaveBeenCalledOnce();
   });
 
+  it('records a user-visible warning when a Codex generated image cannot be uploaded', async () => {
+    const harness = createHarness();
+    handlers.push(harness.handler);
+
+    const sessionId = 'session-1' as SessionId;
+    const turnId = (harness.host.beginConversationTurn as (sessionId: SessionId) => string)(
+      sessionId
+    );
+    await (
+      harness.host.createAssistantEntryForTurn as (
+        sessionId: SessionId,
+        sessionDoc: TestHarness['sessionDoc'],
+        turnId: string,
+        modelInfo: undefined
+      ) => Promise<void>
+    )(sessionId, harness.sessionDoc, turnId, undefined);
+
+    (harness.host.handleImageGenerationBegin as (sessionId: SessionId, event: unknown) => void)(
+      sessionId,
+      {
+        acpSessionId: 'acp-1',
+        callId: 'ig-fail',
+      }
+    );
+
+    vi.spyOn(harness.host, 'validateSessionImageUploadPath').mockRejectedValue(
+      new Error('cloud_attachment_upload_unavailable')
+    );
+
+    (harness.host.handleImageGenerationEnd as (sessionId: SessionId, event: unknown) => void)(
+      sessionId,
+      {
+        acpSessionId: 'acp-1',
+        callId: 'ig-fail',
+        status: 'completed',
+        savedPath: '/tmp/codex-image.png',
+      }
+    );
+    await (harness.host.flushCodexGeneratedImageUploads as (sessionId: SessionId) => Promise<void>)(
+      sessionId
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        harness.history.some((entry) =>
+          (entry.items as MessageContent[] | undefined)?.some(
+            (item) =>
+              item?.type === 'system_notice' &&
+              item.name === 'agent_warning' &&
+              (item.meta as { message?: string } | undefined)?.message?.includes(
+                'could not be attached'
+              )
+          )
+        )
+      ).toBe(true);
+    });
+    expect(
+      harness.history.some((entry) =>
+        (entry.items as MessageContent[] | undefined)?.some((item) => item?.type === 'image_group')
+      )
+    ).toBe(false);
+  });
+
   it('uploads completed-only Codex inline images without persisting base64', async () => {
     const harness = createHarness();
     handlers.push(harness.handler);


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

## Problem / pressure

When Codex finishes image generation, the CLI uploads the file into the conversation. Local (non-cloud) composition has `attachmentUpload: null`, so that upload throws `cloud_attachment_upload_unavailable`. The catch only `logger.debug`. Image-generation payloads are kept out of history on purpose, so the user sees neither the image nor an error.

## Summary

On upload failure, keep the debug log and also `recordAgentWarning` (already used for rejected run-config). Message: the image was generated but could not be attached. No image bytes in history. No new local blob store.

## Before / after

| Before | After |
| ------ | ----- |
| Failed upload → debug log only | Same log plus `agent_warning` system notice |
| Local OSS conversation looks empty | User sees that attach failed |

## Test plan

On this branch (`fix/local-image-generation-upload-warning` @ `7ec7074`), after `pnpm install` and `pnpm --filter acp-extension-core build` (submodule package had no `dist/` until built):

```
corepack pnpm --filter lody exec vitest run tests/message-handler-image-upload.test.ts
```

Result: **10 passed** (includes the new warning case).

Skipped: full CLI suite; live local OSS session.

## Agent handoff

<!-- agent-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** the `.catch` on Codex generated-image upload in `message-handler.ts` and the new case in `message-handler-image-upload.test.ts`.
- **Decisions to challenge:** Warning-only vs also persisting a local file blob (explicitly out of scope).
- **Plausible failures / evidence gaps:** Only this test file was run; `acp-extension-core` had to be built first because the submodule checkout has no `dist/`.

### Authoring context

- **User goal / directives:** If a generated image cannot be attached, tell the user.
- **Constraints / non-goals:** Do not inline base64 into history. Do not add a local attachment store.
- **Risk-bearing decisions:** Uses the existing `agent_warning` history item; duplicate messages are already deduped by text.
- **Destructive or irreversible behavior:** None.
- **Deliberately not done or tested:** Live desktop OSS run; full CLI suite.
- **Unknowns / confidence:** High for the mocked upload-failure case.

### Sharing consent (author side)

Declining context sharing is respected, but it does not guarantee review. If withheld context prevents maintainers from assessing provenance, scope, or risk, they may decline the contribution or close the pull request.

- [x] Author-side user explicitly allowed publishing the Authoring context above
- [ ] Author-side user explicitly declined publishing Authoring context and understands that maintainers may decline or close the contribution; keep every field as `N/A` / redacted

<!-- agent-handoff:end -->
