### PR TITLE
fix(components): keep workspace shell stable while syncing

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2744,6 +2744,7 @@
   "sidebar.filter.trigger": "Filter sidebar",
   "sidebar.githubWorktrees": "GitHub Worktrees",
   "sidebar.pinned": "Pinned",
+  "sidebar.workspace.syncing": "Syncing workspace…",
   "sidebar.home": "New chat",
   "sidebar.joinCommunity": "Join community",
   "sidebar.localProjects": "Local Projects",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -2744,6 +2744,7 @@
   "sidebar.filter.trigger": "筛选侧边栏",
   "sidebar.githubWorktrees": "GitHub Worktrees",
   "sidebar.pinned": "已置顶",
+  "sidebar.workspace.syncing": "正在同步工作空间…",
   "sidebar.home": "新对话",
   "sidebar.joinCommunity": "加入社区",
   "sidebar.localProjects": "本地项目",

--- a/packages/components/src/AGENTS.md
+++ b/packages/components/src/AGENTS.md
@@ -1,0 +1,14 @@
+# `@lody/components` source guidelines
+
+Parent `AGENTS.md` files also apply.
+
+## Workspace transitions
+
+- Authenticated workspace switches keep `MainLayout` mounted: the sidebar and
+  workspace identity are stable chrome, while the content pane shows a scoped
+  placeholder until route, runtime, and doc-meta ownership agree. Pending scope
+  still fails closed — never retain the previous workspace's rows or `<Outlet />`
+  content — and passes `workspaceReady={false}` so workspace-owned background work
+  and the mobile workspace stack do not start early. The workspace identity's
+  syncing state follows that same scoped readiness, not the coarser connection
+  state; an online transport does not imply that workspace data is ready.

--- a/packages/components/src/CLAUDE.md
+++ b/packages/components/src/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/components/src/components/loading-placeholder.tsx
+++ b/packages/components/src/components/loading-placeholder.tsx
@@ -1,14 +1,28 @@
 import { Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 export function LoadingPlaceholder({
   title = 'Loading',
   description = '',
+  variant = 'viewport',
 }: {
   title?: string;
   description?: string;
+  /**
+   * `viewport` is reserved for boot/auth gates where no application shell is
+   * safe to show yet. `content` fills an already-mounted workspace pane so the
+   * sidebar and workspace identity remain stable during scoped synchronization.
+   */
+  variant?: 'viewport' | 'content';
 }) {
   return (
-    <div className="flex min-h-[100dvh] w-full items-center justify-center bg-background p-6 text-muted-foreground">
+    <div
+      className={cn(
+        'flex w-full items-center justify-center bg-background p-6 text-muted-foreground',
+        variant === 'viewport' ? 'min-h-[100dvh]' : 'h-full min-h-0'
+      )}
+      data-loading-placeholder-scope={variant}
+    >
       <div
         className="flex max-w-sm flex-col items-center gap-3 text-center"
         role="status"

--- a/packages/components/src/components/loro-app-sidebar.tsx
+++ b/packages/components/src/components/loro-app-sidebar.tsx
@@ -2240,6 +2240,10 @@ export function LoroAppSidebar({ className }: LoroAppSidebarProps) {
       planPlus: t('billing.plan.plus', 'Plus'),
       planEnterprise: t('billing.plan.enterprise', 'Enterprise'),
       pinned: t('sidebar.pinned', 'Pinned'),
+      connectionLoading: t('chat.mobileHome.connectionBanner.loading', 'Connecting…'),
+      connectionReconnecting: t('chat.mobileHome.connectionBanner.reconnecting', 'Reconnecting…'),
+      connectionOffline: t('chat.mobileHome.connectionBanner.offline', 'Offline'),
+      workspaceSyncing: t('sidebar.workspace.syncing', 'Syncing workspace…'),
       filter: filterLabels,
     };
   }, [t, filterLabels]);
@@ -2608,6 +2612,7 @@ export function LoroAppSidebar({ className }: LoroAppSidebarProps) {
         currentWorkspaceId={resolvedWorkspaceId}
         workspaceSwitcherEnabled={multiWorkspaceAvailable}
         connectionUiState={connectionUiState}
+        workspaceSyncing={sessionsListLoading}
         isElectron={isElectron}
         // Traffic lights auto-hide in native fullscreen — drop the reserved
         // header inset so the sidebar's first row aligns with the top bar.

--- a/packages/components/src/components/loro-sidebar.tsx
+++ b/packages/components/src/components/loro-sidebar.tsx
@@ -120,6 +120,10 @@ export type LoroSidebarLabels = {
   planPlus: string;
   planEnterprise: string;
   pinned: string;
+  connectionLoading: string;
+  connectionReconnecting: string;
+  connectionOffline: string;
+  workspaceSyncing: string;
   filter: SidebarFilterLabels;
   updated: SidebarUpdatedSessionListLabels;
 };
@@ -139,6 +143,12 @@ export interface LoroSidebarProps {
    */
   workspaceSwitcherEnabled?: boolean;
   connectionUiState?: 'online' | 'loading' | 'offline' | 'reconnecting';
+  /**
+   * The network may already be online while the target workspace runtime and
+   * metadata are still converging. Keep that scoped readiness visible in the
+   * workspace identity instead of incorrectly presenting it as ready.
+   */
+  workspaceSyncing?: boolean;
   isElectron?: boolean;
   isElectronMacOS?: boolean;
   defaultWidth?: number;
@@ -277,6 +287,10 @@ const defaultLabels: LoroSidebarLabels = {
   planPlus: 'Plus',
   planEnterprise: 'Enterprise',
   pinned: 'Pinned',
+  connectionLoading: 'Loading',
+  connectionReconnecting: 'Reconnecting',
+  connectionOffline: 'Offline',
+  workspaceSyncing: 'Syncing workspace…',
   filter: {
     triggerAriaLabel: 'Filter sidebar',
     organizeHeading: 'Organize',
@@ -405,25 +419,40 @@ function LineChangeBadge({ lineChange }: { lineChange: LoroSidebarRepoItemDelta 
   );
 }
 
+type WorkspaceIdentityStatus = 'loading' | 'reconnecting' | 'offline' | 'syncing';
+
 function ConnectionPill({
   state,
+  labels,
 }: {
-  state: Exclude<NonNullable<LoroSidebarProps['connectionUiState']>, 'online'>;
+  state: WorkspaceIdentityStatus;
+  labels: Pick<
+    LoroSidebarLabels,
+    'connectionLoading' | 'connectionReconnecting' | 'connectionOffline' | 'workspaceSyncing'
+  >;
 }) {
-  const isLoading = state === 'loading' || state === 'reconnecting';
-  const label = state === 'reconnecting' ? 'Reconnecting' : isLoading ? 'Loading' : 'Offline';
+  const isLoading = state !== 'offline';
+  const label =
+    state === 'syncing'
+      ? labels.workspaceSyncing
+      : state === 'reconnecting'
+        ? labels.connectionReconnecting
+        : state === 'loading'
+          ? labels.connectionLoading
+          : labels.connectionOffline;
   return (
     <span
       className={cn(
-        'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium',
+        'inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium',
         isLoading
           ? 'bg-sidebar-hover text-sidebar-foreground-muted'
           : 'bg-status-danger/[0.12] text-status-danger ring-1 ring-status-danger/20'
       )}
       aria-label={label}
+      data-workspace-status={state}
     >
       {isLoading ? (
-        <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
+        <Loader2 className="h-3 w-3 shrink-0 animate-spin" aria-hidden />
       ) : (
         <span className="h-1.5 w-1.5 rounded-full bg-status-danger" aria-hidden />
       )}
@@ -592,6 +621,7 @@ export const LoroSidebar = memo(function LoroSidebar({
   currentWorkspaceId,
   workspaceSwitcherEnabled = true,
   connectionUiState,
+  workspaceSyncing = false,
   isElectron = false,
   isElectronMacOS = false,
   defaultWidth = 280,
@@ -766,6 +796,12 @@ export const LoroSidebar = memo(function LoroSidebar({
     ? (desktopFilterPlaceholder ?? <span aria-hidden="true" className="block h-5 w-5" />)
     : null;
   const hasPinnedItems = Boolean(pinnedItems?.length);
+  const workspaceIdentityStatus: WorkspaceIdentityStatus | null =
+    connectionUiState && connectionUiState !== 'online'
+      ? connectionUiState
+      : workspaceSyncing
+        ? 'syncing'
+        : null;
   const workspaceIdentity = (
     <>
       <WorkspaceAvatar
@@ -778,8 +814,8 @@ export const LoroSidebar = memo(function LoroSidebar({
       />
       <span className="min-w-0 flex flex-1 items-center gap-2">
         <span className="min-w-0 flex-1 truncate font-medium">{workspaceName}</span>
-        {connectionUiState && connectionUiState !== 'online' ? (
-          <ConnectionPill state={connectionUiState} />
+        {workspaceIdentityStatus ? (
+          <ConnectionPill state={workspaceIdentityStatus} labels={mergedLabels} />
         ) : null}
       </span>
     </>
@@ -856,6 +892,8 @@ export const LoroSidebar = memo(function LoroSidebar({
                     type="button"
                     className={workspaceIdentityClassName}
                     data-workspace-switcher-trigger
+                    data-workspace-syncing={workspaceSyncing ? 'true' : 'false'}
+                    aria-busy={workspaceSyncing || undefined}
                   >
                     {workspaceIdentity}
                   </button>

--- a/packages/components/src/components/main-layout.tsx
+++ b/packages/components/src/components/main-layout.tsx
@@ -15,10 +15,18 @@ export {
   getMobileMainLayoutRootClassName,
 } from './workspace-layout-utils';
 
-export function WorkspaceRuntimeShell({ children }: { children: ReactNode }) {
+export function WorkspaceRuntimeShell({
+  children,
+  workspaceReady = true,
+}: {
+  children: ReactNode;
+  workspaceReady?: boolean;
+}) {
   const isMobile = useIsMobile();
   if (isMobile) {
-    return <MobileWorkspaceLayout>{children}</MobileWorkspaceLayout>;
+    return (
+      <MobileWorkspaceLayout workspaceReady={workspaceReady}>{children}</MobileWorkspaceLayout>
+    );
   }
 
   return <WebWorkspaceLayout>{children}</WebWorkspaceLayout>;
@@ -30,24 +38,34 @@ function TaskIndexSync() {
   return null;
 }
 
-export function MainLayout({ children }: { children: ReactNode }) {
+export function MainLayout({
+  children,
+  workspaceReady = true,
+}: {
+  children: ReactNode;
+  /**
+   * Keeps the navigation shell mounted while a new workspace scope converges,
+   * without starting workspace-owned background work or mobile content stacks.
+   */
+  workspaceReady?: boolean;
+}) {
   // Behind the beta gate none of this mounts: no index subscription, no status
   // watcher, no quick-add dialog listening for its open atom.
   const tasksEnabled = useAtomValue(tasksFeatureEnabledAtom);
 
   return (
-    <WorkspaceRuntimeShell>
+    <WorkspaceRuntimeShell workspaceReady={workspaceReady}>
       {children}
-      {tasksEnabled ? (
+      {tasksEnabled && workspaceReady ? (
         <>
           <TaskIndexSync />
           <TaskStatusWatcher />
           <TaskQuickAddDialogContainer />
         </>
       ) : null}
-      <BugReportDialogContainer />
+      {workspaceReady ? <BugReportDialogContainer /> : null}
       <StuckConnectionBannerContainer />
-      <DesktopSettingsModal />
+      {workspaceReady ? <DesktopSettingsModal /> : null}
     </WorkspaceRuntimeShell>
   );
 }

--- a/packages/components/src/components/mobile/mobile-workspace-layout.tsx
+++ b/packages/components/src/components/mobile/mobile-workspace-layout.tsx
@@ -28,7 +28,14 @@ const MobileWorkspaceStack = lazy(() =>
    at its bottom. The workspace layout therefore renders no bottom bar
    of its own. */
 
-export function MobileWorkspaceLayout({ children }: { children: ReactNode }) {
+export function MobileWorkspaceLayout({
+  children,
+  workspaceReady = true,
+}: {
+  children: ReactNode;
+  /** Do not mount the workspace-owned stack while route/runtime scope is converging. */
+  workspaceReady?: boolean;
+}) {
   // Only the pathname drives this layout (error boundary resets), so
   // search-only navigations don't re-render the whole mobile shell.
   const pathname = useLocation({ select: (l) => l.pathname });
@@ -73,7 +80,7 @@ export function MobileWorkspaceLayout({ children }: { children: ReactNode }) {
                    running on these — the most common — mobile pages.
                The stack is layered on top; since the route components render
                nothing on mobile there is no duplicate content. */}
-            {onStackRoute && workspaceName != null && (
+            {workspaceReady && onStackRoute && workspaceName != null && (
               <Suspense fallback={<div className="h-full w-full bg-background" />}>
                 <MobileWorkspaceStack workspaceName={workspaceName} />
               </Suspense>

--- a/packages/components/src/routes/$workspaceName/_auth.tsx
+++ b/packages/components/src/routes/$workspaceName/_auth.tsx
@@ -366,10 +366,15 @@ function AuthedLayoutContent({
 
     if (!currentWorkspaceId) {
       return (
-        <LoadingPlaceholder
-          title={t('workspace.route.loadingTitle')}
-          description={t('workspace.route.setupLoadingDescription')}
-        />
+        <RouteSuspense>
+          <LazyMainLayout workspaceReady={false}>
+            <LoadingPlaceholder
+              variant="content"
+              title={t('workspace.route.switchingTitle')}
+              description={t('workspace.route.switchingDescription')}
+            />
+          </LazyMainLayout>
+        </RouteSuspense>
       );
     }
 

--- a/packages/components/src/stories/LoroSidebar.stories.tsx
+++ b/packages/components/src/stories/LoroSidebar.stories.tsx
@@ -399,6 +399,7 @@ function StoryLayout(args: Parameters<typeof LoroSidebar>[0]) {
       sessionListProps={{
         sessions: workspaceTasks,
         repos,
+        isLoading: baseSessionListProps.isLoading,
         chatsCollapsed,
         selectedSessionId,
         onSelect: setSelectedSessionId,
@@ -548,6 +549,21 @@ export const Default: Story = {
     onLinkRepoClicked: () => {},
     onSettingsClicked: () => {},
     onRequestCollapse: () => {},
+  },
+};
+
+export const WorkspaceSyncing: Story = {
+  render: (args) => <StoryLayout {...args} />,
+  args: {
+    ...Default.args!,
+    connectionUiState: 'online',
+    workspaceSyncing: true,
+    sessionListProps: {
+      ...demoTaskListProps,
+      sessions: [],
+      repos: [],
+      isLoading: true,
+    },
   },
 };
 

--- a/packages/components/tests/workspace-identity.test.tsx
+++ b/packages/components/tests/workspace-identity.test.tsx
@@ -6,6 +6,7 @@ import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import lodyLogo from '../src/assets/lody-icon.png';
+import { LoadingPlaceholder } from '../src/components/loading-placeholder';
 import { LoroSidebar, type LoroSidebarProps } from '../src/components/loro-sidebar';
 import { MobileHomeScreen } from '../src/components/mobile/mobile-home-screen';
 import { initI18n } from '../src/i18n';
@@ -89,6 +90,48 @@ describe('workspace identity capability boundary', () => {
 
     expect(container?.querySelector('[data-workspace-switcher-trigger]')?.tagName).toBe('BUTTON');
     expect(container?.querySelector('[data-workspace-identity]')).toBeNull();
+  });
+
+  it('keeps scoped workspace synchronization visible after the connection is online', () => {
+    render(
+      <LoroSidebar
+        {...sidebarProps}
+        connectionUiState="online"
+        workspaceSyncing
+        labels={{ workspaceSyncing: 'Syncing target workspace…' }}
+      />
+    );
+
+    const trigger = container?.querySelector('[data-workspace-switcher-trigger]');
+    expect(trigger?.getAttribute('aria-busy')).toBe('true');
+    expect(trigger?.getAttribute('data-workspace-syncing')).toBe('true');
+    const status = container?.querySelector('[data-workspace-status]');
+    expect(status?.getAttribute('data-workspace-status')).toBe('syncing');
+    expect(status?.textContent).toBe('Syncing target workspace…');
+  });
+
+  it('keeps connection failures ahead of workspace synchronization', () => {
+    render(
+      <LoroSidebar
+        {...sidebarProps}
+        connectionUiState="offline"
+        workspaceSyncing
+        labels={{ connectionOffline: 'No connection' }}
+      />
+    );
+
+    const status = container?.querySelector('[data-workspace-status]');
+    expect(status?.getAttribute('data-workspace-status')).toBe('offline');
+    expect(status?.textContent).toBe('No connection');
+  });
+
+  it('supports a content-scoped loading placeholder without taking over the viewport', () => {
+    render(<LoadingPlaceholder variant="content" title="Switching workspace" />);
+
+    const placeholder = container?.querySelector('[data-loading-placeholder-scope]');
+    expect(placeholder?.getAttribute('data-loading-placeholder-scope')).toBe('content');
+    expect(placeholder?.className).toContain('h-full');
+    expect(placeholder?.className).not.toContain('min-h-[100dvh]');
   });
 
   it('renders the mobile local workspace identity without a dialog trigger', () => {


### PR DESCRIPTION
## Summary

- keep the authenticated workspace shell mounted while route, runtime, and metadata scope converge
- show workspace-scoped syncing in the workspace switcher even after the transport is online
- keep previous workspace content fail-closed and gate task, dialog, and mobile stack work until the target scope is ready
- add localized copy, focused tests, Storybook coverage, and the scoped contributor invariant

## UX impact

- removes the full-viewport loading replacement during cached authenticated workspace switches
- preserves the workspace identity and navigation geometry during synchronization
- keeps offline and reconnecting states ahead of the scoped syncing indicator

## Testing

- pnpm --filter @lody/components typecheck
- pnpm --filter @lody/components exec vitest run tests/workspace-identity.test.tsx tests/workspace-data-scope.test.ts tests/use-resolved-workspace-scope.test.tsx
- pnpm check:quick
- Storybook dev visual QA for the WorkspaceSyncing state