### PR TITLE
feat(components): predict outline hover intent

### DIFF
--- a/packages/components/src/components/ai-gui/AGENTS.md
+++ b/packages/components/src/components/ai-gui/AGENTS.md
@@ -1,218 +1,127 @@
-# components/ai-gui — Index
+# components/ai-gui - Maintainer Guide
 
 `CLAUDE.md` is a symlink to this file. Edit `AGENTS.md` only.
 
-This module is **the message-list renderer for the session conversation page**
-(`view.tsx`): markdown, tool calls, terminal output, diff badges. The page shell and
-composer live in `../sessions/` (see its AGENTS.md); how conversation data arrives:
-context/message-flow.md.
+| Area    | Owner                                    | Contract                               |
+| ------- | ---------------------------------------- | -------------------------------------- |
+| Stream  | `view.tsx`, `build-chat-stream-items.ts` | Stable Virtua rows and scroll.         |
+| Turns   | `assistant-turn-render-blocks.ts`        | Activity groups and foldable segments. |
+| Outline | `conversation-outline-*`                 | Round ticks and navigation.            |
 
-- `view.tsx` — renders the session history items (`MessageContent` shapes from
-  `packages/shared/src/schema.ts`); the most frequently edited file here.
-- **In-conversation search indexes PROSE ONLY** (`src/lib/session-chat-search.ts`): user
-  text, assistant text, thinking, proposed-plan markdown. Tool calls (titles, paths, JSON
-  input/output, terminal command/output, diffs), plan checklists, goals, and worktree
-  script output are deliberately excluded — indexing them buried real matches under logs
-  and JSON. Prose folded inside the `Worked for …` group and activity groups still matches
-  (the group auto-expands via `assistantGroupHasActiveSearch`). Do not re-add
-  `searchBlockId` wiring to tool/terminal/diff renderers.
-- `assistant-turn-render-blocks.ts` merges adjacent assistant tool calls and thoughts
-  into one activity group without crossing visible text. `SessionChatStreamView` flattens each assistant
-  turn into `virtua` rows: a collapsed group is one row; expanded tool/thought details
-  are sibling rows in the same main `VList`. Do not reintroduce a fixed-height process
-  panel or nested vertical output scroller. Group keys must remain stable while a turn
-  streams; active search blocks force their owning group open, and `scrollToIndex`
-  translates history indexes to the matching virtual child row.
-- A finished assistant turn keeps its final answer/result tail visible and collapses
-  earlier progress text, activity groups, and subagent work under a `Worked for …`
-  virtual row. Keep streaming turns fully expanded. Expanding completed work must add
-  sibling rows to the main `VList`; search hits inside completed work force that outer
-  row and the owning activity group open.
-  - "Final answer" is not literally the LAST item (`message-copy.ts`
-    `getTextIndexBeforeTrailingNeverCollapsedItems`): the last TEXT stays visible when
-    everything after it is itself never collapsed — generated `image_group`s, and the
-    `switch_mode` "Exited Plan Mode" card.
-  - **One turn can have SEVERAL foldable regions** (`AssistantTurnRenderSegment`).
-    A plan is approved from inside a RUNNING turn, so that same turn implements it;
-    the plan-approval card cuts a segment so the approved work gets its own region
-    under the plan instead of disappearing into the plan's fold — an approved plan
-    otherwise looks like it produced nothing. The cut matches the ACP tool KIND
-    `switch_mode`, never a title: Claude's `ExitPlanMode` renders "Ready to code?"
-    and Codex's plan review renders "Implement this plan?" for the same event.
-    Everything the gate needs is
-    per-segment: `workBlockKeys`, `hasVisibleFinalContent`, the collapse rule's
-    "last item stays visible", and the expansion state
-    (`BubbleExpandState.expandedWorkedGroups`, keyed by segment). The turn duration
-    is NOT per-segment — only the last region may print "Worked for …", earlier ones
-    fall back to "Finished working". Do not collapse this back to one region per
-    message, and do not key expansion by message id alone.
-- **`Worked for …` collapse gate (`view.tsx` `shouldUseWorkedGroup`)** requires THREE
-  things, not just `message.finished`: (1) the turn is finished, (2) there is foldable
-  work, and (3) `hasVisibleFinalContent` — at least one render block is NOT in
-  `workBlockKeys` (a genuine visible answer/result tail). Rationale (do not regress):
-  - Condition (3) exists because activity groups are folded unconditionally
-    (`assistant-turn-render-blocks.ts`), so an **interrupted/cancelled** turn ending
-    mid-tool with no final text would otherwise fold everything into an empty
-    `Worked for …` row. No final answer ⇒ stay expanded. Turns that finish with only
-    tool/thought work and no text answer therefore also stay expanded — intended.
-  - `message.finished` is set on every teardown/cancel path (CLI `finalizeACPState`),
-    not only on a completed answer, so it can never be the sole collapse signal.
-  - A turn that **resumed after its machine died mid-turn** used to collapse while still
-    streaming: the CLI had stamped `finished=true` on the reused entry during teardown
-    and never cleared it. Fixed CLI-side (assistant entry reopen clears `finished`/
-    `endedAt` — see apps/cli/src/session/AGENTS.md); the renderer still trusts
-    `message.finished`, so keep that reset intact upstream.
-- Expanded activity details form one compact timeline: Thought and tool headers share
-  the same icon gutter, 13px hierarchy, spacing, and transparent row surface. Keep
-  execute calls out of standalone card chrome, and keep Thought markdown headings at
-  activity-detail scale rather than assistant-response scale.
-- Assistant turns use the same avatar-free, full-width layout on desktop and mobile.
-  Do not restore a model/avatar header or reserve a desktop avatar indent. Per-turn
-  model, mode, reasoning, and other run configuration lives in the footer info control
-  beside Copy; the popover is the detailed configuration surface.
-- **Turn duration has one owner per layout.** Desktop: `WorkedGroupHeader` when the turn
-  folds, else the footer action bar AFTER the buttons (`showDuration` encodes which).
-  Mobile: always the footer, BEFORE the buttons, ignoring `showDuration` — and
-  `WorkedGroupHeader` suppresses its own copy there, because both read the same
-  `resolveSessionHistoryDurationMs(message)` and would otherwise print an identical
-  "Worked for 12s" twice per turn. The mobile leading slot also reserves
-  `MOBILE_TURN_ACTION_LEADING_INSET_PX` so the copy button clears the session drawer's
-  edge-back strip (see ../mobile/AGENTS.md); it is layout, not decoration.
-- Virtua positions rows with `position:absolute; top:<cumulative measured height>`;
-  stale measured heights make rows overlap. Keep `shift={false}`. `bufferSize` trades
-  fast-scroll blanks against the number of still-resizing rows kept mounted.
-- Horizontal gutter for stream rows lives on `ConversationColumn`
-  (`CONVERSATION_GUTTER_X_CLASS` / `px-3 sm:px-4`), **not** on the `VList`.
-  Virtua absolute rows ignore scroller horizontal padding, which used to leave
-  avatars flush to the screen edge while the composer stayed inset.
-  **One left rail per turn**: no top-level row adds its own leading pad —
-  prose (`MarkdownBlock`), `ActivityGroupHeader`, `WorkedGroupHeader`,
-  `SubagentTaskPanel`, edited-files, footer. `MarkdownBlock` carried `sm:px-2`
-  and the footer/edited-files were tuned to that 8px, so prose read as indented
-  beside the chevrons. Footer keeps `-mx-[7px]` to put its glyph on the rail.
-  Indents belong to CHILD rows only (`activity_detail`, worked-group details).
-  Story: `AssistantTurnAlignment.stories.tsx`.
-- `build-chat-stream-items.ts` — `buildChatStreamItems()` turns `sessionDoc.history`
-  into `VList` items. **Normalizes defensively** so interrupted / bad-network docs
-  can't make virtua overlap deterministically: drops empty assistant entries (they'd
-  render to `null` = an unmeasurable row) and de-dupes by `id` (the VList keys rows
-  by `history.id`; duplicate keys desync virtua). Test: `tests/build-chat-stream-items.test.ts`.
-- `SessionChatStreamView.leadingContent` is a real first Virtua row used for non-history
-  conversation provenance. Its presence must be included in sticky-scroll item counts and added to
-  every imperative/search/group `scrollToIndex` target. Do not absolutely overlay it or persist a
-  synthetic history entry. `session_create` Operation completions render one navigable relation
-  card per successful target and select only that target Session's title from doc meta.
-- **Outline rail** (`conversation-outline-rail.tsx` + `src/lib/conversation-outline.ts`):
-  the left table of contents, one tick per ROUND (a user turn plus the work it
-  produced), hover card showing the round's opening words. Three invariants:
-  - **Data comes from `items`, never from the DOM.** The list is virtualized, so
-    most rounds have no element — an IntersectionObserver / item-registration
-    design (shadcn `MessageScroller`'s approach) silently omits them. Reader
-    position likewise comes from Virtua's index math (`getItemOffset` +
-    `resolveActiveOutlineIndex`), and the active round is the LAST one whose
-    anchor is above the viewport top, so it stays set through a long turn.
-  - **It is a page-level overlay, portalled outside the shrinking message area.**
-    It is never a Virtua row (it would scroll away) or a child of the viewport
-    (`use-sticky-scroll.ts` takes the content element from that div's
-    `firstElementChild`). Its portal root is the full session page so the rail
-    stays vertically centred when the composer changes height; do not replace
-    that with a composer-height measurement or `position: fixed`, which breaks
-    split conversation panes.
-  - **Reader position must not re-render the tick list.** It never enters the
-    list's props: the active round is painted by one absolutely-positioned bar
-    (fixed pitch, pure arithmetic, no measurement) and `aria-current` is synced
-    imperatively. Hover MAGNIFICATION is the deliberate exception — it changes
-    every tick at once, but it is driven by pointer entry rather than by
-    scrolling at frame rate, and each tick is memoized on its own width so a
-    move only re-renders the few inside the bell. The outline itself is rebuilt
-    at token rate, so `buildConversationOutline` memoizes per message and only
-    ever runs the markdown cleanup over a bounded prefix — never a whole answer.
-    Same lesson as `hooks/use-incremental-search-blocks.ts`.
-  - **Magnification blends the bell in, it does not add it on**
-    (`conversation-outline-rail-geometry.ts`). Ticks rest at a width set by how
-    much was said in the round, so ADDING a Gaussian let a heavy neighbour
-    outgrow the tick under the cursor. `outlineTickWidth` interpolates toward
-    the bell weighted by the bell itself, which keeps the pointer's own tick
-    the longest and the run of them reading as one normal distribution, while
-    distant ticks keep the resting texture. `RAIL_TRACK_WIDTH` is derived from
-    the peak, not written down separately: the strip is `overflow-y: auto`,
-    which makes the x axis `auto` too, so a tick wider than the track would
-    scroll the rail sideways instead of extending.
-  - **`scrollRowToTop` is the ONLY place a row index becomes a scroll.** It adds
-    `leadingRowCount` and compensates the viewport's top padding, which Virtua's
-    `align: 'start'` does not know about. That compensation is not cosmetic: the
-    rail reads positions back out of the same coordinate space, so a call site
-    that skips it lands a padding's worth low and the rail then reports the round
-    BEFORE the one that was asked for. Group expansion, outline jumps, and the
-    imperative/search `scrollToIndex` all go through it — do not add a fourth
-    direct `vlistRef.scrollToIndex` call.
-  - **A jump into unmeasured rows must be re-issued once it settles.** Virtua
-    scrolls on ESTIMATED offsets there. It _does_ re-issue internally as
-    measurements arrive, but gives up after 150ms of measurement silence
-    (`virtua/lib/core/index.js`), and a React commit plus the ResizeObserver
-    round trip for a screenful of message rows routinely exceeds that — so a far
-    jump settles a round short. (It is NOT that `shift={false}` disables
-    correction; that was the original, wrong diagnosis.) Arriving is what
-    measures the rows, so `handleStreamScrollEnd` re-runs the same jump until it
-    is within `OUTLINE_JUMP_TOLERANCE_PX`, bounded by
-    `OUTLINE_JUMP_MAX_CORRECTIONS` (the list's tail genuinely cannot reach the
-    top, so it must stop rather than retry against the clamp). Any wheel / touch
-    / keydown on the viewport abandons the pending correction — a reader who has
-    started scrolling must never be yanked back.
-    `OUTLINE_ANCHOR_TOLERANCE_PX` then has to EXCEED the jump tolerance: a jump
-    settles a hair above its target, and an exact-to-the-pixel "has this round
-    started" test reported the previous round while its successor visibly owned
-    the top edge.
-  - **Follow-output suppression for a jump is tied to `pendingOutlineJumpRef`,
-    not to a render.** Group expansion can release in the layout effect of its
-    own commit because it _runs_ in one; a jump is an event handler, and React
-    skips the commit when `setActiveOutlineIndex` gets the value it already has
-    — which is exactly what clicking the current round does. Keying suppression
-    on the pending ref means the release cannot be skipped.
-  - Tests: `tests/conversation-outline.test.ts`,
-    `tests/conversation-outline-active.test.ts`,
-    `tests/conversation-outline-rail-geometry.test.ts`. The
-    `ExtremeConversation` story (120 rounds, turns up to 220 paragraphs, a round
-    with no reply, CJK and degenerate titles) is what surfaces the jump and
-    tolerance behaviour; the comfortable stories do not.
-- `markdown-renderer.tsx` — assistant markdown (story: `MarkdownRenderer.stories.tsx`).
-  Conversation font size is a bounded integer pixel value, not a preset name; keep body,
-  headings, dense monospace output, terminal output, and collapsed-text height scaling
-  through `conversation-font-size-classes.ts`, with legacy preset migration in settings.
-  Keep Streamdown in streaming mode for incomplete Markdown, but do not enable its
-  word-level `animated` option: it wraps every word in an opacity-animated span and can
-  explode Chromium compositor-layer count during long turns.
-- `chat_failed` notices (`ChatFailedNoticeView` in `view.tsx`) put the raw agent error
-  behind a **modal**, never a hover tooltip — a tooltip is unreachable on touch and
-  truncates upstream payloads, so mobile users could not read or copy the real error.
-  `chat-failed-detail-dialog.tsx` renders the full verbatim `meta.message` plus
-  reason/code and a one-tap copy; `chat-failed-error-report.ts` holds the pure
-  readable-message extraction and clipboard-report builder (tested).
-- `terminal-component.tsx` — terminal/tool output rendering.
-- Terminal persistence and legacy preview limits are documented in
-  context/terminal-output-lifecycle.md.
-  Never send a full legacy output through ANSI parsing, search, or React rendering.
-- `assistant-edited-files.tsx` — per-turn edited-file summary + grouped path list. It shows
-  four paths by default, expands in place, and aligns per-file add/delete stats without
-  returning to one-pill-per-file chrome (story exists).
-- `message-content-guards.ts` — type guards for history item variants; update together
-  with new `MessageContent` types (see `context/hotspots.md` "Shared: schemas").
-  **`isMessageContent` gates rendering** — a `MessageContent` variant missing a `case`
-  here is silently dropped from the parsed history (see `index.tsx`).
-- `message-send-status-context.tsx` / `message-copy.ts` — send-state + copy helpers.
-- A user entry negatively acknowledged by missing-history recovery
-  (`SessionMeta.lastMissingHistoryUserMsgId === message.id`, entry still
-  non-terminal) renders as a terminal "Not delivered" label, never as an
-  endless sending spinner. The derivation is display-only
-  (`src/lib/undelivered-user-turn.ts`): the marker permanently excludes the
-  exact turn, so the old turn never revives. The label is the ONLY recovery
-  entry point: clicking it opens `ResendUndeliveredDialog` (local to
-  `view.tsx`), which resends the SAME content as a brand-new message through
-  the interface's ordinary send path (`onResendUndelivered`, threaded through
-  `SessionChatStream` → `MessageRowView`), then the interface supersedes the
-  abandoned entry to `canceled` — the ordinary producer write clears the
-  marker, and without the terminal flip the stale pending entry would
-  duplicate-dispatch once the marker is gone. Never add an automatic or
-  old-turn re-dispatch path.
-- File attachment rendering and mobile image-preview invariants:
+## Stream And Search
+
+- In-conversation search indexes prose only: user/assistant text, thinking, and
+  proposed-plan markdown. Never index tool titles/JSON/output, terminal data,
+  diffs, plan checklists, goals, or worktree script output. Search still reaches
+  prose inside folded work and activity; matches force their owning groups open.
+  Do not restore `searchBlockId` wiring to tool, terminal, or diff renderers.
+- `SessionChatStreamView` flattens turns into one main Virtua list. Collapsed
+  activity is one row; expanded details are sibling rows, never a nested output
+  scroller or fixed-height process panel. Streaming keys must remain stable, and
+  history indexes must translate to the matching virtual child row.
+- Keep Virtua `shift={false}`; stale cumulative heights otherwise overlap rows.
+  `bufferSize` trades fast-scroll blanks against retaining resizing rows.
+- `buildChatStreamItems()` drops empty assistant entries (a `null` render cannot
+  be measured) and de-duplicates history ids (duplicate Virtua keys desync the
+  list). See `tests/build-chat-stream-items.test.ts`.
+- `leadingContent` is a real first row. Include it in sticky counts and every
+  scroll target; never overlay or persist it. A `session_create` completion
+  renders one card per successful target and reads only that target's title.
+
+## Turn Folding And Layout
+
+- Finished turns keep the answer/result tail visible and fold earlier work.
+  Streaming turns stay expanded. Details remain sibling rows; search opens both
+  the worked region and activity group.
+- The final answer is the last text before trailing never-collapsed items, not
+  necessarily the last item. Generated `image_group`s and the `switch_mode`
+  "Exited Plan Mode" card may follow it; use
+  `getTextIndexBeforeTrailingNeverCollapsedItems`.
+- One turn may contain several `AssistantTurnRenderSegment`s. A plan approval
+  inside a running turn cuts a segment so implementation stays under the plan.
+  Match ACP tool kind `switch_mode`, never a rendered title. Keep
+  `workBlockKeys`, `hasVisibleFinalContent`, last-item visibility, and
+  `expandedWorkedGroups` per segment. Expansion keys include the segment; only
+  the last region may show a duration, while earlier regions say "Finished
+  working".
+- `shouldUseWorkedGroup` requires a finished turn, foldable work, and visible
+  final content outside `workBlockKeys`. A cancelled/interrupted or tool-only
+  turn with no answer stays expanded. `message.finished` also marks teardown and
+  cannot prove completion alone. When a reused assistant entry reopens upstream,
+  it must clear `finished` and `endedAt` (see `apps/cli/src/session/AGENTS.md`).
+- Thought and tool rows share one compact transparent timeline, icon gutter,
+  and 13px hierarchy. Execute calls are not cards; Thought headings stay at
+  activity-detail scale.
+- Turns are avatar-free and full-width. Run configuration belongs in the footer
+  info control.
+- Duration has one owner. Desktop uses `WorkedGroupHeader` for folded turns and
+  the footer after buttons otherwise. Mobile always uses the footer before
+  buttons, and the worked header suppresses its copy. Preserve
+  `MOBILE_TURN_ACTION_LEADING_INSET_PX` so actions clear the edge-back strip.
+- Horizontal gutter belongs to `ConversationColumn`, not Virtua: absolute rows
+  ignore scroller padding. Top-level prose, headers, subagents,
+  edited files, and footer share one left rail; only child detail rows indent.
+  Preserve the footer's `-mx-[7px]`. Visual coverage:
+  `AssistantTurnAlignment.stories.tsx`.
+
+## Conversation Outline
+
+`conversation-outline-rail.tsx` renders one tick per round (a user turn plus its
+work) and a hover preview.
+
+- Build entries from `items`, never DOM. Reader position uses Virtua offsets and
+  selects the last round whose anchor is above the viewport top.
+- The rail is a page-level absolute portal outside the shrinking message area.
+  It is not a Virtua row or viewport child. Keep it page-centred as the composer
+  grows and pane-local in splits; never use `position: fixed` or composer height.
+- Reader position never enters tick-list props. Paint one arithmetic active bar
+  and sync `aria-current` imperatively. Pointer magnification may update the
+  memoized ticks; scrolling may not. `buildConversationOutline` runs at token
+  rate, so memoize per message and clean only a bounded markdown prefix.
+- Blend magnification into resting widths so the pointer's tick stays longest.
+  Derive `RAIL_TRACK_WIDTH` from the peak; an undersized auto-overflow track
+  scrolls sideways.
+- Arrival intent belongs to `conversation-outline-arrival-intent.ts`. A directed,
+  braking approach gets one short-lived delay bypass; uncertainty waits 200ms.
+  Only waiting out that delay arms rapid browsing and its 2.5s close window;
+  predictor-opened cards never do. Removing `enableArrivalIntent` installs no
+  detector/listener. Keep inputs numeric and replayable, independent of Session,
+  lifecycle, telemetry, and platform capabilities. The Storybook Lab records
+  only explicit in-memory, rail-relative data; it never persists or uploads.
+- `scrollRowToTop` is the only row-index-to-scroll conversion. It adds
+  `leadingRowCount` and compensates viewport top padding so reads and writes use
+  one coordinate space. Group expansion, outline jumps, search, and imperative
+  scrolling all use it; do not call `vlistRef.scrollToIndex` elsewhere.
+- Far jumps start from estimated offsets. After scroll settles, reissue the same
+  jump until it is within `OUTLINE_JUMP_TOLERANCE_PX`, bounded by
+  `OUTLINE_JUMP_MAX_CORRECTIONS` because the tail may be clamped. Wheel, touch,
+  or key input cancels correction immediately. Keep
+  `OUTLINE_ANCHOR_TOLERANCE_PX` greater than jump tolerance.
+- Follow-output suppression is owned by `pendingOutlineJumpRef`, not a render;
+  React may skip the commit when clicking the already-active round.
+- Coverage: `tests/conversation-outline*.test.ts` and `ExtremeConversation`.
+
+## Content Contracts
+
+- Conversation font size is a bounded integer pixel value. Scale body, headings,
+  dense monospace, terminal output, and collapsed height through
+  `conversation-font-size-classes.ts`; settings own legacy preset migration.
+  Keep Streamdown in streaming mode, but never enable word-level `animated`: its
+  span-per-word compositor cost is unbounded on long turns.
+- `chat_failed` raw errors open a modal, never a hover tooltip. Mobile must be
+  able to read and copy the full `meta.message`, reason, and code. Extraction and
+  clipboard formatting live in `chat-failed-error-report.ts`.
+- Terminal persistence and legacy preview bounds live in
+  `context/terminal-output-lifecycle.md`. Never send full legacy output through
+  ANSI parsing, search, or React rendering.
+- `assistant-edited-files.tsx` shows four paths before expanding and aligns stats
+  without per-file pills.
+- Update `message-content-guards.ts` with every shared `MessageContent` variant.
+  `isMessageContent` gates rendering; a missing case silently drops the item.
+- A user entry marked by `SessionMeta.lastMissingHistoryUserMsgId` renders the
+  terminal "Not delivered" label. That label is the only recovery entry: its
+  dialog resends the same content as a new ordinary message, then marks the old
+  entry `canceled`; the producer clears the marker. Never automatically dispatch
+  or revive the old turn.
+- Attachment and mobile image-preview invariants live in
   [session-files-rendering.md](session-files-rendering.md).

--- a/packages/components/src/components/ai-gui/conversation-outline-arrival-intent.ts
+++ b/packages/components/src/components/ai-gui/conversation-outline-arrival-intent.ts
@@ -1,0 +1,369 @@
+export interface ArrivalIntentPoint {
+  x: number;
+  y: number;
+  /** Monotonic milliseconds, normally from `performance.now()`. */
+  time: number;
+}
+
+export interface ArrivalIntentRect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+export interface ArrivalIntentConfig {
+  /** Samples older than this do not describe the current gesture. */
+  sampleWindowMs: number;
+  /** A pause longer than this starts a new gesture. */
+  resetAfterMs: number;
+  minSamples: number;
+  /** Only arm intent close enough that the target is plausibly the destination. */
+  maxDistancePx: number;
+  minApproachDistancePx: number;
+  minShrinkingSegmentRatio: number;
+  recentShrinkingSegmentCount: number;
+  minHeadingCosine: number;
+  minEarlySpeedPxPerMs: number;
+  minRecentSpeedPxPerMs: number;
+  maxRecentSpeedPxPerMs: number;
+  maxBrakingRatio: number;
+  trajectoryHorizonMs: number;
+  maxTimeToContactMs: number;
+  predictionTtlMs: number;
+}
+
+export const DEFAULT_ARRIVAL_INTENT_CONFIG: Readonly<ArrivalIntentConfig> = {
+  sampleWindowMs: 180,
+  resetAfterMs: 100,
+  minSamples: 5,
+  maxDistancePx: 180,
+  minApproachDistancePx: 24,
+  minShrinkingSegmentRatio: 0.75,
+  recentShrinkingSegmentCount: 3,
+  minHeadingCosine: 0.88,
+  minEarlySpeedPxPerMs: 0.35,
+  minRecentSpeedPxPerMs: 0.08,
+  maxRecentSpeedPxPerMs: 1.2,
+  maxBrakingRatio: 0.78,
+  trajectoryHorizonMs: 220,
+  maxTimeToContactMs: 260,
+  predictionTtlMs: 160,
+};
+
+export interface ArrivalIntentChecks {
+  outsideTarget: boolean;
+  enoughSamples: boolean;
+  withinDistance: boolean;
+  madeApproachProgress: boolean;
+  distanceMostlyShrinking: boolean;
+  distanceRecentlyShrinking: boolean;
+  headingTowardTarget: boolean;
+  earlySpeedHighEnough: boolean;
+  recentSpeedInRange: boolean;
+  braking: boolean;
+  projectsToTarget: boolean;
+  contactSoon: boolean;
+}
+
+export interface ArrivalIntentMetrics {
+  sampleCount: number;
+  distancePx: number | null;
+  approachDistancePx: number | null;
+  shrinkingSegmentRatio: number | null;
+  headingCosine: number | null;
+  earlySpeedPxPerMs: number | null;
+  recentSpeedPxPerMs: number | null;
+  brakingRatio: number | null;
+  approachSpeedPxPerMs: number | null;
+  timeToContactMs: number | null;
+  projectedX: number | null;
+  projectedY: number | null;
+}
+
+export interface ArrivalIntentEvaluation {
+  qualifies: boolean;
+  checks: ArrivalIntentChecks;
+  metrics: ArrivalIntentMetrics;
+}
+
+export interface ArrivalIntentUpdate {
+  evaluation: ArrivalIntentEvaluation;
+  predictionActive: boolean;
+  predictionActivated: boolean;
+  predictedUntil: number | null;
+}
+
+const EMPTY_CHECKS: ArrivalIntentChecks = {
+  outsideTarget: false,
+  enoughSamples: false,
+  withinDistance: false,
+  madeApproachProgress: false,
+  distanceMostlyShrinking: false,
+  distanceRecentlyShrinking: false,
+  headingTowardTarget: false,
+  earlySpeedHighEnough: false,
+  recentSpeedInRange: false,
+  braking: false,
+  projectsToTarget: false,
+  contactSoon: false,
+};
+
+const emptyMetrics = (sampleCount: number): ArrivalIntentMetrics => ({
+  sampleCount,
+  distancePx: null,
+  approachDistancePx: null,
+  shrinkingSegmentRatio: null,
+  headingCosine: null,
+  earlySpeedPxPerMs: null,
+  recentSpeedPxPerMs: null,
+  brakingRatio: null,
+  approachSpeedPxPerMs: null,
+  timeToContactMs: null,
+  projectedX: null,
+  projectedY: null,
+});
+
+export const EMPTY_ARRIVAL_INTENT_EVALUATION: ArrivalIntentEvaluation = {
+  qualifies: false,
+  checks: EMPTY_CHECKS,
+  metrics: emptyMetrics(0),
+};
+
+const isFinitePoint = (point: ArrivalIntentPoint): boolean =>
+  Number.isFinite(point.x) && Number.isFinite(point.y) && Number.isFinite(point.time);
+
+const isValidRect = (rect: ArrivalIntentRect): boolean =>
+  Number.isFinite(rect.left) &&
+  Number.isFinite(rect.top) &&
+  Number.isFinite(rect.right) &&
+  Number.isFinite(rect.bottom) &&
+  rect.right > rect.left &&
+  rect.bottom > rect.top;
+
+const pointInsideRect = (point: ArrivalIntentPoint, rect: ArrivalIntentRect): boolean =>
+  point.x >= rect.left && point.x <= rect.right && point.y >= rect.top && point.y <= rect.bottom;
+
+const nearestPointInRect = (
+  point: ArrivalIntentPoint,
+  rect: ArrivalIntentRect
+): { x: number; y: number } => ({
+  x: Math.max(rect.left, Math.min(point.x, rect.right)),
+  y: Math.max(rect.top, Math.min(point.y, rect.bottom)),
+});
+
+const distanceToRect = (point: ArrivalIntentPoint, rect: ArrivalIntentRect): number => {
+  const nearest = nearestPointInRect(point, rect);
+  return Math.hypot(nearest.x - point.x, nearest.y - point.y);
+};
+
+/** Liang-Barsky clipping against an axis-aligned rectangle. */
+const segmentIntersectsRect = (
+  start: ArrivalIntentPoint,
+  end: { x: number; y: number },
+  rect: ArrivalIntentRect
+): boolean => {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  let near = 0;
+  let far = 1;
+
+  const clip = (origin: number, delta: number, min: number, max: number): boolean => {
+    if (delta === 0) return origin >= min && origin <= max;
+    const first = (min - origin) / delta;
+    const second = (max - origin) / delta;
+    const entry = Math.min(first, second);
+    const exit = Math.max(first, second);
+    near = Math.max(near, entry);
+    far = Math.min(far, exit);
+    return near <= far;
+  };
+
+  return clip(start.x, dx, rect.left, rect.right) && clip(start.y, dy, rect.top, rect.bottom);
+};
+
+const average = (values: readonly number[]): number =>
+  values.reduce((sum, value) => sum + value, 0) / values.length;
+
+const speedBetween = (first: ArrivalIntentPoint, second: ArrivalIntentPoint): number => {
+  const elapsed = second.time - first.time;
+  return elapsed > 0 ? Math.hypot(second.x - first.x, second.y - first.y) / elapsed : 0;
+};
+
+const allChecksPass = (checks: ArrivalIntentChecks): boolean =>
+  Object.values(checks).every(Boolean);
+
+/**
+ * Evaluate one approach without retaining state. Keeping this pure is what lets
+ * the Storybook capture replay the same samples against new thresholds later.
+ */
+export function evaluateArrivalIntent(
+  samples: readonly ArrivalIntentPoint[],
+  rect: ArrivalIntentRect,
+  config: Readonly<ArrivalIntentConfig> = DEFAULT_ARRIVAL_INTENT_CONFIG
+): ArrivalIntentEvaluation {
+  const current = samples.at(-1);
+  const outsideTarget = current !== undefined && !pointInsideRect(current, rect);
+  const enoughSamples = samples.length >= config.minSamples;
+
+  if (!current || !isValidRect(rect) || !outsideTarget || !enoughSamples) {
+    return {
+      qualifies: false,
+      checks: { ...EMPTY_CHECKS, outsideTarget, enoughSamples },
+      metrics: emptyMetrics(samples.length),
+    };
+  }
+
+  const distances = samples.map((sample) => distanceToRect(sample, rect));
+  const distancePx = distances.at(-1) ?? Number.POSITIVE_INFINITY;
+  const approachDistancePx = (distances[0] ?? distancePx) - distancePx;
+  let shrinkingSegments = 0;
+  for (let index = 1; index < distances.length; index += 1) {
+    if ((distances[index] ?? Infinity) < (distances[index - 1] ?? -Infinity)) {
+      shrinkingSegments += 1;
+    }
+  }
+  const shrinkingSegmentRatio = shrinkingSegments / Math.max(distances.length - 1, 1);
+  const recentDistances = distances.slice(-(config.recentShrinkingSegmentCount + 1));
+  const distanceRecentlyShrinking =
+    recentDistances.length > config.recentShrinkingSegmentCount &&
+    recentDistances.slice(1).every((distance, index) => distance < (recentDistances[index] ?? 0));
+
+  const segmentSpeeds: number[] = [];
+  for (let index = 1; index < samples.length; index += 1) {
+    const first = samples[index - 1];
+    const second = samples[index];
+    if (first && second) segmentSpeeds.push(speedBetween(first, second));
+  }
+  const split = Math.max(1, Math.floor(segmentSpeeds.length / 2));
+  const earlySpeeds = segmentSpeeds.slice(0, split);
+  const recentSpeeds = segmentSpeeds.slice(split);
+  const earlySpeedPxPerMs = average(earlySpeeds);
+  const recentSpeedPxPerMs = average(recentSpeeds.length > 0 ? recentSpeeds : earlySpeeds);
+  const brakingRatio = earlySpeedPxPerMs > 0 ? recentSpeedPxPerMs / earlySpeedPxPerMs : null;
+
+  const recentStart = samples[Math.max(0, samples.length - Math.max(3, recentSpeeds.length + 1))];
+  const elapsed = recentStart ? current.time - recentStart.time : 0;
+  const velocityX = recentStart && elapsed > 0 ? (current.x - recentStart.x) / elapsed : 0;
+  const velocityY = recentStart && elapsed > 0 ? (current.y - recentStart.y) / elapsed : 0;
+  const velocityMagnitude = Math.hypot(velocityX, velocityY);
+  const nearest = nearestPointInRect(current, rect);
+  const targetX = nearest.x - current.x;
+  const targetY = nearest.y - current.y;
+  const headingCosine =
+    velocityMagnitude > 0 && distancePx > 0
+      ? (velocityX * targetX + velocityY * targetY) / (velocityMagnitude * distancePx)
+      : -1;
+  const approachSpeedPxPerMs = Math.max(0, velocityMagnitude * headingCosine);
+  const timeToContactMs =
+    approachSpeedPxPerMs > 0 ? distancePx / approachSpeedPxPerMs : Number.POSITIVE_INFINITY;
+  const projectedX = current.x + velocityX * config.trajectoryHorizonMs;
+  const projectedY = current.y + velocityY * config.trajectoryHorizonMs;
+
+  const checks: ArrivalIntentChecks = {
+    outsideTarget,
+    enoughSamples,
+    withinDistance: distancePx <= config.maxDistancePx,
+    madeApproachProgress: approachDistancePx >= config.minApproachDistancePx,
+    distanceMostlyShrinking: shrinkingSegmentRatio >= config.minShrinkingSegmentRatio,
+    distanceRecentlyShrinking,
+    headingTowardTarget: headingCosine >= config.minHeadingCosine,
+    earlySpeedHighEnough: earlySpeedPxPerMs >= config.minEarlySpeedPxPerMs,
+    recentSpeedInRange:
+      recentSpeedPxPerMs >= config.minRecentSpeedPxPerMs &&
+      recentSpeedPxPerMs <= config.maxRecentSpeedPxPerMs,
+    braking: brakingRatio !== null && brakingRatio <= config.maxBrakingRatio,
+    projectsToTarget: segmentIntersectsRect(current, { x: projectedX, y: projectedY }, rect),
+    contactSoon: timeToContactMs <= config.maxTimeToContactMs,
+  };
+
+  return {
+    qualifies: allChecksPass(checks),
+    checks,
+    metrics: {
+      sampleCount: samples.length,
+      distancePx,
+      approachDistancePx,
+      shrinkingSegmentRatio,
+      headingCosine,
+      earlySpeedPxPerMs,
+      recentSpeedPxPerMs,
+      brakingRatio,
+      approachSpeedPxPerMs,
+      timeToContactMs: Number.isFinite(timeToContactMs) ? timeToContactMs : null,
+      projectedX,
+      projectedY,
+    },
+  };
+}
+
+export class ArrivalIntentDetector {
+  private readonly samples: ArrivalIntentPoint[] = [];
+  private predictedUntil = Number.NEGATIVE_INFINITY;
+  private evaluation: ArrivalIntentEvaluation = EMPTY_ARRIVAL_INTENT_EVALUATION;
+
+  constructor(
+    private readonly config: Readonly<ArrivalIntentConfig> = DEFAULT_ARRIVAL_INTENT_CONFIG
+  ) {}
+
+  push(sample: ArrivalIntentPoint, rect: ArrivalIntentRect): ArrivalIntentUpdate {
+    if (!isFinitePoint(sample) || !isValidRect(rect)) {
+      this.reset();
+      return this.updateAt(sample.time);
+    }
+
+    const previous = this.samples.at(-1);
+    if (
+      previous &&
+      (sample.time <= previous.time || sample.time - previous.time > this.config.resetAfterMs)
+    ) {
+      this.samples.length = 0;
+    }
+
+    this.samples.push(sample);
+    const cutoff = sample.time - this.config.sampleWindowMs;
+    while ((this.samples[0]?.time ?? cutoff) < cutoff) this.samples.shift();
+
+    const wasActive = this.hasPrediction(sample.time);
+    this.evaluation = evaluateArrivalIntent(this.samples, rect, this.config);
+    if (this.evaluation.qualifies) {
+      this.predictedUntil = sample.time + this.config.predictionTtlMs;
+    }
+
+    return {
+      evaluation: this.evaluation,
+      predictionActive: this.hasPrediction(sample.time),
+      predictionActivated: this.evaluation.qualifies && !wasActive,
+      predictedUntil: this.hasPrediction(sample.time) ? this.predictedUntil : null,
+    };
+  }
+
+  hasPrediction(time: number): boolean {
+    return Number.isFinite(time) && time <= this.predictedUntil;
+  }
+
+  consumePrediction(time: number): boolean {
+    if (!this.hasPrediction(time)) return false;
+    this.predictedUntil = Number.NEGATIVE_INFINITY;
+    return true;
+  }
+
+  getEvaluation(): ArrivalIntentEvaluation {
+    return this.evaluation;
+  }
+
+  reset(): void {
+    this.samples.length = 0;
+    this.predictedUntil = Number.NEGATIVE_INFINITY;
+    this.evaluation = EMPTY_ARRIVAL_INTENT_EVALUATION;
+  }
+
+  private updateAt(time: number): ArrivalIntentUpdate {
+    return {
+      evaluation: this.evaluation,
+      predictionActive: this.hasPrediction(time),
+      predictionActivated: false,
+      predictedUntil: this.hasPrediction(time) ? this.predictedUntil : null,
+    };
+  }
+}

--- a/packages/components/src/components/ai-gui/conversation-outline-rail.tsx
+++ b/packages/components/src/components/ai-gui/conversation-outline-rail.tsx
@@ -37,6 +37,12 @@ import {
   outlineTickWidthAt,
   tickLineTopOffset,
 } from './conversation-outline-rail-geometry';
+import {
+  ArrivalIntentDetector,
+  EMPTY_ARRIVAL_INTENT_EVALUATION,
+  type ArrivalIntentEvaluation,
+  type ArrivalIntentRect,
+} from './conversation-outline-arrival-intent';
 
 /**
  * A fixed left rail of one tick per conversation round, so a reader can see
@@ -86,8 +92,49 @@ export interface ConversationOutlineRailProps {
    * the intended coordinate system.
    */
   overlayRoot?: HTMLElement | null;
+  /**
+   * Opt into the conservative arrival predictor. Removing this prop restores
+   * the fixed hover warmup with no listener or detector left running.
+   */
+  enableArrivalIntent?: boolean;
+  /** Storybook/dev instrumentation only. The rail never persists or uploads it. */
+  onArrivalIntentDebugEvent?: (event: ConversationOutlineArrivalIntentDebugEvent) => void;
   className?: string;
 }
+
+export type ConversationOutlineHoverOpenSource = 'arrival-intent' | 'warm' | 'delay';
+
+export type ConversationOutlineArrivalIntentDebugEvent =
+  | {
+      type: 'sample';
+      at: number;
+      point: { xFromTarget: number; yFromTarget: number };
+      target: { width: number; height: number };
+      evaluation: ArrivalIntentEvaluation;
+      predictionActive: boolean;
+      predictionActivated: boolean;
+      predictedUntil: number | null;
+    }
+  | {
+      type: 'tick-enter';
+      at: number;
+      index: number;
+      source: ConversationOutlineHoverOpenSource;
+      evaluation: ArrivalIntentEvaluation;
+    }
+  | {
+      type: 'card-open';
+      at: number;
+      index: number;
+      source: ConversationOutlineHoverOpenSource;
+    }
+  | {
+      type: 'rail-leave';
+      at: number;
+      cardWasOpen: boolean;
+      evaluation: ArrivalIntentEvaluation;
+    }
+  | { type: 'round-jump'; at: number; index: number };
 
 const OUTLINE_INDEX_ATTRIBUTE = 'data-outline-index';
 
@@ -210,6 +257,8 @@ export function ConversationOutlineRail({
   activeIndex,
   onJumpToRound,
   overlayRoot = null,
+  enableArrivalIntent = false,
+  onArrivalIntentDebugEvent,
   className,
 }: ConversationOutlineRailProps) {
   const { t } = useTranslation();
@@ -228,6 +277,9 @@ export function ConversationOutlineRail({
   const [cardOpen, setCardOpen] = useState(false);
 
   const activeIndexRef = useLatestRef(activeIndex);
+  const arrivalIntentDebugRef = useLatestRef(onArrivalIntentDebugEvent);
+  const arrivalIntentDetectorRef = useRef<ArrivalIntentDetector | null>(null);
+  const tickCount = entries.length;
 
   const jumpLabel = useCallback(
     (entry: ConversationOutlineEntry) =>
@@ -236,6 +288,70 @@ export function ConversationOutlineRail({
   );
 
   useActiveTickSync(listRef, activeIndex, entries);
+
+  useEffect(() => {
+    if (!enableArrivalIntent) {
+      arrivalIntentDetectorRef.current = null;
+      return undefined;
+    }
+
+    const target = scrollRef.current;
+    const ownerDocument = target?.ownerDocument;
+    const ownerWindow = ownerDocument?.defaultView;
+    if (!target || !ownerDocument || !ownerWindow) return undefined;
+
+    const detector = new ArrivalIntentDetector();
+    arrivalIntentDetectorRef.current = detector;
+    let bounds: ArrivalIntentRect = target.getBoundingClientRect();
+    let boundsReadAt = ownerWindow.performance.now();
+
+    const refreshBounds = () => {
+      bounds = target.getBoundingClientRect();
+      boundsReadAt = ownerWindow.performance.now();
+    };
+    const stopObservingResize = observeResizeOnAnimationFrame(target, refreshBounds);
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (event.pointerType !== 'mouse' || event.buttons !== 0) {
+        detector.reset();
+        return;
+      }
+
+      const now = ownerWindow.performance.now();
+      // Split panes can move the rail without resizing it. Refresh occasionally,
+      // while ResizeObserver handles ordinary pane and viewport changes promptly.
+      if (now - boundsReadAt > 250) refreshBounds();
+      const update = detector.push({ x: event.clientX, y: event.clientY, time: now }, bounds);
+      arrivalIntentDebugRef.current?.({
+        type: 'sample',
+        at: now,
+        point: {
+          xFromTarget: event.clientX - bounds.left,
+          yFromTarget: event.clientY - bounds.top,
+        },
+        target: { width: bounds.right - bounds.left, height: bounds.bottom - bounds.top },
+        evaluation: update.evaluation,
+        predictionActive: update.predictionActive,
+        predictionActivated: update.predictionActivated,
+        predictedUntil: update.predictedUntil,
+      });
+    };
+    const reset = () => detector.reset();
+
+    ownerDocument.addEventListener('pointermove', handlePointerMove, { passive: true });
+    ownerWindow.addEventListener('resize', refreshBounds, { passive: true });
+    ownerWindow.addEventListener('blur', reset);
+
+    return () => {
+      stopObservingResize();
+      ownerDocument.removeEventListener('pointermove', handlePointerMove);
+      ownerWindow.removeEventListener('resize', refreshBounds);
+      ownerWindow.removeEventListener('blur', reset);
+      if (arrivalIntentDetectorRef.current === detector) {
+        arrivalIntentDetectorRef.current = null;
+      }
+    };
+  }, [arrivalIntentDebugRef, enableArrivalIntent, overlayRoot, tickCount]);
 
   // Keep the active tick inside the strip when the rail itself has to scroll.
   // Computed from the fixed pitch rather than `scrollIntoView` so the
@@ -267,7 +383,6 @@ export function ConversationOutlineRail({
   // Only the tick COUNT can change which edges overflow, and `entries` takes a
   // new identity for every delta that grows a preview — so keying this on the
   // array would tear down the observer and re-measure at token rate.
-  const tickCount = entries.length;
   useEffect(() => {
     syncEdgeFade();
     const strip = scrollRef.current;
@@ -279,6 +394,7 @@ export function ConversationOutlineRail({
   const cardOpenRef = useLatestRef(cardOpen);
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastClosedAtRef = useRef(0);
+  const warmBrowsingRef = useRef(false);
 
   const clearOpenTimer = useCallback(() => {
     if (openTimerRef.current === null) return;
@@ -295,25 +411,57 @@ export function ConversationOutlineRail({
       const element = readTickElement(event.target);
       const index = readTickIndexOf(element);
       if (!element || index === -1) return;
+      if (readTickElement(event.relatedTarget) === element) return;
 
       // Magnify immediately — this is direct manipulation and must not wait on
       // the card's warmup, or the rail would feel unresponsive to the cursor.
       setPointerIndex(index);
       clearOpenTimer();
+      const now = performance.now();
       const isWarm =
-        cardOpenRef.current || Date.now() - lastClosedAtRef.current < HOVER_WARM_WINDOW_MS;
-      if (isWarm) {
+        warmBrowsingRef.current &&
+        (cardOpenRef.current || Date.now() - lastClosedAtRef.current < HOVER_WARM_WINDOW_MS);
+      if (!isWarm) warmBrowsingRef.current = false;
+      const bypassWarmup =
+        !isWarm &&
+        event.pointerType === 'mouse' &&
+        (arrivalIntentDetectorRef.current?.consumePrediction(now) ?? false);
+      const source: ConversationOutlineHoverOpenSource = isWarm
+        ? 'warm'
+        : bypassWarmup
+          ? 'arrival-intent'
+          : 'delay';
+      arrivalIntentDebugRef.current?.({
+        type: 'tick-enter',
+        at: now,
+        index,
+        source,
+        evaluation:
+          arrivalIntentDetectorRef.current?.getEvaluation() ?? EMPTY_ARRIVAL_INTENT_EVALUATION,
+      });
+      if (isWarm || bypassWarmup) {
+        if (bypassWarmup) warmBrowsingRef.current = false;
         setHoverCard({ index, element });
         setCardOpen(true);
+        arrivalIntentDebugRef.current?.({ type: 'card-open', at: now, index, source });
         return;
       }
       openTimerRef.current = setTimeout(() => {
         openTimerRef.current = null;
+        // Deliberately waiting out the fixed delay is what earns the old
+        // rapid-browsing window. A predictor bypass never arms it.
+        warmBrowsingRef.current = true;
         setHoverCard({ index, element });
         setCardOpen(true);
+        arrivalIntentDebugRef.current?.({
+          type: 'card-open',
+          at: performance.now(),
+          index,
+          source: 'delay',
+        });
       }, HOVER_WARMUP_MS);
     },
-    [cardOpenRef, clearOpenTimer]
+    [arrivalIntentDebugRef, cardOpenRef, clearOpenTimer]
   );
 
   const handlePointerLeave = useCallback(() => {
@@ -322,9 +470,18 @@ export function ConversationOutlineRail({
     // empty surface.
     setPointerIndex(-1);
     clearOpenTimer();
-    if (cardOpenRef.current) lastClosedAtRef.current = Date.now();
+    arrivalIntentDebugRef.current?.({
+      type: 'rail-leave',
+      at: performance.now(),
+      cardWasOpen: cardOpenRef.current,
+      evaluation:
+        arrivalIntentDetectorRef.current?.getEvaluation() ?? EMPTY_ARRIVAL_INTENT_EVALUATION,
+    });
+    if (cardOpenRef.current && warmBrowsingRef.current) {
+      lastClosedAtRef.current = Date.now();
+    }
     setCardOpen(false);
-  }, [cardOpenRef, clearOpenTimer]);
+  }, [arrivalIntentDebugRef, cardOpenRef, clearOpenTimer]);
 
   // Depends on the COUNT, not the array: the outline gets a new identity per
   // streamed delta, and this callback feeds the list's click/key handlers.
@@ -342,11 +499,18 @@ export function ConversationOutlineRail({
       const index = readTickIndex(event.target);
       if (index === -1) return;
       clearOpenTimer();
-      if (cardOpenRef.current) lastClosedAtRef.current = Date.now();
+      if (cardOpenRef.current && warmBrowsingRef.current) {
+        lastClosedAtRef.current = Date.now();
+      }
       setCardOpen(false);
+      arrivalIntentDebugRef.current?.({
+        type: 'round-jump',
+        at: performance.now(),
+        index,
+      });
       jumpTo(index);
     },
-    [cardOpenRef, clearOpenTimer, jumpTo]
+    [arrivalIntentDebugRef, cardOpenRef, clearOpenTimer, jumpTo]
   );
 
   const focusTick = useCallback((index: number) => {

--- a/packages/components/src/components/ai-gui/view.tsx
+++ b/packages/components/src/components/ai-gui/view.tsx
@@ -1738,6 +1738,7 @@ export const SessionChatStreamView = forwardRef<
                 activeIndex={activeOutlineIndex}
                 onJumpToRound={handleOutlineJump}
                 overlayRoot={outlineOverlayRoot}
+                enableArrivalIntent
               />
             )}
             {showScrollToLatest && !isSticky && (

--- a/packages/components/src/stories/ConversationOutlineArrivalIntentLab.stories.tsx
+++ b/packages/components/src/stories/ConversationOutlineArrivalIntentLab.stories.tsx
@@ -1,0 +1,400 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Check, Circle, Download, Square, Trash2, X } from 'lucide-react';
+import {
+  ConversationOutlineRail,
+  type ConversationOutlineArrivalIntentDebugEvent,
+  type ConversationOutlineHoverOpenSource,
+} from '@/components/ai-gui/conversation-outline-rail';
+import { DEFAULT_ARRIVAL_INTENT_CONFIG } from '@/components/ai-gui/conversation-outline-arrival-intent';
+import type { ConversationOutlineEntry } from '@/lib/conversation-outline';
+import { Button } from '@/ui/button';
+
+const meta = {
+  title: 'Sessions/ConversationOutlineRail/ArrivalIntentLab',
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const entries: ConversationOutlineEntry[] = Array.from({ length: 24 }, (_, index) => ({
+  key: `arrival-lab-${index}`,
+  messageIndex: index * 2,
+  title: `Round ${index + 1}: inspect the arrival predictor`,
+  preview: 'A deterministic synthetic preview used only by the Storybook interaction lab.',
+  startsWithAgent: false,
+  weight: (index % 4) as ConversationOutlineEntry['weight'],
+}));
+
+type TrialLabel = 'intended' | 'accidental';
+type InferredOutcome = 'jumped' | 'quick-exit' | 'inspected' | 'unresolved';
+
+interface CapturedTrial {
+  id: number;
+  enteredAt: number;
+  leftAt: number | null;
+  index: number;
+  openSource: ConversationOutlineHoverOpenSource;
+  cardOpenedAt: number | null;
+  jumpedAt: number | null;
+  inferredOutcome: InferredOutcome;
+  manualLabel: TrialLabel | null;
+}
+
+interface CapturedEvent {
+  sequence: number;
+  event: ConversationOutlineArrivalIntentDebugEvent;
+}
+
+interface LiveReading {
+  predictionActive: boolean;
+  distancePx: number | null;
+  recentSpeedPxPerMs: number | null;
+  brakingRatio: number | null;
+  headingCosine: number | null;
+}
+
+const EMPTY_READING: LiveReading = {
+  predictionActive: false,
+  distancePx: null,
+  recentSpeedPxPerMs: null,
+  brakingRatio: null,
+  headingCosine: null,
+};
+
+const round = (value: number | null, digits = 3): number | null =>
+  value === null ? null : Number(value.toFixed(digits));
+
+const metric = (value: number | null, suffix = ''): string =>
+  value === null ? '—' : `${value.toFixed(2)}${suffix}`;
+
+const normalizeDebugEvent = (
+  event: ConversationOutlineArrivalIntentDebugEvent,
+  startedAt: number
+): ConversationOutlineArrivalIntentDebugEvent => {
+  const at = Math.max(0, event.at - startedAt);
+  if (event.type !== 'sample') return { ...event, at };
+  return {
+    ...event,
+    at,
+    predictedUntil:
+      event.predictedUntil === null ? null : Math.max(0, event.predictedUntil - startedAt),
+    point: {
+      xFromTarget: round(event.point.xFromTarget) ?? 0,
+      yFromTarget: round(event.point.yFromTarget) ?? 0,
+    },
+    target: {
+      width: round(event.target.width) ?? 0,
+      height: round(event.target.height) ?? 0,
+    },
+  };
+};
+
+function ArrivalIntentLab() {
+  const [activeIndex, setActiveIndex] = useState(8);
+  const [recording, setRecording] = useState(false);
+  const [, setRevision] = useState(0);
+  const [liveReading, setLiveReading] = useState(EMPTY_READING);
+  const recordingRef = useRef(false);
+  const captureStartedAtRef = useRef(0);
+  const eventsRef = useRef<CapturedEvent[]>([]);
+  const trialsRef = useRef<CapturedTrial[]>([]);
+  const activeTrialRef = useRef<CapturedTrial | null>(null);
+  const nextTrialIdRef = useRef(1);
+  const sequenceRef = useRef(0);
+  const liveReadingRef = useRef(EMPTY_READING);
+  const liveFrameRef = useRef<number | null>(null);
+
+  const publishLiveReading = useCallback((reading: LiveReading) => {
+    liveReadingRef.current = reading;
+    if (liveFrameRef.current !== null) return;
+    liveFrameRef.current = requestAnimationFrame(() => {
+      liveFrameRef.current = null;
+      setLiveReading(liveReadingRef.current);
+    });
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (liveFrameRef.current !== null) cancelAnimationFrame(liveFrameRef.current);
+    },
+    []
+  );
+
+  const finalizeTrial = useCallback((leftAt: number) => {
+    const trial = activeTrialRef.current;
+    if (!trial) return;
+    trial.leftAt = leftAt;
+    if (trial.jumpedAt !== null) trial.inferredOutcome = 'jumped';
+    else if (trial.cardOpenedAt === null) trial.inferredOutcome = 'unresolved';
+    else if (leftAt - trial.cardOpenedAt < 180) trial.inferredOutcome = 'quick-exit';
+    else trial.inferredOutcome = 'inspected';
+    activeTrialRef.current = null;
+    setRevision((value) => value + 1);
+  }, []);
+
+  const handleDebugEvent = useCallback(
+    (event: ConversationOutlineArrivalIntentDebugEvent) => {
+      if (event.type === 'sample') {
+        const metrics = event.evaluation.metrics;
+        publishLiveReading({
+          predictionActive: event.predictionActive,
+          distancePx: metrics.distancePx,
+          recentSpeedPxPerMs: metrics.recentSpeedPxPerMs,
+          brakingRatio: metrics.brakingRatio,
+          headingCosine: metrics.headingCosine,
+        });
+      }
+
+      if (!recordingRef.current) return;
+      const normalized = normalizeDebugEvent(event, captureStartedAtRef.current);
+      eventsRef.current.push({ sequence: sequenceRef.current, event: normalized });
+      sequenceRef.current += 1;
+
+      if (normalized.type === 'tick-enter' && activeTrialRef.current === null) {
+        const trial: CapturedTrial = {
+          id: nextTrialIdRef.current,
+          enteredAt: normalized.at,
+          leftAt: null,
+          index: normalized.index,
+          openSource: normalized.source,
+          cardOpenedAt: null,
+          jumpedAt: null,
+          inferredOutcome: 'unresolved',
+          manualLabel: null,
+        };
+        nextTrialIdRef.current += 1;
+        trialsRef.current.push(trial);
+        activeTrialRef.current = trial;
+        setRevision((value) => value + 1);
+      } else if (normalized.type === 'card-open' && activeTrialRef.current) {
+        activeTrialRef.current.cardOpenedAt ??= normalized.at;
+      } else if (normalized.type === 'round-jump' && activeTrialRef.current) {
+        activeTrialRef.current.jumpedAt = normalized.at;
+        activeTrialRef.current.inferredOutcome = 'jumped';
+      } else if (normalized.type === 'rail-leave') {
+        finalizeTrial(normalized.at);
+      }
+    },
+    [finalizeTrial, publishLiveReading]
+  );
+
+  const startCapture = useCallback(() => {
+    eventsRef.current = [];
+    trialsRef.current = [];
+    activeTrialRef.current = null;
+    nextTrialIdRef.current = 1;
+    sequenceRef.current = 0;
+    captureStartedAtRef.current = performance.now();
+    recordingRef.current = true;
+    setRecording(true);
+    setRevision((value) => value + 1);
+  }, []);
+
+  const stopCapture = useCallback(() => {
+    finalizeTrial(Math.max(0, performance.now() - captureStartedAtRef.current));
+    recordingRef.current = false;
+    setRecording(false);
+    setRevision((value) => value + 1);
+  }, [finalizeTrial]);
+
+  const clearCapture = useCallback(() => {
+    recordingRef.current = false;
+    eventsRef.current = [];
+    trialsRef.current = [];
+    activeTrialRef.current = null;
+    nextTrialIdRef.current = 1;
+    sequenceRef.current = 0;
+    setRecording(false);
+    setRevision((value) => value + 1);
+  }, []);
+
+  const labelLatestTrial = useCallback((label: TrialLabel) => {
+    const latest = trialsRef.current.at(-1);
+    if (!latest) return;
+    latest.manualLabel = label;
+    setRevision((value) => value + 1);
+  }, []);
+
+  const exportCapture = useCallback(() => {
+    const payload = {
+      schema: 'lody.conversation-outline-arrival-intent-capture',
+      schemaVersion: 1,
+      createdAt: new Date().toISOString(),
+      coordinateSpace: 'pointer coordinates relative to the rail target; time is relative ms',
+      detectorConfig: DEFAULT_ARRIVAL_INTENT_CONFIG,
+      events: eventsRef.current,
+      trials: trialsRef.current,
+    };
+    const url = URL.createObjectURL(
+      new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
+    );
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `outline-arrival-intent-${new Date().toISOString().replaceAll(':', '-')}.json`;
+    document.body.append(link);
+    link.click();
+    link.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  }, []);
+
+  const trials = trialsRef.current;
+  const eventCount = eventsRef.current.length;
+  const latestTrial = trials.at(-1);
+  const intendedCount = trials.filter((trial) => trial.manualLabel === 'intended').length;
+  const accidentalCount = trials.filter((trial) => trial.manualLabel === 'accidental').length;
+  const bypassCount = trials.filter((trial) => trial.openSource === 'arrival-intent').length;
+  return (
+    <div className="grid min-h-screen grid-cols-1 bg-background text-foreground lg:grid-cols-[minmax(640px,1fr)_320px]">
+      <div className="@container relative h-[58vh] min-h-[520px] overflow-hidden border-b border-border lg:h-screen lg:min-h-[680px] lg:border-r lg:border-b-0">
+        <div className="mx-auto flex h-full w-full max-w-[46rem] flex-col gap-3 overflow-hidden px-4 py-8">
+          {entries.slice(activeIndex, activeIndex + 7).map((item, offset) => (
+            <div
+              key={item.key}
+              className="border-b border-border/70 py-4"
+              style={{ opacity: Math.max(1 - offset * 0.1, 0.45) }}
+            >
+              <div className="text-sm font-medium">{item.title}</div>
+              <div className="mt-1 text-[13px] leading-relaxed text-muted-foreground">
+                {item.preview}
+              </div>
+            </div>
+          ))}
+        </div>
+        <ConversationOutlineRail
+          entries={entries}
+          activeIndex={activeIndex}
+          onJumpToRound={setActiveIndex}
+          enableArrivalIntent
+          onArrivalIntentDebugEvent={handleDebugEvent}
+        />
+      </div>
+
+      <aside className="flex min-h-[42vh] flex-col overflow-y-auto bg-muted/15 p-4 lg:h-screen lg:min-h-[680px]">
+        <div className="flex items-center justify-between border-b border-border pb-3">
+          <div>
+            <h2 className="text-sm font-semibold">Arrival intent lab</h2>
+            <div className="mt-0.5 text-xs text-muted-foreground">
+              {recording ? 'Recording locally' : 'Idle'}
+            </div>
+          </div>
+          <span
+            className={`h-2.5 w-2.5 rounded-full ${
+              liveReading.predictionActive
+                ? 'bg-emerald-500'
+                : recording
+                  ? 'bg-red-500'
+                  : 'bg-muted-foreground/35'
+            }`}
+            aria-label={liveReading.predictionActive ? 'Prediction active' : 'Prediction inactive'}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-x-4 gap-y-3 border-b border-border py-4 text-xs">
+          <Metric label="Distance" value={metric(liveReading.distancePx, ' px')} />
+          <Metric label="Speed" value={metric(liveReading.recentSpeedPxPerMs, ' px/ms')} />
+          <Metric label="Braking" value={metric(liveReading.brakingRatio)} />
+          <Metric label="Heading" value={metric(liveReading.headingCosine)} />
+          <Metric label="Samples" value={String(eventCount)} />
+          <Metric label="Trials" value={String(trials.length)} />
+          <Metric label="Bypassed" value={String(bypassCount)} />
+          <Metric label="Labels" value={`${intendedCount} / ${accidentalCount}`} />
+        </div>
+
+        <div className="flex flex-wrap gap-2 border-b border-border py-4">
+          {recording ? (
+            <Button size="sm" variant="outline" onClick={stopCapture}>
+              <Square /> Stop
+            </Button>
+          ) : (
+            <Button size="sm" onClick={startCapture}>
+              <Circle /> Record
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!latestTrial}
+            onClick={() => labelLatestTrial('intended')}
+          >
+            <Check /> Intended
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!latestTrial}
+            onClick={() => labelLatestTrial('accidental')}
+          >
+            <X /> Accidental
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            disabled={eventCount === 0}
+            aria-label="Export capture"
+            title="Export capture"
+            onClick={exportCapture}
+          >
+            <Download />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            disabled={eventCount === 0}
+            aria-label="Clear capture"
+            title="Clear capture"
+            onClick={clearCapture}
+          >
+            <Trash2 />
+          </Button>
+        </div>
+
+        <div className="min-h-0 flex-1 py-3">
+          <div className="mb-2 text-xs font-medium text-muted-foreground">Recent trials</div>
+          <div className="divide-y divide-border">
+            {trials
+              .slice(-8)
+              .reverse()
+              .map((trial) => (
+                <div
+                  key={trial.id}
+                  className="grid grid-cols-[32px_1fr_auto] items-center gap-2 py-2 text-xs"
+                >
+                  <span className="font-mono text-muted-foreground">#{trial.id}</span>
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">{trial.openSource}</div>
+                    <div className="text-muted-foreground">{trial.inferredOutcome}</div>
+                  </div>
+                  <span
+                    className={
+                      trial.manualLabel === 'intended'
+                        ? 'text-emerald-600 dark:text-emerald-400'
+                        : trial.manualLabel === 'accidental'
+                          ? 'text-red-600 dark:text-red-400'
+                          : 'text-muted-foreground'
+                    }
+                  >
+                    {trial.manualLabel ?? 'unlabeled'}
+                  </span>
+                </div>
+              ))}
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-muted-foreground">{label}</div>
+      <div className="mt-0.5 truncate font-mono text-[11px] text-foreground">{value}</div>
+    </div>
+  );
+}
+
+export const CaptureAndLabel: Story = {
+  render: () => <ArrivalIntentLab />,
+};

--- a/packages/components/tests/conversation-outline-arrival-intent.test.ts
+++ b/packages/components/tests/conversation-outline-arrival-intent.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ArrivalIntentDetector,
+  DEFAULT_ARRIVAL_INTENT_CONFIG,
+  evaluateArrivalIntent,
+  type ArrivalIntentPoint,
+  type ArrivalIntentRect,
+} from '../src/components/ai-gui/conversation-outline-arrival-intent';
+
+const RAIL: ArrivalIntentRect = { left: 0, top: 100, right: 48, bottom: 300 };
+
+const path = (xs: readonly number[], y = 180, intervalMs = 20): ArrivalIntentPoint[] =>
+  xs.map((x, index) => ({ x, y, time: index * intervalMs }));
+
+const deliberateApproach = () => path([220, 180, 148, 123, 104, 91, 82]);
+
+describe('evaluateArrivalIntent', () => {
+  it('qualifies a directed approach that brakes before reaching the rail', () => {
+    const result = evaluateArrivalIntent(deliberateApproach(), RAIL);
+
+    expect(result.qualifies).toBe(true);
+    expect(result.checks).toEqual(
+      expect.objectContaining({
+        distanceMostlyShrinking: true,
+        headingTowardTarget: true,
+        braking: true,
+        projectsToTarget: true,
+      })
+    );
+    expect(result.metrics.brakingRatio).toBeLessThan(DEFAULT_ARRIVAL_INTENT_CONFIG.maxBrakingRatio);
+  });
+
+  it('rejects the fast constant-speed fly-by that trajectory-only predictors accept', () => {
+    const result = evaluateArrivalIntent(path([220, 180, 140, 100, 60]), RAIL);
+
+    expect(result.checks.projectsToTarget).toBe(true);
+    expect(result.checks.braking).toBe(false);
+    expect(result.qualifies).toBe(false);
+  });
+
+  it('keeps a slow constant-speed approach on the ordinary hover delay', () => {
+    const result = evaluateArrivalIntent(path([120, 114, 108, 102, 96, 90]), RAIL);
+
+    expect(result.checks.distanceMostlyShrinking).toBe(true);
+    expect(result.checks.earlySpeedHighEnough).toBe(false);
+    expect(result.qualifies).toBe(false);
+  });
+
+  it('rejects movement whose projection misses the rail vertically', () => {
+    const result = evaluateArrivalIntent(
+      deliberateApproach().map((sample) => ({ ...sample, y: 20 })),
+      RAIL
+    );
+
+    expect(result.checks.projectsToTarget).toBe(false);
+    expect(result.qualifies).toBe(false);
+  });
+
+  it('rejects a reversal even when the cursor ends close to the rail', () => {
+    const result = evaluateArrivalIntent(path([220, 170, 125, 96, 118, 88]), RAIL);
+
+    expect(result.checks.distanceRecentlyShrinking).toBe(false);
+    expect(result.qualifies).toBe(false);
+  });
+
+  it('does not qualify points already inside the rail', () => {
+    const result = evaluateArrivalIntent(path([180, 130, 90, 60, 40]), RAIL);
+
+    expect(result.checks.outsideTarget).toBe(false);
+    expect(result.qualifies).toBe(false);
+  });
+});
+
+describe('ArrivalIntentDetector', () => {
+  it('arms one short-lived prediction that can be consumed exactly once', () => {
+    const detector = new ArrivalIntentDetector();
+    let update;
+    let activated = false;
+    for (const sample of deliberateApproach()) {
+      update = detector.push(sample, RAIL);
+      activated ||= update.predictionActivated;
+    }
+
+    expect(update?.predictionActive).toBe(true);
+    expect(activated).toBe(true);
+    expect(detector.consumePrediction(125)).toBe(true);
+    expect(detector.consumePrediction(125)).toBe(false);
+  });
+
+  it('expires an unconsumed prediction', () => {
+    const detector = new ArrivalIntentDetector();
+    for (const sample of deliberateApproach()) detector.push(sample, RAIL);
+
+    const finalTime = deliberateApproach().at(-1)?.time ?? 0;
+    expect(detector.hasPrediction(finalTime + DEFAULT_ARRIVAL_INTENT_CONFIG.predictionTtlMs)).toBe(
+      true
+    );
+    expect(
+      detector.hasPrediction(finalTime + DEFAULT_ARRIVAL_INTENT_CONFIG.predictionTtlMs + 1)
+    ).toBe(false);
+  });
+
+  it('starts a new gesture after a long sampling gap', () => {
+    const detector = new ArrivalIntentDetector();
+    for (const sample of deliberateApproach()) detector.push(sample, RAIL);
+
+    const update = detector.push({ x: 75, y: 180, time: 500 }, RAIL);
+    expect(update.evaluation.metrics.sampleCount).toBe(1);
+    expect(update.evaluation.qualifies).toBe(false);
+  });
+
+  it('resets on invalid input rather than carrying a stale token', () => {
+    const detector = new ArrivalIntentDetector();
+    for (const sample of deliberateApproach()) detector.push(sample, RAIL);
+    expect(detector.hasPrediction(125)).toBe(true);
+
+    detector.push({ x: Number.NaN, y: 180, time: 130 }, RAIL);
+    expect(detector.hasPrediction(130)).toBe(false);
+    expect(detector.getEvaluation().metrics.sampleCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- add a conservative pointer-arrival detector that bypasses the outline hover delay only for directed, braking approaches
- keep the 200ms fallback and arm the legacy 2.5s warm browsing window only after a delay-opened card, never after a predictor bypass
- add an isolated Storybook capture/label lab plus deterministic detector and outline regression coverage

## Testing

- `vitest run tests/conversation-outline-arrival-intent.test.ts tests/conversation-outline-rail-geometry.test.ts tests/conversation-outline.test.ts tests/conversation-outline-active.test.ts --maxWorkers=1` (63 tests)
- focused `oxlint --quiet` on the detector, rail, Storybook lab, and tests (0 warnings, 0 errors)
- Storybook browser validation for predicted arrival, fast fly-by fallback, source-aware warm behavior, desktop, and narrow viewports