### PR TITLE
fix(components): keep Codex implementation below plan

### DIFF
--- a/packages/components/src/components/ai-gui/AGENTS.md
+++ b/packages/components/src/components/ai-gui/AGENTS.md
@@ -37,13 +37,14 @@
   necessarily the last item. Generated `image_group`s and the `switch_mode`
   "Exited Plan Mode" card may follow it; use
   `getTextIndexBeforeTrailingNeverCollapsedItems`.
-- One turn may contain several `AssistantTurnRenderSegment`s. A plan approval
-  inside a running turn cuts a segment so implementation stays under the plan.
-  Match ACP tool kind `switch_mode`, never a rendered title. Keep
+- One turn may contain several `AssistantTurnRenderSegment`s. Plan approval
+  cuts a segment so implementation stays below its plan. Match ACP kind
+  `switch_mode`, never titles. Claude carries the plan on that card; Codex emits
+  `proposed_plan` before it. Keep plans last within each switch-delimited segment,
+  never after later implementation. Keep
   `workBlockKeys`, `hasVisibleFinalContent`, last-item visibility, and
-  `expandedWorkedGroups` per segment. Expansion keys include the segment; only
-  the last region may show a duration, while earlier regions say "Finished
-  working".
+  `expandedWorkedGroups` per segment. Only the last region shows duration;
+  earlier ones say "Finished working".
 - `shouldUseWorkedGroup` requires a finished turn, foldable work, and visible
   final content outside `workBlockKeys`. A cancelled/interrupted or tool-only
   turn with no answer stays expanded. `message.finished` also marks teardown and

--- a/packages/components/src/components/ai-gui/assistant-message-render-items.ts
+++ b/packages/components/src/components/ai-gui/assistant-message-render-items.ts
@@ -25,6 +25,22 @@ const withDisplayIndexes = (
     displayIndex,
   }));
 
+const appendSegmentWithPlansLast = (
+  target: AssistantMessageRenderSeed[],
+  segment: readonly AssistantMessageRenderSeed[]
+): void => {
+  for (const item of segment) {
+    if (item.content.type !== 'proposed_plan') {
+      target.push(item);
+    }
+  }
+  for (const item of segment) {
+    if (item.content.type === 'proposed_plan') {
+      target.push(item);
+    }
+  }
+};
+
 export const buildAssistantMessageRenderItems = (
   items: readonly MessageContent[]
 ): AssistantMessageRenderItem[] => {
@@ -38,15 +54,23 @@ export const buildAssistantMessageRenderItems = (
     return withDisplayIndexes(visibleItems);
   }
 
-  const before: AssistantMessageRenderSeed[] = [];
-  const plans: AssistantMessageRenderSeed[] = [];
+  // A proposed plan should finish the planning region, not the whole assistant
+  // turn. Codex emits it before the switch_mode approval and then continues the
+  // same ACP prompt with implementation work. A global "plans last" partition
+  // therefore put that work above the plan. Keep the existing plan-last
+  // presentation independently inside every switch-delimited region instead.
+  const ordered: AssistantMessageRenderSeed[] = [];
+  let segment: AssistantMessageRenderSeed[] = [];
   for (const item of visibleItems) {
-    if (item.content.type === 'proposed_plan') {
-      plans.push(item);
-    } else {
-      before.push(item);
+    if (item.content.type === 'tool_call' && item.content.kind === 'switch_mode') {
+      appendSegmentWithPlansLast(ordered, segment);
+      segment = [];
+      ordered.push(item);
+      continue;
     }
+    segment.push(item);
   }
+  appendSegmentWithPlansLast(ordered, segment);
 
-  return withDisplayIndexes([...before, ...plans]);
+  return withDisplayIndexes(ordered);
 };

--- a/packages/components/tests/assistant-message-render-items.test.ts
+++ b/packages/components/tests/assistant-message-render-items.test.ts
@@ -116,4 +116,97 @@ describe('buildAssistantMessageRenderItems', () => {
     expect(renderedEntry.key).toBe('assistant-1:3:0:img-agent');
     expect(findSessionImageGalleryEntryIndex(galleryEntries, renderedEntry.key)).toBe(0);
   });
+
+  it('keeps a Codex proposed plan before its approval card and implementation', () => {
+    const items = [
+      { type: 'thought', text: 'Inspect the current behavior.' },
+      {
+        type: 'proposed_plan',
+        turnId: 'plan-1',
+        markdown: '- Update the renderer',
+        status: 'completed',
+        isLatest: true,
+      },
+      {
+        type: 'tool_call',
+        toolCallId: 'plan-review-1',
+        title: 'Implement this plan?',
+        kind: 'switch_mode',
+        status: 'completed',
+      },
+      { type: 'thought', text: 'Implement the renderer change.' },
+      {
+        type: 'tool_call',
+        toolCallId: 'edit-1',
+        kind: 'edit',
+        status: 'completed',
+      },
+      { type: 'text', text: 'Done.' },
+    ] satisfies MessageContent[];
+
+    expect(
+      buildAssistantMessageRenderItems(items).map(({ content, itemIndex }) => ({
+        type: content.type,
+        kind: content.type === 'tool_call' ? content.kind : undefined,
+        itemIndex,
+      }))
+    ).toEqual([
+      { type: 'thought', kind: undefined, itemIndex: 0 },
+      { type: 'proposed_plan', kind: undefined, itemIndex: 1 },
+      { type: 'tool_call', kind: 'switch_mode', itemIndex: 2 },
+      { type: 'thought', kind: undefined, itemIndex: 3 },
+      { type: 'tool_call', kind: 'edit', itemIndex: 4 },
+      { type: 'text', kind: undefined, itemIndex: 5 },
+    ]);
+  });
+
+  it('orders each proposed plan within its own switch-mode segment', () => {
+    const items = [
+      {
+        type: 'proposed_plan',
+        turnId: 'plan-1',
+        markdown: '- First plan',
+        status: 'completed',
+        isLatest: false,
+      },
+      {
+        type: 'tool_call',
+        toolCallId: 'plan-review-1',
+        kind: 'switch_mode',
+        status: 'completed',
+      },
+      { type: 'thought', text: 'Implement the first plan.' },
+      {
+        type: 'proposed_plan',
+        turnId: 'plan-2',
+        markdown: '- Revised plan',
+        status: 'completed',
+        isLatest: true,
+      },
+      {
+        type: 'tool_call',
+        toolCallId: 'plan-review-2',
+        kind: 'switch_mode',
+        status: 'completed',
+      },
+      { type: 'text', text: 'Implemented the revised plan.' },
+    ] satisfies MessageContent[];
+
+    expect(
+      buildAssistantMessageRenderItems(items).map(({ content }) =>
+        content.type === 'proposed_plan'
+          ? `plan:${content.turnId}`
+          : content.type === 'tool_call'
+            ? `tool:${content.toolCallId}`
+            : content.type
+      )
+    ).toEqual([
+      'plan:plan-1',
+      'tool:plan-review-1',
+      'thought',
+      'plan:plan-2',
+      'tool:plan-review-2',
+      'text',
+    ]);
+  });
 });

--- a/packages/components/tests/plan-turn-virtual-rows.test.ts
+++ b/packages/components/tests/plan-turn-virtual-rows.test.ts
@@ -8,10 +8,10 @@ import { buildChatVirtualRows } from '../src/components/ai-gui/view';
  * actually emits the virtual rows the conversation renders, so this is where
  * "an approved plan produces a visible region of its own" is provable.
  *
- * The turn shape mirrors what the bundled adapters emit. A plan is approved
- * from inside a RUNNING turn (Claude's `ExitPlanMode`, Codex's plan review,
- * both ACP kind `switch_mode`), so ONE finished assistant turn carries the
- * pre-plan exploration, the plan, and the whole implementation.
+ * A plan is approved from inside a RUNNING turn, so ONE finished assistant
+ * turn carries the pre-plan exploration, the plan, and the implementation.
+ * Claude carries its plan on the switch card; Codex emits a separate
+ * `proposed_plan` immediately before that card.
  */
 const tool = (
   toolCallId: string,
@@ -20,7 +20,7 @@ const tool = (
 ): MessageContent =>
   ({ type: 'tool_call', toolCallId, kind, status: 'completed', ...overrides }) as MessageContent;
 
-const planTurnItems: MessageContent[] = [
+const claudePlanTurnItems: MessageContent[] = [
   tool('read-1', 'read', { locations: [{ path: 'src/a.ts' }] }),
   tool('grep-1', 'search'),
   tool('plan-exit-1', 'switch_mode', {
@@ -29,6 +29,22 @@ const planTurnItems: MessageContent[] = [
     title: 'Ready to code?',
     content: [{ type: 'content', content: { type: 'text', text: '# Plan\n1. Do the thing' } }],
   } as Partial<Extract<MessageContent, { type: 'tool_call' }>>),
+  { type: 'thought', text: 'Start with the parser.' } as MessageContent,
+  tool('edit-1', 'edit', { locations: [{ path: 'src/a.ts' }] }),
+  { type: 'text', text: 'Done, changed 1 file.' } as MessageContent,
+];
+
+const codexPlanTurnItems: MessageContent[] = [
+  tool('read-1', 'read', { locations: [{ path: 'src/a.ts' }] }),
+  tool('grep-1', 'search'),
+  {
+    type: 'proposed_plan',
+    turnId: 'plan-item-1',
+    markdown: '# Plan\n1. Do the thing',
+    status: 'completed',
+    isLatest: true,
+  },
+  tool('plan-exit-1', 'switch_mode', { title: 'Implement this plan?' }),
   { type: 'thought', text: 'Start with the parser.' } as MessageContent,
   tool('edit-1', 'edit', { locations: [{ path: 'src/a.ts' }] }),
   { type: 'text', text: 'Done, changed 1 file.' } as MessageContent,
@@ -80,39 +96,44 @@ const visibleContentKinds = (rows: ReturnType<typeof buildRows>) =>
   });
 
 describe('approved plan renders its own region', () => {
-  it('gives the implementation a second collapsible region under the plan', () => {
-    const rows = buildRows(planTurnItems, true);
+  it('keeps a structured Codex plan above its approval and implementation regions', () => {
+    const rows = buildRows(codexPlanTurnItems, true);
 
-    // Two independently foldable regions, not one.
     const headers = workedHeaders(rows);
     expect(headers).toHaveLength(2);
-
-    // Only the LAST region may claim the turn duration; the plan region falls
-    // back to the "Finished working" copy.
     expect(headers[0]?.durationMs).toBeNull();
     expect(headers[1]?.durationMs).toBe(5 * 60 * 1000);
-
-    // Distinct row keys, or the VList would desync on duplicate keys.
     expect(headers[0]?.key).not.toBe(headers[1]?.key);
-
-    // Reading top to bottom: the pre-plan work folds, the plan card stays put,
-    // the implementation gets its own fold, and the answer stays visible.
     expect(visibleContentKinds(rows)).toEqual([
       'worked_group_header', // pre-plan exploration
-      'content:tool_call', // the plan / approval card
+      'content:proposed_plan', // structured Codex plan
+      'content:tool_call', // approval card
       'worked_group_header', // the approved implementation
       'content:text', // final answer
     ]);
   });
 
-  it('keeps every step visible while the turn is still streaming', () => {
-    const rows = buildRows(planTurnItems, false);
+  it('keeps a structured Codex plan above implementation while streaming', () => {
+    const rows = buildRows(codexPlanTurnItems, false);
 
     expect(workedHeaders(rows)).toHaveLength(0);
     expect(visibleContentKinds(rows)).toEqual([
       'activity_group_header',
+      'content:proposed_plan',
       'content:tool_call',
       'activity_group_header',
+      'content:text',
+    ]);
+  });
+
+  it('keeps the Claude plan card as the boundary before implementation', () => {
+    const rows = buildRows(claudePlanTurnItems, true);
+
+    expect(workedHeaders(rows)).toHaveLength(2);
+    expect(visibleContentKinds(rows)).toEqual([
+      'worked_group_header',
+      'content:tool_call',
+      'worked_group_header',
       'content:text',
     ]);
   });


### PR DESCRIPTION
## Related issue

Closes #114

This PR addresses only item 2: implementation progress rendering above the Proposed Plan. The Plan-mode exit failures in items 1 and 3 are intentionally separate. At the time of this update, the issue contains no maintainer comment explicitly approving this scope or approach; this PR does not claim otherwise.

## Problem / pressure

Codex keeps planning and implementation in one assistant turn, but represents the plan as a standalone `proposed_plan` item immediately before the `switch_mode` approval:

```text
planning work -> proposed_plan -> switch_mode -> implementation work -> final answer
```

`buildAssistantMessageRenderItems` previously applied a stable "plans last" partition to the entire turn. That moved the standalone plan past every later item, producing:

```text
planning work -> switch_mode -> implementation work -> final answer -> proposed_plan
```

PR #31 correctly split folding regions at `switch_mode`, but its fixture matched Claude's representation, where the plan is carried by the switch card itself. Because that shape has no standalone `proposed_plan`, it did not expose the Codex-specific global reorder.

## Summary

- Split render ordering into regions delimited by ACP tool calls whose `kind` is `switch_mode`.
- Keep the existing "plan last" presentation only within each region, then leave the switch card and all following implementation work in their original region.
- Preserve each item's source `itemIndex`; only `displayIndex` is recomputed for the rendered order.
- Cover finished and streaming Codex turns, repeated plan/review cycles, and the existing Claude representation.
- Record the segment-local ordering contract in the scoped renderer maintainer guide.

This is a renderer-only change. It does not modify ACP events, persisted session documents, Plan-mode selection, or turn segmentation.

## Before / after

| Before | After |
| ------ | ----- |
| The global partition moved Proposed Plan below implementation progress.<br><br><img width="1139" height="858" alt="Implementation progress rendered above Proposed Plan" src="https://github.com/user-attachments/assets/49d3cc22-c087-4002-a707-853dc33d5926" /> | Proposed Plan remains above its approval card and implementation region.<br><br><img width="895" height="1530" alt="Proposed Plan rendered before implementation progress" src="https://github.com/user-attachments/assets/7c232124-56c9-4a19-92fb-f90f265c5a1b" /> |

## Test plan

- `pnpm --filter @lody/components typecheck` — passed on rebased HEAD.
- `pnpm --filter @lody/components exec vitest run tests/assistant-message-render-items.test.ts tests/assistant-turn-render-blocks.test.ts tests/plan-turn-virtual-rows.test.ts tests/message-copy.test.ts` — 4 files and 42 tests passed.
- `git diff --check origin/main...HEAD` — passed.
- No additional desktop click-through was performed after the final rebase; the provided screenshots capture the reported before/after UI, while final row ordering is asserted in both completed and streaming tests.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Verify the `switch_mode` boundary handling in `assistant-message-render-items.ts` and the user-visible row order pinned in `plan-turn-virtual-rows.test.ts`.
- **Decisions to challenge:** Confirm that ordering at the renderer normalization layer, rather than changing ACP or persisted turn data, is the narrowest durable fix.
- **Plausible failures / evidence gaps:** An adapter that emits a standalone plan without `switch_mode` retains whole-turn plan-last behavior, and the rebased HEAD was not manually exercised in the desktop app.

### Authoring context

- **User goal / directives:** Fix only the Codex display-order defect so implementation progress appears below Proposed Plan, and keep the Plan-mode exit work in a separate PR.
- **Constraints / non-goals:** Do not change Plan-mode state, ACP protocol data, session persistence, or ordinary and Claude turn rendering beyond preserving their current behavior.
- **Risk-bearing decisions:** Treat persisted ACP `switch_mode` kind as the semantic ordering boundary and preserve source indexes while recomputing only display indexes.
- **Destructive or irreversible behavior:** The change performs no data migration, deletion, overwrite, external side effect, or irreversible operation; reverting restores the previous renderer ordering.
- **Deliberately not done or tested:** The final rebased commit was not manually clicked through in the desktop app because deterministic row-builder tests cover completed, streaming, Claude, and repeated-switch shapes.
- **Unknowns / confidence:** Confidence is high for the bundled Codex and Claude shapes; #114 currently has no recorded maintainer approval, and adapters lacking `switch_mode` remain outside this fix.

<!-- context-handoff:end -->
