### PR TITLE
fix: exit Codex plan mode for execution actions

### DIFF
--- a/apps/cli/src/agent/agent-client-session-preparation.test.ts
+++ b/apps/cli/src/agent/agent-client-session-preparation.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MachineId, SessionId, WorkspaceId } from '@lody/shared';
+import type { SessionNotification } from '@agentclientprotocol/sdk';
 import type { Logger } from '@/utils/logger';
 
 const connectionMocks = vi.hoisted(() => ({
@@ -225,6 +226,82 @@ describe('AgentClient session preparation gate', () => {
           sessionConfig: {
             version: 1,
             configOptionValues: { permission_mode: 'ask' },
+          },
+        },
+      },
+    });
+  });
+
+  it('replaces retained config values from each agent-published full snapshot', async () => {
+    const onUpdateMessage = vi.fn();
+    const client = new AgentClient({
+      logger: createLogger(),
+      sessionId: 'session-codex-plan-exit' as SessionId,
+      terminalManager: {} as never,
+      agentConfig: { cliType: 'builtin', agentType: 'codex' },
+      configOptionValues: { collaboration_mode: 'plan' },
+      onUpdateMessage,
+      onRequestPermission: vi.fn(),
+    });
+    const collaborationModeOption = {
+      id: 'collaboration_mode',
+      name: 'Collaboration mode',
+      description: 'How Codex collaborates for subsequent turns',
+      category: 'collaboration_mode',
+      type: 'select' as const,
+      currentValue: 'default',
+      options: [
+        { value: 'default', name: 'Default' },
+        { value: 'plan', name: 'Plan' },
+      ],
+    };
+    const modelSpecificOption = {
+      id: 'reasoning_effort',
+      name: 'Reasoning effort',
+      description: 'Reasoning level for the selected model',
+      category: 'thought_level',
+      type: 'select' as const,
+      currentValue: 'high',
+      options: [
+        { value: 'low', name: 'Low' },
+        { value: 'high', name: 'High' },
+      ],
+    };
+
+    await client.startSession({} as never, '/workdir');
+    await client.sessionUpdate({
+      sessionId: 'acp-session-1',
+      update: {
+        sessionUpdate: 'config_option_update',
+        configOptions: [collaborationModeOption, modelSpecificOption],
+      },
+    } as SessionNotification);
+    await client.sessionUpdate({
+      sessionId: 'acp-session-1',
+      update: {
+        sessionUpdate: 'config_option_update',
+        configOptions: [collaborationModeOption],
+      },
+    } as SessionNotification);
+
+    expect(client.getConfigOptions()).toEqual([collaborationModeOption]);
+    expect(onUpdateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ sessionUpdate: 'config_option_update' }),
+      })
+    );
+
+    connectionMocks.newSession.mockResolvedValueOnce({ sessionId: 'acp-session-2' });
+    await client.prepareReplacementSession();
+
+    expect(connectionMocks.newSession).toHaveBeenLastCalledWith({
+      cwd: '/workdir',
+      mcpServers: [],
+      _meta: {
+        lody: {
+          sessionConfig: {
+            version: 1,
+            configOptionValues: { collaboration_mode: 'default' },
           },
         },
       },

--- a/apps/cli/src/agent/agent-client.ts
+++ b/apps/cli/src/agent/agent-client.ts
@@ -646,7 +646,7 @@ export class AgentClient implements acp.Client {
   /** Session config options returned by the agent; the source of model/mode choices and names. */
   private configOptions: acp.SessionConfigOption[] = [];
   /** Desired config retained across same-client replacement sessions. */
-  private readonly configOptionValues: NonNullable<SessionTurnInputConfig['configOptionValues']>;
+  private configOptionValues: NonNullable<SessionTurnInputConfig['configOptionValues']>;
   /** Legacy top-level `models` state proves that `session/set_model` is supported. */
   private legacySessionModelState: LegacySessionModelState | null = null;
   public currentModel?: ModelInfo;
@@ -917,6 +917,7 @@ export class AgentClient implements acp.Client {
 
     const notification = parseSessionNotification(params);
 
+    this.applyConfigOptionUpdateState(notification);
     this.handleGoalSessionInfoUpdate(notification);
     this.handleCodexWarningSessionInfoUpdate(notification);
     this.handleAgentSessionTitleUpdate(notification);
@@ -938,6 +939,32 @@ export class AgentClient implements acp.Client {
 
     this.options.onUpdateMessage(notification);
     return;
+  }
+
+  /**
+   * Apply the agent's full live config snapshot before forwarding it. Adapters
+   * may change configuration themselves (for example, Codex exits Plan after
+   * approval), so treating only client-initiated set_config_option responses as
+   * state would leave replacement sessions carrying stale startup values.
+   */
+  private applyConfigOptionUpdateState(notification: AcpSessionNotification): void {
+    if (notification.update.sessionUpdate !== 'config_option_update') {
+      return;
+    }
+
+    this.configOptions = filterAcpConfigOptions(notification.update.configOptions);
+    this.configOptionValues = Object.fromEntries(
+      this.configOptions.map((option) => [option.id, option.currentValue])
+    );
+
+    const modelOption = this.findConfigOptionByCategory('model');
+    if (modelOption?.type === 'select' && typeof modelOption.currentValue === 'string') {
+      this.currentModel = this.resolveModelInfo(modelOption.currentValue);
+    } else if (this.currentModel) {
+      // Other config changes can still alter the thought-level label attached
+      // to the current model.
+      this.currentModel = this.resolveModelInfo(this.currentModel.modelId);
+    }
   }
 
   private handleGoalSessionInfoUpdate(notification: AcpSessionNotification): void {

--- a/packages/components/src/atoms/plan-mode-exit.ts
+++ b/packages/components/src/atoms/plan-mode-exit.ts
@@ -2,26 +2,56 @@ import { atom } from 'jotai';
 import { atomFamily } from 'jotai/utils';
 import type { SessionId } from '@lody/shared';
 
+export type PlanModeExitApprovalState = {
+  latestRevision: number;
+  consumedRevision: number;
+};
+
+export const createPlanModeExitApprovalState = (): PlanModeExitApprovalState => ({
+  latestRevision: 0,
+  consumedRevision: 0,
+});
+
 /**
  * Pending approvals raised when THIS tab's user approves leaving plan mode
- * from a permission card, so the session view can drop plan mode from its
- * composer selector.
+ * from a permission card, so the session view can keep the next-turn composer
+ * selection out of Plan until that choice becomes durable.
  *
- * A counter rather than a flag: a session can plan, implement, and plan again,
- * and each approval must be observable and consumed exactly once. Two
+ * Monotonic revisions rather than a flag: a session can plan, implement, and
+ * plan again, and each approval must be observable and consumed exactly once. Two
  * permission surfaces raise it (the floating card and the inline one in the
  * transcript) and the composer that owns the mode selection state is far from
  * both, so an atom beats threading a callback through the virtualized message
- * list.
+ * list. Keep an approval pending across composer remounts; consume it only
+ * after a non-Plan user turn is accepted or the user explicitly re-arms Plan.
  *
  * Local to the tab on purpose — the run-config selection it drives is local
  * too. Do not replace this with a doc/history-derived signal: a teammate's
  * approval, or an old approval arriving as the session doc syncs, would then
  * unset plan mode for a user who had just chosen it.
  */
-export const planModeExitApprovalCountAtomFamily = atomFamily((_sessionId: SessionId) => atom(0));
+export const planModeExitApprovalStateAtomFamily = atomFamily((_sessionId: SessionId) =>
+  atom(createPlanModeExitApprovalState())
+);
 
-/** Acknowledge only the approvals a consumer observed, preserving newer ones. */
-export function consumeObservedPlanModeExitApprovals(current: number, observed: number): number {
-  return Math.max(0, current - observed);
+export function raisePlanModeExitApproval(
+  state: PlanModeExitApprovalState
+): PlanModeExitApprovalState {
+  return { ...state, latestRevision: state.latestRevision + 1 };
+}
+
+export function hasPendingPlanModeExitApproval(state: PlanModeExitApprovalState): boolean {
+  return state.latestRevision > state.consumedRevision;
+}
+
+/** Acknowledge only revisions a consumer observed, preserving newer ones. */
+export function consumePlanModeExitApprovalsThrough(
+  state: PlanModeExitApprovalState,
+  observedRevision: number
+): PlanModeExitApprovalState {
+  const consumedRevision = Math.min(
+    state.latestRevision,
+    Math.max(state.consumedRevision, observedRevision)
+  );
+  return consumedRevision === state.consumedRevision ? state : { ...state, consumedRevision };
 }

--- a/packages/components/src/atoms/plan-mode-exit.ts
+++ b/packages/components/src/atoms/plan-mode-exit.ts
@@ -3,14 +3,16 @@ import { atomFamily } from 'jotai/utils';
 import type { SessionId } from '@lody/shared';
 
 /**
- * Bumped when THIS tab's user approves leaving plan mode from a permission
- * card, so the session view can drop plan mode from its composer selector.
+ * Pending approvals raised when THIS tab's user approves leaving plan mode
+ * from a permission card, so the session view can drop plan mode from its
+ * composer selector.
  *
  * A counter rather than a flag: a session can plan, implement, and plan again,
- * and each approval must be observable. Two permission surfaces raise it (the
- * floating card and the inline one in the transcript) and the composer that
- * owns the mode selection state is far from both, so an atom beats threading a
- * callback through the virtualized message list.
+ * and each approval must be observable and consumed exactly once. Two
+ * permission surfaces raise it (the floating card and the inline one in the
+ * transcript) and the composer that owns the mode selection state is far from
+ * both, so an atom beats threading a callback through the virtualized message
+ * list.
  *
  * Local to the tab on purpose — the run-config selection it drives is local
  * too. Do not replace this with a doc/history-derived signal: a teammate's
@@ -18,3 +20,8 @@ import type { SessionId } from '@lody/shared';
  * unset plan mode for a user who had just chosen it.
  */
 export const planModeExitApprovalCountAtomFamily = atomFamily((_sessionId: SessionId) => atom(0));
+
+/** Acknowledge only the approvals a consumer observed, preserving newer ones. */
+export function consumeObservedPlanModeExitApprovals(current: number, observed: number): number {
+  return Math.max(0, current - observed);
+}

--- a/packages/components/src/components/sessions/AGENTS.md
+++ b/packages/components/src/components/sessions/AGENTS.md
@@ -454,10 +454,14 @@ Session conversation page chain:
   the composer), never from the resolved outcome in history: this selection is
   per-device local state, so a history-derived signal would unset plan mode for
   a teammate who just armed it, and would fire again for an OLD approval
-  replaying as the session doc syncs. The pending click is consumed exactly once
-  by the `SessionChatInterface` that owns the composer, only after its selection
-  has reconciled and a non-Plan state is observed; the desktop's duplicate
-  header-only instance must not claim it. Every interactive permission surface
+  replaying as the session doc syncs. The pending click survives composer
+  remounts in tab-local, session-scoped state: after selection reconciliation,
+  the `SessionChatInterface` that owns the composer keeps reapplying the exit
+  until a non-Plan user turn is accepted and carries that choice durably, or
+  until the user explicitly re-arms Plan. Capture the approval revision when a
+  dispatch starts and consume only through that revision, so an approval raised
+  while it is in flight stays pending; the desktop's duplicate header-only
+  instance must not claim or clear it. Every interactive permission surface
   must call the notifier — there are two (`floating-permission-request.tsx` and
   the inline card in `../ai-gui/view.tsx`). Codex exits to
   `collaboration_mode=default`; mode-based agents exit to their default non-plan

--- a/packages/components/src/components/sessions/AGENTS.md
+++ b/packages/components/src/components/sessions/AGENTS.md
@@ -443,20 +443,31 @@ Session conversation page chain:
   replaying its values. `buildRecentRunConfigItems` drops a Role entry whose
   Role is not in the passed `agentRoles` — a Role never falls back, so a deleted
   or unavailable one must not quietly re-run as loose values.
-  The selected mode is applied per TURN (it becomes the user entry's
-  `inputConfig.modeId`; `resolveSessionConversationConfig` reads the latest turn
-  back as the preference). So approving "Yes, implement this plan" — which only
-  switches the mode of the running ACP turn — must ALSO drop the selector out of
-  plan, or the next send quietly plans again. Driven from the CLICK
+  Plan is applied per TURN: Claude carries it in the user entry's
+  `inputConfig.modeId`, while Codex carries it in
+  `inputConfig.configOptionValues.collaboration_mode`;
+  `resolveSessionConversationConfig` reads the latest turn back as the
+  preference. So approving "Yes, implement this plan" — which only switches the
+  running ACP turn — must ALSO drop the local selector/config out of plan, or
+  the next send quietly plans again. Driven from the CLICK
   (`hooks/use-plan-mode-exit-approval.ts` → `atoms/plan-mode-exit.ts`, read by
   the composer), never from the resolved outcome in history: this selection is
   per-device local state, so a history-derived signal would unset plan mode for
   a teammate who just armed it, and would fire again for an OLD approval
-  replaying as the session doc syncs. Every interactive permission surface must
-  call the notifier — there are two (`floating-permission-request.tsx` and the
-  inline card in `../ai-gui/view.tsx`). It exits to the agent's default non-plan
-  mode and deliberately does not infer `acceptEdits` from an `allow_always`
+  replaying as the session doc syncs. The pending click is consumed exactly once
+  by the `SessionChatInterface` that owns the composer, only after its selection
+  has reconciled and a non-Plan state is observed; the desktop's duplicate
+  header-only instance must not claim it. Every interactive permission surface
+  must call the notifier — there are two (`floating-permission-request.tsx` and
+  the inline card in `../ai-gui/view.tsx`). Codex exits to
+  `collaboration_mode=default`; mode-based agents exit to their default non-plan
+  mode and deliberately do not infer `acceptEdits` from an `allow_always`
   answer: that consent was about this plan, not every later turn.
+  Explicit execution entry points (Implement plan, Create PR/Draft PR, Commit &
+  Push, Resolve Conflicts, Fix CI, and Fix review finding) dispatch Codex with
+  `collaboration_mode=default` and retain that local selection only after the
+  turn is accepted. Manual messages, Continue discussing, and generic quick
+  messages preserve the user's current Plan choice; do not disable it globally.
   `DesktopMachineMenu` is the matching elevated machine picker used by chat landing.
   Both render on the app-wide DropdownMenu surface (color-mix bg + layered
   float shadow). The old bottom bar row is gone: machine name + workdir badge moved to

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -391,7 +391,7 @@ import {
   findLatestCompletedCodexProposedPlan,
   shouldShowCodexProposedPlanDecision,
 } from '@/lib/codex-plan-decision';
-import { useConsumePlanModeExitApproval } from '@/hooks/use-plan-mode-exit-approval';
+import { usePlanModeExitOverride } from '@/hooks/use-plan-mode-exit-approval';
 import { canShowSubscriptionRateLimits } from '@/lib/session-usage';
 import { canShowCodexResetForecast } from '@/lib/codex-reset-forecast';
 
@@ -2428,6 +2428,28 @@ export const SessionChatInterface = memo(
       dispatch: dispatchSessionConfigSelection,
     });
 
+    // Approving "Yes, implement this plan" changes only the RUNNING ACP turn.
+    // Keep a tab-local next-turn override in the instance that owns the
+    // composer (the desktop header mounts a second, header-only instance for
+    // the same session) until a non-Plan user turn makes it durable.
+    const {
+      onUserModeChange: handleUserModeChange,
+      onUserConfigOptionChange: handleUserConfigOptionChange,
+      acknowledgeAcceptedTurn: acknowledgePlanModeExitAcceptedTurn,
+    } = usePlanModeExitOverride({
+      enabled: !hideMessageArea,
+      selectionReady:
+        sessionConfigSelectionState.targetKey === sessionConfigTargetKey &&
+        sessionConfigSelectionState.preferenceRevision === sessionConversationConfigRevision,
+      sessionId: session.id,
+      selectedModeId,
+      modeOptions,
+      defaultModeId,
+      configOptionValues,
+      onModeChange: handleModeChange,
+      onConfigOptionChange: handleConfigOptionChange,
+    });
+
     // Session status strip above the composer: one priority-ordered slot for
     // "will my message run?" (self offline > machine removed > machine offline).
     const statusStripState = useMemo(
@@ -2463,7 +2485,7 @@ export const SessionChatInterface = memo(
         : {
             values: modeOptions.map((option) => option.value),
             current: selectedModeId,
-            onSelect: handleModeChange,
+            onSelect: handleUserModeChange,
           },
       model: hideMessageArea
         ? null
@@ -2480,7 +2502,8 @@ export const SessionChatInterface = memo(
                 typeof thinkEffortCurrent === 'string'
                   ? thinkEffortCurrent
                   : thinkEffortSelector.currentValue,
-              onSelect: (value) => handleConfigOptionChange(thinkEffortSelector.configId, value),
+              onSelect: (value) =>
+                handleUserConfigOptionChange(thinkEffortSelector.configId, value),
             }
           : null,
       provider: null,
@@ -3334,22 +3357,6 @@ export const SessionChatInterface = memo(
     const isProposedPlanDecisionReady =
       !isMachineRemoved && !isArchivedSession && !isExternalHistoryRefreshing;
 
-    // Approving "Yes, implement this plan" changes only the RUNNING ACP turn.
-    // Consume the local approval in the instance that owns the composer (the
-    // desktop header mounts a second, header-only instance for the same session).
-    useConsumePlanModeExitApproval({
-      enabled: !hideMessageArea,
-      selectionReady:
-        sessionConfigSelectionState.targetKey === sessionConfigTargetKey &&
-        sessionConfigSelectionState.preferenceRevision === sessionConversationConfigRevision,
-      sessionId: session.id,
-      selectedModeId,
-      modeOptions,
-      defaultModeId,
-      configOptionValues,
-      onModeChange: handleModeChange,
-      onConfigOptionChange: handleConfigOptionChange,
-    });
     const sessionBranch = useMemo(
       () =>
         resolveBaseBranchPreference({
@@ -3759,6 +3766,15 @@ export const SessionChatInterface = memo(
         const turnModelId =
           options?.modelIdOverride !== undefined ? options.modelIdOverride : selectedModelId;
         const turnConfigOptionValues = options?.configOptionValuesOverride ?? configOptionValues;
+        const acknowledgeAcceptedTurn = (accepted: boolean): boolean => {
+          if (accepted) {
+            acknowledgePlanModeExitAcceptedTurn({
+              modeId: turnModeId,
+              configOptionValues: turnConfigOptionValues,
+            });
+          }
+          return accepted;
+        };
         const forceDirect = options?.forceDirect === true;
         const submitRoute = resolveSessionMessageSubmitRoute({
           forceDirect,
@@ -3810,7 +3826,7 @@ export const SessionChatInterface = memo(
               queue_reason: submitRoute.reason,
             }
           );
-          return accepted;
+          return acknowledgeAcceptedTurn(accepted);
         }
 
         if (submitRoute.type === 'guide' && activeAssistantTurnId) {
@@ -3829,7 +3845,7 @@ export const SessionChatInterface = memo(
               duration_ms: getDurationSinceMs(startedAtMs),
             }
           );
-          return accepted;
+          return acknowledgeAcceptedTurn(accepted);
         }
 
         if (directDispatchInFlightRef.current) {
@@ -3858,9 +3874,10 @@ export const SessionChatInterface = memo(
           directDispatchInFlightRef.current = false;
           setInputActionState('ready');
         }
-        return accepted;
+        return acknowledgeAcceptedTurn(accepted);
       },
       [
+        acknowledgePlanModeExitAcceptedTurn,
         captureSessionEvent,
         configOptionValues,
         directDispatchInputBlocks,
@@ -5880,9 +5897,9 @@ export const SessionChatInterface = memo(
                       }
                       mcp={mcpSelection.menu}
                       skipNextViewportResizeAutoScrollRef={skipNextViewportResizeAutoScrollRef}
-                      onModeChange={handleModeChange}
+                      onModeChange={handleUserModeChange}
                       onModelChange={handleModelChange}
-                      onConfigOptionChange={handleConfigOptionChange}
+                      onConfigOptionChange={handleUserConfigOptionChange}
                       onSendMessage={handleSendMessage}
                       onStop={() => {
                         void handleStop();

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -376,7 +376,6 @@ import {
 import { isAskUserQuestionPermissionMeta, type AnalyticsOutcome } from '@lody/shared';
 import { collectPendingScheduledTasksFromHistory, type PendingScheduledTask } from '@lody/shared';
 import { buildAuthorFixPrompt } from '@lody/shared';
-import { ACP_PLAN_PERMISSION_MODE_ID } from '@lody/shared';
 import {
   getPullRequestNumber,
   getPullRequestRepoFullName,
@@ -388,12 +387,11 @@ import {
 } from '@/lib/session-workspace-path';
 import { isNativeAppShell } from '@/lib/native-platform';
 import {
-  disableCodexPlanMode,
+  dispatchCodexExecutionPrompt,
   findLatestCompletedCodexProposedPlan,
   shouldShowCodexProposedPlanDecision,
 } from '@/lib/codex-plan-decision';
-import { resolveModeIdAfterPlanExit } from '@/lib/plan-mode-exit';
-import { planModeExitApprovalCountAtomFamily } from '@/atoms/plan-mode-exit';
+import { useConsumePlanModeExitApproval } from '@/hooks/use-plan-mode-exit-approval';
 import { canShowSubscriptionRateLimits } from '@/lib/session-usage';
 import { canShowCodexResetForecast } from '@/lib/codex-reset-forecast';
 
@@ -2030,6 +2028,7 @@ export const SessionChatInterface = memo(
     const isLocalSession = !!localMachineId && session.machineId === localMachineId;
     const [pendingRemoteHtmlFileName, setPendingRemoteHtmlFileName] = useState<string | null>(null);
     const {
+      state: sessionConfigSelectionState,
       selectedModeId,
       selectedModelId,
       configOptionValues,
@@ -2389,6 +2388,7 @@ export const SessionChatInterface = memo(
     const sessionConversationConfigRevision = `${session.id}:${
       sessionConversationConfig.sourceConfigKey ?? ''
     }`;
+    const sessionConfigTargetKey = `${session.id}:${session.cliType}:${session.agentType}`;
     const sessionConfigPreferences = useMemo(
       () => ({
         modeId: sessionConversationConfig.modeId,
@@ -2421,7 +2421,7 @@ export const SessionChatInterface = memo(
     );
     useReconcileAcpSessionConfigSelection({
       enabled: !hideMessageArea && sessionDocReady,
-      targetKey: `${session.id}:${session.cliType}:${session.agentType}`,
+      targetKey: sessionConfigTargetKey,
       preferenceRevision: sessionConversationConfigRevision,
       preferences: sessionConfigPreferences,
       selectorOptions: sessionSelectorOptions,
@@ -3334,20 +3334,22 @@ export const SessionChatInterface = memo(
     const isProposedPlanDecisionReady =
       !isMachineRemoved && !isArchivedSession && !isExternalHistoryRefreshing;
 
-    // Approving "Yes, implement this plan" switches the mode of the RUNNING
-    // turn only — the composer would still say Plan and quietly plan again on
-    // the next send. The permission cards bump this counter when THIS user
-    // approves, so the selector follows.
-    const planModeExitApprovalCount = useAtomValue(planModeExitApprovalCountAtomFamily(session.id));
-    useEffect(() => {
-      if (planModeExitApprovalCount === 0 || selectedModeId !== ACP_PLAN_PERMISSION_MODE_ID) {
-        return;
-      }
-      const nextModeId = resolveModeIdAfterPlanExit(modeOptions, defaultModeId);
-      if (nextModeId) {
-        handleModeChange(nextModeId);
-      }
-    }, [defaultModeId, handleModeChange, modeOptions, planModeExitApprovalCount, selectedModeId]);
+    // Approving "Yes, implement this plan" changes only the RUNNING ACP turn.
+    // Consume the local approval in the instance that owns the composer (the
+    // desktop header mounts a second, header-only instance for the same session).
+    useConsumePlanModeExitApproval({
+      enabled: !hideMessageArea,
+      selectionReady:
+        sessionConfigSelectionState.targetKey === sessionConfigTargetKey &&
+        sessionConfigSelectionState.preferenceRevision === sessionConversationConfigRevision,
+      sessionId: session.id,
+      selectedModeId,
+      modeOptions,
+      defaultModeId,
+      configOptionValues,
+      onModeChange: handleModeChange,
+      onConfigOptionChange: handleConfigOptionChange,
+    });
     const sessionBranch = useMemo(
       () =>
         resolveBaseBranchPreference({
@@ -3881,6 +3883,26 @@ export const SessionChatInterface = memo(
       [dispatchInputBlocks]
     );
 
+    const dispatchExecutionPrompt = useCallback(
+      async (
+        prompt: string,
+        options?: Omit<DispatchInputBlocksOptions, 'configOptionValuesOverride'>
+      ): Promise<boolean> => {
+        if (!isCodexPlanSession) {
+          return await dispatchPrompt(prompt, options);
+        }
+        return await dispatchCodexExecutionPrompt({
+          configOptionValues,
+          dispatch: (configOptionValuesOverride) =>
+            configOptionValuesOverride
+              ? dispatchPrompt(prompt, { ...options, configOptionValuesOverride })
+              : dispatchPrompt(prompt, options),
+          onPlanModeDisabled: setConfigOptionValues,
+        });
+      },
+      [configOptionValues, dispatchPrompt, isCodexPlanSession, setConfigOptionValues]
+    );
+
     const handleSendMessage = useCallback(
       async (inputBlocks: SessionInputBlock[]): Promise<boolean> => {
         return await dispatchInputBlocks(inputBlocks);
@@ -3938,17 +3960,12 @@ export const SessionChatInterface = memo(
       }
 
       const decisionKey = latestCompletedProposedPlan.key;
-      const nextConfigOptionValues = disableCodexPlanMode(configOptionValues);
       pendingProposedPlanDecisionKeyRef.current = decisionKey;
       setPendingProposedPlanDecisionKey(decisionKey);
-      setConfigOptionValues(nextConfigOptionValues);
 
-      const accepted = await dispatchPrompt(
+      const accepted = await dispatchExecutionPrompt(
         t('sessions.proposedPlanDecision.executePrompt', 'Implement the plan'),
-        {
-          forceDirect: true,
-          configOptionValuesOverride: nextConfigOptionValues,
-        }
+        { forceDirect: true }
       );
 
       if (accepted) {
@@ -3958,13 +3975,12 @@ export const SessionChatInterface = memo(
           return next;
         });
       } else {
-        setConfigOptionValues(configOptionValues);
         toast.error(t('sessions.proposedPlanDecision.executeError', 'Failed to execute plan'));
       }
 
       pendingProposedPlanDecisionKeyRef.current = null;
       setPendingProposedPlanDecisionKey(null);
-    }, [configOptionValues, dispatchPrompt, latestCompletedProposedPlan, setConfigOptionValues, t]);
+    }, [dispatchExecutionPrompt, latestCompletedProposedPlan, t]);
 
     const handleGoalCommand = useCallback(
       async (
@@ -4160,8 +4176,14 @@ export const SessionChatInterface = memo(
         has_existing_pr: hasExistingPr,
         workspace_dirty: workspaceDirty,
       });
-      void dispatchPrompt(createPrPrompt);
-    }, [captureSessionEvent, createPrPrompt, dispatchPrompt, hasExistingPr, workspaceDirty]);
+      void dispatchExecutionPrompt(createPrPrompt);
+    }, [
+      captureSessionEvent,
+      createPrPrompt,
+      dispatchExecutionPrompt,
+      hasExistingPr,
+      workspaceDirty,
+    ]);
 
     const handleCreateDraftPr = useCallback(() => {
       captureSessionEvent('session/quick_action_selected', {
@@ -4169,8 +4191,14 @@ export const SessionChatInterface = memo(
         has_existing_pr: hasExistingPr,
         workspace_dirty: workspaceDirty,
       });
-      void dispatchPrompt(createDraftPrPrompt);
-    }, [captureSessionEvent, createDraftPrPrompt, dispatchPrompt, hasExistingPr, workspaceDirty]);
+      void dispatchExecutionPrompt(createDraftPrPrompt);
+    }, [
+      captureSessionEvent,
+      createDraftPrPrompt,
+      dispatchExecutionPrompt,
+      hasExistingPr,
+      workspaceDirty,
+    ]);
 
     const handleCommitAndPush = useCallback(() => {
       captureSessionEvent('session/quick_action_selected', {
@@ -4178,8 +4206,14 @@ export const SessionChatInterface = memo(
         has_existing_pr: hasExistingPr,
         workspace_dirty: workspaceDirty,
       });
-      void dispatchPrompt(commitAndPushPrompt);
-    }, [captureSessionEvent, commitAndPushPrompt, dispatchPrompt, hasExistingPr, workspaceDirty]);
+      void dispatchExecutionPrompt(commitAndPushPrompt);
+    }, [
+      captureSessionEvent,
+      commitAndPushPrompt,
+      dispatchExecutionPrompt,
+      hasExistingPr,
+      workspaceDirty,
+    ]);
 
     const handleResolveConflicts = useCallback(async () => {
       if (isResolvingConflicts || !latestPr?.url) return;
@@ -4190,7 +4224,7 @@ export const SessionChatInterface = memo(
         workspace_dirty: workspaceDirty,
       });
       try {
-        await dispatchPrompt(
+        await dispatchExecutionPrompt(
           buildResolvePrConflictsPrompt({
             repoFullName: latestPrRepoFullName,
             prNumber: latestPrNumber,
@@ -4202,7 +4236,7 @@ export const SessionChatInterface = memo(
       }
     }, [
       captureSessionEvent,
-      dispatchPrompt,
+      dispatchExecutionPrompt,
       isResolvingConflicts,
       latestPr,
       latestPrNumber,
@@ -4233,7 +4267,7 @@ export const SessionChatInterface = memo(
           toast.info(t('sessions.fixCiErrors.noFailures', 'No failing CI checks were found'));
           return;
         }
-        const accepted = await dispatchPrompt(prompt);
+        const accepted = await dispatchExecutionPrompt(prompt);
         if (!accepted) {
           toast.error(t('sessions.fixCiErrors.sendError', 'Failed to send the CI fix request'));
         }
@@ -4246,7 +4280,7 @@ export const SessionChatInterface = memo(
       }
     }, [
       captureSessionEvent,
-      dispatchPrompt,
+      dispatchExecutionPrompt,
       isPrActionPending,
       latestPrRepoFullName,
       refreshActivePrCheckRuns,
@@ -5723,7 +5757,7 @@ export const SessionChatInterface = memo(
                           void autoReview.resume();
                         }}
                         onFixFinding={(finding) => {
-                          void dispatchPrompt(
+                          void dispatchExecutionPrompt(
                             buildAuthorFixPrompt([finding], {
                               // Same reason as the engine's own dispatch: with a
                               // PR open, a committed-but-unpushed fix is invisible

--- a/packages/components/src/hooks/use-plan-mode-exit-approval.ts
+++ b/packages/components/src/hooks/use-plan-mode-exit-approval.ts
@@ -1,9 +1,21 @@
-import { useCallback } from 'react';
-import { useSetAtom } from 'jotai';
-import type { MessageContent, SessionId } from '@lody/shared';
+import { useCallback, useEffect } from 'react';
+import { useAtom, useSetAtom } from 'jotai';
+import {
+  ACP_COLLABORATION_MODE_CONFIG_ID,
+  ACP_COLLABORATION_MODE_DEFAULT_VALUE,
+  ACP_COLLABORATION_MODE_PLAN_VALUE,
+  ACP_PLAN_PERMISSION_MODE_ID,
+  type AcpConfigOptionValue,
+  type MessageContent,
+  type SessionId,
+} from '@lody/shared';
 
-import { planModeExitApprovalCountAtomFamily } from '@/atoms/plan-mode-exit';
-import { isPlanExitApproval } from '@/lib/plan-mode-exit';
+import {
+  consumeObservedPlanModeExitApprovals,
+  planModeExitApprovalCountAtomFamily,
+} from '@/atoms/plan-mode-exit';
+import { isPlanExitApproval, resolveModeIdAfterPlanExit } from '@/lib/plan-mode-exit';
+import type { AcpSessionSelectOption } from '@/components/shared/acp-session-select';
 
 type ToolCallContent = Extract<MessageContent, { type: 'tool_call' }>;
 type PermissionOption = NonNullable<ToolCallContent['permissionRequest']>['options'][number];
@@ -33,4 +45,86 @@ export function usePlanModeExitApprovalNotifier(sessionId: SessionId) {
     },
     [bumpApprovalCount]
   );
+}
+
+type PlanModeExitApprovalConsumerOptions = {
+  enabled: boolean;
+  selectionReady: boolean;
+  sessionId: SessionId;
+  selectedModeId: string | null;
+  modeOptions: readonly AcpSessionSelectOption[];
+  defaultModeId: string | null;
+  configOptionValues: Readonly<Record<string, AcpConfigOptionValue>>;
+  onModeChange: (modeId: string) => void;
+  onConfigOptionChange: (configId: string, value: AcpConfigOptionValue) => void;
+};
+
+/**
+ * Consume successful plan-exit approvals in the composer that owns the local
+ * run-config selection. Codex carries Plan in `collaboration_mode`; Claude
+ * carries it in the ACP permission mode. Both are local per-turn preferences,
+ * so the adapter changing the running turn does not update the next send.
+ */
+export function useConsumePlanModeExitApproval({
+  enabled,
+  selectionReady,
+  sessionId,
+  selectedModeId,
+  modeOptions,
+  defaultModeId,
+  configOptionValues,
+  onModeChange,
+  onConfigOptionChange,
+}: PlanModeExitApprovalConsumerOptions): void {
+  const [pendingApprovalCount, setPendingApprovalCount] = useAtom(
+    planModeExitApprovalCountAtomFamily(sessionId)
+  );
+
+  useEffect(() => {
+    if (!enabled || !selectionReady || pendingApprovalCount === 0) {
+      return;
+    }
+
+    const codexPlanActive =
+      configOptionValues[ACP_COLLABORATION_MODE_CONFIG_ID] === ACP_COLLABORATION_MODE_PLAN_VALUE;
+    let nextModeId: string | null = null;
+    if (selectedModeId === ACP_PLAN_PERMISSION_MODE_ID) {
+      nextModeId = resolveModeIdAfterPlanExit(modeOptions, defaultModeId);
+      if (!nextModeId) {
+        // Capabilities can arrive after the durable turn selection. Keep the
+        // approval pending until a non-Plan destination is actually available.
+        return;
+      }
+    }
+
+    if (codexPlanActive) {
+      onConfigOptionChange(ACP_COLLABORATION_MODE_CONFIG_ID, ACP_COLLABORATION_MODE_DEFAULT_VALUE);
+    }
+    if (nextModeId) {
+      onModeChange(nextModeId);
+    }
+
+    if (codexPlanActive || nextModeId) {
+      // Observe the reconciled non-Plan selection on the next render before
+      // consuming. If either callback is a no-op, the approval stays pending.
+      return;
+    }
+
+    // Consume exactly the revision this effect observed. If another approval
+    // arrives while the handlers above run, its increment remains pending.
+    setPendingApprovalCount((current) =>
+      consumeObservedPlanModeExitApprovals(current, pendingApprovalCount)
+    );
+  }, [
+    configOptionValues,
+    defaultModeId,
+    enabled,
+    modeOptions,
+    onConfigOptionChange,
+    onModeChange,
+    pendingApprovalCount,
+    selectionReady,
+    selectedModeId,
+    setPendingApprovalCount,
+  ]);
 }

--- a/packages/components/src/hooks/use-plan-mode-exit-approval.ts
+++ b/packages/components/src/hooks/use-plan-mode-exit-approval.ts
@@ -11,8 +11,10 @@ import {
 } from '@lody/shared';
 
 import {
-  consumeObservedPlanModeExitApprovals,
-  planModeExitApprovalCountAtomFamily,
+  consumePlanModeExitApprovalsThrough,
+  hasPendingPlanModeExitApproval,
+  planModeExitApprovalStateAtomFamily,
+  raisePlanModeExitApproval,
 } from '@/atoms/plan-mode-exit';
 import { isPlanExitApproval, resolveModeIdAfterPlanExit } from '@/lib/plan-mode-exit';
 import type { AcpSessionSelectOption } from '@/components/shared/acp-session-select';
@@ -30,7 +32,7 @@ type PermissionOption = NonNullable<ToolCallContent['permissionRequest']>['optio
  * (the floating card and the inline card inside the transcript).
  */
 export function usePlanModeExitApprovalNotifier(sessionId: SessionId) {
-  const bumpApprovalCount = useSetAtom(planModeExitApprovalCountAtomFamily(sessionId));
+  const raiseApproval = useSetAtom(planModeExitApprovalStateAtomFamily(sessionId));
 
   return useCallback(
     (
@@ -41,13 +43,13 @@ export function usePlanModeExitApprovalNotifier(sessionId: SessionId) {
       if (!isPlanExitApproval(toolCall, options, selectedOptionId)) {
         return;
       }
-      bumpApprovalCount((count) => count + 1);
+      raiseApproval(raisePlanModeExitApproval);
     },
-    [bumpApprovalCount]
+    [raiseApproval]
   );
 }
 
-type PlanModeExitApprovalConsumerOptions = {
+type PlanModeExitOverrideOptions = {
   enabled: boolean;
   selectionReady: boolean;
   sessionId: SessionId;
@@ -59,13 +61,26 @@ type PlanModeExitApprovalConsumerOptions = {
   onConfigOptionChange: (configId: string, value: AcpConfigOptionValue) => void;
 };
 
+type AcceptedTurnSelection = {
+  modeId: string | null;
+  configOptionValues: Readonly<Record<string, AcpConfigOptionValue>>;
+};
+
+export type PlanModeExitOverrideController = {
+  onUserModeChange: (modeId: string) => void;
+  onUserConfigOptionChange: (configId: string, value: AcpConfigOptionValue) => void;
+  acknowledgeAcceptedTurn: (selection: AcceptedTurnSelection) => void;
+};
+
 /**
- * Consume successful plan-exit approvals in the composer that owns the local
- * run-config selection. Codex carries Plan in `collaboration_mode`; Claude
- * carries it in the ACP permission mode. Both are local per-turn preferences,
- * so the adapter changing the running turn does not update the next send.
+ * Keep successful plan-exit approvals active in the composer that owns the
+ * local run-config selection. Codex carries Plan in `collaboration_mode`;
+ * Claude carries it in the ACP permission mode. Both are local per-turn
+ * preferences, so the adapter changing the running turn does not update the
+ * next send and a composer remount can otherwise restore the last durable Plan
+ * turn.
  */
-export function useConsumePlanModeExitApproval({
+export function usePlanModeExitOverride({
   enabled,
   selectionReady,
   sessionId,
@@ -75,13 +90,66 @@ export function useConsumePlanModeExitApproval({
   configOptionValues,
   onModeChange,
   onConfigOptionChange,
-}: PlanModeExitApprovalConsumerOptions): void {
-  const [pendingApprovalCount, setPendingApprovalCount] = useAtom(
-    planModeExitApprovalCountAtomFamily(sessionId)
+}: PlanModeExitOverrideOptions): PlanModeExitOverrideController {
+  const [approvalState, setApprovalState] = useAtom(planModeExitApprovalStateAtomFamily(sessionId));
+  const approvalPending = hasPendingPlanModeExitApproval(approvalState);
+  const observedApprovalRevision = approvalState.latestRevision;
+
+  const onUserModeChange = useCallback(
+    (modeId: string) => {
+      if (enabled && modeId === ACP_PLAN_PERMISSION_MODE_ID) {
+        // A newer explicit user choice wins over the retained exit approval.
+        setApprovalState((current) =>
+          consumePlanModeExitApprovalsThrough(current, current.latestRevision)
+        );
+      }
+      onModeChange(modeId);
+    },
+    [enabled, onModeChange, setApprovalState]
+  );
+
+  const onUserConfigOptionChange = useCallback(
+    (configId: string, value: AcpConfigOptionValue) => {
+      if (
+        enabled &&
+        configId === ACP_COLLABORATION_MODE_CONFIG_ID &&
+        value === ACP_COLLABORATION_MODE_PLAN_VALUE
+      ) {
+        // Clear before selecting Plan so the override effect cannot undo the
+        // user's re-arm on the following render.
+        setApprovalState((current) =>
+          consumePlanModeExitApprovalsThrough(current, current.latestRevision)
+        );
+      }
+      onConfigOptionChange(configId, value);
+    },
+    [enabled, onConfigOptionChange, setApprovalState]
+  );
+
+  const acknowledgeAcceptedTurn = useCallback(
+    ({ modeId, configOptionValues: acceptedConfigOptionValues }: AcceptedTurnSelection) => {
+      if (
+        !enabled ||
+        !approvalPending ||
+        modeId === ACP_PLAN_PERMISSION_MODE_ID ||
+        acceptedConfigOptionValues[ACP_COLLABORATION_MODE_CONFIG_ID] ===
+          ACP_COLLABORATION_MODE_PLAN_VALUE
+      ) {
+        return;
+      }
+
+      // The accepted non-Plan turn now carries the preference durably. Consume
+      // only the approvals observed when this dispatch started so a newer
+      // approval raised while it was in flight remains pending.
+      setApprovalState((current) =>
+        consumePlanModeExitApprovalsThrough(current, observedApprovalRevision)
+      );
+    },
+    [approvalPending, enabled, observedApprovalRevision, setApprovalState]
   );
 
   useEffect(() => {
-    if (!enabled || !selectionReady || pendingApprovalCount === 0) {
+    if (!enabled || !selectionReady || !approvalPending) {
       return;
     }
 
@@ -104,17 +172,10 @@ export function useConsumePlanModeExitApproval({
       onModeChange(nextModeId);
     }
 
-    if (codexPlanActive || nextModeId) {
-      // Observe the reconciled non-Plan selection on the next render before
-      // consuming. If either callback is a no-op, the approval stays pending.
-      return;
-    }
-
-    // Consume exactly the revision this effect observed. If another approval
-    // arrives while the handlers above run, its increment remains pending.
-    setPendingApprovalCount((current) =>
-      consumeObservedPlanModeExitApprovals(current, pendingApprovalCount)
-    );
+    // Deliberately keep the approval pending after the selector becomes
+    // non-Plan. The latest durable user turn can still say Plan, so a composer
+    // remount must be able to apply the same override again. The accepted-turn
+    // callback above owns consumption.
   }, [
     configOptionValues,
     defaultModeId,
@@ -122,9 +183,10 @@ export function useConsumePlanModeExitApproval({
     modeOptions,
     onConfigOptionChange,
     onModeChange,
-    pendingApprovalCount,
+    approvalPending,
     selectionReady,
     selectedModeId,
-    setPendingApprovalCount,
   ]);
+
+  return { onUserModeChange, onUserConfigOptionChange, acknowledgeAcceptedTurn };
 }

--- a/packages/components/src/lib/codex-plan-decision.ts
+++ b/packages/components/src/lib/codex-plan-decision.ts
@@ -58,6 +58,30 @@ export function disableCodexPlanMode(
   };
 }
 
+/**
+ * Run an explicit Codex execution action with Plan disabled for that turn, and
+ * persist the same selection locally only after the dispatch was accepted.
+ * Ordinary composer sends deliberately do not use this path.
+ */
+export async function dispatchCodexExecutionPrompt({
+  configOptionValues,
+  dispatch,
+  onPlanModeDisabled,
+}: {
+  configOptionValues: Record<string, AcpConfigOptionValue>;
+  dispatch: (configOptionValuesOverride?: Record<string, AcpConfigOptionValue>) => Promise<boolean>;
+  onPlanModeDisabled: (configOptionValues: Record<string, AcpConfigOptionValue>) => void;
+}): Promise<boolean> {
+  const nextConfigOptionValues = isCodexPlanModeEnabled(configOptionValues)
+    ? disableCodexPlanMode(configOptionValues)
+    : undefined;
+  const accepted = await dispatch(nextConfigOptionValues);
+  if (accepted && nextConfigOptionValues) {
+    onPlanModeDisabled(nextConfigOptionValues);
+  }
+  return accepted;
+}
+
 export function findLatestCompletedCodexProposedPlan(
   history: SessionDoc['history'] | undefined
 ): CompletedCodexProposedPlan | null {

--- a/packages/components/tests/codex-plan-decision.test.ts
+++ b/packages/components/tests/codex-plan-decision.test.ts
@@ -1,5 +1,5 @@
 import type { SessionDoc } from '@lody/shared';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   CODEX_COLLABORATION_MODE_CONFIG_ID,
@@ -10,6 +10,7 @@ import {
 } from '../src/components/shared/acp-selector-options';
 import {
   disableCodexPlanMode,
+  dispatchCodexExecutionPrompt,
   findLatestCompletedCodexProposedPlan,
   isCodexPlanModeEnabled,
   shouldShowCodexProposedPlanDecision,
@@ -128,6 +129,57 @@ describe('codex plan decision helpers', () => {
         [CODEX_COLLABORATION_MODE_CONFIG_ID]: CODEX_COLLABORATION_MODE_DEFAULT_VALUE,
       })
     ).toBe(false);
+  });
+
+  it('dispatches execution with Plan disabled and persists only an accepted transition', async () => {
+    const dispatch = vi.fn().mockResolvedValue(true);
+    const onPlanModeDisabled = vi.fn();
+    const config = {
+      [CODEX_COLLABORATION_MODE_CONFIG_ID]: CODEX_COLLABORATION_MODE_PLAN_VALUE,
+      reasoning_effort: 'high',
+    };
+
+    await expect(
+      dispatchCodexExecutionPrompt({ configOptionValues: config, dispatch, onPlanModeDisabled })
+    ).resolves.toBe(true);
+
+    const expected = {
+      [CODEX_COLLABORATION_MODE_CONFIG_ID]: CODEX_COLLABORATION_MODE_DEFAULT_VALUE,
+      reasoning_effort: 'high',
+    };
+    expect(dispatch).toHaveBeenCalledWith(expected);
+    expect(onPlanModeDisabled).toHaveBeenCalledWith(expected);
+  });
+
+  it('keeps the local Plan selection when execution dispatch is rejected', async () => {
+    const dispatch = vi.fn().mockResolvedValue(false);
+    const onPlanModeDisabled = vi.fn();
+
+    await expect(
+      dispatchCodexExecutionPrompt({
+        configOptionValues: {
+          [CODEX_COLLABORATION_MODE_CONFIG_ID]: CODEX_COLLABORATION_MODE_PLAN_VALUE,
+        },
+        dispatch,
+        onPlanModeDisabled,
+      })
+    ).resolves.toBe(false);
+
+    expect(onPlanModeDisabled).not.toHaveBeenCalled();
+  });
+
+  it('does not add a collaboration override when Plan is already off', async () => {
+    const dispatch = vi.fn().mockResolvedValue(true);
+    const onPlanModeDisabled = vi.fn();
+
+    await dispatchCodexExecutionPrompt({
+      configOptionValues: { reasoning_effort: 'low' },
+      dispatch,
+      onPlanModeDisabled,
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(undefined);
+    expect(onPlanModeDisabled).not.toHaveBeenCalled();
   });
 
   it('keeps the completed plan decision visible after plan mode is manually disabled', () => {

--- a/packages/components/tests/plan-mode-exit-override.test.tsx
+++ b/packages/components/tests/plan-mode-exit-override.test.tsx
@@ -1,0 +1,306 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { createStore, Provider, type Store } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ACP_COLLABORATION_MODE_CONFIG_ID,
+  ACP_COLLABORATION_MODE_DEFAULT_VALUE,
+  ACP_COLLABORATION_MODE_PLAN_VALUE,
+  ACP_PLAN_PERMISSION_MODE_ID,
+  type AcpConfigOptionValue,
+  type SessionId,
+} from '@lody/shared';
+
+import {
+  createPlanModeExitApprovalState,
+  hasPendingPlanModeExitApproval,
+  planModeExitApprovalStateAtomFamily,
+  raisePlanModeExitApproval,
+} from '../src/atoms/plan-mode-exit';
+import type { AcpSessionSelectOption } from '../src/components/shared/acp-session-select';
+import {
+  usePlanModeExitOverride,
+  type PlanModeExitOverrideController,
+} from '../src/hooks/use-plan-mode-exit-approval';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const SESSION_ID = 'session-plan-exit' as SessionId;
+const approvalAtom = planModeExitApprovalStateAtomFamily(SESSION_ID);
+const EMPTY_CONFIG: Record<string, AcpConfigOptionValue> = {};
+const MODE_OPTIONS: AcpSessionSelectOption[] = [
+  { value: 'default', label: 'Default' },
+  { value: ACP_PLAN_PERMISSION_MODE_ID, label: 'Plan' },
+];
+
+type ProbeProps = {
+  enabled?: boolean;
+  selectionReady?: boolean;
+  selectedModeId?: string | null;
+  modeOptions?: AcpSessionSelectOption[];
+  defaultModeId?: string | null;
+  configOptionValues?: Record<string, AcpConfigOptionValue>;
+};
+
+let container: HTMLDivElement;
+let root: Root;
+let store: Store;
+let controller: PlanModeExitOverrideController | null;
+let onModeChange: ReturnType<typeof vi.fn<(modeId: string) => void>>;
+let onConfigOptionChange: ReturnType<
+  typeof vi.fn<(configId: string, value: AcpConfigOptionValue) => void>
+>;
+
+function Probe({
+  enabled = true,
+  selectionReady = true,
+  selectedModeId = null,
+  modeOptions = MODE_OPTIONS,
+  defaultModeId = 'default',
+  configOptionValues = EMPTY_CONFIG,
+}: ProbeProps) {
+  controller = usePlanModeExitOverride({
+    enabled,
+    selectionReady,
+    sessionId: SESSION_ID,
+    selectedModeId,
+    modeOptions,
+    defaultModeId,
+    configOptionValues,
+    onModeChange,
+    onConfigOptionChange,
+  });
+  return null;
+}
+
+function renderProbe(props: ProbeProps): void {
+  act(() => {
+    root.render(
+      <Provider store={store}>
+        <Probe {...props} />
+      </Provider>
+    );
+  });
+}
+
+function unmountProbe(): void {
+  act(() => {
+    root.render(<Provider store={store}>{null}</Provider>);
+  });
+  controller = null;
+}
+
+function getController(): PlanModeExitOverrideController {
+  if (!controller) throw new Error('Plan mode exit controller is not mounted');
+  return controller;
+}
+
+function setPendingApproval(): void {
+  store.set(approvalAtom, raisePlanModeExitApproval(createPlanModeExitApprovalState()));
+}
+
+function expectPendingApproval(expected: boolean): void {
+  expect(hasPendingPlanModeExitApproval(store.get(approvalAtom))).toBe(expected);
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  store = createStore();
+  controller = null;
+  onModeChange = vi.fn();
+  onConfigOptionChange = vi.fn();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('usePlanModeExitOverride', () => {
+  it('reapplies the Codex Default override after the composer remounts', () => {
+    setPendingApproval();
+    const durablePlan = {
+      [ACP_COLLABORATION_MODE_CONFIG_ID]: ACP_COLLABORATION_MODE_PLAN_VALUE,
+    };
+
+    renderProbe({ configOptionValues: durablePlan });
+    expect(onConfigOptionChange).toHaveBeenLastCalledWith(
+      ACP_COLLABORATION_MODE_CONFIG_ID,
+      ACP_COLLABORATION_MODE_DEFAULT_VALUE
+    );
+    expectPendingApproval(true);
+
+    unmountProbe();
+    renderProbe({ configOptionValues: durablePlan });
+    expect(onConfigOptionChange).toHaveBeenCalledTimes(2);
+    expectPendingApproval(true);
+  });
+
+  it('reapplies the mode-based Default override after the composer remounts', () => {
+    setPendingApproval();
+
+    renderProbe({ selectedModeId: ACP_PLAN_PERMISSION_MODE_ID });
+    expect(onModeChange).toHaveBeenLastCalledWith('default');
+    expectPendingApproval(true);
+
+    unmountProbe();
+    renderProbe({ selectedModeId: ACP_PLAN_PERMISSION_MODE_ID });
+    expect(onModeChange).toHaveBeenCalledTimes(2);
+    expectPendingApproval(true);
+  });
+
+  it('consumes the override only after a non-Plan turn is accepted', () => {
+    setPendingApproval();
+    renderProbe({ configOptionValues: { [ACP_COLLABORATION_MODE_CONFIG_ID]: 'default' } });
+
+    act(() => {
+      getController().acknowledgeAcceptedTurn({
+        modeId: null,
+        configOptionValues: {
+          [ACP_COLLABORATION_MODE_CONFIG_ID]: ACP_COLLABORATION_MODE_DEFAULT_VALUE,
+        },
+      });
+    });
+    expectPendingApproval(false);
+
+    unmountProbe();
+    renderProbe({
+      configOptionValues: {
+        [ACP_COLLABORATION_MODE_CONFIG_ID]: ACP_COLLABORATION_MODE_PLAN_VALUE,
+      },
+    });
+    expect(onConfigOptionChange).not.toHaveBeenCalled();
+  });
+
+  it('retains the override when the accepted turn still uses Plan', () => {
+    setPendingApproval();
+    renderProbe({});
+
+    act(() => {
+      getController().acknowledgeAcceptedTurn({
+        modeId: ACP_PLAN_PERMISSION_MODE_ID,
+        configOptionValues: EMPTY_CONFIG,
+      });
+      getController().acknowledgeAcceptedTurn({
+        modeId: null,
+        configOptionValues: {
+          [ACP_COLLABORATION_MODE_CONFIG_ID]: ACP_COLLABORATION_MODE_PLAN_VALUE,
+        },
+      });
+    });
+
+    expectPendingApproval(true);
+  });
+
+  it('does not let a header-only instance consume the override', () => {
+    setPendingApproval();
+    renderProbe({ enabled: false });
+
+    act(() => {
+      getController().onUserModeChange(ACP_PLAN_PERMISSION_MODE_ID);
+      getController().onUserConfigOptionChange(
+        ACP_COLLABORATION_MODE_CONFIG_ID,
+        ACP_COLLABORATION_MODE_PLAN_VALUE
+      );
+      getController().acknowledgeAcceptedTurn({
+        modeId: null,
+        configOptionValues: EMPTY_CONFIG,
+      });
+    });
+
+    expectPendingApproval(true);
+  });
+
+  it('preserves approvals raised after an accepted turn started', () => {
+    setPendingApproval();
+    renderProbe({});
+    const acknowledgeFirstApproval = getController().acknowledgeAcceptedTurn;
+
+    act(() => {
+      store.set(approvalAtom, raisePlanModeExitApproval);
+    });
+    act(() => {
+      acknowledgeFirstApproval({ modeId: null, configOptionValues: EMPTY_CONFIG });
+    });
+
+    const state = store.get(approvalAtom);
+    expect(state).toEqual({ latestRevision: 2, consumedRevision: 1 });
+    expectPendingApproval(true);
+  });
+
+  it('does not let an in-flight turn consume an approval raised after a re-arm', () => {
+    setPendingApproval();
+    renderProbe({});
+    const acknowledgeOldTurn = getController().acknowledgeAcceptedTurn;
+
+    act(() => getController().onUserModeChange(ACP_PLAN_PERMISSION_MODE_ID));
+    act(() => {
+      store.set(approvalAtom, raisePlanModeExitApproval);
+    });
+    act(() => acknowledgeOldTurn({ modeId: null, configOptionValues: EMPTY_CONFIG }));
+
+    expect(store.get(approvalAtom)).toEqual({ latestRevision: 2, consumedRevision: 1 });
+    expectPendingApproval(true);
+  });
+
+  it('lets an explicit Codex Plan re-arm win over the retained override', () => {
+    setPendingApproval();
+    renderProbe({});
+
+    act(() => {
+      getController().onUserConfigOptionChange(
+        ACP_COLLABORATION_MODE_CONFIG_ID,
+        ACP_COLLABORATION_MODE_PLAN_VALUE
+      );
+    });
+    expectPendingApproval(false);
+    expect(onConfigOptionChange).toHaveBeenLastCalledWith(
+      ACP_COLLABORATION_MODE_CONFIG_ID,
+      ACP_COLLABORATION_MODE_PLAN_VALUE
+    );
+
+    unmountProbe();
+    renderProbe({
+      configOptionValues: {
+        [ACP_COLLABORATION_MODE_CONFIG_ID]: ACP_COLLABORATION_MODE_PLAN_VALUE,
+      },
+    });
+    expect(onConfigOptionChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets an explicit mode-based Plan re-arm win over the retained override', () => {
+    setPendingApproval();
+    renderProbe({});
+
+    act(() => getController().onUserModeChange(ACP_PLAN_PERMISSION_MODE_ID));
+    expectPendingApproval(false);
+    expect(onModeChange).toHaveBeenLastCalledWith(ACP_PLAN_PERMISSION_MODE_ID);
+
+    unmountProbe();
+    renderProbe({ selectedModeId: ACP_PLAN_PERMISSION_MODE_ID });
+    expect(onModeChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for a non-Plan fallback and for the owning composer to be ready', () => {
+    setPendingApproval();
+    renderProbe({
+      selectionReady: false,
+      selectedModeId: ACP_PLAN_PERMISSION_MODE_ID,
+    });
+    expect(onModeChange).not.toHaveBeenCalled();
+
+    renderProbe({
+      selectedModeId: ACP_PLAN_PERMISSION_MODE_ID,
+      modeOptions: [{ value: ACP_PLAN_PERMISSION_MODE_ID, label: 'Plan' }],
+      defaultModeId: ACP_PLAN_PERMISSION_MODE_ID,
+    });
+    expect(onModeChange).not.toHaveBeenCalled();
+    expectPendingApproval(true);
+  });
+});

--- a/packages/components/tests/plan-mode-exit.test.ts
+++ b/packages/components/tests/plan-mode-exit.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { consumeObservedPlanModeExitApprovals } from '../src/atoms/plan-mode-exit';
+import {
+  consumePlanModeExitApprovalsThrough,
+  createPlanModeExitApprovalState,
+  hasPendingPlanModeExitApproval,
+  raisePlanModeExitApproval,
+} from '../src/atoms/plan-mode-exit';
 import { isPlanExitApproval, resolveModeIdAfterPlanExit } from '../src/lib/plan-mode-exit';
 
 const PLAN_EXIT_OPTIONS = [
@@ -51,9 +56,27 @@ describe('plan mode exit', () => {
     expect(resolveModeIdAfterPlanExit([], null)).toBeNull();
   });
 
-  it('consumes only the approvals the composer observed', () => {
-    expect(consumeObservedPlanModeExitApprovals(2, 1)).toBe(1);
-    expect(consumeObservedPlanModeExitApprovals(1, 1)).toBe(0);
-    expect(consumeObservedPlanModeExitApprovals(1, 2)).toBe(0);
+  it('consumes only the approval revisions the composer observed', () => {
+    const first = raisePlanModeExitApproval(createPlanModeExitApprovalState());
+    const second = raisePlanModeExitApproval(first);
+    const consumedFirst = consumePlanModeExitApprovalsThrough(second, first.latestRevision);
+
+    expect(consumedFirst).toEqual({ latestRevision: 2, consumedRevision: 1 });
+    expect(hasPendingPlanModeExitApproval(consumedFirst)).toBe(true);
+    expect(consumePlanModeExitApprovalsThrough(consumedFirst, second.latestRevision)).toEqual({
+      latestRevision: 2,
+      consumedRevision: 2,
+    });
+  });
+
+  it('does not let an old dispatch consume an approval raised after a re-arm', () => {
+    const dispatched = raisePlanModeExitApproval(createPlanModeExitApprovalState());
+    const rearmed = consumePlanModeExitApprovalsThrough(dispatched, dispatched.latestRevision);
+    const approvedAgain = raisePlanModeExitApproval(rearmed);
+
+    expect(consumePlanModeExitApprovalsThrough(approvedAgain, dispatched.latestRevision)).toBe(
+      approvedAgain
+    );
+    expect(hasPendingPlanModeExitApproval(approvedAgain)).toBe(true);
   });
 });

--- a/packages/components/tests/plan-mode-exit.test.ts
+++ b/packages/components/tests/plan-mode-exit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { consumeObservedPlanModeExitApprovals } from '../src/atoms/plan-mode-exit';
 import { isPlanExitApproval, resolveModeIdAfterPlanExit } from '../src/lib/plan-mode-exit';
 
 const PLAN_EXIT_OPTIONS = [
@@ -48,5 +49,11 @@ describe('plan mode exit', () => {
     expect(resolveModeIdAfterPlanExit(modeOptions, null)).toBe('default');
     expect(resolveModeIdAfterPlanExit([{ value: 'plan', label: 'Plan' }], 'plan')).toBeNull();
     expect(resolveModeIdAfterPlanExit([], null)).toBeNull();
+  });
+
+  it('consumes only the approvals the composer observed', () => {
+    expect(consumeObservedPlanModeExitApprovals(2, 1)).toBe(1);
+    expect(consumeObservedPlanModeExitApprovals(1, 1)).toBe(0);
+    expect(consumeObservedPlanModeExitApprovals(1, 2)).toBe(0);
   });
 });


### PR DESCRIPTION
## Related issue

Closes #114

This PR addresses items 1 and 3: approving a Codex plan and choosing an explicit execution action should both leave Plan mode. Item 2, the Proposed Plan render order, is handled separately by https://github.com/LodyAI/Lody/pull/120.

The author reports that a project maintainer invited opening this PR in private project chat. Issue #114 itself currently contains no public maintainer approval comment, and this PR does not claim otherwise.

## Problem / pressure

Plan is a per-turn run configuration, while approving `switch_mode` changes only the ACP turn that is already running. The composer's next-turn selection is reconstructed from the latest user turn, which still says Plan, so the next message can silently plan again.

The existing frontend exit path only recognized mode-based agents whose `selectedModeId` was the ACP Plan permission mode. Codex represents the same choice as `configOptionValues.collaboration_mode=plan`, so approving "Yes, implement this plan" did not update the Codex selector.

Explicit execution actions had the same mismatch. Implement Plan, Create PR, Create Draft PR, Commit & Push, Resolve Conflicts, Fix CI, and Fix a review finding all reused generic prompt dispatch and therefore preserved the current Plan selection even though their intent is execution.

There was also a replacement-session path back into stale configuration: an adapter can change its own live config and publish a full `config_option_update`, but `AgentClient` previously forwarded that update without refreshing the config retained for a later replacement session.

## Summary

- Consume successful plan-exit approvals in the composer instance that owns run-config state, after its selection has reconciled.
- Handle both representations: Codex exits to `collaboration_mode=default`, while mode-based agents resolve their default non-Plan mode.
- Keep the approval pending until a non-Plan destination exists and consume only the revision that was observed.
- Route explicit Codex execution actions through a Plan-disabled dispatch override and retain the local non-Plan selection only after dispatch is accepted.
- Leave manual sends, Continue discussing, and generic quick messages unchanged so an explicit user Plan choice is not disabled globally.
- Treat ACP `config_option_update` as an authoritative full snapshot in `AgentClient`, rebuilding retained values so removed options cannot leak into replacement sessions.

No shared schema or ACP protocol changes are introduced.

## Before / after

| Before | After |
| ------ | ----- |
| Approving a plan changed only the running ACP turn; the Codex composer still showed Plan and the next turn could plan again. | The approval updates the local Codex collaboration setting to Default once reconciliation is ready. |
| Create PR and other execution actions inherited `collaboration_mode=plan`. | Explicit execution actions dispatch with `collaboration_mode=default` and retain it only after acceptance. |
| Replacement sessions could reuse stale or removed config values after an agent-originated update. | Full agent config snapshots replace the retained option map used for replacement startup. |

## Test plan

- `pnpm --filter lody typecheck` — passed on the rebased head.
- `pnpm --filter @lody/components typecheck` — passed on the rebased head.
- `pnpm --filter @lody/components exec vitest run tests/codex-plan-decision.test.ts tests/plan-mode-exit.test.ts` — 2 files and 14 tests passed.
- `pnpm --filter lody exec vitest run src/agent/agent-client-session-preparation.test.ts` — 1 file and 10 tests passed.
- `git diff --check origin/main...HEAD` — passed.
- The correctly rebased Plan-exit branch was not manually clicked through in the desktop app; verification is type-level and at the dispatch/config-state helper boundaries.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Trace approval consumption in `use-plan-mode-exit-approval.ts`, execution dispatch wiring in `session-chat-interface.tsx`, and authoritative replacement-session state in `agent-client.ts`.
- **Decisions to challenge:** Validate the click-local signal, explicit execution-action allowlist, accepted-dispatch commit point, and full-snapshot replacement semantics.
- **Plausible failures / evidence gaps:** Composer remount and concurrent run-config edits remain known gaps, and the rebased branch has no final desktop click-through.

### Authoring context

- **User goal / directives:** Fix Codex Plan-mode exit for plan approval and execution actions in a PR separate from the Proposed Plan ordering change.
- **Constraints / non-goals:** Preserve Plan for manual discussion sends, avoid shared schema or protocol changes, and do not combine PR #120's renderer fix.
- **Risk-bearing decisions:** Approval state is tab-local to avoid history sync changing a teammate's selector; explicit execution dispatch overrides Plan only for accepted turns; agent config updates replace retained state as authoritative snapshots.
- **Destructive or irreversible behavior:** The change performs no migration, deletion, external write beyond ordinary prompt dispatch, or irreversible operation; reverting restores the former selection behavior.
- **Deliberately not done or tested:** Per prior scope direction, this PR does not persist the post-exit preference across a composer remount and does not merge only the Plan key when an async execution action resolves; no final desktop interaction test was run.
- **Unknowns / confidence:** Confidence is high for the immediate approval, explicit-action, and replacement-session paths; navigating away before a new turn can restore Plan, and a delayed action can overwrite newer Reasoning or Fast changes with its captured config map.

<!-- context-handoff:end -->
