### PR TITLE
docs: add 0.88.0 stable changelog

### DIFF
--- a/site-docs/content/changelog/en/20260828.mdx
+++ b/site-docs/content/changelog/en/20260828.mdx
@@ -1,0 +1,26 @@
+---
+title: '20260828'
+version: 0.88.0
+date: 2026-08-28
+description: Added predictive hover intent to the conversation outline, improved provider setup and the public site, and fixed undelivered messages, workspace syncing, conversation interactions, and desktop reliability.
+---
+
+Version 0.88.0
+
+### ✨ New
+
+- Added predictive hover intent to the conversation outline, making long conversations easier to navigate with fewer accidental openings ([#51](https://github.com/LodyAI/Lody/pull/51), [#97](https://github.com/LodyAI/Lody/pull/97), [#113](https://github.com/LodyAI/Lody/pull/113)).
+- Provider setup now shows clearer progress and warns when a DeepSeek delegation model may incur additional costs ([#66](https://github.com/LodyAI/Lody/pull/66), [#81](https://github.com/LodyAI/Lody/pull/81)).
+- The public blog now includes English and Chinese RSS feeds, reading times, and previous/next navigation; landing-page demos and the animated atmosphere are smoother too ([#84](https://github.com/LodyAI/Lody/pull/84), [#85](https://github.com/LodyAI/Lody/pull/85)).
+- Public source and contribution moved to LodyAI/Lody, with structured Issue and PR templates, automated checks, and clearer feedback for contributors ([#39](https://github.com/LodyAI/Lody/pull/39), [#63](https://github.com/LodyAI/Lody/pull/63), [#69](https://github.com/LodyAI/Lody/pull/69), [#80](https://github.com/LodyAI/Lody/pull/80), [#91](https://github.com/LodyAI/Lody/pull/91)).
+
+### 🐛 Fixes and Improvements
+
+- Undelivered messages are now clearly marked and can be resent after confirmation, preventing lost or duplicate execution ([#48](https://github.com/LodyAI/Lody/pull/48), [#74](https://github.com/LodyAI/Lody/pull/74)).
+- Improved workspace switching and syncing so sidebar content stays within the current workspace, while increasing compatibility between newer and older clients ([#49](https://github.com/LodyAI/Lody/pull/49), [#55](https://github.com/LodyAI/Lody/pull/55), [#96](https://github.com/LodyAI/Lody/pull/96), [#108](https://github.com/LodyAI/Lody/pull/108)).
+- Fixed missing Chinese translations, task-tool configuration, session-tab renaming, IME confirmation, editing in narrow message columns, queued steering, and Agent question compatibility ([#40](https://github.com/LodyAI/Lody/pull/40), [#42](https://github.com/LodyAI/Lody/pull/42), [#43](https://github.com/LodyAI/Lody/pull/43), [#44](https://github.com/LodyAI/Lody/pull/44), [#52](https://github.com/LodyAI/Lody/pull/52), [#99](https://github.com/LodyAI/Lody/pull/99), [#101](https://github.com/LodyAI/Lody/pull/101)).
+- Improved desktop reliability with lighter Mermaid diagrams, Windows tray left-click behavior, restored local file preview and session controls, and safer window navigation ([#45](https://github.com/LodyAI/Lody/pull/45), [#46](https://github.com/LodyAI/Lody/pull/46), [#50](https://github.com/LodyAI/Lody/pull/50), [#71](https://github.com/LodyAI/Lody/pull/71), [#75](https://github.com/LodyAI/Lody/pull/75), [#77](https://github.com/LodyAI/Lody/pull/77)).
+- Improved the usage calendar on smaller screens, including recent-week positioning and visual details, and fixed ordered-list marker alignment in Markdown ([#53](https://github.com/LodyAI/Lody/pull/53), [#62](https://github.com/LodyAI/Lody/pull/62), [#78](https://github.com/LodyAI/Lody/pull/78), [#82](https://github.com/LodyAI/Lody/pull/82), [#83](https://github.com/LodyAI/Lody/pull/83)).
+- Removing a local project now archives its related sessions first, avoiding inaccessible leftover sessions ([#105](https://github.com/LodyAI/Lody/pull/105)).
+- Corrected repository paths, the Chinese session-guide link, Node.js prerequisites, and public package metadata ([#57](https://github.com/LodyAI/Lody/pull/57), [#60](https://github.com/LodyAI/Lody/pull/60), [#64](https://github.com/LodyAI/Lody/pull/64)).
+- Thanks to [@clanzhang](https://github.com/clanzhang), [@tommy0103](https://github.com/tommy0103), [@lawvs](https://github.com/lawvs), [@Innei](https://github.com/Innei), [@hyoban](https://github.com/hyoban), [@wibus-wee](https://github.com/wibus-wee), [@limichange](https://github.com/limichange), [@27Aaron](https://github.com/27Aaron), [@hcz-czh](https://github.com/hcz-czh), [@Pleasurecruise](https://github.com/Pleasurecruise), [@frostming](https://github.com/frostming), [@natsustan](https://github.com/natsustan), and [@zxch3n](https://github.com/zxch3n) for their public contributions to this release.

--- a/site-docs/content/changelog/zh/20260828.mdx
+++ b/site-docs/content/changelog/zh/20260828.mdx
@@ -1,0 +1,26 @@
+---
+title: '20260828'
+version: 0.88.0
+date: 2026-08-28
+description: 长对话大纲新增智能悬停预判，模型服务配置与官网体验得到改善，并修复未送达消息、工作区同步、会话交互和桌面端稳定性问题。
+---
+
+版本 0.88.0
+
+### ✨ 新功能
+
+- 长对话大纲新增智能悬停预判，定位内容更顺畅，并减少误触展开（[#51](https://github.com/LodyAI/Lody/pull/51)、[#97](https://github.com/LodyAI/Lody/pull/97)、[#113](https://github.com/LodyAI/Lody/pull/113)）。
+- 模型服务配置提供更清晰的检测进度，并在选择可能产生额外费用的 DeepSeek 委派模型时显示提醒（[#66](https://github.com/LodyAI/Lody/pull/66)、[#81](https://github.com/LodyAI/Lody/pull/81)）。
+- 官网博客新增中英文 RSS、阅读时长和前后篇导航；首页演示与动态背景也更加流畅（[#84](https://github.com/LodyAI/Lody/pull/84)、[#85](https://github.com/LodyAI/Lody/pull/85)）。
+- 公开源码与贡献入口迁移至 LodyAI/Lody，并新增结构化 Issue/PR 模板、自动检查和反馈机制（[#39](https://github.com/LodyAI/Lody/pull/39)、[#63](https://github.com/LodyAI/Lody/pull/63)、[#69](https://github.com/LodyAI/Lody/pull/69)、[#80](https://github.com/LodyAI/Lody/pull/80)、[#91](https://github.com/LodyAI/Lody/pull/91)）。
+
+### 🐛 修复与改进
+
+- 未送达的消息现在会被明确标记，并支持确认后重新发送，避免消息丢失或重复执行（[#48](https://github.com/LodyAI/Lody/pull/48)、[#74](https://github.com/LodyAI/Lody/pull/74)）。
+- 改善工作区切换与同步体验，确保侧边栏内容始终属于当前工作区，并增强新旧客户端之间的数据兼容性（[#49](https://github.com/LodyAI/Lody/pull/49)、[#55](https://github.com/LodyAI/Lody/pull/55)、[#96](https://github.com/LodyAI/Lody/pull/96)、[#108](https://github.com/LodyAI/Lody/pull/108)）。
+- 修复中文翻译、任务工具配置、会话标签重命名、输入法确认、窄窗口消息编辑、排队消息和 Agent 提问兼容性问题（[#40](https://github.com/LodyAI/Lody/pull/40)、[#42](https://github.com/LodyAI/Lody/pull/42)、[#43](https://github.com/LodyAI/Lody/pull/43)、[#44](https://github.com/LodyAI/Lody/pull/44)、[#52](https://github.com/LodyAI/Lody/pull/52)、[#99](https://github.com/LodyAI/Lody/pull/99)、[#101](https://github.com/LodyAI/Lody/pull/101)）。
+- 改善桌面端稳定性，包括更轻量的 Mermaid 图表、Windows 托盘左键打开窗口、本地文件预览与会话控制，以及更安全的窗口导航（[#45](https://github.com/LodyAI/Lody/pull/45)、[#46](https://github.com/LodyAI/Lody/pull/46)、[#50](https://github.com/LodyAI/Lody/pull/50)、[#71](https://github.com/LodyAI/Lody/pull/71)、[#75](https://github.com/LodyAI/Lody/pull/75)、[#77](https://github.com/LodyAI/Lody/pull/77)）。
+- 优化使用量日历在小屏幕上的布局、最近记录和视觉细节，并修复 Markdown 有序列表编号对齐（[#53](https://github.com/LodyAI/Lody/pull/53)、[#62](https://github.com/LodyAI/Lody/pull/62)、[#78](https://github.com/LodyAI/Lody/pull/78)、[#82](https://github.com/LodyAI/Lody/pull/82)、[#83](https://github.com/LodyAI/Lody/pull/83)）。
+- 删除本地项目时会先归档相关会话，避免遗留无法访问的会话（[#105](https://github.com/LodyAI/Lody/pull/105)）。
+- 修正文档中的仓库地址、中文页面链接和 Node.js 环境要求，并更新公开包元数据（[#57](https://github.com/LodyAI/Lody/pull/57)、[#60](https://github.com/LodyAI/Lody/pull/60)、[#64](https://github.com/LodyAI/Lody/pull/64)）。
+- 感谢 [@clanzhang](https://github.com/clanzhang)、[@tommy0103](https://github.com/tommy0103)、[@lawvs](https://github.com/lawvs)、[@Innei](https://github.com/Innei)、[@hyoban](https://github.com/hyoban)、[@wibus-wee](https://github.com/wibus-wee)、[@limichange](https://github.com/limichange)、[@27Aaron](https://github.com/27Aaron)、[@hcz-czh](https://github.com/hcz-czh)、[@Pleasurecruise](https://github.com/Pleasurecruise)、[@frostming](https://github.com/frostming)、[@natsustan](https://github.com/natsustan) 和 [@zxch3n](https://github.com/zxch3n) 对本版本的公开贡献。


### PR DESCRIPTION
Risk: 🟢 low | Confidence: high — adds only the confirmed bilingual 0.88.0 changelog entries; formatting and exact-range diff checks pass

## Related issue

https://github.com/LodyAI/Lody/issues/125

## Problem / pressure

The stable 0.88.0 desktop package requires one exact English/Chinese changelog pair, and the public notes must preserve the confirmed user-facing summary while crediting merged public contributions.

## Summary

- publish the confirmed Chinese and naturally equivalent English stable changelog
- link every public PR included in the release notes
- explicitly acknowledge public contributors, especially external contributors

## Before / after

| Before | After |
| ------ | ----- |
| No 2026-08-28 stable entry existed. | Matching English and Chinese 0.88.0 entries document the release, public PRs, and contributors. |

## Test plan

- `corepack pnpm dlx prettier@3.9.6 --check lody-oss/site-docs/content/changelog/{en,zh}/20260828.mdx`
- `git diff --check d814e74a9146418cc3ac213d41763124d55cfed5..806e4a7f05dd802f792242ce02f1a5364fe55e7e`
- verified both files cite the same 40 public PRs and contain version/date 0.88.0 / 2026-08-28
- product builds and tests were intentionally not repeated for this content-only stable-release entry

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Compare the English and Chinese MDX files for equivalent claims, exact version/date, and complete public PR/contributor links.
- **Decisions to challenge:** Check that grouping implementation-oriented PRs under user-observable outcomes does not overstate behavior.
- **Plausible failures / evidence gaps:** A missed or mismatched PR link, contributor handle, or locale claim could make the public notes incomplete; no product code changed.

### Authoring context

- **User goal / directives:** Prepare the next stable Lody release with a confirmed Chinese public changelog that mentions merged public PRs and especially external contributions.
- **Constraints / non-goals:** Change only the two localized changelog entries; do not alter product code, generated release metadata, versions elsewhere, or submodule pointers.
- **Risk-bearing decisions:** The entry is pinned to candidate 0.88.0 and groups PRs by user impact while retaining direct links for auditability.
- **Destructive or irreversible behavior:** This PR only adds content files; removal or correction remains an ordinary follow-up commit before release.
- **Deliberately not done or tested:** Product builds and tests were not repeated because the stable-release workflow treats this confirmed content-only PR as a narrow publication step.
- **Unknowns / confidence:** Release Please remains authoritative for the final version, but linked-version rules and the source feat bump currently derive 0.88.0 with high confidence.

<!-- context-handoff:end -->