### PR TITLE
fix(components): prevent composer focus stealing when clicking model search in subsession tabs

### DIFF
--- a/packages/components/src/components/chat/chat-composer.tsx
+++ b/packages/components/src/components/chat/chat-composer.tsx
@@ -670,18 +670,21 @@ export function ChatComposer({
               onClick={
                 focusOnContainerClick && !promptDisabled
                   ? (event) => {
+                      const target = event.target as HTMLElement | null;
+                      if (!target) return;
                       if (
-                        event.target === event.currentTarget ||
-                        !(event.target as HTMLElement).closest(
-                          'button, a, [data-comment-ref], [data-visual-annotation-ref]'
+                        !event.currentTarget.contains(target) ||
+                        target.closest(
+                          'button, a, input, textarea, select, [role="button"], [role="menuitem"], [role="option"], [data-comment-ref], [data-visual-annotation-ref]'
                         )
                       ) {
-                        const textarea =
-                          promptRef && typeof promptRef === 'object' && 'current' in promptRef
-                            ? promptRef.current
-                            : null;
-                        textarea?.focus();
+                        return;
                       }
+                      const textarea =
+                        promptRef && typeof promptRef === 'object' && 'current' in promptRef
+                          ? promptRef.current
+                          : null;
+                      textarea?.focus();
                     }
                   : undefined
               }

--- a/packages/components/src/ui/dropdown-menu.tsx
+++ b/packages/components/src/ui/dropdown-menu.tsx
@@ -550,7 +550,16 @@ const DropdownMenuSearchInput = React.forwardRef<HTMLInputElement, DropdownMenuS
     };
 
     return (
-      <div className={cn('flex items-center gap-2 px-2.5 py-1.5', className)}>
+      <div
+        className={cn('flex items-center gap-2 px-2.5 py-1.5', className)}
+        onClick={(event) => {
+          event.stopPropagation();
+          inputRef.current?.focus();
+        }}
+        onPointerDown={(event) => {
+          event.stopPropagation();
+        }}
+      >
         <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
         <input
           ref={(node) => {
@@ -562,6 +571,12 @@ const DropdownMenuSearchInput = React.forwardRef<HTMLInputElement, DropdownMenuS
           value={value}
           onChange={(event) => onValueChange(event.target.value)}
           onKeyDown={handleKeyDown}
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          onPointerDown={(event) => {
+            event.stopPropagation();
+          }}
           placeholder={placeholder}
           aria-label={ariaLabel ?? placeholder}
           className="min-w-0 flex-1 border-none bg-transparent text-[0.8rem] leading-tight outline-none placeholder:text-muted-foreground focus:outline-none focus:ring-0"

--- a/packages/components/tests/chat-composer-focus.test.tsx
+++ b/packages/components/tests/chat-composer-focus.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+
+import { act, createElement, createRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/components/mentions/mention-session-source', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useSessionMentionItems: () => [],
+}));
+
+vi.mock('../src/components/mentions/mention-agent-role-source', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useAgentRoleMentionItems: () => [],
+}));
+
+import { ChatComposer } from '../src/components/chat/chat-composer';
+import { initI18n } from '../src/i18n';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('ChatComposer focusOnContainerClick', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(async () => {
+    await initI18n('en');
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }))
+    );
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('focuses textarea when clicking container background with focusOnContainerClick=true', async () => {
+    const promptRef = createRef<HTMLTextAreaElement>();
+    await act(async () => {
+      root.render(
+        createElement(ChatComposer, {
+          promptRef,
+          promptValue: '',
+          onPromptChange: () => undefined,
+          focusOnContainerClick: true,
+        })
+      );
+    });
+
+    const boxContainer = container.querySelector('.group.relative') as HTMLElement;
+    expect(boxContainer).not.toBeNull();
+    expect(document.activeElement).not.toBe(promptRef.current);
+
+    await act(async () => {
+      boxContainer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(document.activeElement).toBe(promptRef.current);
+  });
+
+  it('does not focus textarea when focusOnContainerClick is false', async () => {
+    const promptRef = createRef<HTMLTextAreaElement>();
+    await act(async () => {
+      root.render(
+        createElement(ChatComposer, {
+          promptRef,
+          promptValue: '',
+          onPromptChange: () => undefined,
+          focusOnContainerClick: false,
+        })
+      );
+    });
+
+    const boxContainer = container.querySelector('.group.relative') as HTMLElement;
+    await act(async () => {
+      boxContainer.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(document.activeElement).not.toBe(promptRef.current);
+  });
+
+  it('does not focus textarea when clicking a button, input, or portalled element', async () => {
+    const promptRef = createRef<HTMLTextAreaElement>();
+    const customInputRef = createRef<HTMLInputElement>();
+
+    await act(async () => {
+      root.render(
+        createElement(ChatComposer, {
+          promptRef,
+          promptValue: '',
+          onPromptChange: () => undefined,
+          focusOnContainerClick: true,
+          footerSelector: createElement('input', {
+            ref: customInputRef,
+            'aria-label': 'custom-input',
+          }),
+        })
+      );
+    });
+
+    const input = customInputRef.current;
+    expect(input).not.toBeNull();
+
+    await act(async () => {
+      input?.focus();
+      input?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(document.activeElement).toBe(input);
+    expect(document.activeElement).not.toBe(promptRef.current);
+  });
+});

--- a/packages/components/tests/composer-model-search.test.tsx
+++ b/packages/components/tests/composer-model-search.test.tsx
@@ -14,12 +14,19 @@ import {
 // The menu resolves its default agent pool from machine presence; these
 // surfaces pass their agent in explicitly, so the pool is not under test.
 vi.mock('../src/hooks/use-online-machines', () => ({ useOnlineMachines: () => [] }));
-
+vi.mock('../src/components/mentions/mention-session-source', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useSessionMentionItems: () => [],
+}));
+vi.mock('../src/components/mentions/mention-agent-role-source', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useAgentRoleMentionItems: () => [],
+}));
 import { agentConfigMetaCacheAtom } from '../src/atoms/doc-meta';
+import { ChatComposer } from '../src/components/chat/chat-composer';
 import { DesktopRunConfigMenu } from '../src/components/sessions/desktop-run-config-menu';
 import { MobileRunConfigSheet } from '../src/components/mobile/mobile-run-config-sheet';
 import { initI18n } from '../src/i18n';
-
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
@@ -261,6 +268,45 @@ describe('composer model picker search', () => {
         'a[href="https://github.com/deepseek-ai/deepseek-harness/discussions/4065"]'
       )
     ).toBeNull();
+  });
+
+  it('does not steal focus to composer textarea when clicking search input inside ChatComposer with focusOnContainerClick', async () => {
+    const textareaRef = { current: null as HTMLTextAreaElement | null };
+    await act(async () => {
+      root?.render(
+        createElement(ChatComposer, {
+          promptRef: textareaRef,
+          promptValue: '',
+          onPromptChange: () => undefined,
+          focusOnContainerClick: true,
+          footerSelector: createElement(DesktopRunConfigMenu, desktopProps),
+        })
+      );
+    });
+    // Open menu on pointerdown
+    await act(async () => {
+      container
+        ?.querySelector('button[aria-label="Run configuration"]')
+        ?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }));
+    });
+    const modelRow = [...document.querySelectorAll('[role="menuitem"]')].find((node) =>
+      node.textContent?.trim().startsWith('Model')
+    );
+    await act(async () => {
+      (modelRow as HTMLElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const search = document.querySelector<HTMLInputElement>('input[aria-label="Search models"]');
+    expect(search).not.toBeNull();
+
+    // Click directly on search input
+    await act(async () => {
+      search?.focus();
+      search?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    // Verify search input retained focus and textarea did NOT steal focus
+    expect(document.activeElement).toBe(search);
+    expect(document.activeElement).not.toBe(textareaRef.current);
   });
 
   /* ── Mobile: the same rule inside the run-config sheet ── */


### PR DESCRIPTION
## Related issue

Fixes #128

## Problem / pressure

When opening the model selector dropdown inside a sub-session tab (or draft tab) and clicking into the search input box, the search input loses focus immediately and the popover menu closes.

Root cause:
1. In sub-session tabs, `SessionChatInputArea` mounts `ChatComposer` with `focusOnContainerClick={true}`.
2. The model selector (`DesktopRunConfigMenu`) is mounted in `ChatComposer`'s `footerSelector` slot.
3. Although the dropdown menu content is portalled to the document root in the real DOM, React synthetic events (`onClick`, `onPointerDown`) bubble up the React component tree to `ChatComposer`.
4. `ChatComposer`'s container click handler checked `!(event.target as HTMLElement).closest('button, a, [data-comment-ref], [data-visual-annotation-ref]')`. Because `<input>` is neither a `button` nor an `a` element, clicking the search input was treated as a container background click, triggering `textarea?.focus()`. This stole focus from the search input and caused the Radix dropdown to close due to outside focus blur.
5. In addition, `DropdownMenuSearchInput` did not stop click/pointerdown event propagation.

## Summary

- In `ChatComposer` (`packages/components/src/components/chat/chat-composer.tsx`):
  - Add `!event.currentTarget.contains(target)` check to ignore events originating from portalled content outside the composer container DOM node.
  - Expand the `closest(...)` selector to include `input, textarea, select, [role="button"], [role="menuitem"], [role="option"]`.
- In `DropdownMenuSearchInput` (`packages/components/src/ui/dropdown-menu.tsx`):
  - Stop propagation on `onClick` and `onPointerDown`.
  - Focus the search input directly when clicking the search row wrapper.
- Added comprehensive unit tests:
  - `packages/components/tests/chat-composer-focus.test.tsx` verifying `focusOnContainerClick` boundaries and interactive element exclusions.
  - `packages/components/tests/composer-model-search.test.tsx` verifying search input focus retention inside `ChatComposer` with `focusOnContainerClick=true`.

## Test plan

- `pnpm --filter @lody/components typecheck` — passed.
- `pnpm --filter @lody/components test` — 391 test files, 2,792 tests passed.
- `pnpm --filter @lody/components test tests/composer-model-search.test.tsx tests/chat-composer-focus.test.tsx` — passed.
- Repository boundary scripts (`check-i18n.mjs`, `check-code-collab-imports.mjs`, `check-platform-boundaries.mjs`, `check-public-boundary.mjs`) — all passed.

<!-- context-handoff:begin -->

## Context handoff

### Instructions for reviewing agents

- **Review focus:** Verify that clicking the model search input in `DesktopRunConfigMenu` retains input focus when embedded inside `ChatComposer` with `focusOnContainerClick={true}`.
- **Decisions to challenge:** Verify `ChatComposer` ignores synthetic click events originating outside its physical DOM container (`!event.currentTarget.contains(target)`).
- **Plausible failures / evidence gaps:** Manual click verification in real Electron app has not been run in headless CI environment; covered by automated React DOM integration tests.

### Authoring context

- **User goal / directives:** Fix issue #128 where clicking the search input in model selector loses focus and closes popover in tab sub-sessions.
- **Constraints / non-goals:** Do not alter regular chat composer behavior or Radix dropdown roving focus mechanics.
- **Risk-bearing decisions:** Intercept outside-container synthetic event bubbling at `ChatComposer` and stop event propagation in `DropdownMenuSearchInput`.
- **Destructive or irreversible behavior:** None. Reverting restores previous behavior.
- **Deliberately not done or tested:** Non-regression verified across all 391 component test suites without separate E2E browser session.
- **Unknowns / confidence:** High confidence; fully covered by automated regression tests.

<!-- context-handoff:end -->