### PR TITLE
fix: promote child tab drafts through the startSession accept unit

### DIFF
--- a/apps/cli/src/session/AGENTS.md
+++ b/apps/cli/src/session/AGENTS.md
@@ -22,7 +22,12 @@ delegation proofs or a shared-machine gate without a new product and security de
   `latestUserMsgId` ≠ `lastHandledUserMsgId`. Also accepts `session/dispatch-turn`
   Machine RPC pushes via `offerRpcTurn` (ack-then-execute: stash the payload as a
   third turn source — history → queue → stash — and wake the per-session check
-  chain; the RPC ack means delivered, not authorized/executed). Fast-path turns
+  chain; the RPC ack means delivered, not authorized/executed). Absent session
+  meta during watch reconciliation is "unknown", not foreign: a freshly created
+  session's RPC turn can reach this machine before its meta syncs, so the
+  TTL-bounded RPC stash must survive until meta lands and only a definitive
+  verdict — deleted doc, another machine's session, or an archived one — drops
+  it. Fast-path turns
   that finish before their history entry syncs are reconciled by
   `maybeRepairAlreadyHandledTurn` (late `pending` entry gets flipped to its
   recorded terminal status, never re-dispatched). Extensive header comment is the

--- a/apps/cli/src/session/session-dispatch-watcher.ts
+++ b/apps/cli/src/session/session-dispatch-watcher.ts
@@ -1136,9 +1136,8 @@ export class SessionDispatchWatcher {
       if (!isActive()) {
         return;
       }
-      const meta = isLoroRepoDocDeleted(record)
-        ? undefined
-        : (record?.meta as SessionMeta | undefined);
+      const docDeleted = isLoroRepoDocDeleted(record);
+      const meta = docDeleted ? undefined : (record?.meta as SessionMeta | undefined);
 
       phase = 'evaluate-ownership';
       const isOwned = meta?.machineId === this.deps.machineId && !meta?.isArchived;
@@ -1148,7 +1147,14 @@ export class SessionDispatchWatcher {
         this.watchedSessions.delete(sessionId);
         this.cancelCheckChains.delete(sessionId);
         this.cancelSeenTurn.delete(sessionId);
-        this.rpcTurnStash.delete(sessionId);
+        // Absent metadata is "unknown", not "foreign": a freshly created
+        // session's RPC turn can arrive before its meta syncs to this machine.
+        // Keep the TTL-bounded stash so the metadata watch dispatches it once
+        // the meta lands; only a definitive verdict — deleted doc, another
+        // machine's session, or an archived one — drops the stashed turn.
+        if (meta || docDeleted) {
+          this.rpcTurnStash.delete(sessionId);
+        }
         this.interruptAccessRetry(sessionId);
         return;
       }

--- a/apps/cli/tests/session-dispatch-watcher.test.ts
+++ b/apps/cli/tests/session-dispatch-watcher.test.ts
@@ -384,6 +384,113 @@ describe('SessionDispatchWatcher', () => {
     );
   });
 
+  it('keeps a stashed RPC turn while session meta is unknown and dispatches once meta syncs', async () => {
+    const startSession = vi.fn(async () => {});
+    const sessionId = 'session-rpc-before-meta' as SessionId;
+    const sessionMeta = {
+      id: sessionId,
+      machineId: 'machine-1',
+      userId: 'user-1',
+      createdAt: new Date().toISOString(),
+      cliType: 'builtin',
+      agentType: 'codex',
+      status: { type: 'idle' as const },
+    };
+    // The session was just created on another client: its meta has not synced
+    // to this machine yet, but the dispatch RPC already targeted it.
+    let metaRecord: { meta: typeof sessionMeta } | undefined;
+    let metadataWatchCallback: ((event: { kind: string; docId: string }) => void) | undefined;
+
+    const sessionDoc = {
+      mirror: {
+        subscribe: vi.fn(() => vi.fn()),
+      },
+      getMetaState: vi.fn(async () => metaRecord?.meta),
+      getHistory: vi.fn(async () => []),
+      updateHistory: vi.fn(async () => {}),
+      setStatus: vi.fn(async () => {}),
+      waitForRemoteSync: vi.fn(async () => {}),
+    };
+
+    const getDocMeta = vi.fn(async () => metaRecord);
+    const workspaceDocument = {
+      repo: {
+        getMeta: () => ({ scan: vi.fn(async () => []) }),
+        getDocMeta,
+        upsertDocMeta: vi.fn(async () => {}),
+        watch: vi.fn((callback: (event: { kind: string; docId: string }) => void) => {
+          metadataWatchCallback = callback;
+          return { unsubscribe: vi.fn() };
+        }),
+      },
+      getOrCreateSessionDoc: vi.fn(async () => sessionDoc),
+      onMetaRoomSynced: vi.fn(() => vi.fn()),
+    } as unknown as LoroDocumentManager;
+
+    const watcher = createWatcher({
+      logger: createSilentLogger(),
+      machineId: 'machine-1',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      workspaceDocument,
+      executionService: {
+        getExecutionSnapshot: vi.fn(() => ({
+          hasActiveTurn: false,
+          hasBlockingPendingCreate: false,
+          hasReusableSession: false,
+        })),
+        continueSession: vi.fn(async () => {}),
+        startSession,
+        cancelSession: vi.fn(async () => ({ success: true })),
+      } as unknown as SessionExecutionService,
+      canUseMachine: createAllowMachineAccess(),
+    });
+
+    await watcher.start();
+
+    await expect(
+      watcher.offerRpcTurn({
+        sessionId,
+        userTurnId: 'rpc-turn-early',
+        userId: 'user-1',
+        timestamp: new Date().toISOString(),
+        inputConfig: { prompt: 'created before meta sync' },
+      })
+    ).resolves.toBe('accepted');
+
+    // A metadata reconcile while meta is still absent must treat the session
+    // as unknown, not foreign: the stashed turn survives, nothing dispatches.
+    const reconcileReadsBefore = getDocMeta.mock.calls.length;
+    metadataWatchCallback?.({ kind: 'doc-metadata', docId: `session-${sessionId}` });
+    await vi.waitFor(
+      () => {
+        expect(getDocMeta.mock.calls.length).toBeGreaterThan(reconcileReadsBefore);
+      },
+      { timeout: 3_000 }
+    );
+    await flushMicrotasks(16);
+    expect(startSession).not.toHaveBeenCalled();
+
+    // Meta arrival fires the metadata watch again; the kept stash dispatches.
+    metaRecord = { meta: sessionMeta };
+    metadataWatchCallback?.({ kind: 'doc-metadata', docId: `session-${sessionId}` });
+    await vi.waitFor(
+      () => {
+        expect(startSession).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 3_000 }
+    );
+    expect(startSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'session/create',
+        sessionId,
+        userTurnId: 'rpc-turn-early',
+        acpSessionConfig: expect.objectContaining({ prompt: 'created before meta sync' }),
+      }),
+      { dispatchSource: 'rpc' }
+    );
+    watcher.stop();
+  });
+
   it('preempts an in-flight Doc Room join when an RPC turn arrives', async () => {
     const sessionId = 'session-rpc-during-doc-join' as SessionId;
     const userTurnId = 'rpc-turn-during-doc-join';

--- a/locales/en.json
+++ b/locales/en.json
@@ -1241,6 +1241,7 @@
   "sessions.contextWindow.remaining": "Remaining",
   "sessions.contextWindow.title": "Context Window Usage",
   "sessions.contextWindow.used": "Used",
+  "sessions.tabCloseFailed": "Could not close this tab",
   "sessions.usage.context": "Context",
   "sessions.usage.compacting": "Compacting",
   "sessions.usage.compactingContext": "Compacting context",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -1241,6 +1241,7 @@
   "sessions.contextWindow.remaining": "剩余",
   "sessions.contextWindow.title": "上下文窗口用量",
   "sessions.contextWindow.used": "已用",
+  "sessions.tabCloseFailed": "无法关闭此标签页",
   "sessions.usage.context": "上下文",
   "sessions.usage.compacting": "压缩中",
   "sessions.usage.compactingContext": "正在压缩上下文",

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -173,6 +173,17 @@ mobile surfaces.
 ## Common entry points
 
 - Chat landing: `src/components/chat/chat-landing.tsx`.
+- Child-tab drafts send through the same accept unit as every other first
+  message: `handleSendDraft` (`sessions/session-detail.tsx`) writes Session meta
+  plus the first user turn together via `startSession` and only then promotes
+  the draft tab; `requestSessionDispatch` is acceleration on top of the durable
+  pointer. Never reintroduce a create-then-hand-off flow (pending-turn refs,
+  post-mount ref flushes): a promoted tab must not exist before its first
+  message is locally durable, and preserved composer text crosses the promotion
+  via the input draft cache, not a component ref. `archiveSession` falls back to
+  the rendered meta cache when the repo read lags hydration (a session the UI
+  can show must be closable), and a close failure surfaces a toast — never a
+  silent no-op.
 - Sidebar: `loro-sidebar.tsx`, `loro-app-sidebar.tsx`, and
   `sessions/session-list-rows.ts`. Sidebar rows are sessions, not Tasks.
   EVERY desktop session row is a drag source for a session mention

--- a/packages/components/src/components/sessions/draft-session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/draft-session-chat-interface.tsx
@@ -16,8 +16,10 @@ import type {
   SessionId,
   SessionMeta,
   SessionInputBlock,
+  SessionTurnInputConfig,
 } from '@lody/shared';
 import {
+  buildSessionTurnInputConfig,
   extractPromptPreviewFromInputBlocks,
   getMachineFlockLocalProjects,
   resolveSessionConversationConfig,
@@ -25,6 +27,12 @@ import {
 
 import { getAllAgentConfigAtom } from '@/atoms';
 import { docMetaCacheReadyAtom } from '@/atoms/doc-meta';
+import { tasksFeatureEnabledAtom } from '@/atoms/settings';
+import {
+  extractIssuePRMentionsFromText,
+  useKnownIssuePrItems,
+} from '@/components/mentions/issue-pr-hash-mention';
+import { useSessionMcpSelection } from '@/hooks/use-session-mcp-selection';
 import { canShowSubscriptionRateLimits } from '@/lib/session-usage';
 import { canShowCodexResetForecast } from '@/lib/codex-reset-forecast';
 import { useResolvedTheme } from '../../theme-provider';
@@ -63,7 +71,6 @@ const areConfigOptionValuesEqual = (
 export type DraftSessionSendPayload = {
   draftId: DraftSessionTab['id'];
   sessionId: SessionId;
-  prompt: string;
   inputBlocks: SessionInputBlock[];
   preservedInputText?: string;
   agentConfigId?: DraftSessionTab['agentConfigId'];
@@ -73,10 +80,15 @@ export type DraftSessionSendPayload = {
   customAcp?: CustomAcpLaunchSpec;
   /** Runtime binary override resolved from the selected builtin agent config. */
   runtimeOverrides?: BuiltinRuntimeOverrides;
-  modeId: string | null;
-  modelId: string | null;
-  configOptionValues?: Record<string, AcpConfigOptionValue>;
+  /** Analytics-only; the dispatched values live in `inputConfig`. */
   configOptionSelectors?: AcpConfigOptionSelector[];
+  /**
+   * Complete first-turn input config, built by the composer that owns the
+   * selections. The parent accepts the session with this turn as one unit
+   * (`startSession`), so prompt/mode/model/config values must be read from
+   * here, never carried or reconstructed separately.
+   */
+  inputConfig: SessionTurnInputConfig;
 };
 
 export interface DraftSessionChatInterfaceProps {
@@ -89,8 +101,6 @@ export interface DraftSessionChatInterfaceProps {
 }
 
 export type DraftSessionChatInterfaceHandle = {
-  sendQuickMessage: (prompt: string) => void;
-  setInputText: (text: string) => void;
   focusInput: () => void;
   addCommentReference: (reference: CommentReferencePayload) => boolean;
   insertSessionMention: (sessionId: string) => boolean;
@@ -148,6 +158,12 @@ export const DraftSessionChatInterface = memo(
       );
       const agentConfigs = useAtomValue(getAllAgentConfigAtom);
       const docMetaCacheReady = useAtomValue(docMetaCacheReadyAtom);
+      const tasksFeatureEnabled = useAtomValue(tasksFeatureEnabledAtom);
+      // The draft composer has no MCP picker yet, so the first turn carries the
+      // workspace default selection — the same set the promoted child composer
+      // resolves for an empty session doc.
+      const mcpSelection = useSessionMcpSelection(undefined, {});
+      const { knownItems: knownIssuePrItems } = useKnownIssuePrItems(parentSession.repoFullName);
       const { doc: parentSessionDoc, ready: parentSessionDocReady } = useSessionDoc(
         parentSession.id
       );
@@ -326,22 +342,42 @@ export const DraftSessionChatInterface = memo(
         (
           inputBlocks: SessionInputBlock[],
           preservedInputText?: string
-        ): DraftSessionSendPayload => ({
-          draftId: draft.id,
-          sessionId: draft.sessionId,
-          prompt: extractPromptPreviewFromInputBlocks(inputBlocks),
-          inputBlocks,
-          preservedInputText,
-          agentConfigId: draft.agentConfigId,
-          cliType: draft.cliType,
-          agentType: draft.agentType,
-          customAcp: sessionAgentConfig?.customAcp,
-          runtimeOverrides: sessionAgentConfig?.runtimeOverrides,
-          modeId: selectedModeId,
-          modelId: selectedModelId,
-          configOptionValues: dispatchConfigOptionValues,
-          configOptionSelectors,
-        }),
+        ): DraftSessionSendPayload => {
+          const prompt = extractPromptPreviewFromInputBlocks(inputBlocks);
+          return {
+            draftId: draft.id,
+            sessionId: draft.sessionId,
+            inputBlocks,
+            preservedInputText,
+            agentConfigId: draft.agentConfigId,
+            cliType: draft.cliType,
+            agentType: draft.agentType,
+            customAcp: sessionAgentConfig?.customAcp,
+            runtimeOverrides: sessionAgentConfig?.runtimeOverrides,
+            configOptionSelectors,
+            // Unlike chat-landing's first turn, the prompt deliberately has no
+            // agent-config prompt prefix: a child tab continues the parent's
+            // running context, matching what the promoted composer would send.
+            inputConfig: buildSessionTurnInputConfig({
+              inputBlocks,
+              prompt,
+              cliType: draft.cliType,
+              agentType: draft.agentType,
+              modeId: selectedModeId,
+              modelId: selectedModelId,
+              configOptionValues: dispatchConfigOptionValues,
+              issuePRMentions: prompt
+                ? extractIssuePRMentionsFromText(
+                    prompt,
+                    knownIssuePrItems,
+                    parentSession.repoFullName
+                  )
+                : undefined,
+              mcpServerIds: mcpSelection.selectedIds,
+              taskToolsEnabled: tasksFeatureEnabled,
+            }),
+          };
+        },
         [
           configOptionSelectors,
           draft.agentConfigId,
@@ -352,8 +388,12 @@ export const DraftSessionChatInterface = memo(
           draft.id,
           draft.sessionId,
           dispatchConfigOptionValues,
+          knownIssuePrItems,
+          mcpSelection.selectedIds,
+          parentSession.repoFullName,
           selectedModeId,
           selectedModelId,
+          tasksFeatureEnabled,
         ]
       );
 
@@ -387,17 +427,6 @@ export const DraftSessionChatInterface = memo(
       useImperativeHandle(
         ref,
         () => ({
-          sendQuickMessage: (prompt: string) => {
-            void onSendDraft(
-              buildSendPayload(
-                [{ type: 'text', text: prompt }],
-                draft.prompt.trim().length > 0 ? draft.prompt : undefined
-              )
-            );
-          },
-          setInputText: (text: string) => {
-            inputAreaRef.current?.setInputText(text);
-          },
           focusInput: () => {
             inputAreaRef.current?.focusInput();
           },
@@ -408,7 +437,7 @@ export const DraftSessionChatInterface = memo(
             return inputAreaRef.current?.insertSessionMention(sessionId) ?? false;
           },
         }),
-        [buildSendPayload, draft.prompt, onSendDraft]
+        []
       );
 
       return (

--- a/packages/components/src/components/sessions/draft-session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/draft-session-chat-interface.tsx
@@ -38,7 +38,10 @@ import { canShowCodexResetForecast } from '@/lib/codex-reset-forecast';
 import { useResolvedTheme } from '../../theme-provider';
 import { SessionChatInputArea, type SessionChatInputAreaHandle } from './session-chat-input-area';
 import { useSessionAcpSelectorContext } from '@/hooks/use-session-acp-selector-context';
-import { resolveSessionLocalProjectRootPath } from '@/lib/session-local-file-source';
+import {
+  resolveSessionLocalProjectRootPath,
+  resolveSessionRepoFullName,
+} from '@/lib/session-local-file-source';
 import type { AgentSelection } from '@/components/shared/agent-selector';
 import type { DraftSessionTab } from '@/lib/session-draft-tabs';
 import { agentDefaultsCache } from '@/lib/local-storage-cache';
@@ -163,7 +166,12 @@ export const DraftSessionChatInterface = memo(
       // workspace default selection — the same set the promoted child composer
       // resolves for an empty session doc.
       const mcpSelection = useSessionMcpSelection(undefined, {});
-      const { knownItems: knownIssuePrItems } = useKnownIssuePrItems(parentSession.repoFullName);
+      // Same resolution the composer uses: a local project may carry its repo
+      // only in project.githubRepoFullName, not in repoFullName.
+      const parentRepoFullName = resolveSessionRepoFullName(parentSession);
+      const { knownItems: knownIssuePrItems } = useKnownIssuePrItems(
+        parentRepoFullName || undefined
+      );
       const { doc: parentSessionDoc, ready: parentSessionDocReady } = useSessionDoc(
         parentSession.id
       );
@@ -370,7 +378,7 @@ export const DraftSessionChatInterface = memo(
                 ? extractIssuePRMentionsFromText(
                     prompt,
                     knownIssuePrItems,
-                    parentSession.repoFullName
+                    parentRepoFullName || undefined
                   )
                 : undefined,
               mcpServerIds: mcpSelection.selectedIds,
@@ -390,7 +398,7 @@ export const DraftSessionChatInterface = memo(
           dispatchConfigOptionValues,
           knownIssuePrItems,
           mcpSelection.selectedIds,
-          parentSession.repoFullName,
+          parentRepoFullName,
           selectedModeId,
           selectedModelId,
           tasksFeatureEnabled,

--- a/packages/components/src/components/sessions/session-chat-input-area.tsx
+++ b/packages/components/src/components/sessions/session-chat-input-area.tsx
@@ -279,6 +279,19 @@ const revokeImagePreviewUrls = (images: readonly Pick<PendingImage, 'previewUrl'
   }
 };
 
+/**
+ * Seed the composer text draft for a session that has not mounted yet. The
+ * composer hydrates from this cache on mount, so callers can hand text across
+ * a tab promotion without holding a ref to the future component.
+ */
+export const setSessionChatInputTextDraft = (sessionId: SessionId, text: string): void => {
+  if (text) {
+    sessionDraftsCache.set(sessionId, text);
+  } else {
+    sessionDraftsCache.delete(sessionId);
+  }
+};
+
 export const clearSessionChatInputDrafts = (sessionId: SessionId): void => {
   const images = getSessionImageDrafts(sessionId);
   const files = getSessionFileDrafts(sessionId);
@@ -777,11 +790,7 @@ export const SessionChatInputArea = memo(
       (value: string) => {
         setUserInputState(value);
         onInputValueChange?.(value);
-        if (value) {
-          sessionDraftsCache.set(session.id, value);
-        } else {
-          sessionDraftsCache.delete(session.id);
-        }
+        setSessionChatInputTextDraft(session.id, value);
       },
       [onInputValueChange, session.id]
     );

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -1819,17 +1819,11 @@ function SpinningLoaderIcon({ className }: { className?: string }) {
 const EMPTY_CHAT_STREAM_EMPTY_STATE = <></>;
 
 export type SessionChatInterfaceHandle = {
-  sendQuickMessage: (prompt: string) => void;
-  setInputText: (text: string) => void;
   focusInput: () => void;
   addCommentReference: (reference: CommentReferencePayload) => boolean;
   toggleCommentReference: (reference: CommentReferencePayload) => boolean;
   addVisualAnnotationReference: (reference: VisualAnnotationReferencePayload) => boolean;
   toggleVisualAnnotationReference: (reference: VisualAnnotationReferencePayload) => boolean;
-  dispatchInputBlocks: (
-    inputBlocks: SessionInputBlock[],
-    options?: DispatchInputBlocksOptions
-  ) => Promise<boolean>;
   copyConversationHistory: () => Promise<void>;
   openSearch: () => void;
   getLastAssistantTurnId: () => string | null;
@@ -4604,12 +4598,6 @@ export const SessionChatInterface = memo(
     useImperativeHandle(
       ref,
       () => ({
-        sendQuickMessage: (prompt: string) => {
-          void dispatchPrompt(prompt);
-        },
-        setInputText: (text: string) => {
-          inputAreaRef.current?.setInputText(text);
-        },
         focusInput: () => {
           inputAreaRef.current?.focusInput();
         },
@@ -4625,7 +4613,6 @@ export const SessionChatInterface = memo(
         toggleVisualAnnotationReference: (reference) => {
           return inputAreaRef.current?.toggleVisualAnnotationReference(reference) ?? false;
         },
-        dispatchInputBlocks,
         copyConversationHistory: handleCopyConversationHistory,
         openSearch,
         getLastAssistantTurnId: () => lastCompletedAssistantMessageId,
@@ -4633,13 +4620,7 @@ export const SessionChatInterface = memo(
           return inputAreaRef.current?.insertSessionMention(sessionId) ?? false;
         },
       }),
-      [
-        dispatchInputBlocks,
-        dispatchPrompt,
-        handleCopyConversationHistory,
-        lastCompletedAssistantMessageId,
-        openSearch,
-      ]
+      [handleCopyConversationHistory, lastCompletedAssistantMessageId, openSearch]
     );
 
     const [prevSessionIdForActionReset, setPrevSessionIdForActionReset] = useState(session.id);

--- a/packages/components/src/components/sessions/session-detail.tsx
+++ b/packages/components/src/components/sessions/session-detail.tsx
@@ -1661,6 +1661,7 @@ const SessionDetail = ({
   const {
     startSession,
     requestSessionDispatch,
+    touchSessionActivity,
     updateSessionTitle,
     archiveSession,
     restoreSession,
@@ -1957,6 +1958,12 @@ const SessionDetail = ({
           },
           pendingHistoryEntry
         );
+        // Marks the first message read for the sender and bubbles activity to
+        // the parent session, matching the ordinary send path. The child's own
+        // lastMessageAt is already durable inside the startSession accept unit.
+        touchSessionActivity(childSessionId).catch((err: unknown) => {
+          console.warn('Failed to update child session activity after start', err);
+        });
         persistAgentSessionDefaults(payload.agentConfigId, {
           modeId: payload.inputConfig.modeId,
           modelId: payload.inputConfig.modelId,
@@ -2094,6 +2101,7 @@ const SessionDetail = ({
       setDraftTabs,
       startSession,
       t,
+      touchSessionActivity,
       user,
     ]
   );

--- a/packages/components/src/components/sessions/session-detail.tsx
+++ b/packages/components/src/components/sessions/session-detail.tsx
@@ -27,6 +27,7 @@ import { Button } from '@/ui/button';
 import { useRouter } from '@tanstack/react-router';
 import { usePostHog } from '@posthog/react';
 import {
+  buildPendingUserHistoryEntry,
   getAcpCapabilityCacheKey,
   getProjectRefBranch,
   getServerNow,
@@ -35,7 +36,6 @@ import {
   getAcpCapabilityCacheEntryAuthority,
   resolveProjectGitHubRepo,
   SessionForkOperationSchema,
-  type AcpConfigOptionValue,
   type CommentReferencePayload,
   type LocalProjectHistoryProvider,
   type LocalProjectId,
@@ -43,7 +43,6 @@ import {
   type PrStatus,
   type ProjectRef,
   type SessionId,
-  type SessionInputBlock,
   type SessionMeta,
   type VisualAnnotationReferencePayload,
   type WorkspaceId,
@@ -58,7 +57,10 @@ import {
   type SessionForkDestination,
   type SessionForkWorktreeAvailability,
 } from '@/components/sessions/session-fork-destination-menu';
-import { clearSessionChatInputDrafts } from '@/components/sessions/session-chat-input-area';
+import {
+  clearSessionChatInputDrafts,
+  setSessionChatInputTextDraft,
+} from '@/components/sessions/session-chat-input-area';
 import {
   RenameSessionDialog,
   type RenameSessionDialogTarget,
@@ -688,19 +690,6 @@ const SessionDetail = ({
   const visualAnnotationReferenceChangeHandlersRef = useRef<
     Map<string, (references: VisualAnnotationReferencePayload[]) => void>
   >(new Map());
-  const pendingInitialTurnRef = useRef<
-    Map<
-      SessionId,
-      {
-        inputBlocks?: SessionInputBlock[];
-        prompt?: string;
-        restoredInputText?: string;
-        modeId?: string | null;
-        modelId?: string | null;
-        configOptionValues?: Record<string, AcpConfigOptionValue>;
-      }
-    >
-  >(new Map());
   const sendingDraftIdsRef = useRef<Set<DraftSessionTab['id']>>(new Set());
   const desktopTabFocusRegionRef = useRef<SessionTabFocusRegion>('conversation');
   const initialTabState = getSessionDetailInitialTabState(sessionId, urlTab);
@@ -931,7 +920,6 @@ const SessionDetail = ({
   if (localStateSessionId !== sessionId) {
     const nextInitialTabState = getSessionDetailInitialTabState(sessionId, urlTab);
     detailLoadStartMsRef.current = getPerformanceNowMs();
-    pendingInitialTurnRef.current.clear();
     sendingDraftIdsRef.current.clear();
     desktopTabFocusRegionRef.current = 'conversation';
     restoredPrSidebarRef.current = null;
@@ -973,7 +961,7 @@ const SessionDetail = ({
     []
   );
 
-  // Child meta can appear before createSession() or fork RPC resolves. Hide a
+  // Child meta can appear before startSession() or fork RPC resolves. Hide a
   // requesting target until its RPC succeeds. Once acknowledged, mount the
   // child tab in the background and keep its source button loading until the
   // child conversation surface has durable history ready to paint.
@@ -1671,7 +1659,8 @@ const SessionDetail = ({
   );
   // Multi-tab: create a new child session
   const {
-    createSession,
+    startSession,
+    requestSessionDispatch,
     updateSessionTitle,
     archiveSession,
     restoreSession,
@@ -1696,66 +1685,11 @@ const SessionDetail = ({
     },
     [t, transferSessionOwner, workspaceMembers]
   );
-  const flushPendingInitialTurn = useCallback((tabSessionId: SessionId) => {
-    const pendingTurn = pendingInitialTurnRef.current.get(tabSessionId);
-    if (!pendingTurn) {
-      return;
-    }
-    const ref = chatRefsMap.current.get(tabSessionId);
-    if (!ref) {
-      return;
-    }
-    pendingInitialTurnRef.current.delete(tabSessionId);
-    const dispatchPendingTurn = (
-      targetRef: SessionChatInterfaceHandle | DraftSessionChatInterfaceHandle
-    ) => {
-      if ('dispatchInputBlocks' in targetRef) {
-        const inputBlocks =
-          pendingTurn.inputBlocks ??
-          (pendingTurn.prompt ? [{ type: 'text' as const, text: pendingTurn.prompt }] : []);
-        if (inputBlocks.length > 0) {
-          void targetRef.dispatchInputBlocks(inputBlocks, {
-            modeIdOverride: pendingTurn.modeId,
-            modelIdOverride: pendingTurn.modelId,
-            configOptionValuesOverride: pendingTurn.configOptionValues,
-          });
-          return;
-        }
-      }
-      if (pendingTurn.prompt) {
-        targetRef.sendQuickMessage(pendingTurn.prompt);
-      }
-    };
-    if (typeof window === 'undefined') {
-      dispatchPendingTurn(ref);
-      if (pendingTurn.restoredInputText) {
-        ref.setInputText(pendingTurn.restoredInputText);
-      }
-      return;
-    }
-    window.requestAnimationFrame(() => {
-      const mountedRef = chatRefsMap.current.get(tabSessionId);
-      if (!mountedRef) {
-        return;
-      }
-      dispatchPendingTurn(mountedRef);
-      if (pendingTurn.restoredInputText) {
-        const restoredInputText = pendingTurn.restoredInputText;
-        window.requestAnimationFrame(() => {
-          chatRefsMap.current.get(tabSessionId)?.setInputText(restoredInputText);
-        });
-      }
-    });
-  }, []);
-
   const setChatTabRef = useCallback(
     (tabId: string, ref: SessionChatInterfaceHandle | DraftSessionChatInterfaceHandle | null) => {
       chatRefsMap.current.set(tabId, ref);
-      if (ref && !isDraftSessionTabId(tabId)) {
-        flushPendingInitialTurn(tabId as SessionId);
-      }
     },
-    [flushPendingInitialTurn]
+    []
   );
 
   const handleInsertDroppedSessionMention = useCallback(
@@ -1962,17 +1896,18 @@ const SessionDetail = ({
       sendingDraftIdsRef.current.add(payload.draftId);
       const startedAtMs = getPerformanceNowMs();
       const imageCount = payload.inputBlocks.filter((block) => block.type === 'image').length;
+      const prompt = payload.inputConfig.prompt ?? '';
       const acpAnalyticsProperties = buildSessionCreateAcpAnalyticsProperties({
         cliType: payload.cliType,
         agentType: payload.agentType,
-        modeId: payload.modeId,
-        modelId: payload.modelId,
-        configOptionValues: payload.configOptionValues,
+        modeId: payload.inputConfig.modeId,
+        modelId: payload.inputConfig.modelId,
+        configOptionValues: payload.inputConfig.configOptionValues,
         configOptionSelectors: payload.configOptionSelectors,
       });
       captureSessionDetailEvent('session/tab_draft_send_requested', {
         draft_tab_id: payload.draftId,
-        prompt_length: payload.prompt.length,
+        prompt_length: prompt.length,
         has_preserved_input: Boolean(payload.preservedInputText?.trim()),
         cli_type: payload.cliType,
         agent_type: payload.agentType,
@@ -1982,32 +1917,50 @@ const SessionDetail = ({
       });
       const childSessionId = payload.sessionId;
       try {
-        const draftTitle = getDraftTabLabel({ prompt: payload.prompt }, '').trim();
+        const draftTitle = getDraftTabLabel({ prompt }, '').trim();
+        const pendingHistoryEntry = buildPendingUserHistoryEntry({
+          userId: user.id,
+          inputBlocks: payload.inputBlocks,
+          timestamp: new Date().toISOString(),
+          inputConfig: payload.inputConfig,
+        });
+        if (!pendingHistoryEntry) {
+          toast.error(t('sessions.sendError'));
+          return false;
+        }
         setPendingDraftChildSessionIds((prev) => ({
           ...prev,
           [payload.draftId]: childSessionId,
         }));
 
-        await createSession({
-          sessionId: childSessionId,
-          machineId: activeSession.machineId,
-          userId: user.id,
-          cliType: payload.cliType,
-          agentType: payload.agentType,
-          agentConfigId: payload.agentConfigId,
-          customAcp: payload.customAcp,
-          runtimeOverrides: payload.runtimeOverrides,
-          project: activeSession.project,
-          repoFullName: activeSession.repoFullName,
-          baseBranch: activeSession.baseBranch,
-          parentSessionId: activeSession.id,
-          title: draftTitle || undefined,
-          titleSource: draftTitle ? 'draft' : undefined,
-        });
+        // Meta and the first user turn are one accept unit: the draft is only
+        // promoted after both are durable locally, so a half-created child (a
+        // tab whose message never entered the session doc) cannot exist. The
+        // dispatch RPC below only accelerates; the durable pointer written by
+        // requestSessionDispatch remains recovery truth.
+        const { historyEntry } = await startSession(
+          {
+            sessionId: childSessionId,
+            machineId: activeSession.machineId,
+            userId: user.id,
+            cliType: payload.cliType,
+            agentType: payload.agentType,
+            agentConfigId: payload.agentConfigId,
+            customAcp: payload.customAcp,
+            runtimeOverrides: payload.runtimeOverrides,
+            project: activeSession.project,
+            repoFullName: activeSession.repoFullName,
+            baseBranch: activeSession.baseBranch,
+            parentSessionId: activeSession.id,
+            title: draftTitle || undefined,
+            titleSource: draftTitle ? 'draft' : undefined,
+          },
+          pendingHistoryEntry
+        );
         persistAgentSessionDefaults(payload.agentConfigId, {
-          modeId: payload.modeId,
-          modelId: payload.modelId,
-          configOptionValues: payload.configOptionValues,
+          modeId: payload.inputConfig.modeId,
+          modelId: payload.inputConfig.modelId,
+          configOptionValues: payload.inputConfig.configOptionValues,
         });
 
         captureSessionDetailEvent(SESSION_ACP_CONFIG_USED_EVENT, {
@@ -2022,24 +1975,14 @@ const SessionDetail = ({
           entrypoint: 'session_child_tab',
         });
 
-        const pendingTurn = {
-          inputBlocks: payload.inputBlocks.length > 0 ? payload.inputBlocks : undefined,
-          prompt: payload.prompt.trim() ? payload.prompt : undefined,
-          restoredInputText: payload.preservedInputText?.trim()
-            ? payload.preservedInputText
-            : undefined,
-          modeId: payload.modeId,
-          modelId: payload.modelId,
-          configOptionValues: payload.configOptionValues,
-        };
-        if (pendingTurn.inputBlocks || pendingTurn.prompt || pendingTurn.restoredInputText) {
-          pendingInitialTurnRef.current.set(childSessionId, pendingTurn);
-        }
-
         // Draft tabs reuse the future child session id. Clear input caches before promotion;
         // waiting for the old draft input to clear lets the newly mounted child input hydrate
-        // from stale text/image drafts.
+        // from stale text/image drafts. Preserved text is handed over through the
+        // same cache the promoted composer hydrates from on mount.
         clearSessionChatInputDrafts(childSessionId);
+        if (payload.preservedInputText?.trim()) {
+          setSessionChatInputTextDraft(childSessionId, payload.preservedInputText);
+        }
         setDraftTabs((prev) => prev.filter((draft) => draft.id !== payload.draftId));
         setPendingDraftChildSessionIds((prev) => {
           const { [payload.draftId]: _removed, ...rest } = prev;
@@ -2050,15 +1993,23 @@ const SessionDetail = ({
           setActiveViewerTabId(null);
         }
         setActiveTabSessionId(childSessionId);
-        flushPendingInitialTurn(childSessionId);
+        void requestSessionDispatch(childSessionId, historyEntry.id, {
+          inputConfig: payload.inputConfig,
+          machineId: activeSession.machineId,
+        }).catch((dispatchError: unknown) => {
+          // The turn is already durable; the watcher retries once the machine
+          // syncs. Surface the failure instead of looking stuck silently.
+          console.error('Failed to request child session dispatch', dispatchError);
+          toast.error(t('sessions.sendError'));
+        });
         captureSessionDetailEvent('session/tab_child_created', {
           draft_tab_id: payload.draftId,
           child_session_id: childSessionId,
           duration_ms: getDurationSinceMs(startedAtMs),
-          prompt_length: payload.prompt.length,
-          has_initial_prompt: Boolean(pendingTurn.prompt),
+          prompt_length: prompt.length,
+          has_initial_prompt: Boolean(prompt.trim()),
           image_count: imageCount,
-          has_restored_input: Boolean(pendingTurn.restoredInputText),
+          has_restored_input: Boolean(payload.preservedInputText?.trim()),
           cli_type: payload.cliType,
           agent_type: payload.agentType,
           agent_config_id: payload.agentConfigId ?? null,
@@ -2135,13 +2086,13 @@ const SessionDetail = ({
     [
       activeSession,
       captureSessionDetailEvent,
-      createSession,
       deleteSessions,
-      flushPendingInitialTurn,
       hidesBillingUi,
       isMobile,
       openSettings,
+      requestSessionDispatch,
       setDraftTabs,
+      startSession,
       t,
       user,
     ]
@@ -2165,21 +2116,34 @@ const SessionDetail = ({
         tab_session_id: tabSessionId,
         is_active_tab: tabSessionId === activeTabSessionId,
       });
-      // Switch to parent tab if closing the active tab
-      if (tabSessionId === activeTabSessionId) {
-        setActiveTabSessionId(sessionId);
-      }
       // If the tab has never had a message, just delete it instead of archiving
       const tabMeta = childSessions.find((s) => s.id === tabSessionId);
-      if (tabMeta && !tabMeta.lastMessageAt) {
-        await deleteSessions([tabSessionId]);
-        captureSessionDetailEvent('session/tab_deleted_empty', {
+      try {
+        if (tabMeta && !tabMeta.lastMessageAt) {
+          await deleteSessions([tabSessionId]);
+          captureSessionDetailEvent('session/tab_deleted_empty', {
+            tab_session_id: tabSessionId,
+          });
+        } else {
+          await archiveSession(tabSessionId);
+          captureSessionDetailEvent('session/tab_archived', {
+            tab_session_id: tabSessionId,
+          });
+        }
+        // Switch to the parent tab only once the close is durable; a failed
+        // close keeps the tab selected instead of yanking the user off it.
+        if (tabSessionId === activeTabSessionId) {
+          setActiveTabSessionId(sessionId);
+        }
+      } catch (error) {
+        // A silent failure reads as "the close button does nothing" — surface
+        // it and leave the tab where it was.
+        console.error('Failed to close session tab', { tabSessionId, error });
+        toast.error(t('sessions.tabCloseFailed', 'Could not close this tab'));
+        captureSessionDetailEvent('session/tab_close_failed', {
           tab_session_id: tabSessionId,
-        });
-      } else {
-        await archiveSession(tabSessionId);
-        captureSessionDetailEvent('session/tab_archived', {
-          tab_session_id: tabSessionId,
+          error_name: error instanceof Error ? error.name : typeof error,
+          error_message: error instanceof Error ? error.message : String(error),
         });
       }
     },
@@ -2191,6 +2155,7 @@ const SessionDetail = ({
       closeDraftTab,
       deleteSessions,
       sessionId,
+      t,
     ]
   );
 

--- a/packages/components/src/hooks/use-session-actions.ts
+++ b/packages/components/src/hooks/use-session-actions.ts
@@ -640,6 +640,12 @@ export function useSessionActions(): SessionActions {
         throw new Error('Runtime not ready');
       }
       const { sessionId, sessionMeta } = buildSessionCreateResult(payload);
+      // The accept unit includes the first user message, so the meta it
+      // publishes already carries that activity. Written here, not by a
+      // follow-up touch: a close between acceptance and the first turn must
+      // never make the session look empty (empty tabs are deleted, not
+      // archived).
+      sessionMeta.lastMessageAt = getServerNow();
       const sessionRoomId = getSessionRoomId(sessionId);
       const historyEntry = { ...history, id: uuidv4() } as SessionHistory;
       const inputConfig = normalizeSessionTurnInputConfig(historyEntry.inputConfig);

--- a/packages/components/src/hooks/use-session-actions.ts
+++ b/packages/components/src/hooks/use-session-actions.ts
@@ -1179,9 +1179,15 @@ export function useSessionActions(): SessionActions {
       }
 
       const sessionRoomId = getSessionRoomId(sessionId);
-      const sessionMeta = (await runtime.repo.getDocMeta(sessionRoomId))?.meta as
+      const repoMeta = (await runtime.repo.getDocMeta(sessionRoomId))?.meta as
         | SessionMeta
         | undefined;
+      // The repo read is preferred (freshest lifecycle fields), but it can lag
+      // a session the UI already renders. The archive write below is an
+      // idempotent patch, so the rendered meta cache is enough to proceed — a
+      // session the UI can show must also be closable.
+      const sessionMeta =
+        repoMeta ?? (store.get(sessionMetaCacheAtom)[sessionRoomId] as SessionMeta | undefined);
       if (!sessionMeta) {
         throw new Error(`Session metadata missing for ${sessionId}`);
       }
@@ -1230,7 +1236,7 @@ export function useSessionActions(): SessionActions {
         lifecycleSessionIds: lifecycleSessions.map((session) => session.id),
       });
     },
-    [runtime, getSessionLifecycleMetas]
+    [runtime, store, getSessionLifecycleMetas]
   );
 
   const restoreSession = useCallback(

--- a/packages/components/src/hooks/use-session-mcp-selection.ts
+++ b/packages/components/src/hooks/use-session-mcp-selection.ts
@@ -28,7 +28,11 @@ export function useSessionMcpSelection(
     setOverride(undefined);
   }, [persistedKey]);
 
-  const baseSelection = override ?? persistedIds ?? getDefaultSelectedMcpServerIds(servers);
+  // Memoized so a caller with no persisted ids (a fresh draft/landing composer)
+  // gets an identity-stable selection; a fresh array here would invalidate
+  // every send-payload/menu memo built on `selectedIds` each render.
+  const defaultSelectedIds = useMemo(() => getDefaultSelectedMcpServerIds(servers), [servers]);
+  const baseSelection = override ?? persistedIds ?? defaultSelectedIds;
   const selectedIds = useMemo(() => {
     // An empty catalog is authoritative only after the first remote sync. Until
     // then, preserve persisted ids so a fast send cannot erase a session's MCP

--- a/packages/components/tests/use-session-actions.test.ts
+++ b/packages/components/tests/use-session-actions.test.ts
@@ -719,7 +719,14 @@ describe('useSessionActions', () => {
     expect(startSession).toHaveBeenCalledOnce();
     expect(startSession).toHaveBeenCalledWith(
       sessionId,
-      expect.objectContaining({ id: sessionId, machineId: 'machine-1' }),
+      // lastMessageAt rides the accept unit itself: the meta always carries
+      // the first message's activity, so a close racing the first turn can
+      // never mistake the session for an empty, deletable one.
+      expect.objectContaining({
+        id: sessionId,
+        machineId: 'machine-1',
+        lastMessageAt: expect.any(Number),
+      }),
       expect.objectContaining({ id: result.historyEntry.id, role: 'user' }),
       expect.objectContaining({ userTurnId: result.historyEntry.id })
     );

--- a/packages/components/tests/use-session-actions.test.ts
+++ b/packages/components/tests/use-session-actions.test.ts
@@ -1006,6 +1006,39 @@ describe('useSessionActions', () => {
     );
   });
 
+  it('archives from the rendered meta cache when repo meta has not hydrated', async () => {
+    const sessionId = 'session-archive-known-meta' as SessionId;
+    const renderedMeta = {
+      id: sessionId,
+      machineId: 'machine-1',
+      userId: 'user-1',
+      cliType: 'builtin',
+      createdAt: new Date().toISOString(),
+      parentSessionId: 'parent-session-1' as SessionId,
+    } as SessionMeta;
+    const upsertDocMeta = vi.fn(async () => undefined);
+    // The repo cannot read the doc meta yet (child session still hydrating).
+    const getDocMeta = vi.fn(async () => undefined);
+    const runtime = createRuntime({
+      repo: { getDocMeta, upsertDocMeta } as unknown as WorkspaceRuntime['repo'],
+    });
+    const actions = await renderActions(runtime, {
+      sessionMetaCache: { [getSessionRoomId(sessionId)]: renderedMeta },
+    });
+
+    await actions.archiveSession(sessionId);
+
+    expect(upsertDocMeta).toHaveBeenCalledWith(
+      getSessionRoomId(sessionId),
+      expect.objectContaining({ isArchived: true })
+    );
+
+    // A session neither the repo nor the UI knows still fails loudly.
+    await expect(actions.archiveSession('session-unknown-meta' as SessionId)).rejects.toThrow(
+      'Session metadata missing'
+    );
+  });
+
   it('archives child tabs and independently opened session workspaces together', async () => {
     const rootSession = {
       id: 'archive-root' as SessionId,


### PR DESCRIPTION
## Related issue

https://github.com/LodyAI/Lody/issues/142

## Problem / pressure

v0.88.0 regressed child-tab creation: the first send in a new draft tab produced a "half-created" session — the tab appeared but its message was silently dropped, the tab hung on "syncing" (daemon `outcome=no-meta`), a second click was needed to actually send, and closing the tab did nothing. The root cause is a create-then-hand-off flow: `handleSendDraft` wrote session meta first, promoted the tab, and handed the first message to the *future* composer via `pendingInitialTurnRef` + a `requestAnimationFrame` ref flush that deletes the pending turn before verifying the ref is mounted, so a mount-timing shift (React 19 + the Electron IPC rewrite) permanently drops it. On the CLI side, a dispatch RPC arriving before the session meta synced was treated as "not owned" and its stashed payload deleted.

## Summary

- **Renderer**: `handleSendDraft` now writes session meta and the first user turn as one durable accept unit (`startSession`, the same path chat-landing and task runs already use) *before* promoting the draft tab, then fires `requestSessionDispatch` as acceleration over the durable `latestUserMsgId` pointer. The ref/rAF handoff machinery and its now-dead handle methods (`sendQuickMessage`, `setInputText`, handle-level `dispatchInputBlocks`) are removed; preserved composer text crosses the promotion via the input draft cache.
- **Composer**: the draft composer builds the complete first-turn `inputConfig` (workspace default MCP selection, task tools, issue/PR mentions) as the single source of truth in `DraftSessionSendPayload`; `useSessionMcpSelection` memoizes its default selection so callers without persisted ids keep identity-stable memos.
- **CLI**: `reconcileSessionWatch` treats absent session meta as *unknown*, not foreign — the TTL-bounded RPC stash survives until meta lands, so an RPC turn arriving before metadata sync dispatches exactly once.
- **Close path**: `archiveSession` falls back to the rendered meta cache when the repo read lags hydration, and `handleTabClose` surfaces failures with a toast (new `sessions.tabCloseFailed` locale key) instead of silently doing nothing.
- Updated `packages/components/AGENTS.md` and `apps/cli/src/session/AGENTS.md` with the new invariants.

## Before / after

| Before | After |
| ------ | ----- |
| First send in a child tab creates the tab but can drop the message; tab hangs on "syncing"; second click required | One send durably commits meta + first message, then promotes the tab; dispatch fires exactly once |
| CLI deletes the stashed dispatch RPC when session meta has not synced yet | Stash survives (TTL-bounded) until meta lands; only deleted/foreign/archived verdicts drop it |
| Closing a not-yet-hydrated child tab throws internally and looks like a dead button | Archive falls back to the rendered meta cache; failures surface a toast and keep the tab |

## Test plan

- New CLI regression test: an RPC turn stashed before meta sync survives an unknown-meta reconcile and dispatches exactly once when meta arrives (verified failing on the pre-fix code).
- New components test: archiving succeeds from the rendered meta cache when `repo.getDocMeta` cannot read yet; still fails loudly when neither source knows the session.
- Full `pnpm typecheck`, `pnpm test:ci` (all workspace packages, 392 test files), `pnpm lint`, `pnpm lint:i18n`, and the code-collab/platform/public-boundary guards pass locally.
- Not covered: an end-to-end Electron UI test of the draft-tab send flow; the accept unit and dispatch/stash behavior are covered at the hook and watcher boundaries instead.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `handleSendDraft` in `packages/components/src/components/sessions/session-detail.tsx` (ordering of durable commit vs tab promotion vs dispatch) and the `!isOwned` branch of `reconcileSessionWatch` in `apps/cli/src/session/session-dispatch-watcher.ts`.
- **Decisions to challenge:** deleting the `pendingInitialTurnRef`/handle-method hand-off instead of repairing it; keeping the RPC stash on unknown meta as a guard inside the existing cleanup block rather than a separate verdict branch; resolving archive fallback from `sessionMetaCacheAtom` inside the hook instead of a caller parameter.
- **Plausible failures / evidence gaps:** `startSession` partial failure leaves cleanup to `deleteSessions` in the catch path; preserved composer text hand-off via the input draft cache is untested end-to-end; child first turn deliberately omits the agent-config prompt prefix chat-landing adds (pinned by comment, not by test).

### Authoring context

- **User goal / directives:** fix the v0.88.0 half-created child-tab regression (dropped first message, stuck "syncing", unclosable tab) diagnosed in a prior debugging session, using the smallest architecture that removes the race rather than patching symptoms.
- **Constraints / non-goals:** no new sync mechanism, queue, or remote ACK; UI waits only on local durable commits per the repo's CRDT contract; the local-transport join/ack retry gap identified during diagnosis is out of scope.
- **Risk-bearing decisions:** child tabs now share the `startSession` accept unit with chat-landing; the CLI retains RPC payloads (TTL-bounded) for sessions whose meta has not synced; `archiveSession` proceeds from the rendered meta cache when the repo read lags.
- **Destructive or irreversible behavior:** none new; the existing create-failure path still best-effort deletes the just-created session docs, and archive remains an idempotent meta patch.
- **Deliberately not done or tested:** no Electron end-to-end test of the send flow; no shared helper extracted for the composer inputConfig scaffolding (sixth copy noted in review, left to keep the diff focused); dispatch-failure toast stays per-call-site like existing callers.
- **Unknowns / confidence:** high confidence in the accept-unit ordering and stash retention (regression tests verified failing pre-fix); moderate confidence that no other consumer depended on the removed handle methods (repo-wide grep found none).

<!-- context-handoff:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
