### PR TITLE
fix: Codex goal Stop steer wedge and slash /goal continuation

### DIFF
--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -191,6 +191,7 @@ import { resolveSessionInfoBarGitHubActionIds } from './session-info-action-stat
 import {
   canPauseGoalThroughPromptBridge,
   getPromptBridgeGoalCommands,
+  GOAL_PROMPT_DISPATCH_OPTIONS,
   isSessionPromptBusy,
 } from './session-goal-control';
 import { resolveSessionMessageSubmitRoute } from './session-message-submit-route';
@@ -3995,7 +3996,7 @@ export const SessionChatInterface = memo(
         }
 
         try {
-          const accepted = await dispatchPrompt(`/goal ${command}`);
+          const accepted = await dispatchPrompt(`/goal ${command}`, GOAL_PROMPT_DISPATCH_OPTIONS);
           if (!accepted) {
             throw new Error('Goal command was not accepted for dispatch');
           }
@@ -4806,7 +4807,7 @@ export const SessionChatInterface = memo(
       }
 
       if (goalToPause) {
-        void handleGoalCommand('pause', goalToPause, { showPending: false });
+        await handleGoalCommand('pause', goalToPause, { showPending: false });
       }
     }, [
       activeAssistantTurnId,

--- a/packages/components/src/components/sessions/session-goal-control.ts
+++ b/packages/components/src/components/sessions/session-goal-control.ts
@@ -18,6 +18,14 @@ export const canPauseGoalThroughPromptBridge = (
   agentType: string | null | undefined
 ): boolean => getPromptBridgeGoalCommands(agentType).includes('pause');
 
+/**
+ * Slash `/goal …` commands must never route through steer/guide submit paths.
+ * Steer rejects slash input ("Slash commands cannot steer an active Codex turn")
+ * and Stop's `/goal pause` side-effect would wedge the session when queued
+ * message behavior is set to Steer.
+ */
+export const GOAL_PROMPT_DISPATCH_OPTIONS = { forceDirect: true as const };
+
 export type SessionPromptActivity = {
   isDispatching: boolean;
   isSessionWorking: boolean;

--- a/packages/components/tests/session-goal-control.test.ts
+++ b/packages/components/tests/session-goal-control.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   canPauseGoalThroughPromptBridge,
   getPromptBridgeGoalCommands,
+  GOAL_PROMPT_DISPATCH_OPTIONS,
   isSessionPromptBusy,
 } from '../src/components/sessions/session-goal-control';
 
@@ -46,5 +47,9 @@ describe('session goal prompt bridge', () => {
         isGoalActive: false,
       })
     ).toBe(true);
+  });
+
+  it('forces direct dispatch for slash goal commands so steer cannot reject them', () => {
+    expect(GOAL_PROMPT_DISPATCH_OPTIONS).toEqual({ forceDirect: true });
   });
 });


### PR DESCRIPTION
## Related issue

Closes #145

## Problem / pressure

Codex goal sessions can stall after slash `/goal` commands and wedge on Stop when queued message behavior is Steer. The UI shows an active goal banner but no streaming work turn, or Stop leaves slash `/goal pause` on the steer path where Codex rejects slash input (`Slash commands cannot steer an active Codex turn`).

Native Codex CLI and passthrough hosts (e.g. Orca) do not hit this: they send `/goal` to Codex directly without Lody's ACP steer router. Lody must force-direct slash goal commands and chain ACP continuation when slash setup turns complete.

## Summary

- Add `GOAL_PROMPT_DISPATCH_OPTIONS` (`forceDirect: true`) and route all goal banner/card slash commands through it so Steer cannot intercept `/goal pause|resume|clear`.
- `handleStop` awaits goal pause after cancel instead of fire-and-forget.
- Bump `packages/acp-extension-codex` for slash `/goal` continuation chaining after completed setup turns (companion PR https://github.com/LodyAI/acp-extension-codex/pull/28).

## Before / after

| Before | After |
| ------ | ----- |
| Slash `/goal set|resume` completes a setup turn with `stopReason: end_turn`; session idle while goal banner stays active | Completed setup turn chains into `Continue working toward the active goal.` within the slash prompt (matches UI `_session/goal` when no turn starts) |
| Stop + active goal sends `/goal pause` via steer; Codex rejects slash; session can wedge on "Steering" | Goal commands always use direct dispatch; Stop awaits pause after cancel |

## Test plan

- [x] `pnpm --filter @lody/components test -- --run tests/session-goal-control.test.ts`
- [x] `@lody/components` typecheck
- [x] `acp-extension-codex`: unit + integration tests for goal continuation (`CodexCommands.goal.test.ts`, updated `CodexAcpClient.test.ts`)
- [ ] Full `pnpm check` not run locally; scoped validation above passed
- [ ] Manual Codex goal + Stop with Steer enabled

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `session-goal-control.ts` (`GOAL_PROMPT_DISPATCH_OPTIONS`), `session-chat-interface.tsx` (`handleGoalCommand`, `handleStop`), and submodule bump for ACP PR #28 — verify forceDirect bypasses steer and slash continuation matches UI goal path; merge ACP PR before this one.
- **Decisions to challenge:** Interrupted slash setup turns still end without adapter continuation; confirm cancel semantics. Adapter continuation uses Lody's short prompt, not Codex's full `continuation.md` — acceptable for parity with existing UI path but not identical to native CLI.
- **Plausible failures / evidence gaps:** Possible race if Codex `on_thread_idle` and adapter continuation both start work; no end-to-end Electron test; rate-limit session kills and loadSession hangs out of scope.

### Authoring context

- **User goal / directives:** Diagnose Codex `/goal` breaking Lody workflows, cross-check against Codex CLI/Orca/t3code, implement fixes, update tests and PR/issue text before merge.
- **Constraints / non-goals:** No rate-limit UX, loadSession resume hardening, or steer UX beyond force-direct goal commands; local draft docs not in PR.
- **Risk-bearing decisions:** `forceDirect: true` for all prompt-bridge goal commands; adapter chains continuation for completed (non-interrupted) slash setup turns.
- **Destructive or irreversible behavior:** None; cancel + pause semantics unchanged except dispatch route and await ordering.
- **Deliberately not done or tested:** Full `pnpm check`, manual Steer+Stop QA, investigation of duplicate continuation with Codex idle hook.
- **Unknowns / confidence:** High on unit/integration-tested contracts; medium on manual Steer+Stop and duplicate-continuation edge cases.

<!-- context-handoff:end -->
