### PR TITLE
fix: require a machine before agent selection

### DIFF
--- a/packages/components/src/components/chat/chat-landing.tsx
+++ b/packages/components/src/components/chat/chat-landing.tsx
@@ -3398,7 +3398,7 @@ function WorkspaceChatLanding({
     [handleSelectedLocalProjectChange]
   );
   const desktopAgentMachineIds = useMemo(
-    () => (scopedMachineId ? [scopedMachineId] : undefined),
+    () => (scopedMachineId ? [scopedMachineId] : []),
     [scopedMachineId]
   );
   /* Roles offered for the machine this chat will start on. Scoped to that one
@@ -3674,6 +3674,11 @@ function WorkspaceChatLanding({
         <DesktopRunConfigMenu
           agentSelection={selectedAgent}
           allowedMachineIds={desktopAgentMachineIds}
+          disabledReason={
+            scopedMachineId
+              ? undefined
+              : t('chat.machineSelector.selectFirst', 'Select a machine first')
+          }
           fallbackAgent={{
             cliType: selectedConfig?.cliType,
             agentType: selectedConfig?.agentType,

--- a/packages/components/src/components/sessions/desktop-run-config-menu.tsx
+++ b/packages/components/src/components/sessions/desktop-run-config-menu.tsx
@@ -344,6 +344,8 @@ export type DesktopRunConfigMenuProps = {
   showAgentNameInTrigger?: boolean;
   /** Trigger copy while no agent has been selected. */
   emptyAgentLabel?: string;
+  /** Keep the whole run-config menu inert and explain why on hover/focus. */
+  disabledReason?: string;
   agentLocked?: boolean;
   fallbackAgent?: {
     cliType?: AgentConfigCliType | null;
@@ -398,6 +400,7 @@ export function DesktopRunConfigMenu({
   availableAgentConfigs,
   showAgentNameInTrigger = false,
   emptyAgentLabel,
+  disabledReason,
   agentLocked = false,
   fallbackAgent,
   onAgentConfigChange,
@@ -622,52 +625,69 @@ export function DesktopRunConfigMenu({
     fastSelector != null;
   if (!hasAnyRow) return null;
 
+  const runConfigButtonAriaLabel = t('chat.runConfig.buttonAriaLabel', 'Run configuration');
+  const triggerButton = (
+    <button
+      type="button"
+      className={cn(
+        TRIGGER_CLASS,
+        disabledReason &&
+          'cursor-default opacity-70 hover:bg-transparent hover:text-muted-foreground'
+      )}
+      aria-label={runConfigButtonAriaLabel}
+      aria-disabled={disabledReason ? true : undefined}
+    >
+      {selectedRole ? (
+        <span className="shrink-0 text-sm leading-none" aria-hidden="true">
+          {getAgentRoleEmoji(selectedRole)}
+        </span>
+      ) : selectedAgentConfig ? (
+        <AgentIcon
+          cliType={selectedAgentConfig.cliType}
+          agentType={selectedAgentConfig.agentType}
+          brandId={selectedAgentConfig.brandId}
+          env={selectedAgentConfig.env}
+          className="h-4 w-4 shrink-0"
+        />
+      ) : fallbackAgent?.cliType && fallbackAgent.agentType ? (
+        <AgentIcon
+          cliType={fallbackAgent.cliType}
+          agentType={fallbackAgent.agentType}
+          className="h-4 w-4 shrink-0"
+        />
+      ) : (
+        <Bot className="h-4 w-4 shrink-0" aria-hidden="true" />
+      )}
+      {/* A Role names itself and nothing else: it IS the whole run
+          configuration, so its values belong beside the button rather than
+          crowding the one thing there is to click. */}
+      {selectedRole ? (
+        <span className="block min-w-0 max-w-44 truncate text-left">{selectedRole.name}</span>
+      ) : (
+        <>
+          {showAgentNameInTrigger ? (
+            <span className="block min-w-0 max-w-36 truncate text-left">
+              {selectedAgentConfig?.name ?? emptyAgentLabel ?? agentLabel}
+            </span>
+          ) : null}
+          {withFaceDots(configFaceParts, showAgentNameInTrigger)}
+        </>
+      )}
+    </button>
+  );
+
   const menu = (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className={TRIGGER_CLASS}
-          aria-label={t('chat.runConfig.buttonAriaLabel', 'Run configuration')}
-        >
-          {selectedRole ? (
-            <span className="shrink-0 text-sm leading-none" aria-hidden="true">
-              {getAgentRoleEmoji(selectedRole)}
-            </span>
-          ) : selectedAgentConfig ? (
-            <AgentIcon
-              cliType={selectedAgentConfig.cliType}
-              agentType={selectedAgentConfig.agentType}
-              brandId={selectedAgentConfig.brandId}
-              env={selectedAgentConfig.env}
-              className="h-4 w-4 shrink-0"
-            />
-          ) : fallbackAgent?.cliType && fallbackAgent.agentType ? (
-            <AgentIcon
-              cliType={fallbackAgent.cliType}
-              agentType={fallbackAgent.agentType}
-              className="h-4 w-4 shrink-0"
-            />
-          ) : (
-            <Bot className="h-4 w-4 shrink-0" aria-hidden="true" />
-          )}
-          {/* A Role names itself and nothing else: it IS the whole run
-              configuration, so its values belong beside the button rather than
-              crowding the one thing there is to click. */}
-          {selectedRole ? (
-            <span className="block min-w-0 max-w-44 truncate text-left">{selectedRole.name}</span>
-          ) : (
-            <>
-              {showAgentNameInTrigger ? (
-                <span className="block min-w-0 max-w-36 truncate text-left">
-                  {selectedAgentConfig?.name ?? emptyAgentLabel ?? agentLabel}
-                </span>
-              ) : null}
-              {withFaceDots(configFaceParts, showAgentNameInTrigger)}
-            </>
-          )}
-        </button>
-      </DropdownMenuTrigger>
+      {disabledReason ? (
+        <Tooltip delayDuration={300}>
+          {/* A native disabled button cannot reliably trigger hover/focus events.
+              Keep this focusable but outside DropdownMenuTrigger so it stays inert. */}
+          <TooltipTrigger asChild>{triggerButton}</TooltipTrigger>
+          <TooltipContent side="top">{disabledReason}</TooltipContent>
+        </Tooltip>
+      ) : (
+        <DropdownMenuTrigger asChild>{triggerButton}</DropdownMenuTrigger>
+      )}
       <DropdownMenuContent align="start" className="min-w-56">
         {onRecentRunConfigSelect ? (
           <RecentRunConfigMenuGroup

--- a/packages/components/src/stories/DesktopRunConfigMenu.stories.tsx
+++ b/packages/components/src/stories/DesktopRunConfigMenu.stories.tsx
@@ -195,7 +195,13 @@ const grokSelectors: AcpConfigOptionSelector[] = [
   },
 ];
 
-function StoryShell({ isEmptyConversation }: { isEmptyConversation: boolean }) {
+function StoryShell({
+  isEmptyConversation,
+  machineSelected = true,
+}: {
+  isEmptyConversation: boolean;
+  machineSelected?: boolean;
+}) {
   const store = useMemo(() => {
     const s = createStore();
     s.set(
@@ -217,8 +223,9 @@ function StoryShell({ isEmptyConversation }: { isEmptyConversation: boolean }) {
         {/* Mimic the composer footer row the buttons live in. */}
         <div className="mb-6 flex w-full max-w-3xl items-center gap-2 rounded-xl bg-input/90 px-4 py-3">
           <DesktopRunConfigMenu
-            agentSelection={{ agentId: codexId, machineId }}
-            allowedMachineIds={[machineId]}
+            agentSelection={machineSelected ? { agentId: codexId, machineId } : null}
+            allowedMachineIds={machineSelected ? [machineId] : []}
+            disabledReason={machineSelected ? undefined : 'Select a machine first'}
             agentLocked={!isEmptyConversation}
             onAgentConfigChange={fn()}
             modelOptions={modelOptions}
@@ -376,6 +383,9 @@ type Story = StoryObj<typeof meta>;
 
 export const LockedAgent: Story = { args: { isEmptyConversation: false } };
 export const EmptyConversationAgentPickable: Story = { args: { isEmptyConversation: true } };
+export const MachineRequired: Story = {
+  args: { isEmptyConversation: true, machineSelected: false },
+};
 export const GrokInteractionAndPermission: Story = {
   args: { isEmptyConversation: false },
   render: () => <GrokConfigShell />,

--- a/packages/components/tests/composer-run-config-role-face.test.tsx
+++ b/packages/components/tests/composer-run-config-role-face.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../src/hooks/use-online-machines', () => ({ useOnlineMachines: () => []
 import { DesktopRunConfigMenu } from '../src/components/sessions/desktop-run-config-menu';
 import type { ComposerAgentRoleItem } from '../src/lib/composer-agent-roles';
 import { initI18n } from '../src/i18n';
+import { TooltipProvider } from '../src/ui/tooltip';
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -100,7 +101,13 @@ describe('DesktopRunConfigMenu role face', () => {
 
   const render = async (props: Partial<MenuProps> = {}): Promise<HTMLDivElement> => {
     await act(async () => {
-      root?.render(createElement(DesktopRunConfigMenu, { ...baseProps, ...props }));
+      root?.render(
+        createElement(
+          TooltipProvider,
+          { delayDuration: 0 },
+          createElement(DesktopRunConfigMenu, { ...baseProps, ...props })
+        )
+      );
     });
     return container as HTMLDivElement;
   };
@@ -110,6 +117,26 @@ describe('DesktopRunConfigMenu role face', () => {
     const trigger = view.querySelector('button[aria-label="Run configuration"]');
     expect(trigger?.textContent).toContain('Codex Primary');
     expect(trigger?.textContent).toContain('5.5');
+  });
+
+  it('keeps the menu closed and explains when a machine must be selected first', async () => {
+    const disabledReason = 'Select a machine first';
+    const view = await render({ disabledReason });
+    const trigger = view.querySelector<HTMLButtonElement>('button[aria-label="Run configuration"]');
+    expect(trigger?.getAttribute('aria-disabled')).toBe('true');
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, button: 0 }));
+      trigger?.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, button: 0 }));
+    });
+    expect(document.querySelector('[role="menu"]')).toBeNull();
+
+    await act(async () => {
+      trigger?.focus();
+    });
+    await vi.waitFor(() => {
+      expect(document.querySelector('[role="tooltip"]')?.textContent).toContain(disabledReason);
+    });
   });
 
   it('gives the button to the Role alone and leaves its values inert beside it', async () => {


### PR DESCRIPTION
Risk: 🟢 low | Confidence: high

## Related issue

https://github.com/LodyAI/Lody/issues/152

The repository maintainer explicitly requested and approved this focused scope and approach before implementation.

## Problem / pressure

On the desktop Chat Landing page, the Agent selector could open before a machine was selected. The fallback then exposed agents from online machines even though the execution target was still undefined.

## Summary

- Treat a missing desktop machine selection as an empty agent scope.
- Keep the Agent selector closed and visibly disabled until a machine is selected.
- Show a hover and focus tooltip that asks the user to select a machine first.
- Add a Storybook state and a behavior test for the disabled selector.

## Before / after

| Before | After |
| ------ | ----- |
| The Agent selector opened without a selected machine and could show agents from other online machines. | The selector stays closed, exposes an accessible disabled state, and explains that a machine must be selected first. |

## Test plan

- `pnpm check:affected` from the dependency-owning parent workspace: passed the full repository check after rebasing onto current `origin/main`.
- `pnpm --filter @lody/components exec vitest run tests/composer-run-config-role-face.test.tsx`: 8 tests passed.
- `pnpm --filter @lody/components test`: component suite passed.
- `pnpm --filter @lody/components typecheck`: passed.
- `git diff --check origin/main...HEAD`: passed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the disabled trigger composition in `desktop-run-config-menu.tsx` and the machine-scoped agent filtering in `chat-landing.tsx`.
- **Decisions to challenge:** Confirm that `aria-disabled` plus omission of `DropdownMenuTrigger` is the right balance between blocking the menu and preserving tooltip hover and focus behavior.
- **Plausible failures / evidence gaps:** A future refactor could accidentally wrap the disabled button with the dropdown trigger again; the interaction test should catch that regression.

### Authoring context

- **User goal / directives:** On desktop Chat Landing, prevent Agent selection before machine selection and explain the required order with a tooltip.
- **Constraints / non-goals:** Keep the change limited to desktop run configuration; do not alter machine selection, session dispatch, or mobile behavior.
- **Risk-bearing decisions:** The trigger remains focusable with `aria-disabled` so keyboard users receive the same explanation, while the dropdown trigger is absent to prevent opening.
- **Destructive or irreversible behavior:** The change only affects transient UI interaction and does not modify persisted data, schemas, or remote state.
- **Deliberately not done or tested:** No separate manual Electron smoke run was performed; Storybook coverage, focused interaction tests, typechecking, and the full repository check cover the changed boundary.
- **Unknowns / confidence:** Residual risk is limited to tooltip and dropdown composition behavior; confidence is high after the focused regression test and full validation.

<!-- context-handoff:end -->
