### PR TITLE
fix(components): stop dropping agent file links that match edited files

### DIFF
--- a/packages/components/src/components/ai-gui/markdown-renderer.tsx
+++ b/packages/components/src/components/ai-gui/markdown-renderer.tsx
@@ -665,40 +665,22 @@ type MarkdownTableProps = ComponentPropsWithoutRef<'table'> & {
   node?: unknown;
 };
 
-const normalizeAgentFilePathKey = (path: string): string =>
-  path.replace(/\\/g, '/').replace(/^\.\//, '').toLowerCase();
-
-const pathKeyMatchesCovered = (
-  path: string,
-  coveredFilePaths: ReadonlySet<string> | undefined
-): boolean => {
-  if (!coveredFilePaths || coveredFilePaths.size === 0) return false;
-  const key = normalizeAgentFilePathKey(path);
-  if (coveredFilePaths.has(key)) return true;
-  const base = key.split('/').pop();
-  return Boolean(base && coveredFilePaths.has(base));
-};
-
 const AgentFileLink = ({
   href,
   children,
   onFilePathClick,
   copyAgentFileLabel,
   openAgentFileLabel,
-  coveredFilePaths,
 }: {
   href: string;
   children: ReactNode;
   onFilePathClick?: (href: string) => void;
   copyAgentFileLabel: string;
   openAgentFileLabel: string;
-  /** Paths already shown in the turn's edited-files card — skip chip chrome. */
-  coveredFilePaths?: ReadonlySet<string>;
 }) => {
   const [didCopy, setDidCopy] = useState(false);
   const hasOpenAction = Boolean(onFilePathClick);
   const iconPath = parseMarkdownAgentFileHref(href)?.filePath ?? href;
-  const coveredByEditedFiles = pathKeyMatchesCovered(iconPath, coveredFilePaths);
 
   const handleClick = useCallback(async () => {
     if (onFilePathClick) {
@@ -712,12 +694,6 @@ const AgentFileLink = ({
     setDidCopy(true);
     window.setTimeout(() => setDidCopy(false), 1200);
   }, [href, onFilePathClick]);
-
-  /* Turn footer already lists this path with +/− stats — omit the duplicate
-     chip (common when agents end with a bare `README.md` link). */
-  if (coveredByEditedFiles) {
-    return null;
-  }
 
   return (
     <button
@@ -749,12 +725,10 @@ const createMarkdownComponents = ({
   copyAgentFileLabel,
   openAgentFileLabel,
   onAgentFileLinkClick,
-  coveredFilePaths,
 }: {
   copyAgentFileLabel: string;
   openAgentFileLabel: string;
   onAgentFileLinkClick?: (href: string) => void;
-  coveredFilePaths?: ReadonlySet<string>;
 }): Components => ({
   inlineCode: (props: MarkdownCodeProps) => {
     const { className, children, style: _style, node: _node, inline: _inline, ...rest } = props;
@@ -791,7 +765,6 @@ const createMarkdownComponents = ({
           onFilePathClick={onAgentFileLinkClick}
           copyAgentFileLabel={copyAgentFileLabel}
           openAgentFileLabel={openAgentFileLabel}
-          coveredFilePaths={coveredFilePaths}
         >
           {children}
         </AgentFileLink>
@@ -861,7 +834,6 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   allowHtml = false,
   isStreaming = false,
   onAgentFileLinkClick,
-  coveredFilePaths,
   searchBlockId,
 }: {
   text: string;
@@ -872,11 +844,6 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   /** Enables Streamdown's incremental animation while a turn is still streaming. */
   isStreaming?: boolean;
   onAgentFileLinkClick?: (href: string) => void;
-  /**
-   * Paths already listed in the turn's edited-files footer. Matching agent
-   * file links render as plain mono text instead of a second bordered chip.
-   */
-  coveredFilePaths?: ReadonlySet<string>;
   searchBlockId?: string;
 }) {
   const { t } = useTranslation();
@@ -893,9 +860,8 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
         copyAgentFileLabel,
         openAgentFileLabel,
         onAgentFileLinkClick,
-        coveredFilePaths,
       }),
-    [copyAgentFileLabel, coveredFilePaths, onAgentFileLinkClick, openAgentFileLabel]
+    [copyAgentFileLabel, onAgentFileLinkClick, openAgentFileLabel]
   );
 
   const rehypePlugins = useMemo(() => (allowHtml ? [rehypeRaw, rehypeSanitize] : []), [allowHtml]);

--- a/packages/components/src/components/ai-gui/view.tsx
+++ b/packages/components/src/components/ai-gui/view.tsx
@@ -3731,11 +3731,6 @@ const AssistantChatItem = memo(function AssistantChatItem({
 }: AssistantChatItemProps) {
   const message = row.item.message;
   const { content } = row;
-  const fileDiffsForTurn = fileDiffOverride ?? message.fileDiff ?? EMPTY_EDITED_FILE_ENTRIES;
-  const coveredFilePaths = useMemo(
-    () => (message.finished === true ? buildCoveredFilePathSet(fileDiffsForTurn) : undefined),
-    [fileDiffsForTurn, message.finished]
-  );
   const handleMouseLeave = (event: ReactMouseEvent<HTMLDivElement>) => {
     const nextTurn =
       event.relatedTarget instanceof Element
@@ -3775,7 +3770,6 @@ const AssistantChatItem = memo(function AssistantChatItem({
           isStreaming: message.finished !== true,
           onFilePathClick,
           conversationFontSize,
-          coveredFilePaths,
         });
       }
       case 'activity_group_header':
@@ -4096,21 +4090,6 @@ const formatJsonValue = (value: unknown) => {
   }
 };
 
-const buildCoveredFilePathSet = (
-  files: readonly AssistantEditedFileEntry[] | undefined
-): ReadonlySet<string> | undefined => {
-  if (!files || files.length === 0) return undefined;
-  const keys = new Set<string>();
-  for (const file of files) {
-    if (!file.filePath) continue;
-    const normalized = file.filePath.replace(/\\/g, '/').replace(/^\.\//, '').toLowerCase();
-    keys.add(normalized);
-    const base = normalized.split('/').pop();
-    if (base) keys.add(base);
-  }
-  return keys.size > 0 ? keys : undefined;
-};
-
 const renderAssistantContent = (
   content: MessageContent,
   sessionId: SessionId,
@@ -4120,7 +4099,6 @@ const renderAssistantContent = (
     isStreaming?: boolean;
     onFilePathClick?: (filePath: string) => void;
     conversationFontSize?: ConversationFontSize;
-    coveredFilePaths?: ReadonlySet<string>;
   }
 ) => {
   const messageId = options?.messageId ?? 'assistant';
@@ -4135,7 +4113,6 @@ const renderAssistantContent = (
           size={conversationFontSize}
           isStreaming={options?.isStreaming}
           onFilePathClick={options?.onFilePathClick}
-          coveredFilePaths={options?.coveredFilePaths}
           searchBlockId={getTextSearchBlockId(messageId, itemIndex)}
         />
       );
@@ -4907,15 +4884,12 @@ export const MarkdownBlock = memo(function MarkdownBlock({
   size = DEFAULT_CONVERSATION_FONT_SIZE,
   isStreaming = false,
   onFilePathClick,
-  coveredFilePaths,
   searchBlockId,
 }: {
   text: string;
   size?: ConversationFontSize;
   isStreaming?: boolean;
   onFilePathClick?: (filePath: string) => void;
-  /** Paths already shown in the turn edited-files footer (dedupe chips). */
-  coveredFilePaths?: ReadonlySet<string>;
   searchBlockId?: string;
 }) {
   const handleAgentFileLinkClick = useStableCallback((href: string) => {
@@ -4931,7 +4905,6 @@ export const MarkdownBlock = memo(function MarkdownBlock({
       size={size}
       isStreaming={isStreaming}
       onAgentFileLinkClick={onFilePathClick ? handleAgentFileLinkClick : undefined}
-      coveredFilePaths={coveredFilePaths}
       searchBlockId={searchBlockId}
     />
   );

--- a/packages/components/tests/markdown-agent-file-chip.test.ts
+++ b/packages/components/tests/markdown-agent-file-chip.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MarkdownRenderer } from '../src/components/ai-gui/markdown-renderer';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+/* An absolute path with a `:line` suffix, of the shape agents emit when they
+   cite a file they just touched. These used to vanish from the finished turn:
+   the chip matched the turn's edited-files footer by basename and returned
+   null, taking the link text with it. */
+const MARKDOWN =
+  '改动落在 [README.md](/srv/workspaces/demo-app/README.md:8)、' +
+  '[conductor.json](/srv/workspaces/demo-app/conductor.json:3)、' +
+  '[oss-revision.json](/srv/workspaces/demo-app/apps/cli-cloud/oss-revision.json:2) 三个文件。';
+
+describe('agent file links in finished turns', () => {
+  let root: Root | undefined;
+  let container: HTMLDivElement | undefined;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) await act(async () => void root?.unmount());
+    root = undefined;
+    container?.remove();
+    container = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('renders one clickable chip per cited file, keeping the surrounding prose intact', async () => {
+    await act(async () => {
+      root?.render(createElement(MarkdownRenderer, { text: MARKDOWN, isStreaming: false }));
+    });
+
+    const chips = [...(container?.querySelectorAll('button[title]') ?? [])].filter((el) =>
+      el.getAttribute('title')?.startsWith('/srv/workspaces/demo-app/')
+    );
+
+    expect(chips.map((el) => el.getAttribute('title'))).toEqual([
+      '/srv/workspaces/demo-app/README.md:8',
+      '/srv/workspaces/demo-app/conductor.json:3',
+      '/srv/workspaces/demo-app/apps/cli-cloud/oss-revision.json:2',
+    ]);
+    expect(chips.map((el) => el.textContent?.trim())).toEqual([
+      'README.md',
+      'conductor.json',
+      'oss-revision.json',
+    ]);
+
+    // The enumeration commas must not be left dangling next to a hole.
+    expect(container?.textContent).toContain(
+      '改动落在 README.md、conductor.json、oss-revision.json 三个文件。'
+    );
+  });
+});


### PR DESCRIPTION
## Problem / pressure

Agent-written file citations disappeared from finished turns. Markdown like

```
改动落在 [README.md](/abs/path/README.md:8)、[conductor.json](/abs/path/conductor.json:3) 三个文件。
```

rendered correctly while the turn was streaming, then lost every chip the moment
the turn completed — leaving dangling enumeration commas in the prose.

Root cause: `AssistantChatItem` builds a `coveredFilePaths` set from the turn's
edited-files footer once `message.finished === true`, and `AgentFileLink` did
`return null` for any link whose path matched it. `null` drops the chip *and*
its link text.

Two things made it worse:

- Both sides fall back to the **basename**, so a link to an unrelated file that
  merely shares a name with an edited one was suppressed too.
- The prop's own doc said matching links "render as plain mono text instead of a
  second bordered chip" — the implementation never did that, it rendered nothing.
  Doc and code disagreed from the day the behavior landed.

The premise does not hold either. The footer reports *which files changed* with
`+/−` stats; an inline `README.md:8` is a *jump target*. Different affordances,
not a duplicate — so the path is removed rather than downgraded to plain text.

## Summary

Removes the `coveredFilePaths` suppression end to end:

- `markdown-renderer.tsx` — drop `normalizeAgentFilePathKey` / `pathKeyMatchesCovered`,
  the `coveredByEditedFiles` guard and its `return null`, and the prop from all
  three layers (`AgentFileLink`, `createMarkdownComponents`, `MarkdownRenderer`).
- `view.tsx` — drop `buildCoveredFilePathSet`, the `AssistantChatItem` memo (and
  the now-unused `fileDiffsForTurn`), and the pass-through in
  `renderAssistantContent` / `MarkdownBlock`.
- Adds a jsdom regression test rendering a multi-link sentence.

No repo-wide references remain.

## Before / after

| Before | After |
| ------ | ----- |
| Turn finishes → chips matching an edited file vanish, link text included, leaving `改动落在 、、 三个文件。` | All chips render, `title` keeps the full `path:line`, prose stays intact |
| A link to `other/project/README.md` is suppressed when any `README.md` was edited | Unrelated files are unaffected |

## Test plan

The bug was reproduced against the pre-fix code before removing it: with the fix
stashed and `coveredFilePaths` populated as the app populates it, the new test
fails with `expected [] to deeply equal [ …(3) ]` — zero chips in the DOM. With
the fix applied it passes.

| Check | Result |
| ----- | ------ |
| `pnpm --filter @lody/components exec vitest run tests/markdown-agent-file-chip.test.ts` | pass (fails on pre-fix code) |
| `pnpm --filter @lody/components test` | 392 files / 2802 tests pass |
| `pnpm --filter @lody/components typecheck` (`tsgo --noEmit`) | pass |
| `pnpm lint` (oxlint --type-aware) | 0 errors |
| `pnpm lint:i18n` | pass |
| `pnpm check:public-boundary` | pass (test fixture uses a synthetic path) |
| `prettier --check` on changed files | pass |

Not run: full `pnpm check` — `pnpm typecheck` at the root requires building the
ACP adapters, and the change is confined to `packages/components`.

The new test guards the forward behavior (file links render as chips). It cannot
exercise the old suppression path, because the `coveredFilePaths` API no longer
exists — the guarantee is structural, not assertion-based.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
