### PR TITLE
fix(electron): move window drag onto per-panel title bars

### DIFF
--- a/apps/electron/AGENTS.md
+++ b/apps/electron/AGENTS.md
@@ -82,11 +82,15 @@ Root `AGENTS.md` also applies.
   notify the renderer (`app.nativeTheme`). On macOS also subscribe
   to `AppleInterfaceThemeChangedNotification`; Chromium `matchMedia` and
   `nativeTheme.updated` often miss Control Center switches.
+- Frameless window drag is per-panel, not a root overlay: each column's top
+  header (or a same-height `WindowDragStrip` when there is no header) is
+  `-webkit-app-region: drag`. Interactive descendants use `app-region-no-drag`.
+  Dialog and alert-dialog overlays mount the strip themselves. Hide those
+  regions in native fullscreen. Windows caption buttons stay an OS overlay
+  (`MAIN_WINDOW_TITLE_BAR_OVERLAY_HEIGHT`); right-edge headers pad `pr-[144px]`
+  so toolbar controls do not sit under them.
 - The onboarding window must be native Light before its first renderer paint; normal product windows start from the System theme source.
   An automatic login launch may suppress the initial product window, but onboarding and deep-link launches must remain visible.
-  Windows title-bar geometry must stay aligned across
-  `MAIN_WINDOW_TITLE_BAR_OVERLAY_HEIGHT`, the `h-9` drag strip in
-  `routes/__root.tsx`, and the `pt-9` offset in `web-workspace-layout.tsx`.
 - `sessionControl.send` streams intermediate responses on `sessionControl.response`
   keyed by request id. The renderer subscribes before `invoke`, removes the
   listener after settlement, and treats only the final response as completion.

--- a/apps/electron/src/main/window-theme.ts
+++ b/apps/electron/src/main/window-theme.ts
@@ -12,10 +12,6 @@ const WINDOW_BACKGROUND_COLORS: Record<ResolvedWindowTheme, string> = {
   dark: '#101010'
 }
 
-// Windows caption-button strip (titleBarOverlay) height in CSS px. The
-// renderer reserves the same band at the top of the window
-// (`h-9` drag strip in `packages/components/src/routes/__root.tsx` and the
-// matching `pt-9` in `web-workspace-layout.tsx`) — keep all three in sync.
 export const MAIN_WINDOW_TITLE_BAR_OVERLAY_HEIGHT = 36
 
 // Matches the bundled VS Code themes' `titleBar.*` colors

--- a/apps/electron/src/main/window.ts
+++ b/apps/electron/src/main/window.ts
@@ -342,8 +342,7 @@ export function createMainWindow(options: CreateMainWindowOptions): BrowserWindo
       : {}),
     // Windows: hide the native title bar (its neutral gray clashes with the
     // app canvas) and keep only the OS-drawn caption buttons as an overlay
-    // tinted to match the theme. The renderer reserves a drag band of the
-    // same height at the top of the window.
+    // tinted to match the theme.
     ...(process.platform === 'win32'
       ? {
           titleBarStyle: 'hidden',

--- a/packages/components/src/components/archive/web-archive-screen.tsx
+++ b/packages/components/src/components/archive/web-archive-screen.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { sidebarCollapsedAtom } from '@/atoms/sidebar-state';
 import { isMacOSElectronRenderer, useElectronFullscreen } from '@/lib/electron';
-
+import { useWindowDragRegionClass, useWindowsCaptionPadClass } from '@/ui/window-drag-region';
 import { isNativeAppShell } from '@/lib/native-platform';
 import { Button } from '@/ui/button';
 import {
@@ -51,7 +51,8 @@ export function WebArchiveScreen({
   const { t } = useTranslation();
   const [isLeftSidebarCollapsed, setLeftSidebarCollapsed] = useAtom(sidebarCollapsedAtom);
   const isElectronFullscreen = useElectronFullscreen();
-
+  const windowDragClass = useWindowDragRegionClass();
+  const windowsCaptionPadClass = useWindowsCaptionPadClass();
   // Traffic lights auto-hide in native fullscreen — no inset to reserve then.
   // Mirrors the same derivation in session-detail.tsx.
   const hasMacOSTitlebarInset =
@@ -65,7 +66,9 @@ export function WebArchiveScreen({
         <header
           className={cn(
             'flex h-[calc(2.75rem+var(--safe-area-top))] w-full shrink-0 items-center gap-3 border-b border-border bg-background pl-[calc(16px+var(--safe-area-left))] pr-[calc(16px+var(--safe-area-right))] pt-[var(--safe-area-top)]',
-            isLeftSidebarCollapsed && hasMacOSTitlebarInset && 'pl-[4.5rem]'
+            isLeftSidebarCollapsed && hasMacOSTitlebarInset && 'pl-[4.5rem]',
+            windowDragClass,
+            windowsCaptionPadClass
           )}
         >
           {isLeftSidebarCollapsed ? (

--- a/packages/components/src/components/chat/web-chat-landing-screen.tsx
+++ b/packages/components/src/components/chat/web-chat-landing-screen.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/shared/conversation-drop-overlay';
 import { focusFirstChatLandingOption } from '@/hooks/use-chat-landing-keyboard-nav';
 import { FocusScope } from '@/ui/focus-scope';
+import { WINDOW_DRAG_EXEMPT_CLASS, WindowDragStrip } from '@/ui/window-drag-region';
 
 import { WORKSPACE_FOCUS_SCOPES } from '@/atoms';
 
@@ -54,11 +55,13 @@ export function WebChatLandingScreen({
       )}
       {...dropHandlers}
     >
+      <WindowDragStrip />
       <ConversationDropOverlay active={dropActive} kind={dropKind} />
       {leftSidebarExpandSlot != null ? (
         <div
           className={cn(
-            'absolute top-3 z-10',
+            'absolute top-3 z-20',
+            WINDOW_DRAG_EXEMPT_CLASS,
             // macOS Electron: `top-[9px]` centers the h-7 button at 23px, on the
             // traffic-light centerline (`trafficLightPosition.y` 16 + 7px radius
             // in apps/electron/src/main/window.ts); `left-[96px]` leaves a 24px

--- a/packages/components/src/components/login-page.tsx
+++ b/packages/components/src/components/login-page.tsx
@@ -35,6 +35,7 @@ import { runNativeOAuthSignIn } from '@/lib/native-oauth';
 import { syncNativeAuthSession } from '@/lib/native-auth-session-sync';
 import { isNativeAppShell } from '@/lib/native-platform';
 import { isElectronRenderer as isElectronRendererRuntime } from '@/lib/electron';
+import { WindowDragStrip } from '@/ui/window-drag-region';
 import { getAuthResponseError } from '@/lib/auth-response';
 import { buildEmailVerificationCallbackUrl } from '@/lib/email-verification-callback';
 import { buildEmailSignInInput } from '@/lib/email-sign-in';
@@ -1638,7 +1639,8 @@ export function LoginPage({
   })();
 
   return (
-    <div className="flex h-screen w-full items-center justify-center bg-background p-4">
+    <div className="relative flex h-screen w-full items-center justify-center bg-background p-4">
+      <WindowDragStrip />
       <motion.div
         layout
         transition={VIEW_TRANSITION}

--- a/packages/components/src/components/loro-app-sidebar.tsx
+++ b/packages/components/src/components/loro-app-sidebar.tsx
@@ -25,6 +25,7 @@ import { resolveWorkspaceIdentityLogo } from '@/lib/workspace-identity';
 import { cn } from '@/lib/utils';
 import { formatCompactRelativeTime } from '@/lib/format-relative-time';
 import { isElectronRenderer, useElectronFullscreen } from '@/lib/electron';
+import { WindowDragStrip } from '@/ui/window-drag-region';
 import { getIpcServices } from '@/lib/electron-ipc-client';
 import { formatSessionTabSearch } from '@/lib/session-tab-url';
 import { openExternalUrl } from '@/lib/native-browser';
@@ -2894,11 +2895,13 @@ export function LoroAppSidebar({ className }: LoroAppSidebarProps) {
         className
       )}
     >
+      {!isMobile ? <WindowDragStrip /> : null}
       <LoroSidebar
         className={cn(
           isMobile
             ? 'h-full w-full rounded-none border-0 shadow-none'
-            : 'mb-2 ml-2 mr-1 mt-2 h-[calc(100%_-_1rem)] rounded-xl border border-sidebar-border/80 bg-sidebar shadow-[0_1px_4px_-1px_rgba(0,0,0,0.18)]'
+            : 'mb-2 ml-2 mr-1 mt-2 h-[calc(100%_-_1rem)] rounded-xl border border-sidebar-border/80 bg-sidebar shadow-[0_1px_4px_-1px_rgba(0,0,0,0.18)]',
+          isElectron && !isElectronFullscreen && 'z-20'
         )}
         workspaceName={resolvedWorkspaceName}
         userEmail={user?.email ?? ''}

--- a/packages/components/src/components/loro-sidebar.tsx
+++ b/packages/components/src/components/loro-sidebar.tsx
@@ -12,7 +12,8 @@ import {
   useSyncExternalStore,
 } from 'react';
 import { cn } from '@/lib/utils';
-
+import { WINDOW_DRAG_EXEMPT_CLASS, WINDOW_DRAG_HEADER_CLASS } from '@/ui/window-drag-region';
+import { useElectronFullscreen } from '@/lib/electron';
 import { Badge } from '@/ui/badge';
 import { Button } from '@/ui/button';
 import { Kbd } from '@/ui/kbd';
@@ -677,6 +678,7 @@ export const LoroSidebar = memo(function LoroSidebar({
   onRequestCollapse,
 }: LoroSidebarProps) {
   const isMobile = useIsMobile();
+  const isElectronFullscreen = useElectronFullscreen();
   const mergedLabels: LoroSidebarLabels = {
     ...defaultLabels,
     ...labels,
@@ -820,6 +822,7 @@ export const LoroSidebar = memo(function LoroSidebar({
       </span>
     </>
   );
+  const windowDrag = isElectron && !isElectronFullscreen;
   const workspaceIdentityClassName = cn(
     'grid w-full min-w-0 select-none grid-cols-[20px_1fr_16px] items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm',
     isMobile ? 'h-9' : 'h-8',
@@ -881,7 +884,8 @@ export const LoroSidebar = memo(function LoroSidebar({
               ? 'pl-[calc(12px+var(--safe-area-left))] pr-[calc(12px+var(--safe-area-right))] pt-[calc(12px+var(--safe-area-top))]'
               : isElectronMacOS
                 ? 'h-[72px] px-1.5 pt-7'
-                : 'h-11 px-1.5'
+                : 'h-11 px-1.5',
+            windowDrag && WINDOW_DRAG_HEADER_CLASS
           )}
         >
           {workspaceSwitcherEnabled ? (
@@ -890,7 +894,10 @@ export const LoroSidebar = memo(function LoroSidebar({
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
-                    className={workspaceIdentityClassName}
+                    className={cn(
+                      workspaceIdentityClassName,
+                      windowDrag && WINDOW_DRAG_EXEMPT_CLASS
+                    )}
                     data-workspace-switcher-trigger
                     data-workspace-syncing={workspaceSyncing ? 'true' : 'false'}
                     aria-busy={workspaceSyncing || undefined}
@@ -977,6 +984,7 @@ export const LoroSidebar = memo(function LoroSidebar({
                 'absolute right-1.5 flex h-7 w-7 items-center justify-center rounded-md',
                 isElectronMacOS ? '-top-0.5' : 'top-2',
                 'text-sidebar-foreground-muted hover:bg-sidebar-hover hover:text-sidebar-hover-foreground',
+                windowDrag && WINDOW_DRAG_EXEMPT_CLASS,
                 isElectron
                   ? 'focus-visible:outline-hidden'
                   : 'opacity-0 pointer-events-none group-hover/sidebar-header:opacity-100 group-hover/sidebar-header:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto focus-visible:outline-hidden transition-opacity duration-100'

--- a/packages/components/src/components/onboarding/onboarding-overlay.tsx
+++ b/packages/components/src/components/onboarding/onboarding-overlay.tsx
@@ -18,6 +18,7 @@ import { ProjectsScreen } from './screens/projects-screen';
 import { FirstTaskScreen } from './screens/first-task-screen';
 import { SummaryScreen } from './screens/summary-screen';
 import { useOnboardingBuiltinRuntimePrefetch } from './use-onboarding-builtin-runtime-prefetch';
+import { WindowDragStrip } from '@/ui/window-drag-region';
 
 export type DesktopOnboardingCompletion = {
   sessionId?: string;
@@ -185,6 +186,7 @@ export function OnboardingOverlay({
   return (
     <OnboardingStepsProvider steps={visibleSteps}>
       <div className="fixed inset-0 z-40 overflow-hidden bg-[#f7f5f2] text-slate-950">
+        <WindowDragStrip className="z-30" />
         {phase === 'ceremony' ? (
           <div className="absolute inset-0 z-10">{screens[phase]}</div>
         ) : (

--- a/packages/components/src/components/sessions/session-detail.tsx
+++ b/packages/components/src/components/sessions/session-detail.tsx
@@ -86,6 +86,7 @@ import {
   terminalDockOpenAtom,
 } from '@/components/terminal/terminal-controller';
 import { isElectronRenderer, isMacOSElectronRenderer, useElectronFullscreen } from '@/lib/electron';
+import { useWindowsCaptionPadClass } from '@/ui/window-drag-region';
 import { sidebarCollapsedAtom } from '@/atoms/sidebar-state';
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { useDocumentTitle } from '@/hooks/use-document-title';
@@ -678,6 +679,7 @@ const SessionDetail = ({
   const hidesBillingUi = isMobile || isNativeAppShell();
   const { openSettings } = useOpenSettings();
   const isElectronFullscreen = useElectronFullscreen();
+  const windowsCaptionPadClass = useWindowsCaptionPadClass();
   // Publish ephemeral "viewing this session" presence (drives the owning
   // machine's PR poller priority); actively cleared on switch/hide/unmount.
   usePublishSessionViewing(sessionId);
@@ -5529,7 +5531,8 @@ const SessionDetail = ({
         // 6px higher for them to land on that same line: 2 + (44 - 32) / 2 = 8.
         // Re-derive this if the row or the pill height changes.
         'mt-0.5 h-11',
-        isLeftSidebarCollapsed && hasMacOSTitlebarInset && 'pl-[4.5rem]'
+        isLeftSidebarCollapsed && hasMacOSTitlebarInset && 'pl-[4.5rem]',
+        !isSidebarOpen && windowsCaptionPadClass
       )}
     />
   );
@@ -5701,7 +5704,8 @@ const SessionDetail = ({
           'border-b border-border/50 bg-background',
           // Right panel is never under the macOS traffic lights (top-left) —
           // it must not reserve the titlebar inset the left sidebar needs.
-          'h-11'
+          'h-11',
+          windowsCaptionPadClass
         )}
       />
       <div className="relative min-h-0 flex-1 overflow-hidden">

--- a/packages/components/src/components/sessions/session-side-panel-tab-bar.tsx
+++ b/packages/components/src/components/sessions/session-side-panel-tab-bar.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from '@/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
+import { WINDOW_DRAG_EXEMPT_CLASS, useWindowDragRegionClass } from '@/ui/window-drag-region';
 
 export type SessionSidePanelTabItem = {
   id: string;
@@ -132,7 +133,7 @@ type SessionSidePanelTabBarProps = {
 };
 
 const TAB_CLASS =
-  'group relative flex h-7 max-w-[180px] shrink-0 cursor-pointer items-center gap-1.5 rounded-md text-[13px] transition-colors';
+  `group relative flex h-7 max-w-[180px] shrink-0 cursor-pointer items-center gap-1.5 rounded-md text-[13px] transition-colors ${WINDOW_DRAG_EXEMPT_CLASS}`;
 // Soft cool-gray pills on the white side panel (Linear-like), not heavy slate washes.
 const ACTIVE_TAB_CLASS =
   'bg-foreground/[0.08] text-tab-active-foreground shadow-[inset_0_0_0_1px_hsl(var(--border)/0.7)]';
@@ -213,6 +214,7 @@ export const SessionSidePanelTabBar = memo(function SessionSidePanelTabBar({
   endSlot,
   className,
 }: SessionSidePanelTabBarProps) {
+  const windowDragClass = useWindowDragRegionClass();
   const activeTabRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -220,7 +222,7 @@ export const SessionSidePanelTabBar = memo(function SessionSidePanelTabBar({
   }, [activeTabId]);
 
   return (
-    <div className={cn('flex min-w-0 items-center gap-1 px-2', className)}>
+    <div className={cn('flex min-w-0 items-center gap-1 px-2', windowDragClass, className)}>
       <ScrollArea
         scrollableX
         horizontalOnly
@@ -318,7 +320,10 @@ export const SessionSidePanelTabBar = memo(function SessionSidePanelTabBar({
             type="button"
             disabled={availablePanels.length === 0}
             aria-label={addPanelLabel}
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hover hover:text-hover-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-default disabled:opacity-35 disabled:hover:bg-transparent"
+            className={cn(
+              'flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hover hover:text-hover-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-default disabled:opacity-35 disabled:hover:bg-transparent',
+              WINDOW_DRAG_EXEMPT_CLASS
+            )}
           >
             <Plus className="h-4 w-4" />
           </button>
@@ -337,7 +342,9 @@ export const SessionSidePanelTabBar = memo(function SessionSidePanelTabBar({
           ))}
         </DropdownMenuContent>
       </DropdownMenu>
-      {endSlot ? <div className="flex shrink-0 items-center">{endSlot}</div> : null}
+      {endSlot ? (
+        <div className={cn('flex shrink-0 items-center', WINDOW_DRAG_EXEMPT_CLASS)}>{endSlot}</div>
+      ) : null}
     </div>
   );
 });

--- a/packages/components/src/components/sessions/session-tab-bar.tsx
+++ b/packages/components/src/components/sessions/session-tab-bar.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Plus, Loader2, X, History, Undo2, Pin, FileDiff } from 'lucide-react';
 import { cn } from '@/lib/utils';
-
+import { WINDOW_DRAG_EXEMPT_CLASS, useWindowDragRegionClass } from '@/ui/window-drag-region';
 import { getSessionLaunchConfigLegacyFields, type SessionId, type SessionMeta } from '@lody/shared';
 import { useTranslation } from 'react-i18next';
 import { useAtomValue } from 'jotai';
@@ -119,8 +119,7 @@ const TAB_ITEM_ACTIVE_CLASS = TAB_PILL_ACTIVE_CLASS;
 const TAB_ITEM_INACTIVE_CLASS = TAB_PILL_INACTIVE_CLASS;
 const TAB_INLINE_ACTION_CLASS =
   'ml-auto shrink-0 rounded-sm p-0.5 opacity-70 transition-[opacity,background-color,color] hover:bg-muted-foreground/10 hover:text-tab-hover-foreground hover:opacity-100';
-const TAB_BAR_ACTION_CLASS =
-  'flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hover hover:text-hover-foreground';
+const TAB_BAR_ACTION_CLASS = `flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-hover hover:text-hover-foreground ${WINDOW_DRAG_EXEMPT_CLASS}`;
 
 function clientPointFromDragEnd(event: DragEndEvent): { x: number; y: number } | null {
   const source = event.activatorEvent;
@@ -233,6 +232,7 @@ function TabContent({
       }
       className={cn(
         TAB_ITEM_CLASS,
+        !solo && WINDOW_DRAG_EXEMPT_CLASS,
         solo
           ? 'text-tab-active-foreground'
           : isActive
@@ -362,6 +362,7 @@ function DraftTabContent({
       aria-label={label}
       className={cn(
         TAB_ITEM_CLASS,
+        !solo && WINDOW_DRAG_EXEMPT_CLASS,
         solo
           ? 'text-tab-active-foreground'
           : isActive
@@ -443,6 +444,7 @@ function ViewerTabContent({
       aria-label={saveStateLabel ? `${tab.label}, ${saveStateLabel}` : tab.label}
       className={cn(
         TAB_ITEM_CLASS,
+        !solo && WINDOW_DRAG_EXEMPT_CLASS,
         solo
           ? 'text-tab-active-foreground'
           : isActive
@@ -552,6 +554,7 @@ export const SessionTabBar = memo(function SessionTabBar({
   onMentionSession,
 }: SessionTabBarProps) {
   const { t } = useTranslation();
+  const windowDragClass = useWindowDragRegionClass();
   useListKeyboardNavigation({ scopeId: WORKSPACE_FOCUS_SCOPES.sessionConversation });
   const defaultTitle = t('sessions.untitled', 'Untitled session');
   const showSessionTabs = variant !== 'viewer';
@@ -743,9 +746,15 @@ export const SessionTabBar = memo(function SessionTabBar({
   ) : null;
 
   return (
-    <div className={cn('flex min-w-0 items-center bg-background', className)}>
+    <div className={cn('flex min-w-0 items-center bg-background', windowDragClass, className)}>
       {leftSlot ? (
-        <div className={cn('flex shrink-0 items-center pl-3', soloTab ? 'pr-0' : 'pr-2')}>
+        <div
+          className={cn(
+            'flex shrink-0 items-center pl-3',
+            WINDOW_DRAG_EXEMPT_CLASS,
+            soloTab ? 'pr-0' : 'pr-2'
+          )}
+        >
           {leftSlot}
         </div>
       ) : null}
@@ -819,11 +828,13 @@ export const SessionTabBar = memo(function SessionTabBar({
       </AdaptiveTabStrip>
       {/* Pinned right cluster: new-tab, then the archived-tabs history (only
           when closed tabs exist), then the caller's toolbar ("…" etc.). */}
-      {newTabButton}
-      {showArchivedTabs && archivedChildSessions.length > 0 && onTabRestore && (
-        <ArchivedTabsPopover archivedSessions={archivedChildSessions} onRestore={onTabRestore} />
-      )}
-      {rightSlot}
+      <div className={cn('flex shrink-0 items-center', WINDOW_DRAG_EXEMPT_CLASS)}>
+        {newTabButton}
+        {showArchivedTabs && archivedChildSessions.length > 0 && onTabRestore && (
+          <ArchivedTabsPopover archivedSessions={archivedChildSessions} onRestore={onTabRestore} />
+        )}
+        {rightSlot}
+      </div>
     </div>
   );
 });

--- a/packages/components/src/components/tasks/task-tab-bar.tsx
+++ b/packages/components/src/components/tasks/task-tab-bar.tsx
@@ -2,6 +2,11 @@ import { ListTodo, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import {
+  WINDOW_DRAG_EXEMPT_CLASS,
+  useWindowDragRegionClass,
+  useWindowsCaptionPadClass,
+} from '@/ui/window-drag-region';
+import {
   TAB_PILL_ACTIVE_CLASS,
   TAB_PILL_INACTIVE_CLASS,
 } from '@/components/shared/tab-pill-strip';
@@ -45,26 +50,41 @@ export function TaskTabBar({
   rightSlot,
 }: TaskTabBarProps) {
   const { t } = useTranslation();
+  const windowDragClass = useWindowDragRegionClass();
+  const windowsCaptionPadClass = useWindowsCaptionPadClass();
   const allActive = activeTaskId === null;
   // When only All Tasks is open, the pill reads as page chrome rather than a
   // selected sibling among many — same "solo" treatment as SessionTabBar.
   const solo = tabs.length === 0;
 
   return (
-    <div className="flex h-11 shrink-0 items-center gap-1 border-b border-border/60 bg-background px-2">
+    <div
+      className={cn(
+        'flex h-11 shrink-0 items-center gap-1 border-b border-border/60 bg-background px-2',
+        windowDragClass,
+        windowsCaptionPadClass
+      )}
+    >
       <div
         role="tablist"
         aria-label={t('tasks.tabs.label', 'Task tabs')}
         className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto"
       >
-        <button
-          type="button"
+        <div
           role="tab"
           aria-selected={allActive}
+          tabIndex={allActive ? 0 : -1}
           onClick={onSelectAll}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              onSelectAll();
+            }
+          }}
           className={cn(
             TAB_ITEM_CLASS,
-            'shrink-0 font-medium',
+            'shrink-0 cursor-pointer font-medium',
+            !solo && WINDOW_DRAG_EXEMPT_CLASS,
             solo
               ? 'text-tab-active-foreground'
               : allActive
@@ -74,7 +94,7 @@ export function TaskTabBar({
         >
           <ListTodo className="h-3.5 w-3.5 shrink-0 opacity-70" />
           <span className="truncate">{t('tasks.tabs.allTasks', 'All Tasks')}</span>
-        </button>
+        </div>
 
         {tabs.map((tab) => {
           const active = tab.taskId === activeTaskId;
@@ -88,6 +108,7 @@ export function TaskTabBar({
               aria-label={label}
               className={cn(
                 TAB_ITEM_CLASS,
+                WINDOW_DRAG_EXEMPT_CLASS,
                 active ? TAB_PILL_ACTIVE_CLASS : TAB_PILL_INACTIVE_CLASS
               )}
               onClick={() => onSelectTask(tab.taskId)}
@@ -117,7 +138,11 @@ export function TaskTabBar({
           );
         })}
       </div>
-      {rightSlot ? <div className="ml-1 flex shrink-0 items-center gap-1">{rightSlot}</div> : null}
+      {rightSlot ? (
+        <div className={cn('ml-1 flex shrink-0 items-center gap-1', WINDOW_DRAG_EXEMPT_CLASS)}>
+          {rightSlot}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/components/src/components/web-workspace-layout.tsx
+++ b/packages/components/src/components/web-workspace-layout.tsx
@@ -7,9 +7,9 @@ import { ErrorBoundary } from './error-boundary';
 import { useKeyboardNavigation } from '../hooks/use-keyboard-navigation';
 import { sidebarCollapsedAtom, sidebarLastWidthAtom, WORKSPACE_FOCUS_SCOPES } from '../atoms';
 import { cn } from '@/lib/utils';
-import { isWindowsElectronRenderer, useElectronFullscreen } from '@/lib/electron';
 import { isSettingsRoute, NATIVE_KEYBOARD_OFFSET_CLASS } from './workspace-layout-utils';
 import { FocusScope } from '@/ui/focus-scope';
+import { WindowDragStrip } from '@/ui/window-drag-region';
 
 // LoroSidebar's default expanded width (see loro-sidebar.tsx `defaultWidth`);
 // `sidebarLastWidthAtom` stores 0 until the user resizes, so fall back to this.
@@ -26,22 +26,18 @@ export function WebWorkspaceLayout({ children }: { children: ReactNode }) {
   const sidebarCollapsed = useAtomValue(sidebarCollapsedAtom);
   const sidebarLastWidth = useAtomValue(sidebarLastWidthAtom);
   const shouldReduceMotion = useReducedMotion();
-  const isElectronFullscreen = useElectronFullscreen();
 
   useKeyboardNavigation();
-
-  const windowsTitleBarPadding =
-    isWindowsElectronRenderer() && !isElectronFullscreen ? 'pt-9' : undefined;
 
   if (isSettingsRoute(pathname)) {
     return (
       <div
         className={cn(
-          'flex h-svh w-full overflow-hidden bg-background',
-          NATIVE_KEYBOARD_OFFSET_CLASS,
-          windowsTitleBarPadding
+          'relative flex h-svh w-full overflow-hidden bg-background',
+          NATIVE_KEYBOARD_OFFSET_CLASS
         )}
       >
+        <WindowDragStrip />
         <div className="min-h-0 flex-1 overflow-hidden">
           <ErrorBoundary name="AppContent" variant="section" resetKeys={[pathname]}>
             {children}
@@ -64,8 +60,7 @@ export function WebWorkspaceLayout({ children }: { children: ReactNode }) {
     <div
       className={cn(
         'flex h-svh w-full overflow-hidden bg-background',
-        NATIVE_KEYBOARD_OFFSET_CLASS,
-        windowsTitleBarPadding
+        NATIVE_KEYBOARD_OFFSET_CLASS
       )}
     >
       <AnimatePresence initial={false}>
@@ -86,8 +81,9 @@ export function WebWorkspaceLayout({ children }: { children: ReactNode }) {
       </AnimatePresence>
       <FocusScope
         id={WORKSPACE_FOCUS_SCOPES.content}
-        className="flex min-w-0 flex-1 overflow-hidden"
+        className="relative flex min-w-0 flex-1 overflow-hidden"
       >
+        <WindowDragStrip />
         <ErrorBoundary name="AppContent" variant="section" resetKeys={[pathname]}>
           <div className="flex h-full min-w-0 w-full flex-1 flex-col overflow-hidden">
             {children}

--- a/packages/components/src/routes/__root.tsx
+++ b/packages/components/src/routes/__root.tsx
@@ -42,8 +42,6 @@ import { isNativeAppShell } from '@/lib/native-platform';
 import { resolveDesktopCheckoutReturnDeepLinkPath } from '@/lib/desktop-checkout-return-deep-link';
 import { resolveDesktopGitHubInstallDeepLinkPath } from '@/lib/desktop-github-install-deep-link';
 import { readElectronAuthCallbackToken } from '@/lib/electron-oauth';
-import { isWindowsElectronRenderer, useElectronFullscreen } from '@/lib/electron';
-import { cn } from '@/lib/utils';
 import { LodyPostHogProvider } from '../providers/posthog-provider';
 import { AppLaunchAnalyticsTracker } from '@/components/app-launch-analytics-tracker';
 import { ShortcutAnalyticsTracker } from '@/components/commands/shortcut-analytics-tracker';
@@ -356,8 +354,6 @@ function RootOutletBoundary() {
   const location = useLocation({
     select: (l) => ({ pathname: l.pathname, search: l.search }),
   });
-  const isElectron = typeof window !== 'undefined' && window.__LODY_ELECTRON__ === true;
-  const isElectronFullscreen = useElectronFullscreen();
   return (
     <ErrorBoundary
       name="RootOutlet"
@@ -367,22 +363,6 @@ function RootOutletBoundary() {
       propagateAuthErrors={false}
     >
       <ErrorBoundaryProbe />
-      {/* Window drag strip. Hidden in native fullscreen: the
-          window can't be dragged there, and the strip would only
-          block clicks on the top of the top bar. On Windows the
-          strip is the drag band behind the titleBarOverlay
-          caption buttons (36px, matching
-          MAIN_WINDOW_TITLE_BAR_OVERLAY_HEIGHT in
-          apps/electron/src/main/window-theme.ts); content clears
-          it via the matching pt-9 in web-workspace-layout.tsx. */}
-      {isElectron && !isElectronFullscreen && (
-        <div
-          className={cn(
-            'app-region-drag fixed left-0 top-0 right-0 z-50 select-none bg-transparent',
-            isWindowsElectronRenderer() ? 'h-9' : 'h-5'
-          )}
-        />
-      )}
       <Outlet />
     </ErrorBoundary>
   );

--- a/packages/components/src/ui/alert-dialog.tsx
+++ b/packages/components/src/ui/alert-dialog.tsx
@@ -3,6 +3,7 @@ import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 
 import { cn } from '@/lib/utils';
 import { buttonVariants } from './button';
+import { WindowDragStrip } from '@/ui/window-drag-region';
 
 function AlertDialog({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
   return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />;
@@ -31,7 +32,9 @@ const AlertDialogOverlay = React.forwardRef<
         className
       )}
       {...props}
-    />
+    >
+      <WindowDragStrip />
+    </AlertDialogPrimitive.Overlay>
   );
 });
 AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;

--- a/packages/components/src/ui/dialog.tsx
+++ b/packages/components/src/ui/dialog.tsx
@@ -4,6 +4,7 @@ import { X } from 'lucide-react';
 
 import { isImeComposingNativeKeyboardEvent } from '@/lib/ime';
 import { cn } from '@/lib/utils';
+import { WindowDragStrip } from '@/ui/window-drag-region';
 
 const Dialog = DialogPrimitive.Root;
 
@@ -33,7 +34,9 @@ const DialogOverlay = React.forwardRef<
       className
     )}
     {...props}
-  />
+  >
+    <WindowDragStrip />
+  </DialogPrimitive.Overlay>
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
@@ -70,8 +73,6 @@ const DialogContent = React.forwardRef<
       data-lody-dialog-content=""
       className={cn(dialogBaseClasses, !noAnimation && dialogAnimationClasses, className)}
       onEscapeKeyDown={(event) => {
-        // Esc first cancels an active IME preedit. Treating the same keydown as
-        // dialog dismissal loses any draft held by a form inside the dialog.
         if (isImeComposingNativeKeyboardEvent(event)) {
           event.preventDefault();
           return;

--- a/packages/components/src/ui/window-drag-region.tsx
+++ b/packages/components/src/ui/window-drag-region.tsx
@@ -1,0 +1,48 @@
+import { cn } from '@/lib/utils';
+import {
+  isElectronRenderer,
+  isWindowsElectronRenderer,
+  useElectronFullscreen,
+} from '@/lib/electron';
+
+export const WINDOW_DRAG_REGION_HEIGHT_CLASS = 'h-11';
+export const WINDOW_DRAG_REGION_CLASS = 'app-region-drag';
+export const WINDOW_DRAG_EXEMPT_CLASS = 'app-region-no-drag';
+export const WINDOW_DRAG_HEADER_CLASS = `${WINDOW_DRAG_REGION_CLASS} relative z-20`;
+export const WINDOWS_CAPTION_PAD_CLASS = 'pr-[144px]';
+
+export function useWindowDragRegionClass(): string | undefined {
+  const fullscreen = useElectronFullscreen();
+  if (!isElectronRenderer() || fullscreen) return undefined;
+  return WINDOW_DRAG_HEADER_CLASS;
+}
+
+export function useWindowsCaptionPadClass(): string | undefined {
+  const fullscreen = useElectronFullscreen();
+  if (!isWindowsElectronRenderer() || fullscreen) return undefined;
+  return WINDOWS_CAPTION_PAD_CLASS;
+}
+
+export function WindowDragStrip({
+  className,
+  position = 'absolute',
+}: {
+  className?: string;
+  position?: 'absolute' | 'fixed';
+}) {
+  const fullscreen = useElectronFullscreen();
+  if (!isElectronRenderer() || fullscreen) return null;
+  return (
+    <div
+      aria-hidden
+      data-window-drag-strip=""
+      className={cn(
+        WINDOW_DRAG_REGION_CLASS,
+        WINDOW_DRAG_REGION_HEIGHT_CLASS,
+        position === 'fixed' ? 'fixed' : 'absolute',
+        'inset-x-0 top-0 z-10',
+        className
+      )}
+    />
+  );
+}

--- a/packages/components/tests/session-tab-bar.test.tsx
+++ b/packages/components/tests/session-tab-bar.test.tsx
@@ -79,6 +79,20 @@ describe('SessionTabBar drag sources', () => {
     });
   }
 
+  it('does not mark a solo tab title as a window-drag hole', async () => {
+    await renderTabBar([]);
+    const tab = container.querySelector<HTMLElement>('#session-tab-session-parent')!;
+    expect(tab.className).not.toContain('app-region-no-drag');
+  });
+
+  it('marks each tab as a click target when more than one is open', async () => {
+    await renderTabBar([childSession]);
+    const parent = container.querySelector<HTMLElement>('#session-tab-session-parent')!;
+    const child = container.querySelector<HTMLElement>('#session-tab-session-child')!;
+    expect(parent.className).toContain('app-region-no-drag');
+    expect(child.className).toContain('app-region-no-drag');
+  });
+
   it('disables dragging when only the parent Session tab is visible', async () => {
     await renderTabBar([]);
 

--- a/packages/components/tests/window-drag-region.test.tsx
+++ b/packages/components/tests/window-drag-region.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as electron from '../src/lib/electron';
+import { WindowDragStrip } from '../src/ui/window-drag-region';
+import { WebChatLandingScreen } from '../src/components/chat/web-chat-landing-screen';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('WindowDragStrip', () => {
+  let container: HTMLDivElement | undefined;
+  let root: Root | undefined;
+
+  beforeEach(() => {
+    delete window.__LODY_ELECTRON__;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    root = undefined;
+    container?.remove();
+    container = undefined;
+    vi.restoreAllMocks();
+    delete window.__LODY_ELECTRON__;
+  });
+
+  const renderStrip = () => {
+    root = createRoot(container!);
+    act(() => {
+      root!.render(<WindowDragStrip />);
+    });
+  };
+
+  it('renders nothing outside Electron', () => {
+    renderStrip();
+    expect(container!.querySelector('[data-window-drag-strip]')).toBeNull();
+  });
+
+  it('renders a title-bar-height drag region in Electron', () => {
+    window.__LODY_ELECTRON__ = true;
+    vi.spyOn(electron, 'useElectronFullscreen').mockReturnValue(false);
+    renderStrip();
+    const strip = container!.querySelector('[data-window-drag-strip]');
+    expect(strip).not.toBeNull();
+    expect(strip!.className).toContain('app-region-drag');
+    expect(strip!.className).toContain('h-11');
+  });
+
+  it('hides the drag region in native fullscreen', () => {
+    window.__LODY_ELECTRON__ = true;
+    vi.spyOn(electron, 'useElectronFullscreen').mockReturnValue(true);
+    renderStrip();
+    expect(container!.querySelector('[data-window-drag-strip]')).toBeNull();
+  });
+});
+
+describe('WebChatLandingScreen window drag', () => {
+  let container: HTMLDivElement | undefined;
+  let root: Root | undefined;
+
+  beforeEach(() => {
+    window.__LODY_ELECTRON__ = true;
+    vi.spyOn(electron, 'useElectronFullscreen').mockReturnValue(false);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    root = undefined;
+    container?.remove();
+    container = undefined;
+    vi.restoreAllMocks();
+    delete window.__LODY_ELECTRON__;
+  });
+
+  it('hangs a virtual title-bar drag strip when the landing has no header', () => {
+    root = createRoot(container!);
+    act(() => {
+      root!.render(
+        <WebChatLandingScreen title="New session" composer={<textarea aria-label="composer" />} />
+      );
+    });
+    const strip = container!.querySelector('[data-window-drag-strip]');
+    expect(strip).not.toBeNull();
+    expect(strip!.className).toContain('h-11');
+  });
+});

--- a/packages/configs/tailwind-preset.cjs
+++ b/packages/configs/tailwind-preset.cjs
@@ -228,16 +228,22 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/container-queries'),
-    function ({ addUtilities }) {
-      const newUtilities = {
+    function ({ addUtilities, addComponents }) {
+      addUtilities({
         '.app-region-drag': {
           '-webkit-app-region': 'drag',
         },
         '.app-region-no-drag': {
           '-webkit-app-region': 'no-drag',
+          'pointer-events': 'auto',
         },
-      };
-      addUtilities(newUtilities);
+      });
+      addComponents({
+        '.app-region-drag :is(button, a, input, textarea, select)': {
+          '-webkit-app-region': 'no-drag',
+          'pointer-events': 'auto',
+        },
+      });
     },
   ],
 };


### PR DESCRIPTION
## Related issue

No Lody issue is linked yet. This PR needs the public design discussion and maintainer agreement linked before the external-contribution grace period expires.

## Problem / pressure

The frameless Electron window used a single `fixed z-50` drag overlay (`h-5` / `h-9`) at the top of the renderer. That band was too short to match the visual title bar, and because it sat above the whole tree, raising it blocked clicks. Putting `-webkit-app-region: drag` on every long tab also made multi-tab switching impossible.

## Summary

Window drag now lives on each panel's existing top chrome at title-bar height (`h-11`), not on a global overlay.

- Workspace columns, sidebar headers, archive/task/session tab bars, landing, login, and onboarding host the drag region themselves.
- Surfaces without a header mount a same-height `WindowDragStrip`.
- `Dialog` and `AlertDialog` overlays mount the strip internally, so later modals do not pass extra props.
- Buttons, links, and inputs inside a drag region are `no-drag`. A solo session/task title stays draggable; two or more tabs opt out so click-to-switch still works.
- Windows caption buttons remain the OS overlay; right-edge headers pad `pr-[144px]`. Native fullscreen hides drag regions.

## Before / after

| Before | After |
| ------ | ----- |
| One full-width overlay (`h-5` / `h-9`) stole the top of every page | Each panel header of title-bar height is the drag region |
| Raising the overlay blocked tab and sidebar clicks | Interactive controls opt out with `app-region-no-drag` |
| Long solo titles marked `no-drag` left almost no drag surface | A solo title stays in the drag region |
| Multi-tab rows inherited drag and could not be clicked | Two or more tabs are `no-drag` so they stay selectable |
| Every modal would need its own drag strip prop | Dialog/alert overlays own the strip |

## Test plan

- `pnpm --filter @lody/components test tests/window-drag-region.test.tsx tests/session-tab-bar.test.tsx`
- `pnpm --filter @lody/components exec tsgo --noEmit`
- oxlint on the touched files
- Electron preview rebuild: solo title drags the window; two session tabs switch on click; Settings/dialog overlay top band drags the window

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Start with `packages/components/src/ui/window-drag-region.tsx` and `packages/components/src/ui/dialog.tsx`; then check session/task tab `solo` vs multi-tab `app-region-no-drag`.
- **Decisions to challenge:** Hosting the strip inside dialog overlays (so every modal inherits it) versus keeping drag only on product chrome.
- **Plausible failures / evidence gaps:** A future overlay that is not Dialog/AlertDialog still needs the strip; no automated test drives a real Electron window drag.

### Authoring context

- **User goal / directives:** Make the frameless drag range match title-bar height per panel, keep long titles draggable, keep multi-tab clickable, and stop threading drag props through every modal.
- **Constraints / non-goals:** Do not change traffic-light coordinates, macOS sidebar 72px inset, or native Windows caption overlay drawing.
- **Risk-bearing decisions:** `-webkit-app-region: drag` on a tab title eats clicks, so only a lone tab stays in the drag region.
- **Destructive or irreversible behavior:** None; this is renderer chrome hit-testing only.
- **Deliberately not done or tested:** No OS-level window-drag automation; verification is class/contract tests plus a manual Electron preview.
- **Unknowns / confidence:** High for Dialog/AlertDialog; any custom full-screen overlay outside those primitives still needs an explicit strip.

<!-- context-handoff:end -->