### PR TITLE
fix(electron): detect system language before onboarding

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/LodyAI/Lody",
   "scripts": {
     "format": "prettier --write .",
-    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test src/main/reload-shortcut.test.mjs src/main/onboarding-launch-policy.test.mjs src/main/window-theme.test.mjs src/main/local-platform-snapshot.test.mjs src/main/ipc/ipc-channel-list.test.mjs src/main/services/local-path-launcher-core.test.mjs src/main/services/image-export-core.test.mjs src/main/services/public-browser-state.test.mjs src/main/services/app-updater-metadata.test.mjs src/main/services/loro-data-plane-relay.test.mjs src/renderer/renderer-csp.test.mjs src/renderer/src/auth-callback-transaction.test.mjs src/renderer/src/auth-query-generation.test.mjs src/renderer/src/renderer-error-reporting.test.mjs",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test src/system-language-argument.test.mjs src/main/reload-shortcut.test.mjs src/main/onboarding-launch-policy.test.mjs src/main/window-theme.test.mjs src/main/local-platform-snapshot.test.mjs src/main/ipc/ipc-channel-list.test.mjs src/main/services/local-path-launcher-core.test.mjs src/main/services/image-export-core.test.mjs src/main/services/public-browser-state.test.mjs src/main/services/app-updater-metadata.test.mjs src/main/services/loro-data-plane-relay.test.mjs src/renderer/renderer-csp.test.mjs src/renderer/src/auth-callback-transaction.test.mjs src/renderer/src/auth-query-generation.test.mjs src/renderer/src/renderer-error-reporting.test.mjs",
     "lint": "eslint --cache .",
     "typecheck:node": "tsgo --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsgo --noEmit -p tsconfig.web.json --composite false",

--- a/apps/electron/src/main/window.ts
+++ b/apps/electron/src/main/window.ts
@@ -21,6 +21,7 @@ import {
 } from './window-theme'
 import { formatUnknownError, normalizeExternalHttpUrl } from './utils'
 import { describeDeepLinkForAuthDebug } from './auth-debug'
+import { serializePreferredSystemLanguagesArgument } from '../system-language-argument'
 import {
   clearMountWatchdog,
   clearUnresponsiveWatchdog,
@@ -349,6 +350,12 @@ export function createMainWindow(options: CreateMainWindowOptions): BrowserWindo
       : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
+      // Chromium's packaged locale resources are intentionally English-only.
+      // Carry Electron's OS-level preference into preload so first-run product
+      // language detection does not mistake the available .pak for user intent.
+      additionalArguments: [
+        serializePreferredSystemLanguagesArgument(app.getPreferredSystemLanguages())
+      ],
       sandbox: false,
       nodeIntegration: false,
       contextIsolation: true

--- a/apps/electron/src/preload/index.d.ts
+++ b/apps/electron/src/preload/index.d.ts
@@ -4,6 +4,7 @@ type LodyPlatformInfo = {
   os: string
   homeDir: string
   machineName: string
+  preferredSystemLanguages?: readonly string[]
 }
 
 type LodyNativeAppInfo = {

--- a/apps/electron/src/preload/index.ts
+++ b/apps/electron/src/preload/index.ts
@@ -3,13 +3,15 @@ import { ipcBridge } from './ipc-bridge'
 import { electronAPI } from '@electron-toolkit/preload'
 import { setupRenderer } from '@better-auth/electron/preload'
 import os from 'node:os'
+import { readPreferredSystemLanguagesArgument } from '../system-language-argument'
 
 setupRenderer()
 
 const platformInfo = {
   os: process.platform,
   homeDir: os.homedir(),
-  machineName: os.hostname()
+  machineName: os.hostname(),
+  preferredSystemLanguages: readPreferredSystemLanguagesArgument(process.argv)
 }
 
 if (process.contextIsolated) {

--- a/apps/electron/src/renderer/src/main.tsx
+++ b/apps/electron/src/renderer/src/main.tsx
@@ -2,6 +2,13 @@ import { useLayoutEffect } from 'react'
 import { createRoot } from 'react-dom/client'
 import { createHashHistory, RouterProvider } from '@tanstack/react-router'
 import { createRouter } from '@lody/components/router'
+import {
+  detectBrowserLanguage,
+  fallbackLanguage,
+  initI18n,
+  readStoredLanguagePreference
+} from '@lody/components/i18n'
+import { languageAtom } from '@lody/components/atoms/settings'
 import '@lody/components/tailwind/index.css'
 import { jotaiStore } from '@lody/components/lib'
 import { collectBootDiagnostics, renderBootFailure } from '@lody/components/lib/boot-failure'
@@ -120,6 +127,17 @@ window.addEventListener('unhandledrejection', (event) => {
 })
 
 try {
+  // Resolve and persist the desktop's first-run language before React can
+  // commit. AppInitializer keeps later changes synchronized; awaiting here
+  // closes the window where onboarding could paint once in English first.
+  const storedLanguage = readStoredLanguagePreference()
+  const detectedLanguage = storedLanguage ?? detectBrowserLanguage()
+  const bootLanguage = detectedLanguage ?? fallbackLanguage
+  await initI18n(bootLanguage)
+  if (!storedLanguage && detectedLanguage) {
+    jotaiStore.set(languageAtom, detectedLanguage)
+  }
+
   const isFileProtocol = window.location.protocol === 'file:'
   const router = createRouter({
     authClient,

--- a/apps/electron/src/system-language-argument.test.mjs
+++ b/apps/electron/src/system-language-argument.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  readPreferredSystemLanguagesArgument,
+  serializePreferredSystemLanguagesArgument
+} from './system-language-argument.ts'
+
+void test('round-trips preferred system languages without depending on Chromium locale packs', () => {
+  const argument = serializePreferredSystemLanguagesArgument(['zh-Hans-CN', 'en-US'])
+
+  assert.deepEqual(readPreferredSystemLanguagesArgument(['electron', argument]), [
+    'zh-Hans-CN',
+    'en-US'
+  ])
+})
+
+void test('rejects a missing or malformed preferred-system-languages argument', () => {
+  assert.deepEqual(readPreferredSystemLanguagesArgument(['electron']), [])
+  assert.deepEqual(
+    readPreferredSystemLanguagesArgument([
+      'electron',
+      '--lody-preferred-system-languages=%7Bnot-json'
+    ]),
+    []
+  )
+})
+
+void test('sanitizes values crossing the main-to-preload bootstrap boundary', () => {
+  const encoded = encodeURIComponent(JSON.stringify([' zh_CN ', 42, '', 'en-US']))
+
+  assert.deepEqual(
+    readPreferredSystemLanguagesArgument([
+      'electron',
+      `--lody-preferred-system-languages=${encoded}`
+    ]),
+    ['zh_CN', 'en-US']
+  )
+})

--- a/apps/electron/src/system-language-argument.ts
+++ b/apps/electron/src/system-language-argument.ts
@@ -1,0 +1,33 @@
+const PREFERRED_SYSTEM_LANGUAGES_ARGUMENT_PREFIX = '--lody-preferred-system-languages='
+
+function sanitizePreferredSystemLanguages(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+
+  return value
+    .filter((language): language is string => typeof language === 'string')
+    .map((language) => language.trim())
+    .filter((language) => language.length > 0)
+    .slice(0, 32)
+}
+
+export function serializePreferredSystemLanguagesArgument(
+  preferredSystemLanguages: readonly string[]
+): string {
+  return `${PREFERRED_SYSTEM_LANGUAGES_ARGUMENT_PREFIX}${encodeURIComponent(
+    JSON.stringify(sanitizePreferredSystemLanguages(preferredSystemLanguages))
+  )}`
+}
+
+export function readPreferredSystemLanguagesArgument(argv: readonly string[]): string[] {
+  const argument = argv.find((value) =>
+    value.startsWith(PREFERRED_SYSTEM_LANGUAGES_ARGUMENT_PREFIX)
+  )
+  if (!argument) return []
+
+  try {
+    const encoded = argument.slice(PREFERRED_SYSTEM_LANGUAGES_ARGUMENT_PREFIX.length)
+    return sanitizePreferredSystemLanguages(JSON.parse(decodeURIComponent(encoded)))
+  } catch {
+    return []
+  }
+}

--- a/packages/components/src/components/onboarding/ceremony/intro-sequence.tsx
+++ b/packages/components/src/components/onboarding/ceremony/intro-sequence.tsx
@@ -1,11 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import queueCurrent from '@/assets/onboarding/intro/queue-current.png';
 import quietWork from '@/assets/onboarding/intro/quiet-work.png';
 import continuousScroll from '@/assets/onboarding/intro/continuous-scroll.png';
 import readyToBegin from '@/assets/onboarding/intro/ready-to-begin.png';
-import { languageAtom } from '@/atoms/settings';
 import { cn } from '@/lib/utils';
 import { Button } from '@/ui/button';
 import type { AudioLayers } from './use-onboarding-audio';
@@ -288,9 +286,8 @@ export function IntroSequence({
 }): React.JSX.Element {
   const [current, setCurrent] = useState(0);
   const handoffTimer = useRef<number | null>(null);
-  const { t } = useTranslation();
-  const [language] = useAtom(languageAtom);
-  const chinese = language === 'zh_CN';
+  const { t, i18n } = useTranslation();
+  const chinese = (i18n.resolvedLanguage ?? i18n.language) === 'zh_CN';
   const [departing, setDeparting] = useState(false);
 
   // Remember the beat we came from so its sentence can fade out underneath the

--- a/packages/components/src/i18n/index.tsx
+++ b/packages/components/src/i18n/index.tsx
@@ -78,26 +78,30 @@ const BASE_SUBTAG_TO_SUPPORTED: Record<string, SupportedLanguage> = {
 };
 
 function bcp47ToSupportedLanguage(tag: string): SupportedLanguage | null {
-  const base = tag.toLowerCase().split('-')[0];
+  // Electron returns BCP-47 tags, while some Linux locale configurations still
+  // surface the legacy underscore spelling. Treat both separators identically.
+  const base = tag.toLowerCase().split(/[-_]/)[0];
   return BASE_SUBTAG_TO_SUPPORTED[base] ?? null;
 }
 
 export function detectBrowserLanguage(): SupportedLanguage | null {
-  if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+  if (typeof window === 'undefined') {
     return null;
   }
-  // Rejected: detecting in Electron. The desktop shell inherits the system
-  // locale, which rarely matches the user-facing preference. The settings
-  // panel is the canonical way to pick a language there.
-  if (window.__LODY_ELECTRON__ === true) {
-    return null;
-  }
+  // Electron's Chromium locale may reflect which `.pak` files were packaged,
+  // not the user's OS preference. Main passes the real system language list to
+  // preload before renderer code runs, keeping detection correct on macOS,
+  // Windows, and Linux without an asynchronous first-paint language switch.
   const candidates =
-    navigator.languages && navigator.languages.length > 0
-      ? navigator.languages
-      : navigator.language
-        ? [navigator.language]
-        : [];
+    window.__LODY_ELECTRON__ === true
+      ? (window.__LODY_PLATFORM__?.preferredSystemLanguages ?? [])
+      : typeof navigator === 'undefined'
+        ? []
+        : navigator.languages && navigator.languages.length > 0
+          ? navigator.languages
+          : navigator.language
+            ? [navigator.language]
+            : [];
   for (const candidate of candidates) {
     const matched = bcp47ToSupportedLanguage(candidate);
     if (matched) {
@@ -114,7 +118,10 @@ export const initI18n = async (language: string) => {
     initializationPromise = i18next
       .use(initReactI18next)
       .init({
-        lng: fallbackLanguage,
+        // The first call happens at module bootstrap with the stored/detected
+        // preference. Initializing directly in that language avoids committing
+        // one English frame before AppInitializer's effect can reconcile it.
+        lng: nextLanguage,
         fallbackLng: fallbackLanguage,
         defaultNS,
         ns: [defaultNS],
@@ -147,7 +154,7 @@ export const languageCodeToName = Object.fromEntries(
   currentSupportedLanguages.map((lang) => [lang, resources[lang as SupportedLanguage].lang.name])
 );
 
-void initI18n(fallbackLanguage);
+void initI18n(readStoredLanguagePreference() ?? detectBrowserLanguage() ?? fallbackLanguage);
 
 export const LanguageSelector = ({ triggerClassName }: { triggerClassName?: string }) => {
   const { i18n } = useTranslation();

--- a/packages/components/src/window-globals.d.ts
+++ b/packages/components/src/window-globals.d.ts
@@ -28,7 +28,12 @@ declare global {
     __LODY_NATIVE__?: boolean;
     __LODY_CORDOVA_READY__?: boolean;
     __LODY_ELECTRON__?: true;
-    __LODY_PLATFORM__?: { os: string; homeDir: string; machineName?: string };
+    __LODY_PLATFORM__?: {
+      os: string;
+      homeDir: string;
+      machineName?: string;
+      preferredSystemLanguages?: readonly string[];
+    };
     __LODY_BOOT__?: LodyBootController;
     __LODY_LIVE_ACTIVITY__?: LodyLiveActivityBridge;
     __LODY_APP_STORE_REVIEW__?: LodyAppStoreReviewBridge;

--- a/packages/components/tests/detect-browser-language.test.ts
+++ b/packages/components/tests/detect-browser-language.test.ts
@@ -3,12 +3,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { detectBrowserLanguage } from '../src/i18n';
 
-type GlobalWindow = typeof window & { __LODY_ELECTRON__?: boolean };
+type GlobalWindow = typeof window & {
+  __LODY_ELECTRON__?: true;
+  __LODY_PLATFORM__?: {
+    os: string;
+    homeDir: string;
+    preferredSystemLanguages?: readonly string[];
+  };
+};
 
 afterEach(() => {
   vi.unstubAllGlobals();
   const w = window as GlobalWindow;
   delete w.__LODY_ELECTRON__;
+  delete w.__LODY_PLATFORM__;
 });
 
 function setLanguages(languages: string[] | undefined, language?: string) {
@@ -86,9 +94,29 @@ describe('detectBrowserLanguage', () => {
     expect(detectBrowserLanguage()).toBe('zh_CN');
   });
 
-  it('returns null in the Electron shell', () => {
+  it.each([
+    ['macOS', 'darwin', 'zh-Hans-CN'],
+    ['Windows', 'win32', 'zh-CN'],
+    ['Linux', 'linux', 'zh_CN'],
+  ])('uses the %s system language passed by Electron main', (_label, os, language) => {
+    setLanguages(['en-US'], 'en-US');
+    const electronWindow = window as GlobalWindow;
+    electronWindow.__LODY_ELECTRON__ = true;
+    electronWindow.__LODY_PLATFORM__ = {
+      os,
+      homeDir: '/home/test',
+      preferredSystemLanguages: [language, 'en-US'],
+    };
+
+    expect(detectBrowserLanguage()).toBe('zh_CN');
+  });
+
+  it('does not fall back to Chromium locale packs when Electron system languages are absent', () => {
     setLanguages(['zh-CN'], 'zh-CN');
-    (window as GlobalWindow).__LODY_ELECTRON__ = true;
+    const electronWindow = window as GlobalWindow;
+    electronWindow.__LODY_ELECTRON__ = true;
+    electronWindow.__LODY_PLATFORM__ = { os: 'linux', homeDir: '/home/test' };
+
     expect(detectBrowserLanguage()).toBeNull();
   });
 });


### PR DESCRIPTION
## Related issue

Same-repository branch; no intake issue required.

## Problem / pressure

Electron deliberately ignored language detection and fell back to English when no `lody-language` preference existed. As a result, first-run onboarding rendered in English on Chinese Windows, macOS, and Linux systems, and a stored Chinese preference could still produce an English first frame.

## Summary

- Pass `app.getPreferredSystemLanguages()` from Electron main to preload without relying on the English-only Chromium locale packs.
- Map BCP-47 and legacy underscore Chinese locale forms to `zh_CN` on all three desktop platforms.
- Resolve, persist, and await the boot language before React renders onboarding.
- Use the resolved i18n language for ceremony typography and add cross-platform regression coverage.

## Before / after

| Before | After |
| ------ | ----- |
| A fresh Electron install on a Chinese system defaulted onboarding to English. | A fresh install follows the OS preferred language and renders Simplified Chinese before the first React commit. |
| Electron ignored its system language list and could expose Chromium's packaged English locale instead. | Electron main supplies the real OS preference synchronously through preload. |

## Test plan

- `node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test apps/electron/src/system-language-argument.test.mjs` — 3 tests passed.
- Prettier check over all changed source and test files — passed.
- `git diff --check` — passed.
- `npm --prefix apps/electron test` — 44 tests passed; 3 unrelated suites could not load because this checkout has no installed `typescript` / `@lody/shared` dependencies.
- Component Vitest and full typecheck were not runnable because this embedded checkout has no `node_modules`; CI should run the added macOS, Windows, and Linux detector cases.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the BrowserWindow additional-argument boundary, preload exposure, and pre-render i18n bootstrap as one synchronous first-paint path.
- **Decisions to challenge:** Confirm that explicit stored language should remain authoritative while only first-run users inherit `app.getPreferredSystemLanguages()`.
- **Plausible failures / evidence gaps:** Cross-platform packaged-app smoke tests were not available locally; verify Electron argument propagation and locale return shapes in release builds.

### Authoring context

- **User goal / directives:** Make first-run Electron onboarding render Chinese on Chinese Windows, macOS, and Linux systems and open a formal PR.
- **Constraints / non-goals:** Preserve explicit user language choices and the English-only Chromium locale packaging; do not add a second onboarding renderer or change onboarding flow structure.
- **Risk-bearing decisions:** System language data crosses main to preload through a bounded encoded argument so renderer startup does not depend on asynchronous IPC or Chromium locale packs.
- **Destructive or irreversible behavior:** No data is deleted or migrated; first-run detection persists the same `lody-language` preference that existing settings already own.
- **Deliberately not done or tested:** No three-OS packaged smoke run was performed because this checkout lacks installed dependencies and platform builders.
- **Unknowns / confidence:** Unit coverage exercises representative macOS, Windows, and Linux locale forms; residual risk is limited to packaged Electron argument propagation on each OS.

<!-- context-handoff:end -->