### PR TITLE
fix: fill project settings modal height

### DIFF
--- a/packages/components/src/components/settings/desktop-settings-modal.tsx
+++ b/packages/components/src/components/settings/desktop-settings-modal.tsx
@@ -129,6 +129,7 @@ function SettingsModalBody() {
     resolvedActiveTab === 'projects' ||
     resolvedActiveTab === 'machines' ||
     resolvedActiveTab === 'agents';
+  const usesInternalScrolling = resolvedActiveTab === 'projects';
 
   return (
     <SettingsDataCacheProvider>
@@ -229,13 +230,21 @@ function SettingsModalBody() {
             </header>
           )}
           <div className="min-h-0 flex-1">
-            <ScrollArea className="h-full">
-              <div className={cn('px-6 pb-6', selfTitledTab ? 'pt-6' : 'pt-0')}>
-                <div className="mx-auto max-w-5xl">
+            {usesInternalScrolling ? (
+              <div className="h-full px-6 pb-6 pt-6">
+                <div className="mx-auto h-full max-w-5xl">
                   <SettingsTabContent tabId={resolvedActiveTab} />
                 </div>
               </div>
-            </ScrollArea>
+            ) : (
+              <ScrollArea className="h-full">
+                <div className={cn('px-6 pb-6', selfTitledTab ? 'pt-6' : 'pt-0')}>
+                  <div className="mx-auto max-w-5xl">
+                    <SettingsTabContent tabId={resolvedActiveTab} />
+                  </div>
+                </div>
+              </ScrollArea>
+            )}
           </div>
         </FocusScope>
       </div>

--- a/packages/components/src/components/settings/project-settings.tsx
+++ b/packages/components/src/components/settings/project-settings.tsx
@@ -513,7 +513,7 @@ function ProjectSettingsDesktop({
   };
 
   return (
-    <div className={cn(settingContainerClass, 'md:max-w-6xl')}>
+    <div className={cn(settingContainerClass, 'flex h-full min-h-0 flex-col md:max-w-6xl')}>
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
           <h2 className="text-base font-semibold text-foreground">
@@ -544,7 +544,7 @@ function ProjectSettingsDesktop({
           </p>
         </div>
       ) : (
-        <div className="flex flex-col gap-3">
+        <div className="flex min-h-0 flex-1 flex-col gap-3">
           <MachinePills
             pills={pills}
             selectedId={resolvedPillId}
@@ -553,7 +553,7 @@ function ProjectSettingsDesktop({
               setSelectedProjectKey(null);
             }}
           />
-          <div className="flex h-[calc(90vh-16rem)] min-h-[400px] min-w-0">
+          <div className="flex min-h-0 min-w-0 flex-1">
             <div className="scrollbar-pro w-[240px] shrink-0 overflow-y-auto border-r border-border/60 py-1 pr-2">
               {isGithubPill
                 ? githubSections.map((section) => (

--- a/packages/components/src/stories/ProjectSettings.stories.tsx
+++ b/packages/components/src/stories/ProjectSettings.stories.tsx
@@ -161,7 +161,7 @@ function StoryWrapper({
   const [currentGithubSections, setCurrentGithubSections] = useState(githubSections);
 
   return (
-    <div className="mx-auto max-w-4xl p-4">
+    <div className="mx-auto h-screen max-w-4xl p-4">
       <ProjectSettingsView
         sections={currentSections}
         githubSections={currentGithubSections}
@@ -407,7 +407,7 @@ const meta = {
   title: 'Settings/ProjectSettings',
   component: StoryWrapper,
   parameters: {
-    layout: 'padded',
+    layout: 'fullscreen',
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof StoryWrapper>;


### PR DESCRIPTION
## Summary

- make desktop project settings fill their parent height by default instead of guessing from the viewport
- let the project list and detail pane own their scrolling inside the settings modal
- render all Project Settings stories in the same full-height layout

## Testing

- `pnpm --filter @lody/components typecheck`
- `pnpm exec prettier --check ...`
- `pnpm exec oxlint ...`
- Playwright checks against the default Story at 1600x1000 and 1024x640
- `pnpm --filter @lody/components test` (2776/2848 passed locally; 72 existing failures under Node 26, primarily unavailable jsdom localStorage)
- Storybook development preview rendered successfully; the full static Storybook build transformed 10,796 modules, then exceeded the local 4 GB Node heap during chunk rendering