### PR TITLE
fix(cli): bump pinned Kimi runtime to pick up ACP non-Bash process fix

### DIFF
--- a/apps/cli/src/agent/kimi-runtime-manifest.json
+++ b/apps/cli/src/agent/kimi-runtime-manifest.json
@@ -1,14 +1,14 @@
 {
   "name": "kimi-code",
-  "version": "0.37.0-lody.753c83056944",
+  "version": "0.37.0-lody.a85e939b9da6",
   "sourceVersion": "0.37.0",
-  "sourceCommit": "753c83056944391e91ba8683f6f8d2ec17824da0",
+  "sourceCommit": "a85e939b9da69f2f68709397aae1a02c8215cef6",
   "kind": "node-package",
   "minNodeVersion": "22.19.0",
   "artifact": {
-    "fileName": "lody-kimi-code-0.37.0-lody.753c83056944-037255b0bcbb3afe.tar.zst",
-    "sha256": "037255b0bcbb3afe2ce0456b8a9fa419b18ada24f8d90049696efe11d311b00b",
-    "size": 3253568,
+    "fileName": "lody-kimi-code-0.37.0-lody.a85e939b9da6-b0ea62d19721e3b0.tar.zst",
+    "sha256": "b0ea62d19721e3b045c1117f0459daf9e754abd9a90c7f3d1f5a48cad920afcf",
+    "size": 3252779,
     "compression": "zstd",
     "cmd": "package/dist/main.mjs"
   }


### PR DESCRIPTION
## Related issue

Closes #183

## Problem / pressure

The pinned Kimi managed runtime (`0.37.0-lody.753c83056944`, submodule source commit `753c8305`, 2026-08-19) predates the upstream fix `6d2f67cc` (2026-08-21) that removed the "interactive Bash tool only" guard in `AcpProcessService.spawn`. As a result, the Kimi agent's `Grep` and `Glob` tools — which spawn `rg` directly rather than through a shell — fail on every call under ACP with `ACP runtime only supports interactive Bash tool processes`. Only a rebuilt, republished runtime artifact plus a manifest re-pin can fix this; no Lody-side code change can.

## Summary

- Rebuilt the Kimi runtime artifact from the current `packages/acp-extension-kimi` submodule HEAD `a85e939b9da69f2f68709397aae1a02c8215cef6` (contains `6d2f67cc`) using `scripts/package-kimi-runtime.mjs`.
- Updated `apps/cli/src/agent/kimi-runtime-manifest.json` to the new version `0.37.0-lody.a85e939b9da6` with the new artifact `fileName`, `sha256`, and `size`.
- No source or dependency changes; the submodule pointer already includes the fix.

**Merge blocker:** the new artifact (`lody-kimi-code-0.37.0-lody.a85e939b9da6-<sha16>.tar.zst`) must be uploaded to the managed-runtime channel (`https://api.lody.ai`) before this merges — publication is a maintainer-side step. Merging without the upload would break Kimi runtime installs (download 404 / checksum mismatch).

## Before / after

| Before | After |
| ------ | ----- |
| Manifest pins `0.37.0-lody.753c83056944` (guard present) | Manifest pins `0.37.0-lody.a85e939b9da6` (guard removed upstream) |
| Kimi `Grep`/`Glob` fail every call under Lody ACP | Non-Bash process spawns (`rg`) are allowed; `Grep`/`Glob` work |

## Test plan

- Verified the built artifact's `package/dist/main.mjs` no longer contains the `only supports interactive Bash tool processes` guard and that `AcpProcessService.spawn` no longer rejects non-Bash invocations (matches submodule commit `6d2f67cc`).
- Verified the packaging script's reproducibility check passed (byte-for-byte identical archives).
- Ran the managed-runtime unit tests covering the manifest pin: `managed-agent-runtime.test.ts` (21/21 pass, including "matches the pinned Kimi runtime manifest and Node engine" and the download/extract paths).
- Ran the full repo `pnpm check`: typecheck, lint, i18n, and all boundary checks pass; `apps/cli` tests pass. `packages/components` shows 31 failures that reproduce identically on clean main without this change (jsdom `localStorage` environment issue on this machine) — unrelated to this diff.
- `pnpm format` is clean.
- NOT done: end-to-end install from the managed-runtime channel — the artifact is not yet published (maintainer step); verified locally only.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `apps/cli/src/agent/kimi-runtime-manifest.json` — confirm `version`/`sourceCommit` match submodule HEAD `a85e939b` and that `artifact.sha256`/`size`/`fileName` are self-consistent (fileName embeds `sha256.slice(0,16)`).
- **Decisions to challenge:** pinning submodule HEAD rather than a tagged kimi-code release; relying on the packaging script's reproducibility check instead of an independent maintainer rebuild.
- **Plausible failures / evidence gaps:** artifact is NOT yet on the managed-runtime channel, so merging before upload breaks installs; cross-machine rebuild reproducibility of the bundle is asserted by the script but not independently verified here.

### Authoring context

- **User goal / directives:** fix Kimi `Grep`/`Glob` failing under Lody's managed runtime; user confirmed maintainer agreement for opening this PR.
- **Constraints / non-goals:** no Lody source changes; no submodule pointer change (already contains the fix); artifact publication stays with maintainers.
- **Risk-bearing decisions:** re-pinning the runtime manifest changes what every client downloads and sha256-verifies; wrong values break installs, so the artifact upload must precede merge.
- **Destructive or irreversible behavior:** none in the repo; old runtime versions remain installed locally and the previous pin stays downloadable.
- **Deliberately not done or tested:** no live download of the new artifact (not yet published on the channel); everything else validated, including full `pnpm check` (only pre-existing, unrelated `packages/components` environment failures).
- **Unknowns / confidence:** high confidence in the root cause and pin values (reproduced the failure live, verified the fix in source and in the built bundle); residual risk is purely the publication step.

<!-- context-handoff:end -->
