### PR TITLE
fix(settings): clip settings sections to their rounded corners

### DIFF
--- a/packages/components/src/components/settings/compact-layout.tsx
+++ b/packages/components/src/components/settings/compact-layout.tsx
@@ -32,7 +32,10 @@ export function CompactSection({
 }: CompactSectionProps) {
   return (
     <section
-      className={cn('rounded-lg border border-border/70 bg-card/60 text-sm shadow-none', className)}
+      className={cn(
+        'overflow-hidden rounded-lg border border-border/70 bg-card/60 text-sm shadow-none',
+        className
+      )}
     >
       {title || headerRight ? (
         <header className="flex min-h-10 items-center justify-between gap-2 border-b border-border/70 bg-muted/40 px-3 py-1.5">


### PR DESCRIPTION
## Related issue

Closes #185

## Problem / pressure

`CompactSection` (`packages/components/src/components/settings/compact-layout.tsx`) draws a rounded, bordered card but never clips its children to that radius: it is styled `rounded-lg border border-border/70 bg-card/60` with no `overflow-hidden`. Any child that fills the card edge-to-edge with an opaque background therefore paints over the corner radius.

Settings → Appearance has exactly one such child — the terminal preview, a full-bleed block on `bg-[var(--terminal-background)]`. Its square bottom corners cover the card's rounded ones, so the left border stops short and the bottom border starts inset. The section header (`bg-muted/40`) overflows the top corners the same way; it is only harder to see because that fill sits close to the card color.

Every other bordered card in the same directory already pairs the two utilities — `workspace-join-requests-settings.tsx`, `account-machines-overview.tsx`, `usage-calendar-visualization.tsx`. `CompactSection` was the one that did not.

## Summary

Add `overflow-hidden` to `CompactSection`, so every settings section clips its children to the card radius. One line, at the shared container rather than on the single child that exposed it.

## Before / after

| Before | After |
| ------ | ----- |
| <img width="835" height="121" alt="image" src="https://github.com/user-attachments/assets/01d13569-4cfa-466b-b3a8-11995e03b9b9" /> | <img width="836" height="162" alt="image" src="https://github.com/user-attachments/assets/a7876c8d-8249-48b2-91d4-bcd2d2af8dd9" /> |

## Test plan

- Rendered `Settings/AppearanceSettings` → `Electron` in Storybook and captured the section with Playwright at 3x, light and dark. Before: the bottom corners are square and the border is discontinuous. After: the corners follow the card radius.
- Regression sweep over nine stories that use `CompactSection` (`GeneralSettings` light + dark, `KeyboardShortcutsSetting`, `ExperimentalFeaturesSetting`, `BetaFeaturesSection`, `PathLaunchersSettings`, `CliDaemonSetting`, `AccountSettings`, `ReviewerMachineConfigTable`), captured before and after and compared per pixel. Seven differ by 30–35 pixels each, all inside 4–5px bands at card corners; `PathLaunchersSettings` (which contains the only `absolute`-positioned child in these files) and `ReviewerMachineConfigTable` are byte-identical. No content is clipped.
- Confirmed the font and theme menus portal out of the section (`ui/popover.tsx` renders `PopoverPrimitive.Portal`), so the new clip cannot affect them.
- Ran Prettier on the changed file; it was already formatted.
- Not run: `pnpm check`. The change is a single Tailwind class string with no type or behavior surface, and the visual claims above are covered by the screenshot diff instead. Please run the full suite in CI.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `packages/components/src/components/settings/compact-layout.tsx` — whether clipping belongs on the shared `CompactSection` or only on the appearance terminal preview, and whether any consumer intends to paint outside the card.
- **Decisions to challenge:** fixing the shared container instead of adding `rounded-b-*` to the one visibly broken child; that choice changes 20 `CompactSection` instances across 10 files to fix one visible defect.
- **Plausible failures / evidence gaps:** a future child that must escape the card (a bleeding shadow, an inline non-portaled popover) would now be clipped silently; coverage is nine Storybook stories, not every settings surface, and the desktop app itself was not launched.

### Authoring context

- **User goal / directives:** reported during local QA that the terminal preview at the bottom of Settings → Appearance overflows its container, and asked for the fix.
- **Constraints / non-goals:** no visual redesign of the preview or the settings cards, no change to `CompactRow` column sizing, and no new invariant recorded in `AGENTS.md` for a one-line CSS fix.
- **Risk-bearing decisions:** placing the fix on the shared `CompactSection` rather than the single affected child, which trades a wider blast radius for consistency with every other bordered card in the directory.
- **Destructive or irreversible behavior:** none; the change is one Tailwind class on a presentational container, and reverting the line fully restores prior rendering.
- **Deliberately not done or tested:** `pnpm check` was not run, the Electron app was not launched, and mobile settings were not covered because `MobileAppearanceSettings` does not use `CompactSection` or render a terminal preview.
- **Unknowns / confidence:** high confidence for the nine measured stories; residual uncertainty is limited to settings surfaces without Storybook coverage, where the same clip could hide an intentional overflow.

<!-- context-handoff:end -->
