### PR TITLE
fix(auth): recover rejected mobile sessions [risk:high]

### DIFF
--- a/packages/components/src/atoms/index.ts
+++ b/packages/components/src/atoms/index.ts
@@ -29,3 +29,9 @@ export const userAtom = atom<CurrentUser | null>(readBootstrappedCurrentUser());
 // so the transient unauthenticated window mid-login is not mistaken for an
 // expired session and used to abort the in-flight login.
 export const electronDeepLinkSignInInProgressAtom = atom(false);
+
+// Native sign-in finishes in the same WebView lifecycle. Keep root session
+// invalidation fenced from sign-in start through the successful navigation so a
+// late get-session response for the replaced Capacitor credential cannot sign
+// out the newly established session.
+export const nativeSignInInProgressAtom = atom(false);

--- a/packages/components/src/components/login-page.tsx
+++ b/packages/components/src/components/login-page.tsx
@@ -3,9 +3,9 @@ import { Trans, useTranslation } from 'react-i18next';
 import { AnimatePresence, motion } from 'framer-motion';
 import { ArrowLeft, ArrowRight, ExternalLink, Github, Loader2, Mail } from 'lucide-react';
 import { usePostHog } from '@posthog/react';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import isEmail from 'validator/lib/isEmail';
-import { electronDeepLinkSignInInProgressAtom } from '@/atoms';
+import { electronDeepLinkSignInInProgressAtom, nativeSignInInProgressAtom } from '@/atoms';
 import { Button } from '@/ui/button';
 import { Input } from '@/ui/input';
 import { Label } from '@/ui/label';
@@ -15,6 +15,7 @@ import { setLoginHintCookie } from '@/lib/login-hint-cookie';
 import { formatPasswordValidationFailure, validateNewPassword } from '@/lib/password-validation';
 import { LoadingPlaceholder } from '@/components/loading-placeholder';
 import { useStableSession } from '@/hooks/useStableSession';
+import { hasUsableSessionUser } from '@/hooks/stable-session-state';
 import {
   buildElectronWebLoginCallbackUrl,
   clearElectronAuthorizationCode,
@@ -571,6 +572,7 @@ export function LoginPage({
   // the desktop login shows a "signing in" spinner while better-auth exchanges
   // the token for a session.
   const isCompletingElectronSignIn = useAtomValue(electronDeepLinkSignInInProgressAtom);
+  const setNativeSignInInProgress = useSetAtom(nativeSignInInProgressAtom);
   const [providerContentWidth, setProviderContentWidth] = useState<number | null>(null);
   const hasAutoElectronBridgeAttemptedRef = useRef(false);
   const providerLabelMeasureRef = useRef<HTMLDivElement | null>(null);
@@ -591,7 +593,21 @@ export function LoginPage({
   const privacyUrl = new URL(isChinese ? '/zh/privacy' : '/privacy', legalLinksOrigin).toString();
   const emailAuthCallbackURL = getEmailAuthCallbackURL(electronOAuthQuery);
   const isNativeApp = isNativeAppShell();
-  const { data: session, hasLocalToken, hasRawUser, isPending, isRetrying } = useStableSession();
+  const {
+    data: session,
+    hasLocalToken,
+    hasRawUser,
+    isPending,
+    isRetrying,
+    error: sessionError,
+    confirmedUnauthenticated,
+  } = useStableSession();
+  const canRedirectAuthenticatedUser = hasUsableSessionUser({
+    hasRawUser,
+    isRetrying,
+    hasError: sessionError !== null,
+    confirmedUnauthenticated,
+  });
   const loginSurface = isElectronOAuthFlow
     ? 'electron_browser_callback'
     : isNativeApp
@@ -656,7 +672,7 @@ export function LoginPage({
   // client signal; the authoritative value comes from better-auth (spec §3.5).
   const oauthSucceededFiredRef = useRef(false);
   useEffect(() => {
-    if (!hasRawUser || oauthSucceededFiredRef.current) {
+    if (!canRedirectAuthenticatedUser || oauthSucceededFiredRef.current) {
       return;
     }
     const pending = readAndClearPendingOAuth();
@@ -677,7 +693,7 @@ export function LoginPage({
       is_new_user: inferIsNewUser(sessionUser),
       oauth_round_trip_ms: Date.now() - pending.started_at_ms,
     });
-  }, [hasRawUser, isElectronRenderer, postHog, session]);
+  }, [canRedirectAuthenticatedUser, isElectronRenderer, postHog, session]);
 
   useLayoutEffect(() => {
     const labelContainer = providerLabelMeasureRef.current;
@@ -802,6 +818,11 @@ export function LoginPage({
       const normalizedEmail = trimmedEmail.toLowerCase();
       const emailAuthClient = authClient as AuthClientWithEmailPassword;
       setIsEmailSubmitting(true);
+      const shouldFenceNativeSignIn = isNativeApp && emailAuthMode === 'sign-in';
+      let keepNativeSignInFence = false;
+      if (shouldFenceNativeSignIn) {
+        setNativeSignInInProgress(true);
+      }
 
       try {
         if (emailAuthMode === 'sign-in') {
@@ -858,10 +879,12 @@ export function LoginPage({
           }
           if (electronOAuthQuery) {
             replaceAppWindowLocation(emailAuthCallbackURL);
+            keepNativeSignInFence = true;
             return;
           }
           setLoginHintCookie(true);
           replaceLocation(getRedirectTarget());
+          keepNativeSignInFence = true;
           return;
         }
 
@@ -927,6 +950,9 @@ export function LoginPage({
             : t('login.emailAuthFailed', 'Email authentication failed. Please try again.')
         );
       } finally {
+        if (shouldFenceNativeSignIn && !keepNativeSignInFence) {
+          setNativeSignInInProgress(false);
+        }
         setIsEmailSubmitting(false);
       }
     },
@@ -944,6 +970,7 @@ export function LoginPage({
       postHog,
       replaceLocation,
       sendVerificationEmail,
+      setNativeSignInInProgress,
       t,
     ]
   );
@@ -1004,6 +1031,10 @@ export function LoginPage({
       });
       // Persist a marker so the post-redirect return can fire oauth_succeeded.
       writePendingOAuth({ provider, login_surface: loginSurface, started_at_ms: Date.now() });
+      let keepNativeSignInFence = false;
+      if (isNativeApp) {
+        setNativeSignInInProgress(true);
+      }
 
       try {
         if (electronOAuthQuery) {
@@ -1059,6 +1090,7 @@ export function LoginPage({
             });
             setLoginHintCookie(true);
             replaceLocation(getRedirectTarget());
+            keepNativeSignInFence = true;
           }
           return;
         }
@@ -1079,6 +1111,9 @@ export function LoginPage({
         });
         console.error(`${provider} login error:`, err);
       } finally {
+        if (isNativeApp && !keepNativeSignInFence) {
+          setNativeSignInInProgress(false);
+        }
         setLoadingProvider(null);
       }
     },
@@ -1090,6 +1125,7 @@ export function LoginPage({
       loginSurface,
       postHog,
       replaceLocation,
+      setNativeSignInInProgress,
       t,
     ]
   );
@@ -1197,7 +1233,7 @@ export function LoginPage({
   );
 
   useEffect(() => {
-    if (!isElectronOAuthFlow || !hasRawUser) {
+    if (!isElectronOAuthFlow || !canRedirectAuthenticatedUser) {
       return;
     }
     if (hasAutoElectronBridgeAttemptedRef.current) {
@@ -1205,9 +1241,9 @@ export function LoginPage({
     }
     hasAutoElectronBridgeAttemptedRef.current = true;
     void handleElectronSessionTransfer();
-  }, [handleElectronSessionTransfer, hasRawUser, isElectronOAuthFlow]);
+  }, [canRedirectAuthenticatedUser, handleElectronSessionTransfer, isElectronOAuthFlow]);
 
-  if (isElectronOAuthFlow && hasRawUser && !error) {
+  if (isElectronOAuthFlow && canRedirectAuthenticatedUser && !error) {
     return (
       <LoadingPlaceholder
         title={t('login.redirectingToDesktop', 'Redirecting to desktop app')}
@@ -1219,7 +1255,7 @@ export function LoginPage({
     );
   }
 
-  if (hasRawUser && !isElectronOAuthFlow) {
+  if (canRedirectAuthenticatedUser && !isElectronOAuthFlow) {
     return (
       <BrowserRedirect
         to={getRedirectTarget()}

--- a/packages/components/src/hooks/AGENTS.md
+++ b/packages/components/src/hooks/AGENTS.md
@@ -33,6 +33,18 @@ this file; edit `AGENTS.md` only.
   restoration, search/group-expansion suppression, and viewport resize handling
   for the mobile keyboard and terminal dock. The library observes content growth;
   it does not replace Virtua or own those product-level behaviors.
+- `useStableSession` treats an HTTP 401 from `authClient.useSession()` as a
+  potentially stale response and verifies it once with the current credential.
+  Only a second 401 for the unchanged local token is terminal: stop retrying,
+  ignore cached user/bootstrap and grace state, and confirm unauthenticated so
+  the root sign-out path clears both Lody auth state and platform credential
+  storage. A rotated token or successful verification fences late responses from
+  an older login. Native login also holds `nativeSignInInProgressAtom` from the
+  first sign-in request through successful page replacement because its
+  Capacitor credential and local token are not written atomically; root session
+  invalidation must respect that fence. Do not extend terminal handling to
+  transport failures such as timeouts, 5xx, or `Client disconnected`; those
+  remain retryable and must not sign out an otherwise recoverable user.
 - `use-workspace-catalog.ts` reads a ref-counted per-workspace room in
   `lib/workspace-catalog-room.ts`; it must not open the Flock document,
   subscribe, or join the room per mount. The catalog is ONE small document, but

--- a/packages/components/src/hooks/stable-session-state.ts
+++ b/packages/components/src/hooks/stable-session-state.ts
@@ -36,8 +36,24 @@ type ConfirmUnauthenticatedOptions = {
   isPending: boolean;
   shouldRetry: boolean;
   hasFinalError: boolean;
+  isSessionUnauthorized: boolean;
   preserveUntilMs: number | null;
   now: number;
+};
+
+type SessionErrorRetryOptions = {
+  hasError: boolean;
+  isPending: boolean;
+  isSessionUnauthorized: boolean;
+  retryCount: number;
+  maxRetries: number;
+};
+
+type UsableSessionUserOptions = {
+  hasRawUser: boolean;
+  isRetrying: boolean;
+  hasError: boolean;
+  confirmedUnauthenticated: boolean;
 };
 
 type BrowserResumeRefetchOptions = {
@@ -62,8 +78,47 @@ export function hasAuthenticatedUser(data: AuthSessionLike): boolean {
   return Boolean(data?.user);
 }
 
+export function hasUsableSessionUser(options: UsableSessionUserOptions): boolean {
+  return (
+    options.hasRawUser &&
+    !options.isRetrying &&
+    !options.hasError &&
+    !options.confirmedUnauthenticated
+  );
+}
+
+function readHttpStatus(value: unknown): number | null {
+  if (typeof value !== 'object' || value === null) return null;
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.status === 'number') return record.status;
+  if (typeof record.statusCode === 'number') return record.statusCode;
+  return null;
+}
+
+export function isUnauthorizedSessionError(error: unknown): boolean {
+  const directStatus = readHttpStatus(error);
+  if (directStatus !== null) return directStatus === 401;
+
+  if (typeof error !== 'object' || error === null) return false;
+  const record = error as Record<string, unknown>;
+  const responseStatus = readHttpStatus(record.response);
+  if (responseStatus !== null) return responseStatus === 401;
+
+  return readHttpStatus(record.error) === 401;
+}
+
+export function shouldRetrySessionError(options: SessionErrorRetryOptions): boolean {
+  return (
+    options.hasError &&
+    !options.isPending &&
+    !options.isSessionUnauthorized &&
+    options.retryCount < options.maxRetries
+  );
+}
+
 export function shouldRetryMissingAuthenticatedSession(
-  options: MissingAuthenticatedSessionRetryOptions,
+  options: MissingAuthenticatedSessionRetryOptions
 ): boolean {
   return (
     options.hasLocalToken &&
@@ -108,6 +163,12 @@ export function shouldUsePreservedAuthenticatedSession(options: PreserveSessionO
 }
 
 export function shouldConfirmUnauthenticated(options: ConfirmUnauthenticatedOptions): boolean {
+  // A 401 from useSession() means the session endpoint rejected the credential.
+  // Cached user/bootstrap data must not keep that terminal state authenticated.
+  if (options.isSessionUnauthorized) {
+    return !options.isPending;
+  }
+
   return (
     options.hasLocalToken &&
     !options.hasRawUser &&

--- a/packages/components/src/hooks/useStableSession.ts
+++ b/packages/components/src/hooks/useStableSession.ts
@@ -10,9 +10,11 @@ import {
   DEFAULT_SESSION_KEEPALIVE_REFETCH_INTERVAL_MS,
   DEFAULT_SESSION_RESUME_REFETCH_THROTTLE_MS,
   hasAuthenticatedUser,
+  isUnauthorizedSessionError,
   shouldConfirmUnauthenticated,
   shouldRefetchSessionOnBrowserResume,
   shouldRetryMissingAuthenticatedSession,
+  shouldRetrySessionError,
   shouldStartAuthenticatedSessionGrace,
   shouldUsePreservedAuthenticatedSession,
 } from './stable-session-state';
@@ -43,6 +45,11 @@ const StableSessionContext = createContext<StableSessionValue | null>(null);
 
 export { StableSessionContext };
 
+function readAuthResponseError(value: unknown): unknown {
+  if (typeof value !== 'object' || value === null) return null;
+  return (value as { error?: unknown }).error ?? null;
+}
+
 export function useStableSessionInternal(options?: UseStableSessionOptions): StableSessionValue {
   const authClient = useAuthClient();
   const { data, isPending, error, refetch } = authClient.useSession();
@@ -59,6 +66,12 @@ export function useStableSessionInternal(options?: UseStableSessionOptions): Sta
   const isPendingRef = useRef(isPending);
   const [retryCount, setRetryCount] = useState(0);
   const [preserveUntilMs, setPreserveUntilMs] = useState<number | null>(null);
+  const [confirmedUnauthorizedError, setConfirmedUnauthorizedError] = useState<unknown>(null);
+  const [dismissedUnauthorizedError, setDismissedUnauthorizedError] = useState<unknown>(null);
+  const [isForcedUnauthorizedRefreshPending, setIsForcedUnauthorizedRefreshPending] =
+    useState(false);
+  const unauthorizedCheckSequenceRef = useRef(0);
+  const hasForcedUnauthorizedRefreshRef = useRef(false);
   const lastAuthenticatedDataRef = useRef(data);
   const previousHadRawUserRef = useRef(hasAuthenticatedUser(data));
   const hasConsumedInitialBootstrapGraceRef = useRef(false);
@@ -68,8 +81,20 @@ export function useStableSessionInternal(options?: UseStableSessionOptions): Sta
   const [bootstrapSnapshot] = useState<AuthBootstrapSnapshot | null>(() =>
     typeof window === 'undefined' ? null : readAuthBootstrapSnapshot()
   );
-  const hasLocalToken = Boolean(readStoredAuthToken());
+  const localToken = readStoredAuthToken();
+  const hasLocalToken = Boolean(localToken);
   const hasRawUser = hasAuthenticatedUser(data);
+  const hasUnauthorizedSessionError = isUnauthorizedSessionError(error);
+  const isConfirmedSessionUnauthorized =
+    hasUnauthorizedSessionError && confirmedUnauthorizedError === error;
+  const isDismissedSessionUnauthorized =
+    hasUnauthorizedSessionError && dismissedUnauthorizedError === error;
+  const isConfirmingSessionUnauthorized =
+    hasUnauthorizedSessionError &&
+    !isPending &&
+    !isConfirmedSessionUnauthorized &&
+    !isDismissedSessionUnauthorized;
+  const isSessionUnauthorized = hasUnauthorizedSessionError && !isDismissedSessionUnauthorized;
   const shouldRetryMissingSession = shouldRetryMissingAuthenticatedSession({
     hasLocalToken,
     hasRawUser,
@@ -78,14 +103,92 @@ export function useStableSessionInternal(options?: UseStableSessionOptions): Sta
     retryCount,
     maxRetries,
   });
-  const shouldRetry =
-    (Boolean(error) && !isPending && retryCount < maxRetries) || shouldRetryMissingSession;
-  const finalError = Boolean(error) && retryCount >= maxRetries ? error : null;
+  const shouldScheduleRetry =
+    shouldRetrySessionError({
+      hasError: Boolean(error),
+      isPending,
+      isSessionUnauthorized,
+      retryCount,
+      maxRetries,
+    }) || shouldRetryMissingSession;
+  const finalError =
+    isConfirmedSessionUnauthorized ||
+    (Boolean(error) &&
+      retryCount >= maxRetries &&
+      !isConfirmingSessionUnauthorized &&
+      !isForcedUnauthorizedRefreshPending)
+      ? error
+      : null;
   const hasLastAuthenticatedUser = hasAuthenticatedUser(lastAuthenticatedDataRef.current);
   const hasBootstrapSnapshot = bootstrapSnapshot !== null;
 
   useEffect(() => {
-    if (!shouldRetry) {
+    if (!hasUnauthorizedSessionError) {
+      setConfirmedUnauthorizedError(null);
+      setDismissedUnauthorizedError(null);
+      setIsForcedUnauthorizedRefreshPending(false);
+      hasForcedUnauthorizedRefreshRef.current = false;
+      return undefined;
+    }
+    if (isPending || isConfirmedSessionUnauthorized || isDismissedSessionUnauthorized) {
+      return undefined;
+    }
+
+    const tokenAtStart = localToken;
+    const sequence = unauthorizedCheckSequenceRef.current + 1;
+    unauthorizedCheckSequenceRef.current = sequence;
+    let cancelled = false;
+
+    void authClient.getSession({ fetchOptions: { throw: false } }).then(
+      (result) => {
+        if (cancelled || unauthorizedCheckSequenceRef.current !== sequence) return;
+
+        const tokenChanged = readStoredAuthToken() !== tokenAtStart;
+        const verificationError = readAuthResponseError(result);
+        const verificationRejected = isUnauthorizedSessionError(verificationError);
+        if (!tokenChanged && verificationRejected) {
+          setConfirmedUnauthorizedError(error);
+          return;
+        }
+
+        // The 401 belonged to an older credential, or the current credential
+        // now succeeds. Let the ordinary retry lane refresh the session atom.
+        setDismissedUnauthorizedError(error);
+        if (
+          (tokenChanged || verificationError === null) &&
+          retryCount >= maxRetries &&
+          !hasForcedUnauthorizedRefreshRef.current
+        ) {
+          hasForcedUnauthorizedRefreshRef.current = true;
+          setIsForcedUnauthorizedRefreshPending(true);
+          void refetch().finally(() => setIsForcedUnauthorizedRefreshPending(false));
+        }
+      },
+      () => {
+        if (cancelled || unauthorizedCheckSequenceRef.current !== sequence) return;
+        // A transport failure cannot confirm credential rejection.
+        setDismissedUnauthorizedError(error);
+      }
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    authClient,
+    error,
+    hasUnauthorizedSessionError,
+    isConfirmedSessionUnauthorized,
+    isDismissedSessionUnauthorized,
+    isPending,
+    localToken,
+    maxRetries,
+    refetch,
+    retryCount,
+  ]);
+
+  useEffect(() => {
+    if (!shouldScheduleRetry) {
       if (timerRef.current) {
         clearTimeout(timerRef.current);
         timerRef.current = null;
@@ -110,7 +213,7 @@ export function useStableSessionInternal(options?: UseStableSessionOptions): Sta
         timerRef.current = null;
       }
     };
-  }, [baseDelayMs, maxDelayMs, maxRetries, refetch, retryCount, shouldRetry]);
+  }, [baseDelayMs, maxDelayMs, maxRetries, refetch, retryCount, shouldScheduleRetry]);
 
   useEffect(() => {
     if (hasRawUser) {
@@ -203,7 +306,10 @@ export function useStableSessionInternal(options?: UseStableSessionOptions): Sta
         hasBootstrapSnapshot,
         hasConsumedInitialBootstrapGrace: hasConsumedInitialBootstrapGraceRef.current,
         isPending,
-        shouldRetry,
+        shouldRetry:
+          shouldScheduleRetry ||
+          isConfirmingSessionUnauthorized ||
+          isForcedUnauthorizedRefreshPending,
         hasFinalError: finalError !== null,
         preserveUntilMs,
       })
@@ -224,8 +330,10 @@ export function useStableSessionInternal(options?: UseStableSessionOptions): Sta
     hasLocalToken,
     hasRawUser,
     isPending,
+    isConfirmingSessionUnauthorized,
+    isForcedUnauthorizedRefreshPending,
     preserveUntilMs,
-    shouldRetry,
+    shouldScheduleRetry,
   ]);
 
   useEffect(() => {
@@ -251,32 +359,38 @@ export function useStableSessionInternal(options?: UseStableSessionOptions): Sta
   const optimisticBootstrapSnapshot: AuthBootstrapSnapshot | null =
     hasLocalToken && bootstrapSnapshot ? bootstrapSnapshot : null;
   const now = Date.now();
-  const shouldUsePreservedSession = shouldUsePreservedAuthenticatedSession({
-    hasLocalToken,
-    hasRawUser,
-    hasLastAuthenticatedUser,
-    preserveUntilMs,
-    now,
-  });
   const confirmedUnauthenticated = shouldConfirmUnauthenticated({
     hasLocalToken,
     hasRawUser,
     isPending,
-    shouldRetry,
+    shouldRetry:
+      shouldScheduleRetry || isConfirmingSessionUnauthorized || isForcedUnauthorizedRefreshPending,
     hasFinalError: finalError !== null,
+    isSessionUnauthorized: isConfirmedSessionUnauthorized,
     preserveUntilMs,
     now,
   });
+  const shouldUsePreservedSession =
+    !confirmedUnauthenticated &&
+    shouldUsePreservedAuthenticatedSession({
+      hasLocalToken,
+      hasRawUser,
+      hasLastAuthenticatedUser,
+      preserveUntilMs,
+      now,
+    });
   const shouldUseOptimisticBootstrap =
     !shouldUsePreservedSession &&
     !hasRawUser &&
     optimisticBootstrapSnapshot !== null &&
     !confirmedUnauthenticated;
-  const stableData = shouldUsePreservedSession
-    ? lastAuthenticatedDataRef.current
-    : shouldUseOptimisticBootstrap
-      ? ({ user: optimisticBootstrapSnapshot.user } as typeof data)
-      : data;
+  const stableData = confirmedUnauthenticated
+    ? null
+    : shouldUsePreservedSession
+      ? lastAuthenticatedDataRef.current
+      : shouldUseOptimisticBootstrap
+        ? ({ user: optimisticBootstrapSnapshot.user } as typeof data)
+        : data;
 
   return {
     data: stableData,
@@ -286,7 +400,8 @@ export function useStableSessionInternal(options?: UseStableSessionOptions): Sta
     hasRawUser,
     isOptimistic: shouldUseOptimisticBootstrap,
     isPending,
-    isRetrying: shouldRetry,
+    isRetrying:
+      shouldScheduleRetry || isConfirmingSessionUnauthorized || isForcedUnauthorizedRefreshPending,
     error: finalError,
     confirmedUnauthenticated,
     refetch,

--- a/packages/components/src/routes/__root.tsx
+++ b/packages/components/src/routes/__root.tsx
@@ -34,6 +34,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import {
   authTokenAtom,
   electronDeepLinkSignInInProgressAtom,
+  nativeSignInInProgressAtom,
   setWorkspaceContextAtom,
   userAtom,
 } from '@/atoms';
@@ -252,6 +253,7 @@ function RootLocationEffects() {
   } = useStableSession();
   const userEmail = session?.user?.email;
   const electronSignInInProgress = useAtomValue(electronDeepLinkSignInInProgressAtom);
+  const nativeSignInInProgress = useAtomValue(nativeSignInInProgressAtom);
   const setUser = useSetAtom(userAtom);
   const setAuthToken = useSetAtom(authTokenAtom);
   const setWorkspaceContext = useSetAtom(setWorkspaceContextAtom);
@@ -318,6 +320,9 @@ function RootLocationEffects() {
     if (electronSignInInProgress) {
       return;
     }
+    if (nativeSignInInProgress) {
+      return;
+    }
 
     authInvalidationRef.current = true;
     const redirectPath =
@@ -339,6 +344,7 @@ function RootLocationEffects() {
     confirmedUnauthenticated,
     electronSignInInProgress,
     location.pathname,
+    nativeSignInInProgress,
     navigate,
     setAuthToken,
     setWorkspaceContext,

--- a/packages/components/tests/stable-session-state.test.ts
+++ b/packages/components/tests/stable-session-state.test.ts
@@ -1,18 +1,84 @@
 import { describe, expect, it } from 'vitest';
 import {
   hasAuthenticatedUser,
+  hasUsableSessionUser,
+  isUnauthorizedSessionError,
   shouldConfirmUnauthenticated,
   shouldRefetchSessionOnBrowserResume,
   shouldRetryMissingAuthenticatedSession,
+  shouldRetrySessionError,
   shouldStartAuthenticatedSessionGrace,
   shouldUsePreservedAuthenticatedSession,
 } from '../src/hooks/stable-session-state';
 
 describe('stable-session-state', () => {
+  it('classifies unauthorized session responses without conflating transient failures', () => {
+    expect(isUnauthorizedSessionError({ status: 401 })).toBe(true);
+    expect(isUnauthorizedSessionError({ statusCode: 401 })).toBe(true);
+    expect(isUnauthorizedSessionError({ response: { status: 401 } })).toBe(true);
+    expect(isUnauthorizedSessionError({ error: { status: 401 } })).toBe(true);
+    expect(isUnauthorizedSessionError({ status: 500, message: 'Client disconnected' })).toBe(false);
+    expect(isUnauthorizedSessionError({ status: 500, error: { status: 401 } })).toBe(false);
+    expect(isUnauthorizedSessionError({ response: { status: 500 }, error: { status: 401 } })).toBe(
+      false
+    );
+    expect(isUnauthorizedSessionError(new Error('Client disconnected'))).toBe(false);
+  });
+
+  it('does not retry a session credential rejected with 401', () => {
+    expect(
+      shouldRetrySessionError({
+        hasError: true,
+        isPending: false,
+        isSessionUnauthorized: true,
+        retryCount: 0,
+        maxRetries: 2,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldRetrySessionError({
+        hasError: true,
+        isPending: false,
+        isSessionUnauthorized: false,
+        retryCount: 0,
+        maxRetries: 2,
+      })
+    ).toBe(true);
+  });
+
   it('detects authenticated users from session-like data', () => {
     expect(hasAuthenticatedUser({ user: { id: 'user-1' } })).toBe(true);
     expect(hasAuthenticatedUser({})).toBe(false);
     expect(hasAuthenticatedUser(null)).toBe(false);
+  });
+
+  it('allows login redirect only for a settled error-free authenticated session', () => {
+    expect(
+      hasUsableSessionUser({
+        hasRawUser: true,
+        isRetrying: false,
+        hasError: false,
+        confirmedUnauthenticated: false,
+      })
+    ).toBe(true);
+
+    for (const blocked of [
+      { hasRawUser: false },
+      { isRetrying: true },
+      { hasError: true },
+      { confirmedUnauthenticated: true },
+    ]) {
+      expect(
+        hasUsableSessionUser({
+          hasRawUser: true,
+          isRetrying: false,
+          hasError: false,
+          confirmedUnauthenticated: false,
+          ...blocked,
+        })
+      ).toBe(false);
+    }
   });
 
   it('starts an initial grace window from a bootstrapped session snapshot', () => {
@@ -96,6 +162,7 @@ describe('stable-session-state', () => {
         isPending: false,
         shouldRetry: false,
         hasFinalError: false,
+        isSessionUnauthorized: false,
         preserveUntilMs: 5_000,
         now: 4_999,
       })
@@ -108,8 +175,24 @@ describe('stable-session-state', () => {
         isPending: false,
         shouldRetry: false,
         hasFinalError: false,
+        isSessionUnauthorized: false,
         preserveUntilMs: 5_000,
         now: 5_000,
+      })
+    ).toBe(true);
+  });
+
+  it('confirms rejected credentials even while stale authenticated data is cached', () => {
+    expect(
+      shouldConfirmUnauthenticated({
+        hasLocalToken: false,
+        hasRawUser: true,
+        isPending: false,
+        shouldRetry: false,
+        hasFinalError: true,
+        isSessionUnauthorized: true,
+        preserveUntilMs: 5_000,
+        now: 1_000,
       })
     ).toBe(true);
   });

--- a/packages/components/tests/use-stable-session.test.tsx
+++ b/packages/components/tests/use-stable-session.test.tsx
@@ -1,0 +1,175 @@
+/** @vitest-environment jsdom */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  localToken: 'stored-session-token' as string | null,
+  session: {
+    data: {
+      session: { id: 'stale-session' },
+      user: { id: 'user-1' },
+    } as unknown,
+    error: null as Error | null,
+    isPending: false,
+    refetch: vi.fn(),
+  },
+  getSession: vi.fn(),
+}));
+
+vi.mock('../src/providers/convex-provider', () => ({
+  useAuthClient: () => ({ useSession: () => mocks.session, getSession: mocks.getSession }),
+}));
+
+vi.mock('../src/lib/auth-bootstrap', () => ({
+  readAuthBootstrapSnapshot: () => null,
+  readStoredAuthToken: () => mocks.localToken,
+}));
+
+import { useStableSessionInternal, type StableSessionValue } from '../src/hooks/useStableSession';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('useStableSessionInternal', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let current: StableSessionValue | null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.localToken = 'stored-session-token';
+    mocks.session.data = {
+      session: { id: 'stale-session' },
+      user: { id: 'user-1' },
+    };
+    mocks.session.error = null;
+    mocks.session.isPending = false;
+    mocks.session.refetch.mockReset();
+    mocks.session.refetch.mockResolvedValue(undefined);
+    mocks.getSession.mockReset();
+    mocks.getSession.mockResolvedValue({ error: { status: 401 } });
+    current = null;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  function Consumer() {
+    current = useStableSessionInternal();
+    return null;
+  }
+
+  it('rejects stale cached user data after the current credential also returns 401', async () => {
+    const unauthorized = Object.assign(new Error('Unauthorized'), { status: 401 });
+    mocks.session.error = unauthorized;
+
+    await act(async () => root.render(<Consumer />));
+
+    expect(current?.confirmedUnauthenticated).toBe(true);
+    expect(current?.isRetrying).toBe(false);
+    expect(current?.data).toBeNull();
+    expect(current?.error).toBe(unauthorized);
+    expect(mocks.session.refetch).not.toHaveBeenCalled();
+  });
+
+  it('keeps retrying transient session transport failures', async () => {
+    const disconnected = Object.assign(new Error('Client disconnected'), { status: 500 });
+    mocks.session.error = disconnected;
+
+    await act(async () => root.render(<Consumer />));
+
+    expect(current?.confirmedUnauthenticated).toBe(false);
+    expect(current?.isRetrying).toBe(true);
+    expect(current?.data).toEqual(mocks.session.data);
+    expect(current?.error).toBeNull();
+
+    await act(async () => vi.advanceTimersByTimeAsync(300));
+
+    expect(mocks.session.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not accept a stale 401 after the current credential succeeds', async () => {
+    mocks.session.error = Object.assign(new Error('Unauthorized'), { status: 401 });
+    mocks.getSession.mockResolvedValue({ data: mocks.session.data, error: null });
+
+    await act(async () => root.render(<Consumer />));
+
+    expect(mocks.getSession).toHaveBeenCalledTimes(1);
+    expect(current?.confirmedUnauthenticated).toBe(false);
+    expect(current?.data).toEqual(mocks.session.data);
+    expect(current?.error).toBeNull();
+
+    await act(async () => vi.advanceTimersByTimeAsync(300));
+
+    expect(mocks.session.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('forces one refresh when verification disproves a stale 401 after retries are exhausted', async () => {
+    mocks.session.error = Object.assign(new Error('Client disconnected'), { status: 500 });
+
+    await act(async () => root.render(<Consumer />));
+    await act(async () => vi.advanceTimersByTimeAsync(300));
+    await act(async () => vi.advanceTimersByTimeAsync(600));
+    expect(mocks.session.refetch).toHaveBeenCalledTimes(2);
+
+    mocks.session.error = Object.assign(new Error('Unauthorized'), { status: 401 });
+    mocks.getSession.mockResolvedValue({ data: mocks.session.data, error: null });
+    await act(async () => root.render(<Consumer />));
+
+    expect(current?.confirmedUnauthenticated).toBe(false);
+    expect(current?.error).toMatchObject({ status: 401 });
+    expect(mocks.session.refetch).toHaveBeenCalledTimes(3);
+
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+
+    expect(mocks.session.refetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('bounds retries when unauthorized verification hits a transport failure', async () => {
+    mocks.session.error = Object.assign(new Error('Client disconnected'), { status: 500 });
+
+    await act(async () => root.render(<Consumer />));
+    await act(async () => vi.advanceTimersByTimeAsync(300));
+    await act(async () => vi.advanceTimersByTimeAsync(600));
+    expect(mocks.session.refetch).toHaveBeenCalledTimes(2);
+
+    const unauthorized = Object.assign(new Error('Unauthorized'), { status: 401 });
+    mocks.session.error = unauthorized;
+    mocks.getSession.mockRejectedValue(new Error('Client disconnected'));
+    await act(async () => root.render(<Consumer />));
+
+    expect(current?.confirmedUnauthenticated).toBe(false);
+    expect(current?.isRetrying).toBe(false);
+    expect(current?.error).toBe(unauthorized);
+
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+
+    expect(mocks.session.refetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels a queued transport retry when the session changes to unauthorized', async () => {
+    mocks.session.error = Object.assign(new Error('Client disconnected'), { status: 500 });
+
+    await act(async () => root.render(<Consumer />));
+    expect(current?.isRetrying).toBe(true);
+
+    mocks.session.error = Object.assign(new Error('Unauthorized'), { status: 401 });
+    await act(async () => root.render(<Consumer />));
+
+    expect(current?.confirmedUnauthenticated).toBe(true);
+    expect(current?.isRetrying).toBe(false);
+
+    await act(async () => vi.advanceTimersByTimeAsync(300));
+
+    expect(mocks.session.refetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Risk: 🔴 high | Confidence: high — changes auth recovery and native credential lifecycle; covered by targeted state/hook tests, full affected checks, and three adversarial review rounds

## Summary

- distinguish terminal session 401 from retryable transport failures and verify current credentials before sign-out
- fence native email and social sign-in so stale responses cannot erase a new Capacitor credential
- block stale login redirects and bound recovery retries

## Affected packages

- `packages/components`

## Issues

- None

## Verification

- `pnpm check:affected`
- `pnpm --filter @lody/components exec vitest run tests/stable-session-state.test.ts tests/use-stable-session.test.tsx`
- `pnpm --filter @lody/components typecheck`
- adversarial auth review: security, correctness/lifecycle, scope, and final refutation