### PR TITLE
fix(components): preserve active tab on session reselect

### DIFF
--- a/packages/components/src/components/loro-app-sidebar.tsx
+++ b/packages/components/src/components/loro-app-sidebar.tsx
@@ -1790,6 +1790,7 @@ export function LoroAppSidebar({ className }: LoroAppSidebarProps) {
     (sessionId: string, tabSessionId?: string) => {
       if (!workspaceSlug) return;
       closeMobileDrawer();
+      if (selectedSessionId === sessionId && tabSessionId === undefined) return;
       void router.navigate({
         to: '/$workspaceName/sessions/$sessionId',
         params: { workspaceName: workspaceSlug, sessionId: sessionId as SessionId },
@@ -1802,7 +1803,7 @@ export function LoroAppSidebar({ className }: LoroAppSidebarProps) {
           : {}),
       });
     },
-    [closeMobileDrawer, router, workspaceSlug]
+    [closeMobileDrawer, router, selectedSessionId, workspaceSlug]
   );
 
   const handleNavigateToNewSession = useCallback(


### PR DESCRIPTION
## Related issue

Fixes #193

## Problem / pressure

With a child tab active, clicking the already-selected parent Session row removes the `tab` search value. The route-to-active-tab and active-tab-to-route effects then restore each other's stale state, producing an unbounded navigation loop that freezes the renderer.

This PR intentionally addresses the direct trigger reported in #193. It is not the root reconciliation fix.

## Summary

- Treat a repeated click on the current parent Session row as a no-op.
- Preserve the active child tab and its URL state.
- Keep navigation to another parent Session or an explicit child tab unchanged.

This prevents the reproducible freeze path in #193. It does not resolve the underlying competing tab/URL synchronization in `SessionDetail`; a follow-up PR will refactor that logic around one arbitration path and add convergence coverage.

## Before / after

| Before | After |
| ------ | ----- |
| Re-clicking the current parent Session while a child tab is active clears the tab search state and can start an infinite navigation loop. | Re-clicking the current parent Session does nothing, preserves the child tab, and keeps the renderer responsive. |

## Test plan

- `pnpm --filter @lody/components test` — 397 files and 2,848 tests passed.
- `pnpm --filter @lody/components typecheck` — passed.
- `pnpm exec oxlint packages/components/src/components/loro-app-sidebar.tsx` — passed with zero warnings or errors.
- `pnpm exec prettier --check packages/components/src/components/loro-app-sidebar.tsx` — passed.
- `git diff --check` — passed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the guard in `loro-app-sidebar.tsx` and confirm it only suppresses a repeated parent-row navigation while preserving explicit child-tab and cross-session navigation.
- **Decisions to challenge:** Assess the temporary product contract that re-clicking the selected parent row is a no-op instead of activating the parent tab.
- **Plausible failures / evidence gaps:** The underlying bidirectional tab/URL synchronization remains and no new focused sidebar-to-router regression test was added; this patch only removes the reported trigger.

### Authoring context

- **User goal / directives:** Fix #193 with the smallest source change by preserving the current child tab when the active parent Session row is clicked again.
- **Constraints / non-goals:** Do not refactor `SessionDetail` tab reconciliation in this PR; that work will be delivered separately.
- **Risk-bearing decisions:** The repeated parent-row click semantics change from navigating to the parent URL to a no-op, deliberately preventing entry into the existing reconciliation race.
- **Destructive or irreversible behavior:** The change performs no data mutation or migration, and reverting the single commit restores the previous navigation behavior.
- **Deliberately not done or tested:** Root-cause tab reconciliation and dedicated end-to-end coverage are deferred; the existing component suite, typecheck, formatting, lint, and diff checks were run.
- **Unknowns / confidence:** Confidence is high for preventing the exact sidebar trigger in #193, while other unverified paths could still expose the underlying synchronization race.

<!-- context-handoff:end -->