### PR TITLE
fix(cli): deliver MCP child-session completion notifications over the HTTP transport

### DIFF
--- a/apps/cli/src/mcp/lody-mcp-server.test.ts
+++ b/apps/cli/src/mcp/lody-mcp-server.test.ts
@@ -23,8 +23,13 @@ import {
   WorkspaceSyncUnavailableError,
 } from '@/lib/command-runtime';
 import type { LoroDocumentManager } from '@/lib/loro/doc';
+import { getLodyOperationStorePath } from '@/orchestration/operation-store';
 
-import { __lodyMcpServerInternals, buildLodyMcpServer } from './lody-mcp-server';
+import {
+  __lodyMcpServerInternals,
+  buildLodyMcpServer,
+  runWithMcpSessionContext,
+} from './lody-mcp-server';
 
 const {
   TaskListToolInputSchema,
@@ -63,6 +68,7 @@ const {
   buildOperationTargetCancelArgs,
   summarizeAgentConfig,
   getSessionContext,
+  resolveOperationStorePathForContext,
   resolveUploadPath,
   resolveInvokingHistoryInput,
   summarizeProjectRefForMcp,
@@ -106,6 +112,37 @@ const agentRole = (overrides: Partial<AgentRole> = {}): AgentRole => ({
   createdAt: 1,
   updatedAt: 1,
   ...overrides,
+});
+
+describe('shared Operation store path', () => {
+  // Regression: the daemon-hosted HTTP MCP transport carries its session
+  // context in AsyncLocalStorage and its process has no LODY_MCP_MACHINE_ID,
+  // so an env-derived store path silently falls back to the 'local' store that
+  // no daemon coordinator reconciles — accepted Operations never finish and
+  // the requester Session never receives its completion turn.
+  it('resolves the coordinator-visible store from the context machineId without env', () => {
+    const savedEnv = {
+      LODY_MCP_MACHINE_ID: process.env.LODY_MCP_MACHINE_ID,
+      LODY_PREVIEW_MCP_MACHINE_ID: process.env.LODY_PREVIEW_MCP_MACHINE_ID,
+    };
+    delete process.env.LODY_MCP_MACHINE_ID;
+    delete process.env.LODY_PREVIEW_MCP_MACHINE_ID;
+    try {
+      const context = { ...createMcpContext(), machineId: 'http-host-machine-id' };
+      const storePath = runWithMcpSessionContext(context, () =>
+        resolveOperationStorePathForContext()
+      );
+      // Same path the daemon coordinator opens for this machine id...
+      expect(storePath).toBe(getLodyOperationStorePath(context.machineId));
+      // ...and NOT the legacy 'local'-keyed store nobody reconciles.
+      expect(storePath).not.toBe(getLodyOperationStorePath('local'));
+    } finally {
+      for (const [name, value] of Object.entries(savedEnv)) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+    }
+  });
 });
 
 const listPublishedToolNames = async (taskToolsEnabled: boolean): Promise<string[]> => {

--- a/apps/cli/src/mcp/lody-mcp-server.ts
+++ b/apps/cli/src/mcp/lody-mcp-server.ts
@@ -131,6 +131,7 @@ import type {
 } from '@/commands/session-output';
 import { MAX_AGENT_FEEDBACK_LENGTH, submitAgentFeedback } from '@/lib/feedback';
 import {
+  getLodyOperationStorePath,
   LodyOperationStore,
   LodyOperationStoreError,
   runWithOperationStoreBusyRetry,
@@ -908,16 +909,31 @@ const getSessionContext = (): McpSessionContext =>
     taskToolsEnabled: readOptionalEnv('LODY_MCP_TASK_TOOLS_ENABLED') === '1',
   };
 
-// One connection for the whole MCP server process, opened without the
-// maintenance writes (the daemon-side coordinator owns those). Per-call
-// open/close made every tool call a burst of write transactions plus a
-// checkpoint-on-close against the shared machine-level WAL store, which is
-// exactly the contention that surfaces as "database is locked".
-let sharedOperationStore: LodyOperationStore | undefined;
+// One connection per machine-level store for the whole MCP server process,
+// opened without the maintenance writes (the daemon-side coordinator owns
+// those). Per-call open/close made every tool call a burst of write
+// transactions plus a checkpoint-on-close against the shared machine-level WAL
+// store, which is exactly the contention that surfaces as "database is locked".
+//
+// The store path MUST come from the session context's machineId, never from
+// this process's environment: the daemon-hosted HTTP transport carries its
+// context in per-request AsyncLocalStorage, and its process has no
+// LODY_MCP_MACHINE_ID, so the env fallback silently selects the 'local' store
+// that no daemon coordinator watches — Operations accepted there are never
+// finalized and their completion is never delivered back to the requester.
+const sharedOperationStores = new Map<string, LodyOperationStore>();
+
+const resolveOperationStorePathForContext = (): string =>
+  getLodyOperationStorePath(getSessionContext().machineId);
 
 const getSharedOperationStore = (): LodyOperationStore => {
-  sharedOperationStore ??= new LodyOperationStore(undefined, undefined, { maintenance: false });
-  return sharedOperationStore;
+  const storePath = resolveOperationStorePathForContext();
+  let store = sharedOperationStores.get(storePath);
+  if (!store) {
+    store = new LodyOperationStore(storePath, undefined, { maintenance: false });
+    sharedOperationStores.set(storePath, store);
+  }
+  return store;
 };
 
 const withOperationStore = <T>(fn: (store: LodyOperationStore) => T): Promise<T> =>
@@ -3771,6 +3787,7 @@ export const __lodyMcpServerInternals = {
   startSessionChatOperation,
   startSessionChatManyOperation,
   getSessionContext,
+  resolveOperationStorePathForContext,
   postFileUpload,
   postImageUpload,
   postPreviewCandidate,

--- a/apps/cli/src/orchestration/AGENTS.md
+++ b/apps/cli/src/orchestration/AGENTS.md
@@ -57,6 +57,16 @@ Root and `apps/cli/AGENTS.md` apply. Normative behavior lives in
   absence. Keep the item/Delivery pending until positive evidence or deadline.
 - Deadlines finish the root with item `TARGET_TIMEOUT` results but never cancel
   target Turns. Operation cancel is the only best-effort remote-cancel path.
+- A pending Delivery still undeliverable 8h after its Operation's deadline is
+  consumed as `expired_stale` without a continuation turn: waking a Session
+  with a completion for work that ended long ago (stranded store, multi-day
+  downtime) surprises the user and spends tokens on a stale result.
+- Store paths are keyed strictly by an explicit machineId
+  (`getLodyOperationStorePath` has no default): the MCP server resolves it from
+  the session context, never from its own process environment. The former
+  env/`'local'` fallback let the daemon-hosted HTTP transport (whose process
+  has no `LODY_MCP_MACHINE_ID`) silently write Operations into a store no
+  coordinator reconciles, so completions were never delivered.
 - `session_create_many` and `session_chat_many` target writes bypass cooperative
   Session/Turn quotas. Preserve the bypass in both MCP-process materialization
   and daemon recovery replay; otherwise quota rejection degrades into a false

--- a/apps/cli/src/orchestration/operation-coordinator.test.ts
+++ b/apps/cli/src/orchestration/operation-coordinator.test.ts
@@ -813,6 +813,38 @@ describe('LodyOperationCoordinator', () => {
     }
   });
 
+  it('expires a Delivery 8h past its Operation deadline instead of waking the requester', async () => {
+    // deadline + 8h grace lands exactly on TEST_NOW: stranded completions from
+    // a long-dead store or downtime must not restart old conversations.
+    const harness = await makeHarness({ deadlineAt: '2026-07-19T16:00:00.000Z' });
+    harness.coordinator.start();
+    await harness.coordinator.idle();
+    harness.coordinator.stop();
+
+    expect(harness.continueSession).not.toHaveBeenCalled();
+    expect(harness.histories.get(harness.requesterSessionId)).toEqual([]);
+    const store = new LodyOperationStore(harness.storePath, () => TEST_NOW_MS);
+    try {
+      expect(store.get(harness.requesterSessionId, 'review-round-1')).toMatchObject({
+        state: 'finished',
+      });
+      expect(store.listPendingDeliveries('workspace-1' as WorkspaceId)).toEqual([]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('still delivers a completion within the 8h post-deadline grace window', async () => {
+    const harness = await makeHarness({ deadlineAt: '2026-07-19T16:00:01.000Z' });
+    harness.coordinator.start();
+    await harness.coordinator.idle();
+    harness.coordinator.stop();
+
+    expect(harness.continueSession).toHaveBeenCalledTimes(1);
+    const requesterHistory = harness.histories.get(harness.requesterSessionId)!;
+    expect(requesterHistory.filter((turn) => turn.role === 'system')).toHaveLength(1);
+  });
+
   it('keeps a persisted terminal assistant result at the deadline before handled catches up', async () => {
     const harness = await makeHarness({ deadlineAt: '2026-07-19T23:59:59.000Z' });
     const targetHistory = harness.histories.get(harness.targetSessionId)!;

--- a/apps/cli/src/orchestration/operation-coordinator.ts
+++ b/apps/cli/src/orchestration/operation-coordinator.ts
@@ -43,6 +43,13 @@ type TargetSubscription = {
 const TARGET_OUTPUT_PREVIEW_MAX_BYTES = 8 * 1024;
 const MATERIALIZATION_RETRY_MIN_MS = 1_000;
 const MATERIALIZATION_RETRY_MAX_MS = 30_000;
+// A Delivery that could not run within this grace window after its Operation's
+// deadline is expired instead of dispatched: waking a Session with a
+// continuation turn for work that ended long ago (stranded store, daemon down
+// for days) surprises the user and spends tokens on a stale result. The
+// default Operation deadline is 24h, so a legitimately finished completion
+// always has at least this window to reach the requester's idle boundary.
+const DELIVERY_EXPIRY_GRACE_MS = 8 * 60 * 60 * 1_000;
 
 const truncateTargetOutput = (
   text: string
@@ -804,12 +811,16 @@ export class LodyOperationCoordinator {
       this.consumeDelivery(delivery, reason, continuationEvidence);
       return;
     }
-    if (execution.hasActiveTurn) return;
-    if (this.options.dispatchWatcher.hasPendingDispatch(delivery.requesterSessionId)) return;
-
     const operation = this.withStore((store) =>
       store.get(delivery.requesterSessionId, delivery.operationId)
     );
+    if (this.now() >= Date.parse(operation.deadlineAt) + DELIVERY_EXPIRY_GRACE_MS) {
+      this.consumeDelivery(delivery, reason, 'expired_stale');
+      return;
+    }
+    if (execution.hasActiveTurn) return;
+    if (this.options.dispatchWatcher.hasPendingDispatch(delivery.requesterSessionId)) return;
+
     const configuration = await this.resolveFrozenConfiguration(operation, delivery, reason);
     if (configuration === 'unknown') {
       this.armConfigurationRetry(delivery.requesterSessionId);

--- a/apps/cli/src/orchestration/operation-store.ts
+++ b/apps/cli/src/orchestration/operation-store.ts
@@ -354,10 +354,12 @@ export const canonicalizeLodyCommand = (value: unknown): string => {
 export const fingerprintLodyCommand = (kind: LodyOperationKind, canonical: string): string =>
   createHash('sha256').update(kind).update('\0').update(canonical).digest('hex');
 
-export const getLodyOperationStorePath = (
-  machineId = process.env.LODY_MCP_MACHINE_ID ?? process.env.LODY_PREVIEW_MCP_MACHINE_ID ?? 'local',
-  homeDir = os.homedir()
-): string => {
+// machineId is deliberately required: an env-derived default here once made the
+// daemon-hosted HTTP MCP transport (whose process has no LODY_MCP_MACHINE_ID)
+// silently fall back to a 'local'-keyed store that no coordinator reconciles,
+// so accepted Operations were never finalized or delivered. Callers must pass
+// the machine id they authenticated (session context, coordinator options).
+export const getLodyOperationStorePath = (machineId: string, homeDir = os.homedir()): string => {
   const machineKey = createHash('sha256').update(machineId).digest('hex').slice(0, 24);
   return path.join(
     getLodyDataDir(undefined, homeDir),
@@ -396,7 +398,7 @@ export class LodyOperationStore {
    * daemon-side coordinator keeps the default and owns maintenance.
    */
   constructor(
-    dbPath = getLodyOperationStorePath(),
+    dbPath: string,
     private readonly now: () => number = Date.now,
     options: { maintenance?: boolean } = {}
   ) {


### PR DESCRIPTION
## Summary

Conversations that created child Sessions via the Lody MCP tools never received the completion notification when the child finished.

**Root cause**: the daemon-hosted HTTP MCP transport carries its session context in per-request AsyncLocalStorage, and its process has no `LODY_MCP_MACHINE_ID`, so the shared Operation store singleton's env-derived default path silently fell back to a `sha256('local')`-keyed store that no daemon coordinator reconciles. Operations accepted over HTTP sat `active` forever (past deadline, no logs), the `deliveries` table stayed empty, and the requester Session was never woken. The stdio per-session subprocess was unaffected because its env carries the machine id.

## Changes

- Resolve the MCP server's Operation store path from the session context's machineId (covers both stdio env and HTTP headers), with one connection per resolved path.
- Make `getLodyOperationStorePath`'s machineId a required parameter — the former env/`'local'` fallback is removed so a missing id fails fast instead of selecting an unreconciled store.
- Expire a pending Delivery still undeliverable 8h past its Operation deadline as `expired_stale` without a continuation turn, so stranded completions (store migration leftovers, multi-day downtime) cannot wake old conversations. The default Operation deadline is 24h, so real completions keep an 8h+ delivery window.
- Record both invariants in `apps/cli/src/orchestration/AGENTS.md`.

## Tests

- New regression test pins the MCP store path to the coordinator-visible `getLodyOperationStorePath(machineId)` under an env-free AsyncLocalStorage context.
- New coordinator tests cover the 8h expiry boundary (exactly stale → consumed without `continueSession`; 1s inside the window → delivered) with injected clocks.
- Full `apps/cli` suite: 2415 passed / 0 failed; `tsgo --noEmit` clean; oxlint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)