### PR TITLE
fix(components): grow the Rename Chat field to fit a wrapped title

### DIFF
--- a/packages/components/src/components/sessions/rename-session-dialog.tsx
+++ b/packages/components/src/components/sessions/rename-session-dialog.tsx
@@ -96,7 +96,7 @@ export function RenameSessionDialogView({
   // only input that changes here — the heights written back never alter it —
   // so re-measuring on an unchanged width would be pure churn.
   useEffect(() => {
-    if (!titleField) return;
+    if (!titleField) return undefined;
     return observeResizeOnAnimationFrame(titleField, () => {
       if (titleField.clientWidth === measuredWidthRef.current) return;
       resizeTitle(titleField);

--- a/packages/components/src/components/sessions/rename-session-dialog.tsx
+++ b/packages/components/src/components/sessions/rename-session-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
 import type { SessionId } from '@lody/shared';
@@ -14,6 +14,7 @@ import { Button } from '@/ui/button';
 import { Textarea } from '@/ui/textarea';
 import { useSessionActions } from '@/hooks/use-session-actions';
 import { isImeComposingKeyboardEvent } from '@/lib/ime';
+import { observeResizeOnAnimationFrame } from '@/lib/resize-observer';
 
 const MAX_VISIBLE_TITLE_LINES = 4;
 
@@ -64,7 +65,18 @@ export function RenameSessionDialogView({
   const { t } = useTranslation();
   const [draft, setDraft] = useState('');
   const [saving, setSaving] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // The field is held as state rather than in a ref so that measuring and
+  // observing follow the element itself: the dialog content can remount under
+  // us, and an effect keyed on anything else would keep working on the node it
+  // first saw.
+  const [titleField, setTitleField] = useState<HTMLTextAreaElement | null>(null);
+  const measuredWidthRef = useRef<number | null>(null);
+
+  const resizeTitle = useCallback((field: HTMLTextAreaElement | null) => {
+    if (!field) return;
+    resizeTitleTextarea(field);
+    measuredWidthRef.current = field.clientWidth;
+  }, []);
 
   useEffect(() => {
     if (target) {
@@ -74,23 +86,22 @@ export function RenameSessionDialogView({
   }, [target]);
 
   useLayoutEffect(() => {
-    if (textareaRef.current) {
-      resizeTitleTextarea(textareaRef.current);
-    }
-  }, [draft, target]);
+    resizeTitle(titleField);
+  }, [draft, titleField, resizeTitle]);
 
+  // How many lines a title wraps to is only knowable once the field has its
+  // real width, and the measurement above can run before the portalled dialog
+  // panel has been laid out. Without this the field keeps the one-line height
+  // that first measurement produced and clips a wrapped title. Width is the
+  // only input that changes here — the heights written back never alter it —
+  // so re-measuring on an unchanged width would be pure churn.
   useEffect(() => {
-    const handleResize = () => {
-      if (textareaRef.current) {
-        resizeTitleTextarea(textareaRef.current);
-      }
-    };
-
-    if (target) {
-      window.addEventListener('resize', handleResize);
-    }
-    return () => window.removeEventListener('resize', handleResize);
-  }, [target]);
+    if (!titleField) return;
+    return observeResizeOnAnimationFrame(titleField, () => {
+      if (titleField.clientWidth === measuredWidthRef.current) return;
+      resizeTitle(titleField);
+    });
+  }, [titleField, resizeTitle]);
 
   const handleOpenChange = (open: boolean) => {
     if (!open && !saving) {
@@ -130,7 +141,7 @@ export function RenameSessionDialogView({
 
         <div className="px-4 py-4 sm:px-5">
           <Textarea
-            ref={textareaRef}
+            ref={setTitleField}
             autoFocus
             rows={1}
             value={draft}

--- a/packages/components/tests/rename-session-dialog.test.tsx
+++ b/packages/components/tests/rename-session-dialog.test.tsx
@@ -13,6 +13,66 @@ import { initI18n } from '../src/i18n';
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+type MockResizeObserverInstance = {
+  callback: ResizeObserverCallback;
+  targets: Set<Element>;
+};
+
+const resizeObserverInstances: MockResizeObserverInstance[] = [];
+
+class MockResizeObserver {
+  private readonly instance: MockResizeObserverInstance;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.instance = { callback, targets: new Set<Element>() };
+    resizeObserverInstances.push(this.instance);
+  }
+
+  observe = (target: Element) => {
+    this.instance.targets.add(target);
+  };
+
+  unobserve = (target: Element) => {
+    this.instance.targets.delete(target);
+  };
+
+  disconnect = () => {
+    this.instance.targets.clear();
+  };
+}
+
+/**
+ * jsdom has no layout, so on mount the field reports the zero width and zero
+ * scroll height that a not-yet-laid-out textarea reports in a browser. This
+ * stands in for the layout that arrives afterwards: `scrollHeight` wraps the
+ * current value at the current width, which is what the dialog measures.
+ */
+function attachLayout(textarea: HTMLTextAreaElement, lineHeight: number, charWidth: number) {
+  const computed = window.getComputedStyle(textarea);
+  const padding =
+    (Number.parseFloat(computed.paddingTop) || 0) +
+    (Number.parseFloat(computed.paddingBottom) || 0);
+  let width = 0;
+  Object.defineProperty(textarea, 'clientWidth', {
+    configurable: true,
+    get: () => width,
+  });
+  Object.defineProperty(textarea, 'scrollHeight', {
+    configurable: true,
+    get: () => {
+      if (width <= 0) return 0;
+      const charsPerLine = Math.max(1, Math.floor(width / charWidth));
+      const lines = Math.max(1, Math.ceil(textarea.value.length / charsPerLine));
+      return lines * lineHeight + padding;
+    },
+  });
+  return {
+    setWidth: (next: number) => {
+      width = next;
+    },
+  };
+}
+
 function setTextareaValue(textarea: HTMLTextAreaElement, value: string): void {
   const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
   setter?.call(textarea, value);
@@ -157,5 +217,62 @@ describe('RenameSessionDialogView', () => {
     });
 
     expect(onRenameSession).toHaveBeenCalledWith('sidebar-session', 'Renamed from sidebar');
+  });
+
+  it('grows the title field once the dialog panel has been laid out', async () => {
+    // `observeResizeOnAnimationFrame` defers to a frame; run it inline so the
+    // assertions do not depend on the scheduler.
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {});
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+    resizeObserverInstances.length = 0;
+
+    // jsdom applies no Tailwind, so the line height is the function's own
+    // fallback and the padding/border come from the UA stylesheet. Assertions
+    // are relative to the one-line height so they do not encode either.
+    const LINE_HEIGHT = 20;
+    const CHAR_WIDTH = 8;
+    const title = 'A generated session title long enough to wrap onto a second line';
+
+    await act(async () => {
+      root?.render(
+        <RenameSessionDialogView
+          target={{ sessionId: 'grow-session' as SessionId, initialTitle: title }}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+        />
+      );
+    });
+
+    const textarea = document.body.querySelector<HTMLTextAreaElement>('textarea');
+    expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
+    const field = textarea as HTMLTextAreaElement;
+    // The mount measurement ran before the portalled panel had a width, so the
+    // field sits at its one-line height holding a value that wraps.
+    const oneLineHeight = Number.parseFloat(field.style.height);
+    expect(oneLineHeight).toBeGreaterThan(0);
+
+    const layout = attachLayout(field, LINE_HEIGHT, CHAR_WIDTH);
+    const observed = resizeObserverInstances.find((instance) => instance.targets.has(field));
+    expect(observed).toBeDefined();
+
+    await act(async () => {
+      layout.setWidth(CHAR_WIDTH * 40);
+      observed?.callback([], observed as unknown as ResizeObserver);
+    });
+
+    expect(field.style.height).toBe(`${oneLineHeight + LINE_HEIGHT}px`);
+    expect(field.style.overflowY).toBe('hidden');
+
+    await act(async () => {
+      setTextareaValue(field, title.repeat(4));
+    });
+
+    // Past four lines the field stops growing and scrolls instead.
+    expect(field.style.height).toBe(`${oneLineHeight + LINE_HEIGHT * 3}px`);
+    expect(field.style.overflowY).toBe('auto');
   });
 });


### PR DESCRIPTION
## Related issue

<!-- Same-repository branch; no intake Issue. -->

## Problem / pressure

Opening **Rename Chat** on a session whose title wraps showed the title clipped: the field
rendered at exactly `line-height + padding + border` (38px) with its second line cut in half,
and nothing ever grew it.

The dialog already contained auto-grow code, but both of its effects were keyed on props
(`[draft, target]`) rather than on the textarea element. The content mounts through a Radix
portal, so the element appears on a commit where neither dep changes — the measurement that
decided the height ran against a node without usable layout and produced the one-line minimum.
The `window` resize listener was keyed the same way and so could not recover it either.

Generated session titles are routinely long enough to wrap, so this was the common case for
renaming, not an edge case.

## Summary

- Hold the field as callback-ref state instead of a ref, so measuring follows the element
  through any remount rather than whichever node the effect first saw.
- Re-measure from a `ResizeObserver` (the shared `observeResizeOnAnimationFrame`) whenever the
  field's own width settles. This covers the pre-layout mount and subsumes the `window` resize
  listener, which is removed.
- Guard the observer on width: the heights written back never change width, so an unchanged
  width means nothing to re-measure.
- Behavior is otherwise unchanged — the field grows to at most four lines, then scrolls.

## Before / after

| Before | After |
| ------ | ----- |
| A wrapped title opens clipped at one line height; typing more never fixes the initial state, and resizing the window does not recover it. | The field opens sized to the wrapped title (up to four lines, scrolling past that) and keeps tracking as the width changes. |

## Test plan

- New regression test in `packages/components/tests/rename-session-dialog.test.tsx`: mounts with
  no layout (the failing state — one-line height holding a value that wraps), then simulates
  layout arriving and asserts the field grows to two lines, and caps at four with
  `overflow-y: auto`. Assertions are relative to the measured one-line height, so they do not
  encode jsdom UA padding.
- `corepack pnpm --filter @lody/components test` — 400 files / 2868 tests pass.
- `corepack pnpm --filter @lody/components typecheck` (`tsgo --noEmit`) — clean.
- `corepack pnpm lint:fast` (oxlint) — 0 errors.
- Existing Storybook coverage `Components/RenameSessionDialog` → `WrappingTitle` exercises the
  wrapped-title state.
- Not run: the full repo `pnpm check` (only the components package plus repo-wide lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
