### PR TITLE
feat(components): put a plan-mode turn on one rail and one panel

### DIFF
--- a/packages/components/src/components/ai-gui/AGENTS.md
+++ b/packages/components/src/components/ai-gui/AGENTS.md
@@ -58,11 +58,11 @@
   the footer after buttons otherwise. Mobile always uses the footer before
   buttons, and the worked header suppresses its copy. Preserve
   `MOBILE_TURN_ACTION_LEADING_INSET_PX` so actions clear the edge-back strip.
-- Horizontal gutter belongs to `ConversationColumn`, not Virtua: absolute rows
-  ignore scroller padding. Top-level prose, headers, subagents,
-  edited files, and footer share one left rail; only child detail rows indent.
-  Preserve the footer's `-mx-[7px]`. Visual coverage:
-  `AssistantTurnAlignment.stories.tsx`.
+- Gutter belongs to `ConversationColumn`, not Virtua: absolute rows ignore
+  scroller padding. EVERY row shares one left rail with no shell pad, INCLUDING
+  the contents of an expanded region: expanding reveals rows, it never shifts
+  them right, and the chevron carries the hierarchy. Hover pills bleed instead
+  (footer `-mx-[7px]`, steps `-mx-1`). See `AssistantTurnAlignment.stories`.
 
 ## Conversation Outline
 

--- a/packages/components/src/components/ai-gui/assistant-message-render-items.ts
+++ b/packages/components/src/components/ai-gui/assistant-message-render-items.ts
@@ -25,6 +25,21 @@ const withDisplayIndexes = (
     displayIndex,
   }));
 
+/**
+ * Attachments the agent produced. In a turn that ALSO carries a plan they sort
+ * below it: a plan runs long, and a file card stranded above one is a small
+ * thing the reader has to find in the middle of a wall of markdown. Below the
+ * plan it is always in the same place — the last thing in the turn.
+ *
+ * Images travel with files. Splitting them (images above the plan, files below)
+ * would read as two unrelated attachment areas separated by the plan.
+ */
+const AGENT_ATTACHMENT_TYPES = new Set<MessageContent['type']>(['file', 'image', 'image_group']);
+
+/** The plan-approval card that closes a plan (ACP kind, never a title). */
+const isPlanExitSeed = (seed: AssistantMessageRenderSeed): boolean =>
+  seed.content.type === 'tool_call' && seed.content.kind === 'switch_mode';
+
 export const buildAssistantMessageRenderItems = (
   items: readonly MessageContent[]
 ): AssistantMessageRenderItem[] => {
@@ -34,19 +49,39 @@ export const buildAssistantMessageRenderItems = (
       : [{ content, itemIndex }]
   );
 
+  // No plan, no reordering: a turn's natural order is the right one, and moving
+  // attachments on their own would separate them from the answer they belong to.
   if (!visibleItems.some((item) => item.content.type === 'proposed_plan')) {
     return withDisplayIndexes(visibleItems);
   }
 
-  const before: AssistantMessageRenderSeed[] = [];
+  const rest: AssistantMessageRenderSeed[] = [];
   const plans: AssistantMessageRenderSeed[] = [];
+  const attachments: AssistantMessageRenderSeed[] = [];
   for (const item of visibleItems) {
     if (item.content.type === 'proposed_plan') {
       plans.push(item);
+    } else if (AGENT_ATTACHMENT_TYPES.has(item.content.type)) {
+      attachments.push(item);
     } else {
-      before.push(item);
+      rest.push(item);
     }
   }
 
-  return withDisplayIndexes([...before, ...plans]);
+  /* The plan and the card that approves it are ONE thing, so the plan renders
+     immediately BEFORE its approval rather than at the end of the turn: read the
+     plan, then read the decision. Codex is why this matters — it keeps the plan
+     in a separate `proposed_plan` item and puts nothing readable in the card, so
+     unmoved the two halves of one question sat a whole implementation apart.
+     Without an approval card (the plan is still being drafted) the plan stays at
+     the end, which is where a growing plan belongs. */
+  const planExitIndex = rest.findIndex(isPlanExitSeed);
+  const ordered =
+    planExitIndex === -1
+      ? [...rest, ...plans]
+      : [...rest.slice(0, planExitIndex), ...plans, ...rest.slice(planExitIndex)];
+
+  // `itemIndex` stays the ORIGINAL history index through the reorder — image
+  // gallery keys, search block ids, and expansion state are keyed on it.
+  return withDisplayIndexes([...ordered, ...attachments]);
 };

--- a/packages/components/src/components/ai-gui/conversation-panel.ts
+++ b/packages/components/src/components/ai-gui/conversation-panel.ts
@@ -1,0 +1,52 @@
+/**
+ * The ONE panel treatment for framed conversation content: the plan-exit card's
+ * command block, terminal command/output, tool input/output, the permission
+ * card, and the proposed plan.
+ *
+ * The rule is that the HEADER carries the lighter fill and the body stays on the
+ * frame's own surface — never the reverse. Panels used to disagree about which
+ * half got the fill (terminal filled its header, the proposed plan filled an
+ * inner body panel, tool output filled a bare `pre` under an unfilled label), so
+ * the same structure read as three different components stacked in one turn.
+ *
+ * Import these instead of re-typing the tokens; a panel that hand-rolls its own
+ * fill is the drift this module exists to prevent.
+ */
+
+/** Outer frame. Carries the border, the base surface, and the clipping. */
+export const CONVERSATION_PANEL_FRAME_CLASS =
+  'overflow-hidden rounded-xl border border-border/60 bg-background/70 shadow-xs';
+
+/**
+ * Header band — the raised fill. `border-b` belongs here only when a body
+ * follows; a collapsed panel must not paint a rule against nothing.
+ *
+ * THE RULE: the header is a step off the surface it sits on — LIGHTER in dark,
+ * DARKER in light. Measured today at +12 / -13 (terminal +11 / -12).
+ *
+ * The tint is therefore an alpha of the FOREGROUND, not `bg-muted`. Vesper's
+ * `--muted` resolves to the same value as `--background`, so a `bg-muted` header
+ * over a `bg-background` frame measured as a zero-step band in dark — the fill
+ * simply did not render and only the rule was holding the header up. A
+ * foreground alpha steps the right way in both themes whatever the base is.
+ *
+ * That base must be the SAME surface the body sits on, or the step is against
+ * the wrong thing: the terminal paints its VS Code `terminal.background` on a
+ * wrapper around header AND body for exactly this reason. While that colour was
+ * on the body alone, the header tinted the frame instead and measured -1 in dark
+ * and +7 in light — inverted.
+ *
+ * Measure the COMPOSITED pixel when changing this, never the token name (see
+ * `sessions/AGENTS.md` on the surface ladder).
+ */
+export const CONVERSATION_PANEL_HEADER_CLASS =
+  'flex items-center gap-2 bg-muted-foreground/[0.09] px-3 py-1.5 text-foreground';
+
+export const CONVERSATION_PANEL_HEADER_RULE_CLASS = 'border-b border-border/60';
+
+/** Header label: quiet next to the content it introduces. */
+export const CONVERSATION_PANEL_TITLE_CLASS =
+  'min-w-0 flex-1 truncate text-[11px] font-medium text-muted-foreground';
+
+/** Body padding. No fill of its own — the frame already provides the surface. */
+export const CONVERSATION_PANEL_BODY_CLASS = 'px-3 py-2';

--- a/packages/components/src/components/ai-gui/message-copy.ts
+++ b/packages/components/src/components/ai-gui/message-copy.ts
@@ -9,6 +9,28 @@ import {
 export const USER_TEXT_RENDER_LINE_LIMIT = 10;
 export const USER_TEXT_RENDER_CHAR_LIMIT = 900;
 
+/**
+ * Items that are never folded into a turn's work region: attachments the agent
+ * produced, the plan surfaces, the goal marker, and the "Exited Plan Mode"
+ * switch that closes a plan turn.
+ *
+ * ONE list, used for both questions it answers — "does this item fold?" and
+ * "is this item part of the tail that trails the answer?". They were two lists
+ * (the tail one held only `image_group` and `switch_mode`), so a turn ending in
+ * a `file` or a `proposed_plan` found no trailing tail, reported no visible
+ * answer text, and folded the answer itself into "Worked for …". Attachments
+ * now sort BELOW the plan, which puts a `file` last far more often, so the two
+ * lists have to agree.
+ */
+const isNeverCollapsedAssistantItem = (content: MessageContent | undefined): boolean =>
+  content?.type === 'image_group' ||
+  content?.type === 'image' ||
+  content?.type === 'file' ||
+  content?.type === 'plan' ||
+  content?.type === 'goal' ||
+  content?.type === 'proposed_plan' ||
+  (content?.type === 'tool_call' && content.kind === 'switch_mode');
+
 export const shouldCollapseAssistantMessageItem = ({
   content,
   index,
@@ -28,32 +50,22 @@ export const shouldCollapseAssistantMessageItem = ({
     itemCount > 1 &&
     index < itemCount - 1 &&
     index !== visibleTextIndex &&
-    content.type !== 'image_group' &&
-    content.type !== 'file' &&
-    content.type !== 'plan' &&
-    content.type !== 'goal' &&
-    content.type !== 'proposed_plan' &&
-    !(content.type === 'tool_call' && content.kind === 'switch_mode')
+    !isNeverCollapsedAssistantItem(content)
   );
 };
 
 /**
- * Items that are appended AFTER the assistant's answer and are themselves never
- * collapsed: generated images, and the "Exited Plan Mode" switch that closes a
- * plan turn. The answer before them is still the answer, so it must not be
- * demoted to process output just because it is no longer the last item.
+ * The answer is the last text BEFORE the never-collapsed tail, not necessarily
+ * the last item — it must not be demoted to process output just because a plan
+ * or an attachment follows it.
  */
-const isTrailingNeverCollapsedItem = (content: MessageContent | undefined): boolean =>
-  content?.type === 'image_group' ||
-  (content?.type === 'tool_call' && content.kind === 'switch_mode');
-
 const getTextIndexBeforeTrailingNeverCollapsedItems = (items: MessageContent[]): number => {
   let index = items.length - 1;
-  if (!isTrailingNeverCollapsedItem(items[index])) {
+  if (!isNeverCollapsedAssistantItem(items[index])) {
     return -1;
   }
 
-  while (index >= 0 && isTrailingNeverCollapsedItem(items[index])) {
+  while (index >= 0 && isNeverCollapsedAssistantItem(items[index])) {
     index -= 1;
   }
 

--- a/packages/components/src/components/ai-gui/permission-record.ts
+++ b/packages/components/src/components/ai-gui/permission-record.ts
@@ -1,0 +1,53 @@
+import type { MessageContent } from '@lody/shared';
+
+type PermissionRequest = NonNullable<
+  Extract<MessageContent, { type: 'tool_call' }>['permissionRequest']
+>;
+
+/**
+ * How a permission request should read in conversation scrollback.
+ *
+ * `pending` is still a decision the reader can make, so it keeps the full card.
+ * A SETTLED one is a fact: re-rendering the header, every option, and the
+ * selection re-asks a question that was already answered, and made the record
+ * the heaviest object in the turn. It collapses to one line — the outcome and
+ * what was chosen. A `withdrawn` request (the turn was interrupted before
+ * anyone answered) recorded nothing, so it shows nothing.
+ */
+export type PermissionRecord =
+  | { kind: 'pending' }
+  | { kind: 'withdrawn' }
+  | { kind: 'settled'; allowed: boolean; optionName: string | null };
+
+export const resolvePermissionRecord = (permission: PermissionRequest): PermissionRecord => {
+  const outcome = permission.outcome;
+  if (!outcome) return { kind: 'pending' };
+  if (outcome.outcome === 'cancelled') return { kind: 'withdrawn' };
+
+  const selected = permission.options.find((option) => option.optionId === outcome.optionId);
+  const optionName = selected?.name?.trim();
+  return {
+    kind: 'settled',
+    // An unknown option id (stale history) reads as allowed, matching the
+    // card's own assumption rather than inventing a denial.
+    allowed: selected ? selected.kind?.startsWith('allow') === true : true,
+    optionName: optionName ? optionName : null,
+  };
+};
+
+/**
+ * Is this turn's plan approval still waiting on the reader? Keyed on the ACP
+ * tool kind and an ABSENT outcome — a CANCELLED request is answered (withdrawn),
+ * not pending, so it must not hold the plan open.
+ *
+ * Drives `ProposedPlanBlock`'s default: a plan you are being asked to approve
+ * opens in full, a plan you already decided on clamps.
+ */
+export const hasUnansweredPlanApproval = (items: readonly MessageContent[]): boolean =>
+  items.some(
+    (item) =>
+      item.type === 'tool_call' &&
+      item.kind === 'switch_mode' &&
+      Boolean(item.permissionRequest) &&
+      !item.permissionRequest?.outcome
+  );

--- a/packages/components/src/components/ai-gui/session-file-card.tsx
+++ b/packages/components/src/components/ai-gui/session-file-card.tsx
@@ -39,7 +39,6 @@ const KIND_ICON: Record<SessionFileKind, typeof FileIcon> = {
   binary: FileIcon,
 };
 
-
 export type SessionFileCardProps = {
   file: SessionFilePayload;
   /** Resolved display name of the machine holding the bytes (transport='local'). */
@@ -179,8 +178,11 @@ export function SessionFileCard({
         <span
           className={cn(
             'flex size-8 shrink-0 items-center justify-center rounded-lg transition-colors',
+            /* One rest tone for every icon in a turn — an interactive affordance
+               resting DIMMER than the static chrome around it read as disabled.
+               Hover still brightens it. */
             isInteractive
-              ? 'text-muted-foreground/70 group-hover:bg-background group-hover:text-foreground'
+              ? 'text-muted-foreground group-hover:bg-background group-hover:text-foreground'
               : 'text-muted-foreground'
           )}
         >
@@ -207,8 +209,11 @@ export function SessionFileCardList({
   return (
     <div
       className={cn(
-        'flex w-full flex-col gap-2 px-2 pt-1',
-        align === 'end' ? 'items-end' : 'items-start'
+        'flex w-full flex-col gap-2',
+        /* An assistant attachment (`align="start"`) is a top-level conversation
+           row: the horizontal gutter belongs to `ConversationColumn` and the row
+           gap to `cardSiblingGap`. User attachments keep their own insets. */
+        align === 'end' ? 'items-end px-2 pt-1' : 'items-start'
       )}
     >
       {children}

--- a/packages/components/src/components/ai-gui/terminal-component.tsx
+++ b/packages/components/src/components/ai-gui/terminal-component.tsx
@@ -11,6 +11,11 @@ import Anser from 'anser';
 import { Terminal } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
+  CONVERSATION_PANEL_FRAME_CLASS,
+  CONVERSATION_PANEL_HEADER_CLASS,
+  CONVERSATION_PANEL_HEADER_RULE_CLASS,
+} from './conversation-panel';
+import {
   createVSCodeTerminalTheme,
   resolveAnsiColorToCss,
   type VSCodeTerminalTheme,
@@ -159,102 +164,115 @@ export const TerminalComponent = memo(function TerminalComponent({
     <div
       className={cn(
         'overflow-hidden',
-        showBorder ? 'rounded-md border border-border/60 bg-background/70 shadow-xs' : null,
+        showBorder ? CONVERSATION_PANEL_FRAME_CLASS : null,
         className
       )}
     >
-      {showHeader ? (
-        onHeaderClick ? (
-          <button
-            type="button"
-            className={cn(
-              'flex w-full items-center gap-2 bg-muted/70 px-3 py-1.5 text-left text-foreground transition-colors hover:bg-muted',
-              bodyVisible ? 'border-b border-border/60' : null
-            )}
-            onClick={onHeaderClick}
-            aria-expanded={headerExpanded}
-          >
-            {headerContent}
-          </button>
-        ) : (
-          <div className="flex items-center gap-2 border-b border-border/60 bg-muted/70 px-3 py-1.5 text-foreground">
-            {headerContent}
-          </div>
-        )
-      ) : null}
-
-      {bodyVisible ? (
-        <div
-          className={cn(showBackground ? 'bg-muted/[0.35]' : null, 'text-foreground')}
-          style={terminalContainerStyle}
-        >
-          {shouldRenderInput ? (
+      {/* The terminal's own surface (VS Code `terminal.background`, or the muted
+          fallback) wraps the header AND the body, so the header's raised tint
+          steps away from the SAME base the output sits on. While the surface
+          lived on the body alone, the header was tinting the frame instead and
+          the step measured -1 in dark and inverted to +7 in light. */}
+      <div
+        className={cn(showBackground && !terminalBackgroundColor ? 'bg-muted/[0.35]' : null)}
+        style={terminalContainerStyle}
+      >
+        {showHeader ? (
+          onHeaderClick ? (
+            <button
+              type="button"
+              className={cn(
+                CONVERSATION_PANEL_HEADER_CLASS,
+                'w-full text-left transition-colors hover:bg-muted',
+                bodyVisible ? CONVERSATION_PANEL_HEADER_RULE_CLASS : null
+              )}
+              onClick={onHeaderClick}
+              aria-expanded={headerExpanded}
+            >
+              {headerContent}
+            </button>
+          ) : (
             <div
               className={cn(
-                'flex items-start gap-2 px-3 py-2 font-terminal',
-                hasOutput ? 'border-b border-border/50' : null
+                CONVERSATION_PANEL_HEADER_CLASS,
+                bodyVisible ? CONVERSATION_PANEL_HEADER_RULE_CLASS : null
               )}
             >
-              <span
-                className="leading-none text-muted-foreground"
-                style={conversationTextFontSizeStyle(fontSize)}
-              >
-                $
-              </span>
-              <pre
-                className="scrollbar-pro min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap break-words font-terminal"
-                style={terminalTextFontSizeStyle(fontSize)}
-              >
-                {command}
-              </pre>
+              {headerContent}
             </div>
-          ) : null}
+          )
+        ) : null}
 
-          {hasOutput ? (
-            <div
-              ref={outputRef}
-              className={cn(
-                'relative',
-                shouldUseFullOutput
-                  ? null
-                  : shouldUseScrollOutput || isFocused
-                    ? cn(
-                        'scrollbar-pro overflow-auto',
-                        shouldUseScrollOutput ? null : 'ring-1 ring-ring/30'
-                      )
-                    : 'overflow-hidden'
-              )}
-              style={{
-                maxHeight:
-                  !shouldUseFullOutput && (shouldUseScrollOutput || isFocused)
-                    ? focusedMaxHeightPx
-                    : undefined,
-              }}
-            >
-              <pre
-                className="px-3 py-2 font-terminal leading-relaxed whitespace-pre-wrap break-words"
-                style={terminalTextFontSizeStyle(fontSize)}
+        {bodyVisible ? (
+          <div className="text-foreground">
+            {shouldRenderInput ? (
+              <div
+                className={cn(
+                  'flex items-start gap-2 px-3 py-2 font-terminal',
+                  hasOutput ? 'border-b border-border/50' : null
+                )}
               >
-                {renderAnsiToReactNodes({ value: outputTextForDisplay, terminalTheme })}
-              </pre>
-
-              {!shouldUseScrollOutput && !shouldUseFullOutput && !isFocused && isTruncatedView ? (
-                <button
-                  type="button"
-                  className="absolute inset-0 h-full cursor-pointer bg-transparent"
-                  onClick={() => setIsFocused(true)}
-                  aria-label="Focus terminal output"
+                <span
+                  className="leading-none text-muted-foreground"
+                  style={conversationTextFontSizeStyle(fontSize)}
                 >
-                  <div
-                    className="pointer-events-none absolute inset-x-0 top-0 h-8 bg-gradient-to-b from-muted/90 to-transparent"
-                    style={collapsedOutputFadeStyle}
-                  />
-                </button>
-              ) : null}
-            </div>
-          ) : null}
-        </div>
-      ) : null}
+                  $
+                </span>
+                <pre
+                  className="scrollbar-pro min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap break-words font-terminal"
+                  style={terminalTextFontSizeStyle(fontSize)}
+                >
+                  {command}
+                </pre>
+              </div>
+            ) : null}
+
+            {hasOutput ? (
+              <div
+                ref={outputRef}
+                className={cn(
+                  'relative',
+                  shouldUseFullOutput
+                    ? null
+                    : shouldUseScrollOutput || isFocused
+                      ? cn(
+                          'scrollbar-pro overflow-auto',
+                          shouldUseScrollOutput ? null : 'ring-1 ring-ring/30'
+                        )
+                      : 'overflow-hidden'
+                )}
+                style={{
+                  maxHeight:
+                    !shouldUseFullOutput && (shouldUseScrollOutput || isFocused)
+                      ? focusedMaxHeightPx
+                      : undefined,
+                }}
+              >
+                <pre
+                  className="px-3 py-2 font-terminal leading-relaxed whitespace-pre-wrap break-words"
+                  style={terminalTextFontSizeStyle(fontSize)}
+                >
+                  {renderAnsiToReactNodes({ value: outputTextForDisplay, terminalTheme })}
+                </pre>
+
+                {!shouldUseScrollOutput && !shouldUseFullOutput && !isFocused && isTruncatedView ? (
+                  <button
+                    type="button"
+                    className="absolute inset-0 h-full cursor-pointer bg-transparent"
+                    onClick={() => setIsFocused(true)}
+                    aria-label="Focus terminal output"
+                  >
+                    <div
+                      className="pointer-events-none absolute inset-x-0 top-0 h-8 bg-gradient-to-b from-muted/90 to-transparent"
+                      style={collapsedOutputFadeStyle}
+                    />
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 });

--- a/packages/components/src/components/ai-gui/view.tsx
+++ b/packages/components/src/components/ai-gui/view.tsx
@@ -92,6 +92,7 @@ import {
   Brain,
   BrushCleaning,
   Check,
+  X,
   CheckCircle2,
   ChevronRight,
   Circle,
@@ -142,6 +143,14 @@ import {
 } from './assistant-turn-render-blocks';
 import { SubagentTaskPanel, collectSubagentTasks } from './subagent-task-panel';
 import { UserMessageEditor } from './user-message-editor';
+import { hasUnansweredPlanApproval, resolvePermissionRecord } from './permission-record';
+import {
+  CONVERSATION_PANEL_BODY_CLASS,
+  CONVERSATION_PANEL_FRAME_CLASS,
+  CONVERSATION_PANEL_HEADER_CLASS,
+  CONVERSATION_PANEL_HEADER_RULE_CLASS,
+  CONVERSATION_PANEL_TITLE_CLASS,
+} from './conversation-panel';
 import { TerminalComponent } from './terminal-component';
 import { prepareTerminalOutputBlocksPreview } from './terminal-preview';
 import { type DurationUnitLabels, formatDurationCompact } from '@/lib/format-duration';
@@ -2968,7 +2977,9 @@ const AssistantTurnConfigInfoButton = ({
                 type="button"
                 className={cn(
                   'inline-flex shrink-0 items-center justify-center rounded-sm',
-                  'text-muted-foreground/80 transition-colors',
+                  /* Rest tone matches every other icon in the turn; hover is
+                     what brightens. */
+                  'text-muted-foreground transition-colors',
                   'hover:bg-hover/50 hover:text-foreground',
                   'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
                   className
@@ -3026,9 +3037,14 @@ const AssistantTurnConfigInfoButton = ({
    step under it — one size, one color so the stack reads as one list. */
 const ACTIVITY_PROCESS_TEXT_CLASS = 'text-[12.5px] font-medium leading-snug text-muted-foreground';
 const ACTIVITY_PROCESS_ICON_CLASS = 'h-3.5 w-3.5 shrink-0 text-muted-foreground';
-const ACTIVITY_STEP_ICON_CLASS = cn(ACTIVITY_PROCESS_ICON_CLASS, 'mt-0.5 opacity-90');
+/* One tone for every icon in a turn — see `ACTIVITY_PROCESS_ICON_CLASS`. Only
+   the optical nudge is local; no per-icon opacity. */
+const ACTIVITY_STEP_ICON_CLASS = cn(ACTIVITY_PROCESS_ICON_CLASS, 'mt-0.5');
+/* `-mx-1` + `px-1`: the hover pill still bleeds a little past the text, but the
+   icon starts ON the rail. A plain `px-1` pushed every expanded step 4px right
+   of the group header that owns it. */
 const ACTIVITY_STEP_BUTTON_CLASS = cn(
-  'min-h-7 items-start rounded-md px-1 py-1 hover:bg-hover/40',
+  '-mx-1 min-h-7 items-start rounded-md px-1 py-1 hover:bg-hover/40',
   ACTIVITY_PROCESS_TEXT_CLASS
 );
 const ACTIVITY_STEP_TITLE_CLASS = cn('min-w-0 flex-1', ACTIVITY_PROCESS_TEXT_CLASS);
@@ -3150,7 +3166,7 @@ const WorkedGroupHeader = ({
     >
       <ChevronRight
         className={cn(
-          'h-3.5 w-3.5 flex-none shrink-0 opacity-60 transition-transform duration-200 group-hover:opacity-100',
+          'h-3.5 w-3.5 flex-none shrink-0 text-muted-foreground transition-transform duration-200',
           expanded && 'rotate-90'
         )}
       />
@@ -3174,7 +3190,9 @@ function ActivityProcessStep({
   return (
     <div
       className={cn(
-        'flex w-full min-h-7 items-start gap-1.5 px-1 py-1',
+        /* No horizontal shell pad: a step inside an expanded region starts on
+           the rail, like the group header above it. */
+        'flex w-full min-h-7 items-start gap-1.5 py-1',
         ACTIVITY_PROCESS_TEXT_CLASS,
         className
       )}
@@ -3246,6 +3264,23 @@ const AssistantSubagentTasksRow = ({ message }: { message: SessionHistoryParsed 
   const tasks = useMemo(() => collectSubagentTasks(message.items), [message.items]);
   return <SubagentTaskPanel tasks={tasks} />;
 };
+
+/**
+ * Does this top-level block paint a surface (card, attachment, plan) rather than
+ * flow as prose? Surfaces are separate objects and take `cardSiblingGap`; prose
+ * takes the tighter `turnSiblingGap` because its leading already separates it.
+ */
+const CARD_CONTENT_TYPES = new Set<MessageContent['type']>([
+  'tool_call',
+  'proposed_plan',
+  'plan',
+  'image',
+  'image_group',
+  'file',
+]);
+
+const isCardContentBlock = (block: AssistantTurnRenderBlock): boolean =>
+  block.kind === 'content' && CARD_CONTENT_TYPES.has(block.entry.content.type);
 
 const isAssistantToolCallActivityEntry = (
   entry: AssistantActivityRenderItem
@@ -3769,6 +3804,7 @@ const AssistantChatItem = memo(function AssistantChatItem({
           isStreaming: message.finished !== true,
           onFilePathClick,
           conversationFontSize,
+          planAwaitingDecision: hasUnansweredPlanApproval(message.items),
         });
       }
       case 'activity_group_header':
@@ -3784,29 +3820,27 @@ const AssistantChatItem = memo(function AssistantChatItem({
         );
       case 'activity_detail': {
         const { entry } = content;
-        /* Indent under the group header so steps read as children. */
-        return (
-          <div className="pl-3 sm:pl-3.5">
-            {isAssistantToolCallActivityEntry(entry) ? (
-              <AssistantToolCallVirtualRow
-                sessionId={row.item.sessionId}
-                messageId={message.id}
-                entry={entry}
-                onFilePathClick={onFilePathClick}
-                fontSize={conversationFontSize}
-              />
-            ) : (
-              <AssistantThoughtVirtualRow
-                messageId={message.id}
-                itemIndex={entry.itemIndex}
-                text={entry.content.text}
-                showLabel={content.showThoughtLabel}
-                isThinking={content.isThinking}
-                isStreaming={message.finished !== true}
-                fontSize={conversationFontSize}
-              />
-            )}
-          </div>
+        /* No indent: expanding a region must not shift its contents off the
+           rail. The disclosure chevron and the group header carry the
+           hierarchy — see `cardSiblingGap` above and `ai-gui/AGENTS.md`. */
+        return isAssistantToolCallActivityEntry(entry) ? (
+          <AssistantToolCallVirtualRow
+            sessionId={row.item.sessionId}
+            messageId={message.id}
+            entry={entry}
+            onFilePathClick={onFilePathClick}
+            fontSize={conversationFontSize}
+          />
+        ) : (
+          <AssistantThoughtVirtualRow
+            messageId={message.id}
+            itemIndex={entry.itemIndex}
+            text={entry.content.text}
+            showLabel={content.showThoughtLabel}
+            isThinking={content.isThinking}
+            isStreaming={message.finished !== true}
+            fontSize={conversationFontSize}
+          />
         );
       }
       case 'subagent_tasks':
@@ -3837,16 +3871,24 @@ const AssistantChatItem = memo(function AssistantChatItem({
      answer so edited-files is not double-spaced by line-height + pt-1. */
   const turnSiblingGap = 'pt-1 pb-0';
   const processSiblingGap = 'pt-0.5 pb-0.5';
+  /* A row that paints a surface needs a real gap, not the prose gap. `pt-1`
+     left cards 4-8px apart while their own padding was 10-12px, so the space
+     BETWEEN objects read tighter than the space inside one and the turn
+     collapsed into a stack of bordered strips. Prose keeps `pt-1`: its line
+     leading already supplies the separation. */
+  const cardSiblingGap = 'pt-3 pb-0';
   const verticalClass = (() => {
     if (isWorkedDetail) {
       return processSiblingGap;
     }
     switch (content.kind) {
+      case 'content':
+        return isCardContentBlock(content.block) ? cardSiblingGap : turnSiblingGap;
+      case 'plan':
+        return cardSiblingGap;
       case 'worked_group_header':
       case 'activity_group_header':
-      case 'content':
       case 'subagent_tasks':
-      case 'plan':
         return turnSiblingGap;
       case 'footer':
         /* No top pad: answer markdown already has leading below the last line.
@@ -3886,8 +3928,9 @@ const AssistantChatItem = memo(function AssistantChatItem({
         <div
           className={cn(
             'max-w-[800px] break-words',
-            /* Same inset the old process rail used, without the border. */
-            isWorkedDetail && 'pl-2.5 sm:pl-3',
+            /* A folded region's contents stay on the rail: expanding "Worked
+               for 12s" must reveal rows, not shift them right. Tone below is
+               what separates process from answer. */
             /* L4 result: full contrast. Process: muted so answer pops. */
             isFinalAnswer || content.kind === 'footer'
               ? 'text-foreground'
@@ -4098,6 +4141,8 @@ const renderAssistantContent = (
     isStreaming?: boolean;
     onFilePathClick?: (filePath: string) => void;
     conversationFontSize?: ConversationFontSize;
+    /** This turn's plan approval is still unanswered — see `ProposedPlanBlock`. */
+    planAwaitingDecision?: boolean;
   }
 ) => {
   const messageId = options?.messageId ?? 'assistant';
@@ -4117,7 +4162,7 @@ const renderAssistantContent = (
       );
     case 'image':
       return (
-        <div className="flex w-full px-2 pt-1">
+        <div className="flex w-full">
           <UserImageBlock
             entry={createSessionImageGalleryEntry({
               sessionId,
@@ -4160,12 +4205,25 @@ const renderAssistantContent = (
           itemIndex={itemIndex}
           onFilePathClick={options?.onFilePathClick}
           fontSize={conversationFontSize}
+          awaitingDecision={options?.planAwaitingDecision}
         />
       );
     case 'goal':
       return <GoalBlock goal={content} />;
     case 'tool_call':
-      return (
+      /* The plan-approval card has no title of its own to show: the plan is
+         right above it (Codex's `proposed_plan`, moved next to its approval) or
+         inside it (Claude's `content`), and "Implement this plan?" directly over
+         "Yes, implement this plan" asked and answered the same question twice.
+         What is left is the decision. */
+      return content.kind === 'switch_mode' ? (
+        <PlanExitBlock
+          sessionId={sessionId}
+          toolCall={content}
+          onFilePathClick={options?.onFilePathClick}
+          fontSize={conversationFontSize}
+        />
+      ) : (
         <ToolCallCard
           sessionId={sessionId}
           toolCall={content}
@@ -4412,7 +4470,10 @@ const UserImageBlock = ({
     <div
       ref={previewPortalAnchorRef}
       className={cn(
-        'overflow-hidden rounded-lg border border-border/70 bg-muted/20',
+        /* 12px: the shared radius of every top-level conversation card (file
+           card, proposed plan, permission record). An 8px frame beside them
+           read as a different family of object. */
+        'overflow-hidden rounded-xl border border-border/70 bg-muted/20',
         isThumbnail ? thumbnailFrameClass : 'inline-flex max-w-full flex-col'
       )}
     >
@@ -4496,7 +4557,11 @@ export const ImageGroupBubble = ({
   const sessionImagePreview = useContext(SessionImagePreviewContext);
   const previewPortalAnchorRef = useRef<HTMLDivElement>(null);
   const [localActiveImageKey, setLocalActiveImageKey] = useState<string | null>(null);
-  const justifyClass = align === 'end' ? 'justify-end' : 'justify-start';
+  /* An assistant attachment (`align="start"`) is a top-level row on the turn's
+     left rail: no horizontal pad (the gutter belongs to `ConversationColumn`)
+     and no top pad (the row gap belongs to `cardSiblingGap`). The user's own
+     attachments keep hugging the right edge exactly as they did. */
+  const rowClass = align === 'end' ? 'justify-end px-2 pt-1' : 'justify-start';
   const gridMaxWidthClass = thumbnailSize === 'large' ? 'max-w-[32rem]' : 'max-w-[26rem]';
   const entries = useMemo(
     () =>
@@ -4527,7 +4592,7 @@ export const ImageGroupBubble = ({
 
     return (
       <>
-        <div ref={previewPortalAnchorRef} className={cn('flex w-full px-2 pt-1', justifyClass)}>
+        <div ref={previewPortalAnchorRef} className={cn('flex w-full', rowClass)}>
           <UserImageBlock entry={entry} onPreviewRequest={handlePreviewRequest} variant="full" />
         </div>
         {!sessionImagePreview ? (
@@ -4550,7 +4615,7 @@ export const ImageGroupBubble = ({
 
   return (
     <>
-      <div ref={previewPortalAnchorRef} className={cn('flex w-full px-2 pt-1', justifyClass)}>
+      <div ref={previewPortalAnchorRef} className={cn('flex w-full', rowClass)}>
         <div className={cn('grid grid-cols-2 gap-2', gridMaxWidthClass)}>
           {entries.map((entry, index) => (
             <UserImageBlock
@@ -5048,7 +5113,7 @@ const CollapsibleCard = ({
           {canToggle && showDisclosureIcon ? (
             <ChevronRight
               className={cn(
-                'h-3.5 w-3.5 flex-none shrink-0 text-current opacity-70 transition-all duration-200 ease-out group-hover:opacity-100',
+                'h-3.5 w-3.5 flex-none shrink-0 text-current transition-transform duration-200 ease-out',
                 isExpanded ? 'rotate-90' : ''
               )}
             />
@@ -5138,20 +5203,17 @@ export const ProposedPlanBlock = ({
   itemIndex,
   onFilePathClick,
   fontSize = DEFAULT_CONVERSATION_FONT_SIZE,
+  awaitingDecision = false,
 }: {
   plan: ProposedPlanMessage;
   messageId: string;
   itemIndex: number;
   onFilePathClick?: (filePath: string) => void;
   fontSize?: ConversationFontSize;
+  /** The approval below this plan is still unanswered. */
+  awaitingDecision?: boolean;
 }) => {
   const searchBlockId = getProposedPlanSearchBlockId(messageId, itemIndex);
-  const statusLabel =
-    plan.status === 'delta'
-      ? 'Drafting'
-      : plan.status === 'completed'
-        ? 'Ready for review'
-        : 'Cleared';
   const handleAgentFileLinkClick = useCallback(
     (href: string) => {
       onFilePathClick?.(href);
@@ -5166,56 +5228,120 @@ export const ProposedPlanBlock = ({
     window.setTimeout(() => setDidCopy(false), 1200);
   }, [plan.markdown]);
 
+  /* A plan is long by nature and it now sits near the TOP of its turn, above the
+     work it produced — unclamped it would push everything that happened after it
+     off the screen. So it clamps ONCE IT IS HISTORY. While the plan is still
+     being written, or while its approval is unanswered, it opens in full: a
+     reader asked to approve or reject has to see the whole thing, and hiding
+     two thirds of it behind a chevron is the one moment that is unacceptable.
+     Collapsing then happens on the next render after the decision, never under
+     the reader who just made it (`useState` keeps the mounted value).
+     The toggle only appears when there is actually more to show, so a
+     three-line plan keeps no chrome. */
+  const defaultExpanded = awaitingDecision || plan.status === 'delta';
+  const cachedExpanded = getExpandState(messageId).expandedByIndex[itemIndex];
+  const [expanded, setExpandedState] = useState(cachedExpanded ?? defaultExpanded);
+  // Persisted so Virtua unmounting the row while it scrolls away does not throw
+  // away a reader's manual expansion.
+  const setExpanded = useCallback(
+    (next: boolean) => {
+      setExpandedState(next);
+      const cached = getExpandState(messageId);
+      setExpandState(messageId, {
+        ...cached,
+        expandedByIndex: { ...cached.expandedByIndex, [itemIndex]: next },
+      });
+    },
+    [itemIndex, messageId]
+  );
+  const [overflows, setOverflows] = useState(false);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const searchState = useSessionSearchBlockPrefix(searchBlockId);
+  const forceOpen = searchState.hasActive;
+  const isOpen = expanded || forceOpen;
+  useEffect(() => {
+    const element = bodyRef.current;
+    if (!element) return undefined;
+    const check = () => setOverflows(element.scrollHeight > element.clientHeight + 1);
+    check();
+    return observeResizeOnAnimationFrame(element, check);
+  }, [plan.markdown, isOpen]);
+
   if (!plan.markdown.trim()) {
     return null;
   }
 
+  /* The plan is the same kind of object as the command block and the tool
+     output beside it, so it wears the same panel: lighter header, plain body,
+     no accent. The tinted border/fill made one ordinary panel in the turn look
+     like the turn's alert, and the status pill restated what the surrounding
+     turn already shows (a drafting plan is visibly still growing). */
   return (
-    <div className="space-y-2 rounded-xl border border-primary/20 bg-primary/[0.035] p-3 shadow-xs">
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          <FileText className="h-4 w-4 text-primary/80" />
-          <span>Proposed Plan</span>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <span
-            className={cn(
-              'shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide',
-              plan.status === 'completed'
-                ? 'border-status-success/30 bg-status-success/[0.08] text-status-success'
-                : 'border-border/60 bg-background/60 text-muted-foreground'
-            )}
-          >
-            {statusLabel}
-          </span>
-          <TooltipProvider>
-            <Tooltip delayDuration={500}>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 text-muted-foreground hover:bg-hover hover:text-foreground"
-                  onClick={() => {
-                    void handleCopy();
-                  }}
-                  aria-label="Copy plan"
-                >
-                  {didCopy ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{didCopy ? 'Copied' : 'Copy plan'}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
+    <div className={CONVERSATION_PANEL_FRAME_CLASS}>
+      <div className={cn(CONVERSATION_PANEL_HEADER_CLASS, CONVERSATION_PANEL_HEADER_RULE_CLASS)}>
+        {/* The whole header toggles, matching `TerminalComponent`. The chevron is
+            the affordance; it only exists when the body is actually clipped. */}
+        <button
+          type="button"
+          className="-my-1 -ml-1 flex min-w-0 flex-1 items-center gap-2 rounded py-1 pl-1 text-left"
+          onClick={overflows || isOpen ? () => setExpanded(!isOpen) : undefined}
+          aria-expanded={overflows || isOpen ? isOpen : undefined}
+          disabled={!overflows && !isOpen}
+        >
+          {overflows || isOpen ? (
+            <ChevronRight
+              className={cn(
+                'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-200',
+                isOpen && 'rotate-90'
+              )}
+            />
+          ) : (
+            <FileText className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          )}
+          <span className={CONVERSATION_PANEL_TITLE_CLASS}>Proposed Plan</span>
+        </button>
+        <TooltipProvider>
+          <Tooltip delayDuration={500}>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="-mr-1 h-6 w-6 shrink-0 text-muted-foreground hover:bg-hover hover:text-foreground"
+                onClick={() => {
+                  void handleCopy();
+                }}
+                aria-label="Copy plan"
+              >
+                {didCopy ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{didCopy ? 'Copied' : 'Copy plan'}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
-      <div className="rounded-lg bg-background/55 px-2 py-1.5">
-        <MarkdownRenderer
-          text={plan.markdown}
-          size={fontSize}
-          onAgentFileLinkClick={onFilePathClick ? handleAgentFileLinkClick : undefined}
-          searchBlockId={searchBlockId}
-        />
+      <div className="relative">
+        <div
+          ref={bodyRef}
+          className={cn(
+            CONVERSATION_PANEL_BODY_CLASS,
+            !isOpen && 'max-h-56 overflow-hidden',
+            isOpen && 'scrollbar-pro max-h-[32rem] overflow-y-auto'
+          )}
+        >
+          <MarkdownRenderer
+            text={plan.markdown}
+            size={fontSize}
+            onAgentFileLinkClick={onFilePathClick ? handleAgentFileLinkClick : undefined}
+            searchBlockId={searchBlockId}
+          />
+        </div>
+        {!isOpen && overflows ? (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-background/95 to-transparent"
+          />
+        ) : null}
       </div>
     </div>
   );
@@ -5389,7 +5515,11 @@ const ToolCallCard = memo(function ToolCallCard({
 
   const hasOutput = Boolean(toolCall.rawOutput);
   const hasContent = Boolean(contentBlocks?.length);
-  const hasPermission = Boolean(toolCall.permissionRequest);
+  /* A cancelled request records nothing, so it must not count towards the body:
+     otherwise the card stays collapsible and opens onto empty padding. */
+  const hasPermission =
+    Boolean(toolCall.permissionRequest) &&
+    toolCall.permissionRequest?.outcome?.outcome !== 'cancelled';
   const hasDetails = hasOutput || hasContent || hasPermission;
 
   const title = toolCall.title
@@ -5545,9 +5675,16 @@ const ToolCallCard = memo(function ToolCallCard({
       }
 
       nodes.push(
+        /* Inside a folded activity row the block needs its own surface to read as
+           output. At top level the only tool call that gets here is the plan-exit
+           `switch_mode` card, whose content is the plan prose itself — boxing it
+           there stacked a near-invisible frame above the permission card and made
+           one row look like three unrelated objects. Space groups it instead. */
         <div
           key={`${block.type}-${index}`}
-          className="rounded-lg border border-border/60 bg-muted/20 p-2.5"
+          className={cn(
+            isActivityRow && cn(CONVERSATION_PANEL_FRAME_CLASS, CONVERSATION_PANEL_BODY_CLASS)
+          )}
         >
           <ToolCallContentRenderer
             block={block}
@@ -5578,22 +5715,31 @@ const ToolCallCard = memo(function ToolCallCard({
           ? ACTIVITY_STEP_BUTTON_CLASS
           : isTerminalExecuteToolCall
             ? 'rounded-none bg-muted/70 px-3 py-1.5 text-foreground hover:bg-muted/90'
-            : undefined
+            : /* A top-level tool call (the plan-approval `switch_mode` card) is a
+                 SIBLING of the worked headers and the answer prose, so it starts
+                 on the turn's left rail. `CollapsibleCard`'s default `px-1` put
+                 its title 4px right of every chevron in the same column — and 8px
+                 right of its own `px-0` body. */
+              'px-0'
       }
       bodyClassName={cn(
-        isActivityRow ? 'space-y-1.5 pb-1.5 pl-7 pr-1' : 'space-y-3 px-0',
-        !isActivityRow && (isTerminalExecuteToolCall ? 'border-t border-border/60 pb-0' : 'pb-1')
+        /* An expanded body starts on the rail, like every other collapsible
+           region in a turn. It still needs air under the title — they were 0px
+           apart — but not an indent. */
+        isActivityRow
+          ? 'space-y-1.5 px-0 pb-1.5 pt-1'
+          : isTerminalExecuteToolCall
+            ? /* Bordered card: the body is full-bleed to its own frame. */
+              'space-y-3 border-t border-border/60 px-0 pb-0'
+            : 'space-y-2.5 px-0 pb-1 pt-1.5'
       )}
       right={runningIndicator}
       left={
         <div
           className={cn(
             'flex min-w-0 flex-1 items-start gap-1.5',
-            isActivityRow
-              ? titleColorClass
-              : isTerminalExecuteToolCall
-                ? null
-                : titleColorClass + ' ml-1'
+            /* No leading margin: see `buttonClassName` — the rail is shared. */
+            isTerminalExecuteToolCall ? null : titleColorClass
           )}
         >
           <KindIcon className={kindIconClass} />
@@ -5675,13 +5821,18 @@ const ToolCallCard = memo(function ToolCallCard({
               fontSize={fontSize}
             />
           ) : hasOutput ? (
-            <div className="space-y-1">
-              <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Output
+            <div className={CONVERSATION_PANEL_FRAME_CLASS}>
+              <div
+                className={cn(
+                  CONVERSATION_PANEL_HEADER_CLASS,
+                  CONVERSATION_PANEL_HEADER_RULE_CLASS
+                )}
+              >
+                <span className={CONVERSATION_PANEL_TITLE_CLASS}>Output</span>
               </div>
               <pre
                 className={cn(
-                  'rounded-md bg-muted/40 p-2',
+                  CONVERSATION_PANEL_BODY_CLASS,
                   inlineOutput ? 'overflow-x-auto' : 'max-h-60 overflow-auto'
                 )}
                 style={conversationMonoFontSizeStyle(fontSize)}
@@ -5933,6 +6084,42 @@ const StandardToolContentBlock = ({
   }
 };
 
+/**
+ * A plan exit (`switch_mode`) renders as the DECISION, nothing else.
+ *
+ * Claude's `ExitPlanMode` carries the plan as a `content` text block, so that
+ * still renders here; Codex puts the plan in `rawInput` (never displayed) and
+ * emits a separate `proposed_plan`, which `buildAssistantMessageRenderItems`
+ * moves directly above this row. Either way the reader gets plan-then-decision,
+ * with no title restating the question the outcome already answers.
+ */
+const PlanExitBlock = ({
+  toolCall,
+  sessionId,
+  fontSize,
+  onFilePathClick,
+}: {
+  toolCall: ToolCallMessage;
+  sessionId: SessionId;
+  fontSize: ConversationFontSize;
+  onFilePathClick?: (filePath: string) => void;
+}) => {
+  const blocks = toolCall.content?.filter((block) => block.type === 'content');
+  return (
+    <div className="space-y-2">
+      {blocks?.map((block, index) => (
+        <ToolCallContentRenderer
+          key={`plan-exit-content-${index}`}
+          block={block}
+          onFilePathClick={onFilePathClick}
+          fontSize={fontSize}
+        />
+      ))}
+      <PermissionRequestBlock sessionId={sessionId} toolCall={toolCall} />
+    </div>
+  );
+};
+
 const PermissionRequestBlock = ({
   toolCall,
   sessionId,
@@ -5941,6 +6128,7 @@ const PermissionRequestBlock = ({
   sessionId: SessionId;
 }) => {
   const permission = toolCall.permissionRequest;
+  const { t } = useTranslation();
   const { respondToPermission, isReady } = usePermissionResponse();
   const [pendingOptionId, setPendingOptionId] = useState<string | null>(null);
 
@@ -5973,6 +6161,37 @@ const PermissionRequestBlock = ({
     permission.outcome?.outcome === 'selected' ? permission.outcome.optionId : undefined;
   const isResolved = Boolean(permission.outcome);
   const isCancelled = permission.outcome?.outcome === 'cancelled';
+  const record = resolvePermissionRecord(permission);
+
+  // `ToolCallCard` also drops the body for a withdrawn request, so this is the
+  // second gate rather than the only one.
+  if (record.kind === 'withdrawn') {
+    return null;
+  }
+
+  if (record.kind === 'settled') {
+    const label =
+      record.optionName ??
+      (record.allowed
+        ? t('sessions.permissionApproved', 'Permission Approved')
+        : t('sessions.permissionDenied', 'Permission Denied'));
+    const OutcomeIcon = record.allowed ? Check : X;
+    return (
+      <div
+        className={cn('flex min-h-7 w-full items-start gap-1.5 py-1', ACTIVITY_PROCESS_TEXT_CLASS)}
+      >
+        {/* Check vs cross already carries approved-vs-denied, so the icon keeps
+            the turn's one icon tone instead of introducing a hue no other icon
+            in the row has. */}
+        <OutcomeIcon className={ACTIVITY_STEP_ICON_CLASS} aria-hidden="true" />
+        {/* Truncated like every other process row: an `allow_always` name runs
+            to a full sentence, and the record must stay one line. */}
+        <span className="min-w-0 flex-1 truncate" title={label}>
+          {label}
+        </span>
+      </div>
+    );
+  }
 
   const handleSelect = async (optionId: string) => {
     if (isResolved || isCancelled || !isReady) {
@@ -5998,7 +6217,9 @@ const PermissionRequestBlock = ({
       isReady={isReady}
       pendingOptionId={pendingOptionId}
       selectedOptionId={selectedOptionId}
-      className="ml-4 w-[calc(100%-1rem)] max-w-[43rem]"
+      /* On the rail with the rest of its tool call's body. A private `ml-4`
+         used to put it 16px right of its own siblings. */
+      className="w-full max-w-[43rem]"
       onSelect={(optionId) => {
         void handleSelect(optionId);
       }}
@@ -6020,15 +6241,14 @@ const StructuredObject = ({
   fontSize?: ConversationFontSize;
 }) => {
   return (
-    <div className={cn('space-y-1', dense && 'space-y-0.5')}>
-      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        {label}
+    <div className={CONVERSATION_PANEL_FRAME_CLASS}>
+      <div className={cn(CONVERSATION_PANEL_HEADER_CLASS, CONVERSATION_PANEL_HEADER_RULE_CLASS)}>
+        <span className={CONVERSATION_PANEL_TITLE_CLASS}>{label}</span>
       </div>
       <pre
         className={cn(
-          'rounded-md bg-muted/40',
-          unbounded ? 'overflow-x-auto' : 'max-h-60 overflow-auto',
-          dense ? 'p-2' : 'p-3'
+          CONVERSATION_PANEL_BODY_CLASS,
+          unbounded ? 'overflow-x-auto' : 'max-h-60 overflow-auto'
         )}
         style={
           dense ? conversationMonoFontSizeStyle(fontSize) : conversationTextFontSizeStyle(fontSize)

--- a/packages/components/src/components/sessions/floating-permission-request.tsx
+++ b/packages/components/src/components/sessions/floating-permission-request.tsx
@@ -4,6 +4,11 @@ import { Button } from '@/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/ui/card';
 import { ScrollArea } from '@/ui/scroll-area';
 import { cn } from '@/lib/utils';
+import {
+  CONVERSATION_PANEL_FRAME_CLASS,
+  CONVERSATION_PANEL_HEADER_CLASS,
+  CONVERSATION_PANEL_HEADER_RULE_CLASS,
+} from '@/components/ai-gui/conversation-panel';
 import { ConversationColumn } from '@/components/shared/conversation-column';
 import { observeResizeOnAnimationFrame } from '@/lib/resize-observer';
 import { usePermissionResponse } from '@/hooks/use-permission-response';
@@ -203,11 +208,20 @@ export function PermissionRequestCard({
   return (
     <Card
       className={cn(
-        'overflow-hidden border-border/60 bg-secondary/25 text-xs shadow-sm animate-in fade-in slide-in-from-bottom-2 duration-300',
+        /* Same panel as the command block, tool output, and the proposed plan:
+           the header carries the lighter fill, the body sits on the frame. */
+        CONVERSATION_PANEL_FRAME_CLASS,
+        'text-xs animate-in fade-in slide-in-from-bottom-2 duration-300',
         className
       )}
     >
-      <CardHeader className="flex flex-col gap-0.5 border-b border-border/40 bg-secondary/55 px-3 py-2">
+      <CardHeader
+        className={cn(
+          CONVERSATION_PANEL_HEADER_CLASS,
+          CONVERSATION_PANEL_HEADER_RULE_CLASS,
+          'flex-col items-stretch gap-0.5 py-2'
+        )}
+      >
         <CardTitle className="text-[13px] font-medium text-muted-foreground">
           {headerLabel}
         </CardTitle>

--- a/packages/components/src/stories/AssistantTurnAlignment.stories.tsx
+++ b/packages/components/src/stories/AssistantTurnAlignment.stories.tsx
@@ -8,9 +8,31 @@
  * indent (the prose used to carry `sm:px-2` and sat 8px right of the chevrons).
  */
 import type { Meta, StoryObj } from '@storybook/react';
+import { Provider, createStore } from 'jotai';
+import type { ReactNode } from 'react';
 import type { SessionHistoryParsed, SessionId } from '@lody/shared';
 import type { ChatStreamItem, SessionChatStreamViewProps } from '@/components/ai-gui/view';
 import { MessageRowView, SessionChatStreamView } from '@/components/ai-gui/view';
+import { runtimeAtom } from '@/atoms';
+import { CONVERSATION_CONTENT_WIDTH_CLASS } from '@/lib/conversation-layout';
+import { cn } from '@/lib/utils';
+
+/**
+ * `usePermissionResponse` reports `isReady: !!runtime`, and a NOT-ready card
+ * renders its disabled-state footer ("Permission actions are disabled in this
+ * environment") and is taller than the real one. That state belongs to a
+ * workspace whose runtime has not opened — not to plan mode — so a story about
+ * plan-mode geometry must stub the runtime or it measures the wrong card.
+ * Same stub as `FloatingPermissionRequest.stories.tsx`: click handlers reject
+ * if exercised, screenshots show the active design.
+ */
+const stubRuntime = { withSessionStore: () => Promise.reject(new Error('stub')) };
+const storyStore = createStore();
+storyStore.set(runtimeAtom, stubRuntime as never);
+
+const WithRuntime = ({ children }: { children: ReactNode }) => (
+  <Provider store={storyStore}>{children}</Provider>
+);
 
 const meta = {
   title: 'Sessions/AssistantTurnAlignment',
@@ -152,5 +174,377 @@ export const DesktopFinishedTurn: Story = {
         lastCompletedAssistantMessageId={finishedTurn.id}
       />
     </div>
+  ),
+};
+
+/**
+ * PLAN-MODE TURN — the widest set of top-level row shells in one column.
+ *
+ * A plan approval cuts one turn into two regions (`isPlanExitBlock` in
+ * `assistant-turn-render-blocks.ts`), so a single turn shows two worked
+ * headers, the `switch_mode` approval card, its resolved permission card, an
+ * image group, a file card, and the proposed-plan card — plus the next turn's
+ * prose. Those are all SIBLINGS in one `ConversationColumn`, so EVERY one of
+ * them starts on the guide line. Measure with `getBoundingClientRect` against
+ * the guide; do not eyeball it.
+ *
+ * Each of those shells used to carry a private horizontal pad, which rendered
+ * the turn as a 0 / 8 / 16px ladder — the `switch_mode` title 8px right of the
+ * chevrons above it (and 8px right of its OWN `px-0` body), the resolved
+ * permission card 16px right of everything. The pads are gone; a new shell that
+ * re-adds one shows up here immediately.
+ *
+ * GEOMETRY CONTRACT for those rows (`ai-gui/AGENTS.md` points here; it is at its
+ * 8 KiB ceiling, so the numbers live where they are rendered):
+ *
+ *   - One radius. Every top-level card is `rounded-xl` — proposed plan, file
+ *     card, image frame, the resolved permission record.
+ *   - No indent, ever. An expanded region's contents start on the rail too —
+ *     the worked section, the activity group, and a tool call's own body. The
+ *     chevron and the header carry the hierarchy; expanding reveals rows, it
+ *     never shifts them right. Hover pills bleed with `-mx-1` instead.
+ *   - One gap. A row that PAINTS a surface takes `cardSiblingGap` (12px);
+ *     prose keeps `turnSiblingGap` (4px) because its leading already separates
+ *     it. Add a new card-shaped content type to `CARD_CONTENT_TYPES` or it
+ *     silently inherits the prose gap and reads as a stack of strips.
+ *   - The gap between rows is never smaller than the padding inside one. That
+ *     is what broke before: cards 4-8px apart with 10-12px of internal padding.
+ *   - No surface inside a surface. The plan-exit body renders bare; a nested
+ *     panel cannot be concentric with a 12px card that has 12px padding, and it
+ *     reads as a frame around nothing.
+ *   - Order. When a turn carries a plan, agent attachments sort BELOW it
+ *     (`AGENT_ATTACHMENT_TYPES`): a plan runs long, and a file card stranded
+ *     above one is a small thing to find mid-markdown. The answer text still
+ *     reads above that whole tail.
+ *   - One panel. Every framed block — command, tool input/output, permission,
+ *     proposed plan — uses `conversation-panel.ts`: the HEADER carries the
+ *     raised fill, the body sits on the frame. Never the reverse, and never an
+ *     accent-tinted frame for one panel among neutral siblings. The header tint
+ *     is a FOREGROUND alpha, because Vesper's `--muted` equals `--background`
+ *     and a `bg-muted` header measured as a zero-step band in dark.
+ *   - A settled permission is ONE LINE, not a card: check/cross plus the option
+ *     that was chosen (`resolvePermissionRecord`). Pending keeps the full card —
+ *     it is still a decision. A withdrawn request renders nothing, and
+ *     `ToolCallCard` drops its body so the card does not open onto empty
+ *     padding. Covered by `DesktopPlanDenied` / `DesktopPlanWithdrawn`.
+ *   - The plan and its approval are ONE unit. The plan renders directly above
+ *     the card that approves it (`buildAssistantMessageRenderItems` moves it
+ *     there), and the card has NO title — "Implement this plan?" stacked on
+ *     "Yes, implement this plan" asked and answered the same question twice.
+ *     The plan panel clamps and expands from its header, because it now sits
+ *     near the top of the turn, above everything it produced — but ONLY once it
+ *     is history. While the approval is unanswered (or the plan is still
+ *     streaming) it opens in full: `hasUnansweredPlanApproval`. Hiding two
+ *     thirds of a plan behind a chevron at the moment someone is asked to
+ *     approve it is the one state where clamping is unacceptable. See
+ *     `DesktopPlanAwaitingDecision`.
+ *   - ONE icon tone. Every icon in a turn is `text-muted-foreground` at full
+ *     opacity — no per-icon `opacity-60/70/80/90`, and no hue on the outcome
+ *     icon (check vs cross already carries approved vs denied). An interactive
+ *     icon rests at that tone too and brightens on hover; resting DIMMER than
+ *     the static chrome around it read as disabled.
+ *
+ * The guide line below is story-only chrome; it marks where
+ * `ConversationColumn`'s content box starts (`CONVERSATION_GUTTER_X_CLASS`).
+ */
+const planModeTurn: SessionHistoryParsed = {
+  id: 'alignment-plan-mode',
+  role: 'assistant',
+  timestamp: '2026-08-11T09:10:00.000Z',
+  read: true,
+  finished: true,
+  endedAt: Date.parse('2026-08-11T09:38:35.000Z'),
+  items: [
+    /* Region 1 — the work that produced the plan. Folds under "Finished
+       working": an earlier region never shows a duration. */
+    { type: 'thought', text: '先确认这一页的布局来源,再决定改哪一层。' },
+    {
+      type: 'tool_call',
+      toolCallId: 'plan-read-1',
+      title: 'Read packages/components/src/components/ai-gui/view.tsx',
+      kind: 'read',
+      status: 'completed',
+      locations: [{ path: 'packages/components/src/components/ai-gui/view.tsx' }],
+    },
+    {
+      type: 'tool_call',
+      toolCallId: 'plan-search-1',
+      title: 'rg ConversationColumn packages/components/src',
+      kind: 'search',
+      status: 'completed',
+    },
+    /* CODEX's plan exit: the plan goes in `rawInput` (never rendered) and the
+       readable plan is the separate `proposed_plan` below, which
+       `buildAssistantMessageRenderItems` moves up to sit directly above this
+       card. So this row contributes only the decision. Claude's shape — plan in
+       `content`, no `proposed_plan` — is covered by `DesktopPlanDenied`. NEVER
+       give one card both: it prints the plan twice, which no adapter does. */
+    {
+      type: 'tool_call',
+      toolCallId: 'plan-review:plan-1',
+      title: 'Implement this plan?',
+      kind: 'switch_mode',
+      status: 'completed',
+      rawInput: { plan: '# Plan' },
+      permissionRequest: {
+        requestId: 'plan-exit-permission-1',
+        options: [
+          { optionId: 'implement', name: 'Yes, implement this plan', kind: 'allow_once' },
+          {
+            optionId: 'revise',
+            name: 'No, and tell Codex what to do differently',
+            kind: 'reject_once',
+          },
+        ],
+        outcome: { outcome: 'selected', optionId: 'implement' },
+      },
+    },
+    /* Region 2 — the approved implementation. Last region, so it owns the
+       duration: "Worked for 28m 35s". */
+    { type: 'thought', text: '按计划先改 ToolCallCard 的外壳内边距。' },
+    {
+      type: 'tool_call',
+      toolCallId: 'plan-edit-1',
+      title: 'Edit packages/components/src/components/ai-gui/view.tsx',
+      kind: 'edit',
+      status: 'completed',
+      locations: [{ path: 'packages/components/src/components/ai-gui/view.tsx' }],
+    },
+    {
+      type: 'tool_call',
+      toolCallId: 'plan-edit-2',
+      title: 'Edit packages/components/src/stories/AssistantTurnAlignment.stories.tsx',
+      kind: 'edit',
+      status: 'completed',
+      locations: [{ path: 'packages/components/src/stories/AssistantTurnAlignment.stories.tsx' }],
+    },
+    {
+      type: 'image_group',
+      images: [
+        {
+          imageId: 'alignment-plan-shot-1',
+          mimeType: 'image/png',
+          fileName: 'plan-mode-turn.png',
+          sizeBytes: 40_000,
+          width: 320,
+          height: 200,
+        },
+      ],
+    },
+    {
+      type: 'text',
+      text: '计划卡、权限卡、附件和正文都落在同一条左轨上,任何外壳自带的水平内边距都会在这条参考线上暴露出来。',
+    },
+    {
+      type: 'file',
+      fileId: 'alignment-plan-file-1',
+      fileName: 'plan-mode-alignment.md',
+      mimeType: 'text/markdown',
+      sizeBytes: 2048,
+      sha256: 'f'.repeat(64),
+      textPreview: true,
+      uploadedAt: Date.parse('2026-08-11T09:38:30.000Z'),
+      transport: 'local',
+      machineId: 'machine-alignment-storybook',
+    },
+    {
+      type: 'proposed_plan',
+      turnId: 'alignment-plan-turn',
+      status: 'completed',
+      isLatest: true,
+      markdown: [
+        '## Goal',
+        '',
+        'Keep every top-level row of a plan-mode turn on one left rail.',
+        '',
+        '## Steps',
+        '',
+        '1. No per-shell horizontal pad on the `switch_mode` card.',
+        '2. The resolved permission card sits on the rail, not on its own `ml-4`.',
+      ].join('\n'),
+    },
+  ],
+};
+
+const planModeItems: ChatStreamItem[] = [
+  { type: 'message', sessionId, message: planModeTurn } as const,
+];
+
+/** Story-only guide at the column's content edge. */
+const RailGuide = () => (
+  <div aria-hidden className="pointer-events-none absolute inset-0 z-10">
+    <div className={cn(CONVERSATION_CONTENT_WIDTH_CLASS, 'relative h-full')}>
+      {/* `left-4` == the `sm:px-4` gutter, i.e. where every top-level row starts. */}
+      <div className="absolute inset-y-0 left-4 w-px bg-status-danger/70" />
+    </div>
+  </div>
+);
+
+/**
+ * The other two outcomes of the same card. A settled permission is one line —
+ * check + what was chosen, or a cross when it was denied — and a WITHDRAWN
+ * request (interrupted turn) renders nothing at all, not an empty card.
+ */
+const planExitOutcomeTurn = (
+  id: string,
+  outcome: { outcome: 'selected'; optionId: string } | { outcome: 'cancelled' }
+): SessionHistoryParsed => ({
+  id,
+  role: 'assistant',
+  timestamp: '2026-08-11T09:10:00.000Z',
+  read: true,
+  finished: true,
+  endedAt: Date.parse('2026-08-11T09:10:20.000Z'),
+  items: [
+    {
+      type: 'tool_call',
+      toolCallId: 'read-1',
+      title: 'Read view.tsx',
+      kind: 'read',
+      status: 'completed',
+    },
+    {
+      type: 'tool_call',
+      toolCallId: `${id}-plan-exit`,
+      title: 'Ready to code?',
+      kind: 'switch_mode',
+      status: 'completed',
+      /* CLAUDE's shape: `ExitPlanMode` carries the plan as a `content` text
+         block, so the card renders it above the outcome and there is no
+         separate `proposed_plan` item. */
+      content: [
+        {
+          type: 'content',
+          content: {
+            type: 'text',
+            text: '**Plan**\n\n1. Drop the per-shell horizontal pads.\n2. Re-measure against the rail guide.',
+          },
+        },
+      ],
+      permissionRequest: {
+        requestId: `${id}-permission`,
+        options: [
+          { optionId: 'approve', name: 'Yes, implement the plan', kind: 'allow_once' },
+          { optionId: 'reject', name: 'No, and tell Codex what to change', kind: 'reject_once' },
+        ],
+        outcome,
+      },
+    },
+    { type: 'text', text: 'Recorded the decision above.' },
+  ],
+});
+
+const outcomeStory = (message: SessionHistoryParsed, height = 'h-[320px]'): Story => ({
+  args: {
+    sessionId,
+    items: [{ type: 'message', sessionId, message } as const],
+    renderMessageRow,
+  },
+  globals: { theme: 'dark' },
+  render: () => (
+    <WithRuntime>
+      <div className={cn('relative w-full bg-background', height)}>
+        <SessionChatStreamView
+          items={[{ type: 'message', sessionId, message } as const]}
+          sessionId={sessionId}
+          renderMessageRow={renderMessageRow}
+          lastAssistantMessageId={message.id}
+          lastCompletedAssistantMessageId={message.id}
+        />
+        <RailGuide />
+      </div>
+    </WithRuntime>
+  ),
+});
+
+/**
+ * The moment the plan matters most: the approval is unanswered, so the plan
+ * opens IN FULL and the pending permission card keeps all its options. Compare
+ * with `DesktopPlanModeTurn`, where the same plan is clamped because the
+ * decision is already made.
+ */
+const planAwaitingDecisionTurn: SessionHistoryParsed = {
+  id: 'alignment-plan-pending',
+  role: 'assistant',
+  timestamp: '2026-08-11T09:10:00.000Z',
+  read: true,
+  finished: false,
+  items: [
+    {
+      type: 'tool_call',
+      toolCallId: 'pending-read-1',
+      title: 'Read packages/components/src/components/ai-gui/view.tsx',
+      kind: 'read',
+      status: 'completed',
+    },
+    {
+      type: 'proposed_plan',
+      turnId: 'alignment-pending-turn',
+      status: 'completed',
+      isLatest: true,
+      markdown: [
+        '## Goal',
+        '',
+        'Keep every top-level row of a plan-mode turn on one left rail.',
+        '',
+        '## Steps',
+        '',
+        '1. No per-shell horizontal pad on the `switch_mode` card.',
+        '2. The resolved permission card sits on the rail.',
+        '3. Attachments sort below the plan.',
+        '4. One icon tone for the whole turn.',
+      ].join('\n'),
+    },
+    {
+      type: 'tool_call',
+      toolCallId: 'plan-review:pending',
+      title: 'Implement this plan?',
+      kind: 'switch_mode',
+      status: 'pending',
+      rawInput: { plan: '# Plan' },
+      permissionRequest: {
+        requestId: 'pending-permission',
+        options: [
+          { optionId: 'implement', name: 'Yes, implement this plan', kind: 'allow_once' },
+          {
+            optionId: 'revise',
+            name: 'No, and tell Codex what to do differently',
+            kind: 'reject_once',
+          },
+        ],
+      },
+    },
+  ],
+};
+
+export const DesktopPlanAwaitingDecision: Story = outcomeStory(
+  planAwaitingDecisionTurn,
+  'h-[760px]'
+);
+
+export const DesktopPlanDenied: Story = outcomeStory(
+  planExitOutcomeTurn('alignment-plan-denied', { outcome: 'selected', optionId: 'reject' })
+);
+
+export const DesktopPlanWithdrawn: Story = outcomeStory(
+  planExitOutcomeTurn('alignment-plan-cancelled', { outcome: 'cancelled' })
+);
+
+export const DesktopPlanModeTurn: Story = {
+  args: { sessionId, items: planModeItems, renderMessageRow },
+  globals: { theme: 'dark' },
+  render: () => (
+    <WithRuntime>
+      <div className="relative h-[900px] w-full bg-background">
+        <SessionChatStreamView
+          items={planModeItems}
+          sessionId={sessionId}
+          renderMessageRow={renderMessageRow}
+          lastAssistantMessageId={planModeTurn.id}
+          lastCompletedAssistantMessageId={planModeTurn.id}
+        />
+        <RailGuide />
+      </div>
+    </WithRuntime>
   ),
 };

--- a/packages/components/src/stories/SessionConversationPage.stories.tsx
+++ b/packages/components/src/stories/SessionConversationPage.stories.tsx
@@ -137,7 +137,7 @@ const storyPlatform = createLocalPlatformProvider({
   }),
 });
 
-type PageState = 'idle' | 'working' | 'permission' | 'question';
+type PageState = 'idle' | 'working' | 'permission' | 'question' | 'plan';
 type DeviceFrame = 'desktop' | 'mobile';
 
 const action = fn();
@@ -307,7 +307,10 @@ const buildSessionId = (state: PageState, frame: DeviceFrame): SessionId =>
 const buildSession = (state: PageState, frame: DeviceFrame): SessionMeta => {
   const sessionId = buildSessionId(state, frame);
   const status =
-    state === 'idle'
+    // `plan` is a FINISHED plan-mode turn, so the session is idle like any
+    // other completed turn — it is the history that is interesting, not a
+    // pending state.
+    state === 'idle' || state === 'plan'
       ? ({ type: 'idle' } as const)
       : state === 'working'
         ? ({ type: 'running' } as const)
@@ -351,6 +354,11 @@ const buildMessage = (
   userId: input.userId,
   items: input.items,
   finished: input.finished,
+  // `endedAt` drives the worked header's duration and `fileDiff` the footer's
+  // edited-files card. Dropping them here silently rendered every finished turn
+  // as "Finished working" with no diff summary.
+  endedAt: input.endedAt,
+  fileDiff: input.fileDiff,
   modelInfo: input.modelInfo,
 });
 
@@ -553,9 +561,191 @@ const questionToolCall = (): MessageContent => ({
   },
 });
 
+const PLAN_MARKDOWN = [
+  '## Goal',
+  '',
+  'Give every framed block in a turn the same panel, and put every row on one left rail.',
+  '',
+  '## Steps',
+  '',
+  '1. Move the frame / header / body tokens into `conversation-panel.ts` so the',
+  '   header always carries the raised fill and the body never does.',
+  '2. Drop the per-shell horizontal pads (`ToolCallCard`, attachments, the',
+  '   permission card) so top-level rows share the column edge.',
+  '3. Collapse a settled permission to one line; keep the pending card actionable.',
+  '',
+  '## Risk',
+  '',
+  'The terminal paints its own VS Code surface, so its header has to step off',
+  '**that** colour rather than the frame.',
+].join('\n');
+
+/**
+ * A finished plan-mode turn, end to end: exploration, the plan-approval card
+ * and its one-line outcome, the approved implementation, the answer, and the
+ * artefacts the agent left behind. This is the shape the bundled adapters emit
+ * (`switch_mode` carries the plan as a `content` text block), and the one place
+ * to look at plan geometry inside the real page chrome.
+ */
+const buildPlanHistory = (): SessionHistoryParsed[] => [
+  buildMessage({
+    id: 'plan-user-1',
+    role: 'user',
+    userId: STORY_USER_ID,
+    timestamp: '2026-07-09T09:31:00.000Z',
+    items: [
+      {
+        type: 'text',
+        text: 'The plan-approval card is styled unlike everything else in the turn. Plan a fix first, then implement it.',
+      },
+    ],
+  }),
+  buildMessage({
+    id: 'plan-assistant-1',
+    role: 'assistant',
+    timestamp: '2026-07-09T09:31:20.000Z',
+    finished: true,
+    endedAt: Date.parse('2026-07-09T09:59:55.000Z'),
+    modelInfo: { modelId: 'gpt-5', name: 'GPT-5', description: null, _meta: null },
+    fileDiff: [
+      { filePath: 'packages/components/src/components/ai-gui/view.tsx', add: 96, del: 74 },
+      {
+        filePath: 'packages/components/src/components/ai-gui/conversation-panel.ts',
+        add: 34,
+        del: 0,
+      },
+    ],
+    items: [
+      // Pre-plan exploration. Folds under "Finished working": an earlier region
+      // never claims the duration.
+      {
+        type: 'thought',
+        text: 'Read the conversation renderer first, then decide which layer owns the geometry.',
+      },
+      {
+        type: 'tool_call',
+        toolCallId: 'plan-read-1',
+        title: 'Read packages/components/src/components/ai-gui/view.tsx',
+        kind: 'read',
+        status: 'completed',
+        locations: [{ path: 'packages/components/src/components/ai-gui/view.tsx' }],
+      },
+      {
+        type: 'tool_call',
+        toolCallId: 'plan-search-1',
+        title: 'rg "bg-muted/70|bg-secondary/55" packages/components/src',
+        kind: 'search',
+        status: 'completed',
+      },
+      // The plan-approval card. Codex titles it "Implement this plan?"; the
+      // region cut keys on `kind: switch_mode`, never the title.
+      // CODEX shape (this session's `agentType`), copied from
+      // `CodexAcpServer.requestPlanImplementationPermission`: the plan travels
+      // in `rawInput`, which the card does not render, and the readable plan is
+      // the separate `proposed_plan` item below. Claude's `ExitPlanMode` is the
+      // other shape — plan in `content`, no `proposed_plan` — and is covered by
+      // `AssistantTurnAlignment.stories.tsx`. Do not merge the two: a card with
+      // BOTH prints the plan twice, which no adapter actually does.
+      {
+        type: 'tool_call',
+        toolCallId: 'plan-review:plan-1',
+        title: 'Implement this plan?',
+        kind: 'switch_mode',
+        status: 'completed',
+        rawInput: { plan: PLAN_MARKDOWN },
+        permissionRequest: {
+          requestId: 'plan-exit-permission-1',
+          options: [
+            { optionId: 'implement', name: 'Yes, implement this plan', kind: 'allow_once' },
+            {
+              optionId: 'revise',
+              name: 'No, and tell Codex what to do differently',
+              kind: 'reject_once',
+            },
+          ],
+          outcome: { outcome: 'selected', optionId: 'implement' },
+        },
+      },
+      // The approved implementation. Last region, so it owns the duration.
+      {
+        type: 'thought',
+        text: 'Start with the shared panel tokens, then remove the shell pads one file at a time.',
+      },
+      {
+        type: 'tool_call',
+        toolCallId: 'plan-edit-1',
+        title: 'Edit packages/components/src/components/ai-gui/conversation-panel.ts',
+        kind: 'edit',
+        status: 'completed',
+        locations: [{ path: 'packages/components/src/components/ai-gui/conversation-panel.ts' }],
+      },
+      {
+        type: 'tool_call',
+        toolCallId: 'plan-edit-2',
+        title: 'Edit packages/components/src/components/ai-gui/view.tsx',
+        kind: 'edit',
+        status: 'completed',
+        locations: [{ path: 'packages/components/src/components/ai-gui/view.tsx' }],
+      },
+      {
+        type: 'tool_call',
+        toolCallId: 'plan-exec-1',
+        title: 'pnpm --filter @lody/components test',
+        kind: 'execute',
+        status: 'completed',
+        content: [
+          {
+            type: 'terminal_command',
+            command: '/bin/bash',
+            args: ['-lc', 'pnpm --filter @lody/components test'],
+            cwd: '/repo',
+          },
+          {
+            type: 'terminal_output',
+            output: [
+              ' Test Files  401 passed (401)',
+              '      Tests  2873 passed (2873)',
+              '   Duration  38.99s',
+            ].join('\n'),
+          },
+        ],
+      },
+      {
+        type: 'text',
+        text: [
+          'Every framed block now uses one panel: the header carries the raised fill and the body sits on the frame.',
+          '',
+          'Measured against the column edge, all top-level rows start at 0 and the header step is +12 in dark / -13 in light.',
+        ].join('\n'),
+      },
+      {
+        type: 'proposed_plan',
+        turnId: 'plan-turn-1',
+        markdown: PLAN_MARKDOWN,
+        status: 'completed',
+        isLatest: true,
+      },
+      {
+        type: 'file',
+        fileId: 'plan-report-1',
+        fileName: 'panel-geometry-report.md',
+        mimeType: 'text/markdown',
+        sizeBytes: 4096,
+        sha256: 'c'.repeat(64),
+        textPreview: true,
+        uploadedAt: Date.parse('2026-07-09T09:59:50.000Z'),
+        transport: 'r2',
+      },
+    ],
+  }),
+];
+
 const buildHistory = (state: PageState, streamChunkCount = 0): SessionHistoryParsed[] => {
   if (state === 'working') {
     return buildWorkingHistory(streamChunkCount);
+  }
+  if (state === 'plan') {
+    return buildPlanHistory();
   }
   const messages = baseMessages();
   if (state === 'permission') {
@@ -625,7 +815,7 @@ function createStoryStore(session: SessionMeta, state: PageState) {
   store.set(sessionMetaCacheAtom, {
     [getSessionRoomId(session.id)]: session,
   });
-  if (state !== 'idle') {
+  if (state !== 'idle' && state !== 'plan') {
     const instanceId = `storybook-${state}` as LodyPresenceInstanceId;
     const status =
       state === 'working'
@@ -1195,6 +1385,24 @@ export const DesktopAgentQuestion: Story = {
   decorators: [withDesktopViewport],
 };
 
+/**
+ * The whole plan-mode round inside the real page chrome: propose → approve →
+ * implement → result. Use this to look at plan geometry rather than the
+ * component stories, which show the pieces without the header, tab bar,
+ * info bar, and composer around them.
+ */
+export const DesktopPlanFlow: Story = {
+  args: { state: 'plan' },
+  globals: { theme: 'dark' },
+  decorators: [withDesktopViewport],
+};
+
+export const DesktopPlanFlowLight: Story = {
+  args: { state: 'plan' },
+  globals: { theme: 'light' },
+  decorators: [withDesktopViewport],
+};
+
 export const MobileIdle: Story = {
   args: { frame: 'mobile' },
   globals: { theme: 'dark' },
@@ -1218,6 +1426,12 @@ export const MobilePermissionApproval: Story = {
 
 export const MobileAgentQuestion: Story = {
   args: { frame: 'mobile', state: 'question' },
+  globals: { theme: 'dark' },
+  decorators: [withMobileViewport],
+};
+
+export const MobilePlanFlow: Story = {
+  args: { frame: 'mobile', state: 'plan' },
   globals: { theme: 'dark' },
   decorators: [withMobileViewport],
 };

--- a/packages/components/tests/assistant-message-render-items.test.ts
+++ b/packages/components/tests/assistant-message-render-items.test.ts
@@ -91,8 +91,8 @@ describe('buildAssistantMessageRenderItems', () => {
       }))
     ).toEqual([
       { type: 'text', itemIndex: 1, displayIndex: 0 },
-      { type: 'image_group', itemIndex: 3, displayIndex: 1 },
-      { type: 'proposed_plan', itemIndex: 2, displayIndex: 2 },
+      { type: 'proposed_plan', itemIndex: 2, displayIndex: 1 },
+      { type: 'image_group', itemIndex: 3, displayIndex: 2 },
     ]);
 
     const imageRenderItem = renderItems.find((item) => item.content.type === 'image_group');
@@ -115,5 +115,57 @@ describe('buildAssistantMessageRenderItems', () => {
 
     expect(renderedEntry.key).toBe('assistant-1:3:0:img-agent');
     expect(findSessionImageGalleryEntryIndex(galleryEntries, renderedEntry.key)).toBe(0);
+  });
+  it('sorts agent attachments below the plan, and leaves plan-less turns alone', () => {
+    // A plan runs long; an attachment above it is stranded mid-markdown.
+    const withPlan = [
+      { type: 'text', text: 'Answer' },
+      { type: 'file', fileId: 'f1' },
+      {
+        type: 'proposed_plan',
+        turnId: 't',
+        markdown: '# Plan',
+        status: 'completed',
+        isLatest: true,
+      },
+      { type: 'image_group', images: [{ imageId: 'i1', mimeType: 'image/png', sizeBytes: 1 }] },
+    ] as unknown as MessageContent[];
+
+    expect(buildAssistantMessageRenderItems(withPlan).map((i) => i.content.type)).toEqual([
+      'text',
+      'proposed_plan',
+      'file',
+      'image_group',
+    ]);
+
+    // Files and images stay together rather than straddling the plan.
+    const attachmentsFirst = [
+      { type: 'image_group', images: [{ imageId: 'i1', mimeType: 'image/png', sizeBytes: 1 }] },
+      {
+        type: 'proposed_plan',
+        turnId: 't',
+        markdown: '# Plan',
+        status: 'completed',
+        isLatest: true,
+      },
+      { type: 'file', fileId: 'f1' },
+    ] as unknown as MessageContent[];
+
+    expect(buildAssistantMessageRenderItems(attachmentsFirst).map((i) => i.content.type)).toEqual([
+      'proposed_plan',
+      'image_group',
+      'file',
+    ]);
+
+    // No plan: the turn's own order is authoritative.
+    const withoutPlan = [
+      { type: 'file', fileId: 'f1' },
+      { type: 'text', text: 'Answer' },
+    ] as unknown as MessageContent[];
+
+    expect(buildAssistantMessageRenderItems(withoutPlan).map((i) => i.content.type)).toEqual([
+      'file',
+      'text',
+    ]);
   });
 });

--- a/packages/components/tests/permission-record.test.ts
+++ b/packages/components/tests/permission-record.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { MessageContent } from '@lody/shared';
+
+import {
+  hasUnansweredPlanApproval,
+  resolvePermissionRecord,
+} from '../src/components/ai-gui/permission-record';
+
+type PermissionRequest = NonNullable<
+  Extract<MessageContent, { type: 'tool_call' }>['permissionRequest']
+>;
+
+const request = (overrides: Partial<PermissionRequest> = {}): PermissionRequest =>
+  ({
+    requestId: 'req-1',
+    options: [
+      { optionId: 'allow', name: 'Yes, implement the plan', kind: 'allow_once' },
+      { optionId: 'deny', name: 'No, and tell Codex what to change', kind: 'reject_once' },
+    ],
+    ...overrides,
+  }) as PermissionRequest;
+
+describe('resolvePermissionRecord', () => {
+  it('keeps an unanswered request actionable', () => {
+    expect(resolvePermissionRecord(request())).toEqual({ kind: 'pending' });
+  });
+
+  it('collapses an answered request to the option that was chosen', () => {
+    expect(
+      resolvePermissionRecord(request({ outcome: { outcome: 'selected', optionId: 'allow' } }))
+    ).toEqual({ kind: 'settled', allowed: true, optionName: 'Yes, implement the plan' });
+
+    expect(
+      resolvePermissionRecord(request({ outcome: { outcome: 'selected', optionId: 'deny' } }))
+    ).toEqual({
+      kind: 'settled',
+      allowed: false,
+      optionName: 'No, and tell Codex what to change',
+    });
+  });
+
+  it('shows nothing for a request that was withdrawn before anyone answered', () => {
+    expect(resolvePermissionRecord(request({ outcome: { outcome: 'cancelled' } }))).toEqual({
+      kind: 'withdrawn',
+    });
+  });
+
+  it('falls back to generic approval copy when the chosen option is gone', () => {
+    // Stale history: the recorded id no longer matches an offered option.
+    expect(
+      resolvePermissionRecord(request({ outcome: { outcome: 'selected', optionId: 'vanished' } }))
+    ).toEqual({ kind: 'settled', allowed: true, optionName: null });
+
+    // A blank name is not a label either.
+    expect(
+      resolvePermissionRecord(
+        request({
+          options: [{ optionId: 'allow', name: '   ', kind: 'allow_once' }],
+          outcome: { outcome: 'selected', optionId: 'allow' },
+        })
+      )
+    ).toEqual({ kind: 'settled', allowed: true, optionName: null });
+  });
+});
+
+describe('hasUnansweredPlanApproval', () => {
+  const planExit = (permissionRequest: unknown): MessageContent =>
+    ({
+      type: 'tool_call',
+      toolCallId: 'plan-exit',
+      kind: 'switch_mode',
+      status: 'pending',
+      permissionRequest,
+    }) as MessageContent;
+
+  it('holds the plan open while the approval is unanswered', () => {
+    expect(hasUnansweredPlanApproval([planExit(request())])).toBe(true);
+  });
+
+  it('lets the plan clamp once the reader has answered', () => {
+    expect(
+      hasUnansweredPlanApproval([
+        planExit(request({ outcome: { outcome: 'selected', optionId: 'allow' } })),
+      ])
+    ).toBe(false);
+  });
+
+  it('treats a withdrawn request as answered, not pending', () => {
+    // A cancelled request has nothing left to decide, so it must not pin the
+    // plan open for the rest of the session.
+    expect(
+      hasUnansweredPlanApproval([planExit(request({ outcome: { outcome: 'cancelled' } }))])
+    ).toBe(false);
+  });
+
+  it('ignores tool calls that are not a plan exit', () => {
+    const edit = {
+      type: 'tool_call',
+      toolCallId: 'edit-1',
+      kind: 'edit',
+      status: 'pending',
+      permissionRequest: request(),
+    } as MessageContent;
+    expect(hasUnansweredPlanApproval([edit])).toBe(false);
+    expect(hasUnansweredPlanApproval([{ type: 'text', text: 'hi' } as MessageContent])).toBe(false);
+  });
+});

--- a/packages/components/tests/plan-turn-virtual-rows.test.ts
+++ b/packages/components/tests/plan-turn-virtual-rows.test.ts
@@ -105,6 +105,45 @@ describe('approved plan renders its own region', () => {
     ]);
   });
 
+  it('sorts agent attachments below the plan and keeps the answer visible above them', () => {
+    // A plan runs long, so an attachment above it is stranded mid-markdown.
+    // Emitted attachment-first; rendered plan-first.
+    const rows = buildRows(
+      [
+        tool('read-1', 'read'),
+        {
+          type: 'file',
+          fileId: 'f1',
+          fileName: 'report.md',
+          mimeType: 'text/markdown',
+          sizeBytes: 10,
+          sha256: 'a',
+          textPreview: true,
+          uploadedAt: 0,
+          transport: 'r2',
+        },
+        { type: 'text', text: 'Here is the plan and the report.' },
+        {
+          type: 'proposed_plan',
+          turnId: 'turn-plan',
+          markdown: '# Plan',
+          status: 'completed',
+          isLatest: true,
+        },
+      ] as unknown as MessageContent[],
+      true
+    );
+
+    // The answer keeps its place above the tail: a turn ending in a `file` used
+    // to report no visible answer, which folded the answer into "Worked for …".
+    expect(visibleContentKinds(rows)).toEqual([
+      'worked_group_header',
+      'content:text',
+      'content:proposed_plan',
+      'content:file',
+    ]);
+  });
+
   it('keeps every step visible while the turn is still streaming', () => {
     const rows = buildRows(planTurnItems, false);
 


### PR DESCRIPTION
## Summary

A plan approval renders several kinds of surface in one turn — the `switch_mode` card, its permission record, the proposed plan, attachments — and each shell carried its own geometry. Reported as "the plan-mode turn looks ragged / unprofessional".

Measured against `ConversationColumn`'s content edge, before:

| | Before | After |
| --- | --- | --- |
| Top-level row left offsets | 0 / 8 / 16px | **0px** |
| Gap between cards | 4–8px (their own padding was 10–12px) | **12px** |
| Card radii | 6 / 8 / 12px, two broken concentric pairs | **12px** |
| Panel header step (dark) | **0** — `--muted` == `--background` in Vesper, the fill never rendered | **+12** |
| Panel header step (light) | inverted on the terminal (+7) | **−13** |
| Distinct icon tones | opacity 60 / 70 / 90 + a green | **one** |

## What changed

**One rail.** Every top-level row shares the column edge with no shell pad, *including the contents of an expanded region* — expanding "Worked for …" or an activity group reveals rows, it never shifts them right. Card-shaped rows take a real 12px inter-group gap (`cardSiblingGap` / `CARD_CONTENT_TYPES`); prose keeps the tighter gap its leading already supplies.

**One panel.** `conversation-panel.ts` owns the framed-block treatment for command, tool input/output, permission, and proposed plan: the header carries the raised fill and the body sits on the frame, never the reverse. The tint is a foreground alpha, because `bg-muted` over `bg-background` measured as a zero-step band in dark. The terminal paints its VS Code surface around header *and* body so its header steps off the same base it did not before.

**Plan surfaces become one unit.** The plan renders immediately before the approval that closes it (rather than at the end of the turn), the approval card drops the title that restated the question its outcome answers, and a settled permission collapses to one line; a withdrawn request renders nothing. The plan clamps once it is history but opens in full while its approval is unanswered or it is still streaming.

**Agent attachments sort below the plan** — which exposed a real fold bug: `shouldCollapseAssistantMessageItem` and the trailing-tail check kept two different never-collapse lists, so a turn ending in a `file` or a `proposed_plan` reported no visible answer and folded the answer itself into "Worked for …". One list now.

## Review focus

- **`buildAssistantMessageRenderItems` reordering.** `itemIndex` must stay the original history index through the reorder — image gallery keys, search block ids, and expansion state are keyed on it. Worth challenging whether images belong with files below the plan (the ask named files; splitting them would put two attachment areas either side of the plan).
- **The never-collapse list merge** in `message-copy.ts` is the one change that can hide an answer if wrong. `tests/plan-turn-virtual-rows.test.ts` asserts the visible rows end-to-end.
- **`PermissionRequestCard` is shared with the floating surface.** The live prompt is deliberately unchanged; only the in-scrollback record collapsed. Verified across all 12 `PermissionRequestCard` / `FloatingPermissionRequest` stories.
- **Evidence gap:** everything is verified through Storybook against the real components, not in the running desktop app. Theme coverage is Vesper dark + light only; other VS Code themes could resolve `--muted` differently again, which is exactly the failure this PR fixes once.

## Verification

- `pnpm --filter @lody/components test` — 401 files / 2877 tests pass (+10 new)
- `tsgo --noEmit`, `oxlint` (0 errors), `prettier --check` on touched files
- `pnpm lint:i18n`, `pnpm check:platform-boundaries`, `pnpm check:public-boundary`
- Geometry, header steps, and icon tones measured with `getBoundingClientRect` and by sampling painted pixels, in **both themes** — not eyeballed
- New stories: `AssistantTurnAlignment` → `DesktopPlanModeTurn`, `DesktopPlanAwaitingDecision`, `DesktopPlanDenied`, `DesktopPlanWithdrawn`; `SessionConversationPage` → `DesktopPlanFlow`, `DesktopPlanFlowLight`, `MobilePlanFlow`

Both story fixtures mirror a specific adapter — Claude carries the plan in `content`, Codex in `rawInput` plus a separate `proposed_plan` — because a card with both prints the plan twice, which no adapter actually does.

## Known follow-ups (not in this PR)

- Claude-shape plans render inside the approval card and do **not** clamp in scrollback; Codex-shape ones do.
- `UserImageBlock` outlines images with a tinted neutral (`border-border/70`) rather than a pure black/white alpha; fixing it touches every image in the app.
- `packages/components/src/components/ai-gui/AGENTS.md` is at 8147/8192 bytes, so the full geometry contract lives in the story it points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
