### PR TITLE
fix(acp): map pi, grok, and kimi to the skill dirs their engines scan

### DIFF
--- a/packages/components/src/components/mentions/AGENTS.md
+++ b/packages/components/src/components/mentions/AGENTS.md
@@ -23,6 +23,9 @@ Product-level mention sources built on `src/ui/mention`.
   it. The scanner handles flat `~/<agent>/skills/<skill>/SKILL.md` and catalog
   `~/<agent>/skills/<category>/<skill>/SKILL.md`; paths outside the provider's
   registered roots (e.g. plugin caches) appear only once their dirs are added.
+- A registered entry mapping to no dir (`deepagents`) keeps its empty
+  whitelist; an unregistered agent type gets `null` instead, because an empty
+  `Set` here filters every candidate out rather than restricting nothing.
 - Before send, known `$` skill tokens are expanded in prompt text to
   `use /token [Skill Path](path)`. Project skills use their project-relative
   `SKILL.md` path; home-scoped (`global` + `system`) skills use the CLI-provided

--- a/packages/components/src/components/mentions/mention-skill-source.tsx
+++ b/packages/components/src/components/mentions/mention-skill-source.tsx
@@ -5,6 +5,7 @@ import {
   getRegisteredGlobalSkillDirs,
   getRegisteredSkillDirs,
   getRegisteredSystemSkillDirs,
+  isRegisteredSkillAgentType,
   type AgentConfigCliType,
   type ProjectSkill,
   type ProjectSkillScope,
@@ -167,6 +168,11 @@ export function getAllowedSkillMentionDirs(
   skillAgent: { cliType?: AgentConfigCliType; agentType?: string } | undefined
 ): ReadonlySet<string> | null {
   if (!skillAgent?.cliType || !skillAgent.agentType) {
+    return null;
+  }
+  // Unregistered types have no known dirs; an empty whitelist would hide every
+  // skill, so they get none. A registered one keeps its whitelist when empty.
+  if (!isRegisteredSkillAgentType(skillAgent.agentType)) {
     return null;
   }
   const agent = { cliType: skillAgent.cliType, agentType: skillAgent.agentType };

--- a/packages/components/tests/mention-skill-source.test.ts
+++ b/packages/components/tests/mention-skill-source.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { applyTextRewrites, type ProjectSkill, type ProjectSkillGroup } from '@lody/shared';
+import {
+  applyTextRewrites,
+  DEFAULT_AGENTS_GLOBAL_SKILL_DIR,
+  type ProjectSkill,
+  type ProjectSkillGroup,
+} from '@lody/shared';
 import {
   buildSkillMentionItems,
   buildSkillMentionRewrites,
+  getAllowedSkillMentionDirs,
   getSkillMentionToken,
   hydrateSkillMentionsFromText,
   mergeMentionSkillState,
@@ -111,6 +117,45 @@ describe('buildSkillMentionItems', () => {
         .map((i) => i.dir)
         .sort()
     ).toEqual(['.agents/skills', '.claude/skills', '~/.claude/skills']);
+  });
+});
+
+describe('getAllowedSkillMentionDirs', () => {
+  it('returns no whitelist when the agent is unknown or only partly identified', () => {
+    expect(getAllowedSkillMentionDirs(undefined)).toBeNull();
+    expect(getAllowedSkillMentionDirs({ cliType: 'custom' })).toBeNull();
+    expect(getAllowedSkillMentionDirs({ agentType: 'claude' })).toBeNull();
+  });
+
+  it('returns no whitelist for an unregistered agent type instead of an empty one', () => {
+    // An empty-but-present whitelist filters every candidate out; `null` keeps
+    // them. Custom agents get generated `custom-<uuid>` types.
+    const allowed = getAllowedSkillMentionDirs({ cliType: 'custom', agentType: 'custom-2f1a' });
+    expect(allowed).toBeNull();
+
+    const items = buildSkillMentionItems(GROUPS);
+    expect(selectSkillMentionCandidates(items, '', allowed).map((i) => i.token)).toEqual([
+      'claude-only',
+      'code-review',
+      'deep-research',
+      'global-only',
+      'qwen-only',
+    ]);
+  });
+
+  it('keeps an explicit empty whitelist for a registered agent that reads no skills', () => {
+    const allowed = getAllowedSkillMentionDirs({ cliType: 'registry', agentType: 'deepagents' });
+    expect(allowed).not.toBeNull();
+    expect([...(allowed ?? [])]).toEqual([]);
+    expect(selectSkillMentionCandidates(buildSkillMentionItems(GROUPS), '', allowed)).toEqual([]);
+  });
+
+  it('offers ~/.agents/skills to grok, pi, and kimi', () => {
+    for (const agentType of ['grok', 'pi-acp', 'kimi-code']) {
+      expect(getAllowedSkillMentionDirs({ cliType: 'registry', agentType })).toContain(
+        DEFAULT_AGENTS_GLOBAL_SKILL_DIR
+      );
+    }
   });
 });
 

--- a/packages/shared/src/acp/skills.ts
+++ b/packages/shared/src/acp/skills.ts
@@ -85,6 +85,13 @@ export const ACP_SKILL_DIRS_BY_AGENT_TYPE: Record<string, SkillDirsByAgentType> 
   crush: skillDirs(['.crush/skills'], ['~/.config/crush/skills']),
   cursor: skillDirs([DEFAULT_PROJECT_SKILL_DIR], ['~/.cursor/skills']),
   deepagents: skillDirs([], []),
+  /* `dsh-skill-filesystem`, mounted by the standard and code presets with no
+     roots configured, discovers the project and user defaults. `minimal` and
+     `cordis` differ, which this per-agent table cannot express. */
+  deepseek: skillDirs(
+    [DEFAULT_PROJECT_SKILL_DIR, '.dsh/skills'],
+    ['~/.dsh/skills', DEFAULT_AGENTS_GLOBAL_SKILL_DIR]
+  ),
   devin: skillDirs(
     ['.devin/skills', '.windsurf/skills'],
     [DEFAULT_AGENTS_GLOBAL_SKILL_DIR, '~/.config/devin/skills']
@@ -120,6 +127,12 @@ export const ACP_SKILL_DIRS_BY_AGENT_TYPE: Record<string, SkillDirsByAgentType> 
     [DEFAULT_PROJECT_SKILL_DIR, '.goose/skills'],
     ['~/.config/goose/skills', DEFAULT_AGENTS_GLOBAL_SKILL_DIR]
   ),
+  /* Grok's skill roots are `.grok`, `.agents`, and — on by default — the
+     `.claude` and `.cursor` compat roots, at every tier. */
+  grok: skillDirs(
+    [DEFAULT_PROJECT_SKILL_DIR, '.grok/skills', CLAUDE_PROJECT_SKILL_DIR, '.cursor/skills'],
+    ['~/.grok/skills', DEFAULT_AGENTS_GLOBAL_SKILL_DIR, CLAUDE_GLOBAL_SKILL_DIR, '~/.cursor/skills']
+  ),
   'hermes-agent': skillDirs(['.hermes/skills'], ['~/.hermes/skills']),
   iflow: skillDirs(['.iflow/skills'], ['~/.iflow/skills']),
   'iflow-cli': skillDirs(['.iflow/skills'], ['~/.iflow/skills']),
@@ -136,9 +149,18 @@ export const ACP_SKILL_DIRS_BY_AGENT_TYPE: Record<string, SkillDirsByAgentType> 
   ),
   kiro: skillDirs(['.kiro/skills'], ['~/.kiro/skills']),
   'kiro-cli': skillDirs(['.kiro/skills'], ['~/.kiro/skills']),
-  kimi: skillDirs([DEFAULT_PROJECT_SKILL_DIR, '.kimi/skills'], []),
-  'kimi-code': skillDirs([DEFAULT_PROJECT_SKILL_DIR, '.kimi/skills'], []),
-  'kimi-code-cli': skillDirs([DEFAULT_PROJECT_SKILL_DIR, '.kimi/skills'], []),
+  kimi: skillDirs(
+    [DEFAULT_PROJECT_SKILL_DIR, '.kimi-code/skills'],
+    ['~/.kimi-code/skills', DEFAULT_AGENTS_GLOBAL_SKILL_DIR]
+  ),
+  'kimi-code': skillDirs(
+    [DEFAULT_PROJECT_SKILL_DIR, '.kimi-code/skills'],
+    ['~/.kimi-code/skills', DEFAULT_AGENTS_GLOBAL_SKILL_DIR]
+  ),
+  'kimi-code-cli': skillDirs(
+    [DEFAULT_PROJECT_SKILL_DIR, '.kimi-code/skills'],
+    ['~/.kimi-code/skills', DEFAULT_AGENTS_GLOBAL_SKILL_DIR]
+  ),
   kode: skillDirs(['.kode/skills'], ['~/.kode/skills']),
   lingma: skillDirs(['.lingma/skills'], ['~/.lingma/skills']),
   loaf: skillDirs([DEFAULT_PROJECT_SKILL_DIR], [DEFAULT_AGENTS_GLOBAL_SKILL_DIR]),
@@ -154,8 +176,14 @@ export const ACP_SKILL_DIRS_BY_AGENT_TYPE: Record<string, SkillDirsByAgentType> 
     ['~/.config/opencode/skills', CLAUDE_GLOBAL_SKILL_DIR, DEFAULT_AGENTS_GLOBAL_SKILL_DIR]
   ),
   openhands: skillDirs(['.openhands/skills'], ['~/.openhands/skills']),
-  pi: skillDirs([DEFAULT_PROJECT_SKILL_DIR, '.pi/skills'], ['~/.pi/agent/skills']),
-  'pi-acp': skillDirs([DEFAULT_PROJECT_SKILL_DIR, '.pi/skills'], ['~/.pi/agent/skills']),
+  pi: skillDirs(
+    [DEFAULT_PROJECT_SKILL_DIR, '.pi/skills'],
+    ['~/.pi/agent/skills', DEFAULT_AGENTS_GLOBAL_SKILL_DIR]
+  ),
+  'pi-acp': skillDirs(
+    [DEFAULT_PROJECT_SKILL_DIR, '.pi/skills'],
+    ['~/.pi/agent/skills', DEFAULT_AGENTS_GLOBAL_SKILL_DIR]
+  ),
   pochi: skillDirs(['.pochi/skills'], ['~/.pochi/skills']),
   promptscript: skillDirs([DEFAULT_PROJECT_SKILL_DIR], []),
   qoder: skillDirs(['.qoder/skills'], ['~/.qoder/skills']),
@@ -189,8 +217,10 @@ export const ACP_SKILL_DIRS_BY_AGENT_TYPE: Record<string, SkillDirsByAgentType> 
    v7: project `.agents/skills` is provider-specific, not a universal ACP fallback.
    v8: local/global scans include absolute SKILL.md paths for prompt expansion.
    v9: home scan also surfaces agent built-in `system` skills (codex
-   `~/.codex/skills/.system`) under the new `'system'` scope. */
-export const KNOWN_SKILL_DIRS_VERSION = 9;
+   `~/.codex/skills/.system`) under the new `'system'` scope.
+   v10: grok is registered, and pi/kimi global dirs match their engines
+   (`~/.agents/skills` for both, `.kimi-code` for kimi's brand dirs). */
+export const KNOWN_SKILL_DIRS_VERSION = 10;
 
 export const DEFAULT_PROJECT_SKILLS_CONTENT_BUDGET_BYTES = 2 * 1024 * 1024;
 export const DEFAULT_PROJECT_SKILLS_RESULT_MAX_SKILLS = 5_000;
@@ -341,6 +371,12 @@ export type ProjectSkillFrontmatter = {
 
 export function getSkillScanCandidateDirs(): string[] {
   return ALL_KNOWN_PROJECT_SKILL_DIRS;
+}
+
+/** Whether the table has an entry at all. An entry mapping to no directory
+   (`deepagents`) is registered: it asserts the agent reads none. */
+export function isRegisteredSkillAgentType(agentType: string): boolean {
+  return Object.hasOwn(ACP_SKILL_DIRS_BY_AGENT_TYPE, agentType);
 }
 
 export function getRegisteredSkillDirs(

--- a/packages/shared/tests/acp-skills.test.ts
+++ b/packages/shared/tests/acp-skills.test.ts
@@ -14,8 +14,10 @@ import {
   getRegisteredSystemSkillDirs,
   getSkillMarkdownBody,
   getSkillScanCandidateDirs,
+  isRegisteredSkillAgentType,
   parseSkillFrontmatter,
 } from '../src/acp/skills';
+import { BUILTIN_AGENTS } from '../src/ai';
 
 describe('getSkillMarkdownBody', () => {
   it('strips a leading frontmatter block and returns the trimmed body', () => {
@@ -140,12 +142,52 @@ describe('project skills helpers', () => {
     expect([
       ...getRegisteredGlobalSkillDirs([{ cliType: 'registry', agentType: 'cline' }]),
     ]).toEqual(['~/.cline/skills']);
+    // Project dirs but no global dir at all — distinct from an all-empty mapping.
     expect([
-      ...getRegisteredGlobalSkillDirs([{ cliType: 'registry', agentType: 'kimi-code-cli' }]),
+      ...getRegisteredGlobalSkillDirs([{ cliType: 'registry', agentType: 'promptscript' }]),
     ]).toEqual([]);
+    expect([
+      ...getRegisteredSkillDirs([{ cliType: 'registry', agentType: 'promptscript' }]),
+    ]).toEqual([DEFAULT_PROJECT_SKILL_DIR]);
     expect([
       ...getRegisteredGlobalSkillDirs([{ cliType: 'registry', agentType: 'deepagents' }]),
     ]).toEqual([]);
+  });
+
+  it('maps pi, grok, kimi, and deepseek to the shared ~/.agents/skills dir their engines scan', () => {
+    for (const agentType of [
+      'pi',
+      'pi-acp',
+      'grok',
+      'kimi',
+      'kimi-code',
+      'kimi-code-cli',
+      'deepseek',
+    ]) {
+      expect(
+        getRegisteredGlobalSkillDirs([{ cliType: 'registry', agentType }]).has(
+          DEFAULT_AGENTS_GLOBAL_SKILL_DIR
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('maps kimi to the .kimi-code brand dirs its engine scans, not the .kimi ones', () => {
+    for (const agentType of ['kimi', 'kimi-code', 'kimi-code-cli']) {
+      const agent = { cliType: 'registry' as const, agentType };
+      expect([...getRegisteredSkillDirs([agent])].sort()).toEqual(
+        [DEFAULT_PROJECT_SKILL_DIR, '.kimi-code/skills'].sort()
+      );
+      expect(getRegisteredGlobalSkillDirs([agent]).has('~/.kimi-code/skills')).toBe(true);
+    }
+    expect(ALL_KNOWN_GLOBAL_SKILL_DIRS).not.toContain('~/.kimi/skills');
+    expect(getSkillScanCandidateDirs()).not.toContain('.kimi/skills');
+  });
+
+  it('registers every builtin agent type so none falls back to an unfiltered menu', () => {
+    for (const { agentType } of BUILTIN_AGENTS) {
+      expect(isRegisteredSkillAgentType(agentType)).toBe(true);
+    }
   });
 
   it('exposes codex built-in system skill dirs separate from global dirs', () => {


### PR DESCRIPTION
## Related issue

Closes #150

## Problem / pressure

`ACP_SKILL_DIRS_BY_AGENT_TYPE` is a hand-maintained mirror of facts owned by each engine, and it had drifted from what the engines actually scan:

- **pi** (`packages/coding-agent/docs/skills.md`, "Locations") scans `~/.pi/agent/skills` **and** `~/.agents/skills`; the table listed only the first.
- **grok** had no entry at all. `MANAGED_BUILTIN_RUNTIMES` maps `grok-build` to `agentType: 'grok'`, but no `grok` key existed. Its skill roots come from `CompatConfig::skill_config_dirs()` in `xai-grok-tools/src/types/compat.rs`, which returns `[".grok", ".agents", ".claude", ".cursor"]` under the all-on `VendorCompat::default()` (pinned by that file's own `skill_config_dirs_all_on_matches_legacy_constant` test), at every tier.
- **kimi** uses `.kimi-code/skills` + `.agents/skills` per project and `~/.kimi-code/skills` + `~/.agents/skills` globally (`packages/agent-core-v2/src/features/skill/catalog/skillRoots.ts`). The table had `.kimi/skills` and an empty global list. `.kimi/skills` is not in the engine's project tier at all, so it is stale rather than merely incomplete. (The documented first-launch migration copies the *user* dir `~/.kimi/skills`; the project dir was never migrated, it simply stopped being scanned.)
- **deepseek** had no entry either, and it is a `BUILTIN_AGENTS` member. `dsh-skill-filesystem` — mounted by the standard and code presets (`packages/acp-extension-dsh/presets/*/agent.cordis.yml`) with no roots configured — discovers `.dsh/skills` and `.agents/skills` per project and `~/.dsh/skills` and `~/.agents/skills` per user (`skill-filesystem` config defaults: `dshHome` = `$DSH_HOME` or `~/.dsh`, `agentsHome` = `$DSH_AGENTS_HOME` or `~/.agents`).

The grok symptom was worse than a missing row. `getAllowedSkillMentionDirs` returned an **empty but non-null** `Set` for an agent type absent from the table, and `selectSkillMentionCandidates` treats non-null as "apply this whitelist" — so every scanned `$` skill was filtered out. A lookup miss meant "hide everything". The Skills panel, reading the same table via `annotateAndSortGroups`, treats a miss as merely unannotated and hides nothing, so the two surfaces disagreed about the same miss. Custom `custom-<uuid>` agents hit this too.

Nothing tied the table to the authoritative agent lists, so `grok` and `deepseek` could go missing without any check noticing.

## Summary

- Register `grok` and `deepseek`, and align `pi` / `pi-acp` / `kimi` / `kimi-code` / `kimi-code-cli` with their engines' dirs.
- `deepseek` therefore gets the same treatment as the other three: it is a fourth agent that reads `~/.agents/skills` while Lody could not see it. (The `skills: enabled: false` in `profile.ts` disables the demo spine's own bundled wiring — alongside `toolBash`, `goals`, and `persona` — because the host composition mounts the real skill registry and the presets mount the discovery and loader plugins.)
- Return `null` (no whitelist) from `getAllowedSkillMentionDirs` for an unregistered agent type, via a new `isRegisteredSkillAgentType`. A registered entry that maps to nothing keeps its explicit empty whitelist — "reads no skills" and "we have no mapping" stay distinct.
- Add a test asserting every `BUILTIN_AGENTS` type is registered, so a new builtin cannot repeat this.
- Bump `KNOWN_SKILL_DIRS_VERSION` to 10 so cached scans re-fetch.

This revives the `null` change from #76 (closed unmerged under `status:needs-pr-body`, not on technical grounds); #150 names that same mechanism.

## Before / after

| Before | After |
| ------ | ----- |
| `$` menu showed no skills for grok: an unregistered type produced an empty whitelist that filtered every candidate. | An unregistered type applies no whitelist; grok and deepseek are also registered outright. |
| `~/.agents/skills` was invisible to pi, grok, and kimi although all three load it. | All three map to `~/.agents/skills`. |
| kimi mapped to `.kimi/skills` and no global dir. | kimi maps to `.kimi-code/skills`, `~/.kimi-code/skills`, and `~/.agents/skills`. |
| deepseek, a builtin, was absent, so its `$` menu was empty. | deepseek maps to `.dsh/skills`, `.agents/skills`, `~/.dsh/skills`, `~/.agents/skills`. |
| A builtin could be missing from the table undetected. | A test fails unless every builtin is registered. |

## Test plan

- `pnpm --filter @lody/shared exec vitest run tests/acp-skills.test.ts` — 22 passed.
- `pnpm --filter @lody/components exec vitest run tests/mention-skill-source.test.ts` — 22 passed.
- `pnpm format`, then `pnpm typecheck`, `pnpm lint`, `pnpm lint:i18n`, `pnpm check:code-collab-imports`, `pnpm check:platform-boundaries`, `pnpm check:public-boundary` — all clean.
- `packages/components` has 19 test files / 72 tests failing on this branch, all pre-existing: the same 19/72 fail on an unmodified tree at the same base commit (`use-chat-landing-defaults`, `vscode-diff-theme-registration` and similar jsdom teardown failures, none skill-related).
- Regression check: reverting only `mention-skill-source.tsx` to the base revision makes `returns no whitelist for an unregistered agent type instead of an empty one` fail while the other 21 cases pass, so that test fails on the old behavior through the production owner rather than a fixture.
- Scan-set effect, diffed on the built aggregates: project gains `.grok/skills`, `.kimi-code/skills`, `.cursor/skills`, `.dsh/skills` and loses `.kimi/skills`; global gains `~/.grok/skills`, `~/.kimi-code/skills`, `~/.dsh/skills`. Only `.cursor/skills` is new to the shared scan set — the Claude dirs were already in it via the `claude` entry.
- Replaced one stale assertion that pinned `kimi-code-cli` to no global dirs. It now uses `promptscript`, which keeps the same shape under test (project dirs, zero global dirs) rather than duplicating the adjacent `cline` case.
- Not done: no desktop run against live sessions. Dir facts come from each engine's source or docs.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** the entries in `packages/shared/src/acp/skills.ts`, and the `null`-vs-empty whitelist change in `getAllowedSkillMentionDirs`, which reaches every unregistered agent, not only grok.
- **Decisions to challenge:** (1) grok's entry includes the Claude and Cursor compat roots. They are on by default in the engine but user-disablable, and the table cannot express "configurable"; including them also adds `.cursor/skills` to the shared project scan set. (2) `deepseek`'s dirs hold for the standard and code presets; `minimal` mounts no skill plugin and `cordis` adds a packaged root, and this per-agent table cannot vary by preset. (3) #150 also proposed making `.agents/skills` an unconditional baseline for every agent. Not done: it contradicts the invariant in `mentions/AGENTS.md` that the dir is "a provider-specific alias, not a universal fallback".
- **Plausible failures / evidence gaps:** Kimi's user dirs follow `KIMI_CODE_HOME`, so the hardcoded `~/.kimi-code` misses a relocated data root.

### Authoring context

- **User goal / directives:** After the maintainer invited a PR on #150, the repo user asked whether a cleaner fix existed than patching three table rows, then asked to open the PR and resolve objections in review.
- **Constraints / non-goals:** No behavior change for agents already correctly mapped; no new dir claim without a source in that engine's own source or docs.
- **Risk-bearing decisions:** Widening the `$` menu for unregistered agents (more candidates offered, never fewer); dropping `.kimi/skills`, which removes it from the shared project scan set so a project that still has one stops being surfaced, matching what the engine reads.
- **Destructive or irreversible behavior:** None. No migration, no writes to user data. The version bump only discards a cache that is rebuilt on demand.
- **Deliberately not done or tested:** The table stores each engine's dirs once per agent-type alias, so ~94 keys hold ~69 distinct dir tuples. Splitting engine facts from the alias mapping would remove that duplication but touches every row, so it is left out of a fix PR and can be raised separately. Kimi's `extra_skill_dirs` and built-in tiers are not modeled.
- **Unknowns / confidence:** High confidence in the pi, grok, kimi, and deepseek mappings — grok's and kimi's come from engine source, deepseek's from its plugin config defaults plus Lody's preset composition, pi's from its documented locations. The `null` contract is already stated at the call site (`null = show all`). Lower confidence on whether the grok compat roots belong in the table given they are configurable.

<!-- context-handoff:end -->
