### PR TITLE
feat(components): render every agent's plan through one panel

### DIFF
--- a/packages/components/src/components/ai-gui/AGENTS.md
+++ b/packages/components/src/components/ai-gui/AGENTS.md
@@ -39,7 +39,8 @@
   `getTextIndexBeforeTrailingNeverCollapsedItems`.
 - One turn may contain several `AssistantTurnRenderSegment`s. A plan approval
   inside a running turn cuts a segment so implementation stays under the plan.
-  Match ACP tool kind `switch_mode`, never a rendered title. Keep
+  Match ACP kind `switch_mode`, never a title; carrier varies
+  (`plan-surface.ts`). Keep
   `workBlockKeys`, `hasVisibleFinalContent`, last-item visibility, and
   `expandedWorkedGroups` per segment. Expansion keys include the segment; only
   the last region may show a duration, while earlier regions say "Finished

--- a/packages/components/src/components/ai-gui/permission-record.ts
+++ b/packages/components/src/components/ai-gui/permission-record.ts
@@ -34,20 +34,3 @@ export const resolvePermissionRecord = (permission: PermissionRequest): Permissi
     optionName: optionName ? optionName : null,
   };
 };
-
-/**
- * Is this turn's plan approval still waiting on the reader? Keyed on the ACP
- * tool kind and an ABSENT outcome — a CANCELLED request is answered (withdrawn),
- * not pending, so it must not hold the plan open.
- *
- * Drives `ProposedPlanBlock`'s default: a plan you are being asked to approve
- * opens in full, a plan you already decided on clamps.
- */
-export const hasUnansweredPlanApproval = (items: readonly MessageContent[]): boolean =>
-  items.some(
-    (item) =>
-      item.type === 'tool_call' &&
-      item.kind === 'switch_mode' &&
-      Boolean(item.permissionRequest) &&
-      !item.permissionRequest?.outcome
-  );

--- a/packages/components/src/components/ai-gui/plan-surface.ts
+++ b/packages/components/src/components/ai-gui/plan-surface.ts
@@ -1,0 +1,77 @@
+import type { MessageContent } from '@lody/shared';
+
+type ToolCallMessage = Extract<MessageContent, { type: 'tool_call' }>;
+
+/**
+ * WHERE EACH AGENT PUTS ITS PLAN.
+ *
+ * The bundled adapters disagree, and the disagreement is invisible from the
+ * rendered turn — so this module is the one place that knows, and every agent's
+ * plan reaches the SAME panel from here.
+ *
+ *   Claude (`ExitPlanMode`, `acp-extension-claude/src/tools.ts`)
+ *     kind `switch_mode`, plan as a `content` text block.
+ *   Kimi (`ExitPlanMode`, `acp-extension-kimi` `convert.ts` `plan_review`)
+ *     plan as a `content` text block, optionally prefixed `Plan saved to: …`.
+ *   Codex (`CodexAcpServer.requestPlanImplementationPermission`)
+ *     kind `switch_mode`, plan in `rawInput.plan`, which the card never renders
+ *     — the readable copy is a SEPARATE `proposed_plan` item.
+ *
+ * So `content` and `rawInput.plan` are both real carriers and neither is
+ * universal. A new adapter that picks either one renders correctly without a
+ * change here; one that invents a third carrier adds a case to
+ * `resolvePlanExitMarkdown` and nothing else.
+ */
+
+/**
+ * Plan text carried by the approval card itself, if any.
+ *
+ * The FIRST text block, not all of them joined: Kimi builds its approval card as
+ * `[plan, "Requesting approval to <action>"]`
+ * (`acp-adapter/src/approval.ts` `buildPermissionToolCallUpdate`), so joining
+ * would paste its action summary into the plan. Claude sends the plan as its
+ * only block, and Codex sends none, so the first block is the plan for every
+ * adapter that carries one.
+ */
+export const resolvePlanExitMarkdown = (toolCall: ToolCallMessage): string | null => {
+  const fromContent = (toolCall.content ?? []).find(
+    (block) =>
+      block.type === 'content' && block.content.type === 'text' && block.content.text.trim()
+  );
+  if (fromContent?.type === 'content' && fromContent.content.type === 'text') {
+    return fromContent.content.text.trim();
+  }
+
+  // Codex's carrier. Read defensively: `rawInput` is agent-supplied.
+  const rawPlan = (toolCall.rawInput as { plan?: unknown } | undefined)?.plan;
+  if (typeof rawPlan === 'string' && rawPlan.trim()) return rawPlan.trim();
+
+  return null;
+};
+
+/**
+ * Does the turn already render the plan as its own `proposed_plan` row?
+ *
+ * When it does (Codex), the approval card must NOT render its own copy or the
+ * plan prints twice — `rawInput.plan` and the `proposed_plan` item are the same
+ * text arriving by two routes.
+ */
+export const hasSeparatePlanItem = (items: readonly MessageContent[]): boolean =>
+  items.some((item) => item.type === 'proposed_plan' && item.markdown.trim().length > 0);
+
+/**
+ * Is this turn's plan approval still waiting on the reader? Keyed on the ACP
+ * tool kind and an ABSENT outcome — a CANCELLED request is answered (withdrawn),
+ * not pending, so it must not hold the plan open.
+ *
+ * Drives the plan panel's default: a plan you are being asked to approve opens
+ * in full, a plan you already decided on clamps.
+ */
+export const hasUnansweredPlanApproval = (items: readonly MessageContent[]): boolean =>
+  items.some(
+    (item) =>
+      item.type === 'tool_call' &&
+      item.kind === 'switch_mode' &&
+      Boolean(item.permissionRequest) &&
+      !item.permissionRequest?.outcome
+  );

--- a/packages/components/src/components/ai-gui/view.tsx
+++ b/packages/components/src/components/ai-gui/view.tsx
@@ -145,7 +145,12 @@ import {
 } from './assistant-turn-render-blocks';
 import { SubagentTaskPanel, collectSubagentTasks } from './subagent-task-panel';
 import { UserMessageEditor } from './user-message-editor';
-import { hasUnansweredPlanApproval, resolvePermissionRecord } from './permission-record';
+import { resolvePermissionRecord } from './permission-record';
+import {
+  hasSeparatePlanItem,
+  hasUnansweredPlanApproval,
+  resolvePlanExitMarkdown,
+} from './plan-surface';
 import {
   CONVERSATION_PANEL_BODY_CLASS,
   CONVERSATION_PANEL_FRAME_CLASS,
@@ -3819,6 +3824,7 @@ const AssistantChatItem = memo(function AssistantChatItem({
           onFilePathClick,
           conversationFontSize,
           planAwaitingDecision: hasUnansweredPlanApproval(message.items),
+          planRenderedSeparately: hasSeparatePlanItem(message.items),
         });
       }
       case 'activity_group_header':
@@ -4155,8 +4161,10 @@ const renderAssistantContent = (
     isStreaming?: boolean;
     onFilePathClick?: (filePath: string) => void;
     conversationFontSize?: ConversationFontSize;
-    /** This turn's plan approval is still unanswered — see `ProposedPlanBlock`. */
+    /** This turn's plan approval is still unanswered — see `PlanPanel`. */
     planAwaitingDecision?: boolean;
+    /** This turn renders the plan as its own row, so the card must not repeat it. */
+    planRenderedSeparately?: boolean;
   }
 ) => {
   const messageId = options?.messageId ?? 'assistant';
@@ -4236,6 +4244,10 @@ const renderAssistantContent = (
           toolCall={content}
           onFilePathClick={options?.onFilePathClick}
           fontSize={conversationFontSize}
+          messageId={messageId}
+          itemIndex={itemIndex}
+          awaitingDecision={options?.planAwaitingDecision}
+          planRenderedSeparately={options?.planRenderedSeparately}
         />
       ) : (
         <ToolCallCard
@@ -5211,23 +5223,36 @@ const PlanBlock = ({
   </div>
 );
 
-export const ProposedPlanBlock = ({
-  plan,
+/**
+ * The ONE plan surface. Every agent's plan reaches it, whatever carrier the
+ * adapter used (`plan-surface.ts`): Codex's separate `proposed_plan` item and
+ * Claude's / Kimi's card-carried `content` render the same panel, clamp the
+ * same way, and open the same way while a decision is pending. Rendering the
+ * card-carried ones as bare markdown was why a Claude plan looked nothing like
+ * a Codex one.
+ */
+const PlanPanel = ({
+  markdown,
+  searchBlockId,
   messageId,
   itemIndex,
   onFilePathClick,
   fontSize = DEFAULT_CONVERSATION_FONT_SIZE,
   awaitingDecision = false,
+  isStreaming = false,
 }: {
-  plan: ProposedPlanMessage;
+  markdown: string;
+  searchBlockId: string;
   messageId: string;
   itemIndex: number;
   onFilePathClick?: (filePath: string) => void;
   fontSize?: ConversationFontSize;
   /** The approval below this plan is still unanswered. */
   awaitingDecision?: boolean;
+  /** The plan is still being written. */
+  isStreaming?: boolean;
 }) => {
-  const searchBlockId = getProposedPlanSearchBlockId(messageId, itemIndex);
+  const plan = { markdown, status: isStreaming ? ('delta' as const) : ('completed' as const) };
   const handleAgentFileLinkClick = useCallback(
     (href: string) => {
       onFilePathClick?.(href);
@@ -5360,6 +5385,33 @@ export const ProposedPlanBlock = ({
     </div>
   );
 };
+
+export const ProposedPlanBlock = ({
+  plan,
+  messageId,
+  itemIndex,
+  onFilePathClick,
+  fontSize = DEFAULT_CONVERSATION_FONT_SIZE,
+  awaitingDecision = false,
+}: {
+  plan: ProposedPlanMessage;
+  messageId: string;
+  itemIndex: number;
+  onFilePathClick?: (filePath: string) => void;
+  fontSize?: ConversationFontSize;
+  awaitingDecision?: boolean;
+}) => (
+  <PlanPanel
+    markdown={plan.markdown}
+    searchBlockId={getProposedPlanSearchBlockId(messageId, itemIndex)}
+    messageId={messageId}
+    itemIndex={itemIndex}
+    onFilePathClick={onFilePathClick}
+    fontSize={fontSize}
+    awaitingDecision={awaitingDecision}
+    isStreaming={plan.status === 'delta'}
+  />
+);
 
 // Inline marker so the user can locate where the goal entered the timeline.
 // Rich controls and metrics live in the sticky `SessionGoalBanner`.
@@ -6112,23 +6164,38 @@ const PlanExitBlock = ({
   sessionId,
   fontSize,
   onFilePathClick,
+  messageId,
+  itemIndex,
+  awaitingDecision = false,
+  planRenderedSeparately = false,
 }: {
   toolCall: ToolCallMessage;
   sessionId: SessionId;
   fontSize: ConversationFontSize;
   onFilePathClick?: (filePath: string) => void;
+  messageId: string;
+  itemIndex: number;
+  awaitingDecision?: boolean;
+  /** The turn renders the plan as its own `proposed_plan` row (Codex). */
+  planRenderedSeparately?: boolean;
 }) => {
-  const blocks = toolCall.content?.filter((block) => block.type === 'content');
+  /* Claude and Kimi carry the plan in the card; Codex renders it as its own row
+     just above. Take it from the card only when nobody else is showing it, or
+     the plan prints twice. */
+  const carriedMarkdown = planRenderedSeparately ? null : resolvePlanExitMarkdown(toolCall);
   return (
     <div className="space-y-2">
-      {blocks?.map((block, index) => (
-        <ToolCallContentRenderer
-          key={`plan-exit-content-${index}`}
-          block={block}
+      {carriedMarkdown ? (
+        <PlanPanel
+          markdown={carriedMarkdown}
+          searchBlockId={getProposedPlanSearchBlockId(messageId, itemIndex)}
+          messageId={messageId}
+          itemIndex={itemIndex}
           onFilePathClick={onFilePathClick}
           fontSize={fontSize}
+          awaitingDecision={awaitingDecision}
         />
-      ))}
+      ) : null}
       <PermissionRequestBlock sessionId={sessionId} toolCall={toolCall} />
     </div>
   );

--- a/packages/components/src/stories/AssistantTurnAlignment.stories.tsx
+++ b/packages/components/src/stories/AssistantTurnAlignment.stories.tsx
@@ -10,7 +10,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Provider, createStore } from 'jotai';
 import type { ReactNode } from 'react';
-import type { SessionHistoryParsed, SessionId } from '@lody/shared';
+import type { MessageContent, SessionHistoryParsed, SessionId } from '@lody/shared';
 import type { ChatStreamItem, SessionChatStreamViewProps } from '@/components/ai-gui/view';
 import { MessageRowView, SessionChatStreamView } from '@/components/ai-gui/view';
 import { runtimeAtom } from '@/atoms';
@@ -216,6 +216,10 @@ export const DesktopFinishedTurn: Story = {
  *     (`AGENT_ATTACHMENT_TYPES`): a plan runs long, and a file card stranded
  *     above one is a small thing to find mid-markdown. The answer text still
  *     reads above that whole tail.
+ *   - One plan surface, whatever the adapter. Claude and Kimi carry the plan in
+ *     the approval card's `content`, Codex in `rawInput` plus a separate
+ *     `proposed_plan` row. `plan-surface.ts` resolves the carrier and they all
+ *     render one `PlanPanel` — see `DesktopPlanAdapterParity`.
  *   - One panel. Every framed block — command, tool input/output, permission,
  *     proposed plan — uses `conversation-panel.ts`: the HEADER carries the
  *     raised fill, the body sits on the frame. Never the reverse, and never an
@@ -515,6 +519,115 @@ const planAwaitingDecisionTurn: SessionHistoryParsed = {
       },
     },
   ],
+};
+
+/**
+ * ADAPTER PARITY. The bundled agents put the plan in different places
+ * (`plan-surface.ts`), and the turn must not show it: Claude and Kimi carry it
+ * in the card's `content`, Codex in `rawInput` plus a separate `proposed_plan`
+ * row. All three render the same panel here. If one of these starts looking
+ * different, an adapter grew a carrier `resolvePlanExitMarkdown` does not know.
+ */
+const PARITY_PLAN = [
+  '## Goal',
+  '',
+  'Render the same plan panel whichever adapter produced it.',
+  '',
+  '## Steps',
+  '',
+  '1. Resolve the carrier in `plan-surface.ts`.',
+  '2. Feed every carrier into one `PlanPanel`.',
+].join('\n');
+
+const parityTurn = (
+  id: string,
+  label: string,
+  planExit: Record<string, unknown>,
+  extraItems: MessageContent[] = []
+): SessionHistoryParsed =>
+  ({
+    id,
+    role: 'assistant',
+    timestamp: '2026-08-11T09:10:00.000Z',
+    read: true,
+    finished: true,
+    endedAt: Date.parse('2026-08-11T09:10:30.000Z'),
+    items: [
+      { type: 'text', text: label },
+      ...extraItems,
+      {
+        type: 'tool_call',
+        toolCallId: `${id}-exit`,
+        kind: 'switch_mode',
+        status: 'completed',
+        permissionRequest: {
+          requestId: `${id}-permission`,
+          options: [
+            { optionId: 'approve', name: 'Yes, implement this plan', kind: 'allow_once' },
+            { optionId: 'reject', name: 'No, keep planning', kind: 'reject_once' },
+          ],
+          outcome: { outcome: 'selected', optionId: 'approve' },
+        },
+        ...planExit,
+      },
+    ],
+  }) as unknown as SessionHistoryParsed;
+
+const parityTurns: SessionHistoryParsed[] = [
+  // Claude: `ExitPlanMode` puts the plan in a `content` text block.
+  parityTurn('parity-claude', 'Claude — plan in the card `content`', {
+    title: 'Ready to code?',
+    content: [{ type: 'content', content: { type: 'text', text: PARITY_PLAN } }],
+  }),
+  // Kimi: same carrier, with the `Plan saved to:` prefix its adapter composes.
+  parityTurn('parity-kimi', 'Kimi — same carrier, plus its trailing action summary', {
+    title: 'ExitPlanMode',
+    content: [
+      {
+        type: 'content',
+        content: { type: 'text', text: `Plan saved to: /tmp/plan.md\n\n${PARITY_PLAN}` },
+      },
+      // `buildPermissionToolCallUpdate` always appends this after the plan; it
+      // must not end up inside the plan panel.
+      { type: 'content', content: { type: 'text', text: 'Requesting approval to exit plan mode' } },
+    ],
+  }),
+  // Codex: `rawInput` plus a separate `proposed_plan` row, which wins.
+  parityTurn(
+    'parity-codex',
+    'Codex — `rawInput` plus a separate plan row',
+    { title: 'Implement this plan?', rawInput: { plan: PARITY_PLAN } },
+    [
+      {
+        type: 'proposed_plan',
+        turnId: 'parity-codex-turn',
+        markdown: PARITY_PLAN,
+        status: 'completed',
+        isLatest: true,
+      } as MessageContent,
+    ]
+  ),
+];
+
+export const DesktopPlanAdapterParity: Story = {
+  args: {
+    sessionId,
+    items: parityTurns.map((message) => ({ type: 'message', sessionId, message }) as const),
+    renderMessageRow,
+  },
+  globals: { theme: 'dark' },
+  render: () => (
+    <WithRuntime>
+      <div className="relative h-[1100px] w-full bg-background">
+        <SessionChatStreamView
+          items={parityTurns.map((message) => ({ type: 'message', sessionId, message }) as const)}
+          sessionId={sessionId}
+          renderMessageRow={renderMessageRow}
+        />
+        <RailGuide />
+      </div>
+    </WithRuntime>
+  ),
 };
 
 export const DesktopPlanAwaitingDecision: Story = outcomeStory(

--- a/packages/components/tests/permission-record.test.ts
+++ b/packages/components/tests/permission-record.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { MessageContent } from '@lody/shared';
 
-import {
-  hasUnansweredPlanApproval,
-  resolvePermissionRecord,
-} from '../src/components/ai-gui/permission-record';
+import { resolvePermissionRecord } from '../src/components/ai-gui/permission-record';
 
 type PermissionRequest = NonNullable<
   Extract<MessageContent, { type: 'tool_call' }>['permissionRequest']
@@ -60,48 +57,5 @@ describe('resolvePermissionRecord', () => {
         })
       )
     ).toEqual({ kind: 'settled', allowed: true, optionName: null });
-  });
-});
-
-describe('hasUnansweredPlanApproval', () => {
-  const planExit = (permissionRequest: unknown): MessageContent =>
-    ({
-      type: 'tool_call',
-      toolCallId: 'plan-exit',
-      kind: 'switch_mode',
-      status: 'pending',
-      permissionRequest,
-    }) as MessageContent;
-
-  it('holds the plan open while the approval is unanswered', () => {
-    expect(hasUnansweredPlanApproval([planExit(request())])).toBe(true);
-  });
-
-  it('lets the plan clamp once the reader has answered', () => {
-    expect(
-      hasUnansweredPlanApproval([
-        planExit(request({ outcome: { outcome: 'selected', optionId: 'allow' } })),
-      ])
-    ).toBe(false);
-  });
-
-  it('treats a withdrawn request as answered, not pending', () => {
-    // A cancelled request has nothing left to decide, so it must not pin the
-    // plan open for the rest of the session.
-    expect(
-      hasUnansweredPlanApproval([planExit(request({ outcome: { outcome: 'cancelled' } }))])
-    ).toBe(false);
-  });
-
-  it('ignores tool calls that are not a plan exit', () => {
-    const edit = {
-      type: 'tool_call',
-      toolCallId: 'edit-1',
-      kind: 'edit',
-      status: 'pending',
-      permissionRequest: request(),
-    } as MessageContent;
-    expect(hasUnansweredPlanApproval([edit])).toBe(false);
-    expect(hasUnansweredPlanApproval([{ type: 'text', text: 'hi' } as MessageContent])).toBe(false);
   });
 });

--- a/packages/components/tests/plan-surface.test.ts
+++ b/packages/components/tests/plan-surface.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import type { MessageContent } from '@lody/shared';
+import {
+  hasSeparatePlanItem,
+  hasUnansweredPlanApproval,
+  resolvePlanExitMarkdown,
+} from '../src/components/ai-gui/plan-surface';
+
+const toolCall = (overrides: Record<string, unknown>): MessageContent =>
+  ({
+    type: 'tool_call',
+    toolCallId: 't',
+    kind: 'switch_mode',
+    status: 'completed',
+    ...overrides,
+  }) as MessageContent;
+
+const request = (overrides: Record<string, unknown> = {}) => ({
+  requestId: 'r',
+  options: [{ optionId: 'allow', name: 'Yes', kind: 'allow_once' }],
+  ...overrides,
+});
+
+/**
+ * The bundled adapters put the plan in different places. These are the shapes
+ * they actually emit, so a regression here means one agent's plan silently
+ * stops rendering (or renders twice).
+ */
+describe('resolvePlanExitMarkdown', () => {
+  it("reads Claude's and Kimi's card-carried content block", () => {
+    expect(
+      resolvePlanExitMarkdown(
+        toolCall({
+          content: [{ type: 'content', content: { type: 'text', text: '# Plan\n1. Go' } }],
+        })
+      )
+    ).toBe('# Plan\n1. Go');
+  });
+
+  it("reads Codex's rawInput carrier", () => {
+    expect(resolvePlanExitMarkdown(toolCall({ rawInput: { plan: '# Codex plan' } }))).toBe(
+      '# Codex plan'
+    );
+  });
+
+  it('prefers the rendered content block over rawInput when an agent sends both', () => {
+    expect(
+      resolvePlanExitMarkdown(
+        toolCall({
+          content: [{ type: 'content', content: { type: 'text', text: 'shown' } }],
+          rawInput: { plan: 'raw' },
+        })
+      )
+    ).toBe('shown');
+  });
+
+  it("takes only the first block, so Kimi's action summary stays out of the plan", () => {
+    // Kimi builds `[plan, "Requesting approval to <action>"]`; joining pasted
+    // the summary into the plan body.
+    expect(
+      resolvePlanExitMarkdown(
+        toolCall({
+          content: [
+            { type: 'content', content: { type: 'text', text: 'Plan saved to: /p\n\n# Plan' } },
+            { type: 'content', content: { type: 'text', text: 'Requesting approval to run' } },
+          ],
+        })
+      )
+    ).toBe('Plan saved to: /p\n\n# Plan');
+  });
+
+  it('returns null when the card carries no plan, and ignores non-string rawInput', () => {
+    expect(resolvePlanExitMarkdown(toolCall({}))).toBeNull();
+    expect(resolvePlanExitMarkdown(toolCall({ content: [] }))).toBeNull();
+    expect(resolvePlanExitMarkdown(toolCall({ rawInput: { plan: { nested: true } } }))).toBeNull();
+    expect(resolvePlanExitMarkdown(toolCall({ rawInput: { plan: '   ' } }))).toBeNull();
+  });
+});
+
+describe('hasSeparatePlanItem', () => {
+  const planItem = (markdown: string): MessageContent =>
+    ({
+      type: 'proposed_plan',
+      turnId: 't',
+      markdown,
+      status: 'completed',
+      isLatest: true,
+    }) as MessageContent;
+
+  it('is true when the turn renders its own plan row (Codex)', () => {
+    expect(hasSeparatePlanItem([planItem('# Plan')])).toBe(true);
+  });
+
+  it('is false without one, so the card renders its own copy (Claude, Kimi)', () => {
+    expect(hasSeparatePlanItem([toolCall({})])).toBe(false);
+  });
+
+  it('ignores an empty plan row, which renders nothing to duplicate', () => {
+    expect(hasSeparatePlanItem([planItem('   ')])).toBe(false);
+  });
+});
+
+describe('hasUnansweredPlanApproval', () => {
+  const planExit = (permissionRequest: unknown): MessageContent =>
+    ({
+      type: 'tool_call',
+      toolCallId: 'plan-exit',
+      kind: 'switch_mode',
+      status: 'pending',
+      permissionRequest,
+    }) as MessageContent;
+
+  it('holds the plan open while the approval is unanswered', () => {
+    expect(hasUnansweredPlanApproval([planExit(request())])).toBe(true);
+  });
+
+  it('lets the plan clamp once the reader has answered', () => {
+    expect(
+      hasUnansweredPlanApproval([
+        planExit(request({ outcome: { outcome: 'selected', optionId: 'allow' } })),
+      ])
+    ).toBe(false);
+  });
+
+  it('treats a withdrawn request as answered, not pending', () => {
+    // A cancelled request has nothing left to decide, so it must not pin the
+    // plan open for the rest of the session.
+    expect(
+      hasUnansweredPlanApproval([planExit(request({ outcome: { outcome: 'cancelled' } }))])
+    ).toBe(false);
+  });
+
+  it('ignores tool calls that are not a plan exit', () => {
+    const edit = {
+      type: 'tool_call',
+      toolCallId: 'edit-1',
+      kind: 'edit',
+      status: 'pending',
+      permissionRequest: request(),
+    } as MessageContent;
+    expect(hasUnansweredPlanApproval([edit])).toBe(false);
+    expect(hasUnansweredPlanApproval([{ type: 'text', text: 'hi' } as MessageContent])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #215. The bundled adapters disagree about **where a plan's text rides**, and the rendered turn showed it — the same feature looked like two different products depending on which agent you ran.

| Agent | ACP kind | Plan carrier | Rendered before |
| --- | --- | --- | --- |
| Claude (`ExitPlanMode`) | `switch_mode` | `content` text block | bare markdown — no panel, no header, no clamp |
| Codex (`requestPlanImplementationPermission`) | `switch_mode` | `rawInput.plan` + a separate `proposed_plan` row | the full panel |
| Kimi (`ExitPlanMode`) | **`other`** | `content` text block | see "known gap" below |
| grok / dsh | — | no plan support found | — |

## What changed

`plan-surface.ts` owns the carrier question. `resolvePlanExitMarkdown` reads the card's first text block, else `rawInput.plan`, and every carrier now feeds one `PlanPanel` — the same frame, header, clamp, and pending-expansion rule that `proposed_plan` already had. `hasSeparatePlanItem` keeps Codex from printing the plan twice, since its `rawInput` copy and its `proposed_plan` row are the same text arriving by two routes.

The resolver takes the **first** text block rather than joining them: Kimi builds its approval card as `[plan, "Requesting approval to <action>"]` (`acp-adapter/src/approval.ts`), so joining pasted its action summary into the plan body.

`hasUnansweredPlanApproval` moves into the new module with the rest of the plan-shape helpers; `permission-record.ts` keeps only outcome resolution.

## Known gap — Kimi still needs a one-line change in its own repo

Kimi maps `ExitPlanMode` through `inferToolKind`, which has no plan case, so it arrives as kind `other`. The region split keys on `switch_mode`, so a Kimi plan review still folds into the activity group instead of getting a plan region at all.

The fix belongs in `acp-extension-kimi` (`packages/acp-adapter/src/events-map.ts`) — an isolated submodule shipped as a prebuilt, checksummed runtime artifact, so it cannot land here. **Once it sends `switch_mode`, Kimi renders identically with no further change on this side**: `DesktopPlanAdapterParity` already covers its exact content shape, trailing action summary included.

I deliberately did not work around it Lody-side. The only available signals are the rendered title (`ExitPlanMode`) and vendor `_meta`, and `ai-gui/AGENTS.md` requires matching the ACP kind and never a title — title-matching is the fragmentation this PR exists to remove.

## Review focus

- **`resolvePlanExitMarkdown` carrier precedence.** Content-before-`rawInput` matters: an agent sending both would otherwise show the unrendered raw copy. Worth challenging whether "first text block" is right versus "first non-summary block" if another adapter puts a preamble first.
- **`hasSeparatePlanItem` is the only thing preventing a double render for Codex.** If a future adapter emits `proposed_plan` *and* a readable `content` plan, this suppresses the card's copy — verify that is the wanted precedence.
- **Evidence gap:** verified in Storybook against the real components, not against live agents. The Kimi shape is reconstructed from its adapter source, not captured from a running Kimi session.

## Verification

- `pnpm --filter @lody/components test` — 405 files / 2915 tests pass (+12 new in `tests/plan-surface.test.ts`, covering each adapter's carrier, the precedence rule, the Kimi trailing-summary case, and the double-render guard)
- `tsgo --noEmit`, `oxlint` (0 errors), `prettier --check` on touched files
- `pnpm lint:i18n`, `pnpm check:platform-boundaries`, `pnpm check:public-boundary`
- New story `Sessions/AssistantTurnAlignment → DesktopPlanAdapterParity` renders all three shapes in one view; measured all three panels at left `0`, width `704`, radius `12px`, and asserted Kimi's action summary never reaches the plan panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)
