### PR TITLE
fix(mcp): clarify child session workspace reuse

### DIFF
--- a/apps/cli/src/mcp/lody-mcp-server.test.ts
+++ b/apps/cli/src/mcp/lody-mcp-server.test.ts
@@ -364,7 +364,7 @@ describe('session MCP input schemas', () => {
     ).toBe(false);
   });
 
-  it('publishes session create work contexts as object schemas over MCP', async () => {
+  it('publishes session create work contexts and child workspace sharing over MCP', async () => {
     const server = new McpServer({ name: 'schema-test-server', version: '1.0.0' });
     server.registerTool(
       'lody_session_create',
@@ -411,6 +411,10 @@ describe('session MCP input schemas', () => {
       expect(createTool?.inputSchema).toMatchObject({
         type: 'object',
         properties: {
+          useCurrentSessionAsParent: {
+            description:
+              'Create a child of the current Session that reuses the exact same workspace directory; cannot be combined with workContext.',
+          },
           workContext: workContextSchema,
         },
       });
@@ -419,13 +423,25 @@ describe('session MCP input schemas', () => {
         properties: {
           defaults: {
             type: 'object',
-            properties: { workContext: workContextSchema },
+            properties: {
+              useCurrentSessionAsParent: {
+                description:
+                  'Create a child of the current Session that reuses the exact same workspace directory; cannot be combined with workContext.',
+              },
+              workContext: workContextSchema,
+            },
           },
           items: {
             type: 'array',
             items: {
               type: 'object',
-              properties: { workContext: workContextSchema },
+              properties: {
+                useCurrentSessionAsParent: {
+                  description:
+                    'Create a child of the current Session that reuses the exact same workspace directory; cannot be combined with workContext.',
+                },
+                workContext: workContextSchema,
+              },
             },
           },
         },

--- a/apps/cli/src/mcp/lody-mcp-server.ts
+++ b/apps/cli/src/mcp/lody-mcp-server.ts
@@ -539,7 +539,9 @@ const SessionCreateToolInputSchema = z
     useCurrentSessionAsParent: z
       .boolean()
       .optional()
-      .describe('Create a child of the current Session; cannot be combined with workContext.'),
+      .describe(
+        'Create a child of the current Session that reuses the exact same workspace directory; cannot be combined with workContext.'
+      ),
     workContext: SessionWorkContextInputSchema.optional().describe(
       'Execution context for an independent Session; cannot be combined with useCurrentSessionAsParent=true.'
     ),
@@ -722,7 +724,9 @@ const SessionCreateBatchPublishedItemSchema = z
     useCurrentSessionAsParent: z
       .boolean()
       .optional()
-      .describe('Create a child of the current Session; cannot be combined with workContext.'),
+      .describe(
+        'Create a child of the current Session that reuses the exact same workspace directory; cannot be combined with workContext.'
+      ),
     workContext: SessionWorkContextInputSchema.optional().describe(
       'Execution context for an independent Session; cannot be combined with useCurrentSessionAsParent=true.'
     ),


### PR DESCRIPTION
## Related issue

Closes #224

## Problem / pressure

The MCP description for `useCurrentSessionAsParent` identified the new Session as a child but did not explain the operationally important consequence: it reuses the current Session's workspace directory. An Agent could therefore select the child mode while intending to isolate concurrent file changes.

## Summary

- Clarify the single-session create schema description to state that a child reuses the exact same workspace directory.
- Apply the same description to batch session creation defaults and items.
- Assert the published MCP schemas retain that workspace-sharing description.

## Before / after

| Before | After |
| ------ | ----- |
| Child creation was described without saying whether its workspace was shared or isolated. | Child creation explicitly says it reuses the current Session's exact workspace directory. |

## Test plan

- `vitest run src/mcp/lody-mcp-server.test.ts` — 46 tests passed.
- `prettier --check apps/cli/src/mcp/lody-mcp-server.ts apps/cli/src/mcp/lody-mcp-server.test.ts` — passed.
- `git diff HEAD^ --check` — passed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the published single-create and batch-create `useCurrentSessionAsParent` descriptions and their schema assertions.
- **Decisions to challenge:** Confirm that “reuses the exact same workspace directory” is concise while accurately covering both ordinary directories and existing worktrees.
- **Plausible failures / evidence gaps:** Only the targeted MCP schema suite was run; no runtime behavior changed or required end-to-end execution coverage.

### Authoring context

- **User goal / directives:** Make the MCP distinction clear with one concise sentence, commit it, and open an Issue-backed PR.
- **Constraints / non-goals:** Keep the change below the behavior layer; do not alter Session creation, worktree ownership, or status response fields.
- **Risk-bearing decisions:** The description intentionally states directory reuse without adding broader concurrency guidance or duplicating the `workContext` documentation.
- **Destructive or irreversible behavior:** The change performs no deletion, migration, overwrite, or runtime mutation; reverting restores the prior schema wording.
- **Deliberately not done or tested:** The full repository suite was not run because the change is limited to two schema descriptions and their focused publication test.
- **Unknowns / confidence:** Confidence is high that MCP clients receive the new text; downstream Agents may still interpret concise schema descriptions differently.

<!-- context-handoff:end -->
