### PR TITLE
fix(components): correct nested reset forecast overlay

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -280,6 +280,9 @@ mobile surfaces.
   NOT own the dialog — opening a Radix Dialog from inside a Popover dismisses the
   popover and unmounts a dialog rendered in its content, so `SessionUsagePopover`
   renders `CodexResetForecastDialogHost` as a sibling of the popover instead.
+  The provider-row dialog is nested inside desktop settings: pass `nestedInDialog`
+  there so its overlay uses `--z-dialog` plus `bg-black/20`; mobile settings and the
+  usage-popover host stay top-level and retain the default dialog overlay.
   `forecast_window` is FREE TEXT, not a timestamp ("the next 6 hours", "later today").
   Do not show that untranslated phrase as the forecast time: render the absolute UTC
   `expires_at` instant semantically ("Today 2:00 PM", "明天 14:00") in the user's

--- a/packages/components/src/components/codex-reset/codex-reset-forecast-dialog.tsx
+++ b/packages/components/src/components/codex-reset/codex-reset-forecast-dialog.tsx
@@ -26,6 +26,8 @@ const SUBTLE_FIELD = 'rounded-md border border-border/60 bg-foreground/[0.03]';
 export type CodexResetForecastDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Render above an already-open dialog, such as the desktop settings modal. */
+  nestedInDialog?: boolean;
   state: CodexResetForecastState;
   /** The still-valid forecast, already selected against `nowMs` by the caller. */
   watch: CodexResetWatch | null;
@@ -46,6 +48,7 @@ export type CodexResetForecastDialogProps = {
 export function CodexResetForecastDialog({
   open,
   onOpenChange,
+  nestedInDialog = false,
   state,
   watch,
   isExpired,
@@ -72,7 +75,10 @@ export function CodexResetForecastDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="gap-4 sm:max-w-md">
+      <DialogContent
+        overlayClassName={nestedInDialog ? 'z-[var(--z-dialog)] bg-black/20' : undefined}
+        className="gap-4 sm:max-w-md"
+      >
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-base">
             <TimerReset className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />

--- a/packages/components/src/components/codex-reset/codex-reset-forecast-entry.tsx
+++ b/packages/components/src/components/codex-reset/codex-reset-forecast-entry.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TimerReset } from 'lucide-react';
 
+import { useIsMobile } from '@/hooks/use-mobile';
 import { useCodexResetForecast } from '@/hooks/use-codex-reset-forecast';
 import { formatCodexResetExpiry } from '@/lib/codex-reset-forecast';
 import { CodexResetForecastDialog } from './codex-reset-forecast-dialog';
@@ -27,6 +28,7 @@ export type CodexResetForecastChipProps = {
  */
 export function CodexResetForecastChip({ enabled }: CodexResetForecastChipProps) {
   const { t } = useTranslation();
+  const isMobile = useIsMobile();
   const [open, setOpen] = useState(false);
   const forecast = useCodexResetForecast(enabled);
 
@@ -59,6 +61,9 @@ export function CodexResetForecastChip({ enabled }: CodexResetForecastChipProps)
       <CodexResetForecastDialog
         open={open}
         onOpenChange={setOpen}
+        // Desktop settings already owns the full-page /80 veil. Lift this
+        // later overlay above that dialog and dim it only lightly.
+        nestedInDialog={!isMobile}
         state={forecast.state}
         watch={forecast.watch}
         isExpired={forecast.isExpired}


### PR DESCRIPTION
## Related issue

Closes #223

## Problem / pressure

Opening the Codex reset forecast dialog from desktop Agents settings reused the top-level `bg-black/80` backdrop. Since this dialog is layered above an existing settings modal, the second heavy veil made the surrounding settings context appear almost completely black.

## Summary

- Add an explicit nested-dialog presentation mode for the reset forecast dialog.
- Use a lighter `bg-black/20` backdrop at the dialog z-index only from desktop provider settings.
- Keep mobile settings and the session usage entry on the existing top-level backdrop.
- Record the layering invariant next to the Codex reset forecast component guidance.

## Before / after

| Before | After |
| ------ | ----- |
| <img width="3656" height="2368" alt="before" src="https://github.com/user-attachments/assets/96dd41b2-6821-4f6f-80a5-1def46a084f8" /> | <img width="3656" height="2368" alt="after" src="https://github.com/user-attachments/assets/1747b054-9c7e-49d0-b559-c142e98d6e95" /> |

## Test plan

- `corepack pnpm --filter @lody/components typecheck`
- `corepack pnpm exec prettier --check packages/components/AGENTS.md packages/components/src/components/codex-reset/codex-reset-forecast-dialog.tsx packages/components/src/components/codex-reset/codex-reset-forecast-entry.tsx`
- `corepack pnpm exec oxlint --quiet packages/components/src/components/codex-reset/codex-reset-forecast-dialog.tsx packages/components/src/components/codex-reset/codex-reset-forecast-entry.tsx`
- `corepack pnpm check:public-boundary`
- `git diff --check upstream/main...HEAD`
- Visually verified the nested `--z-dialog` / `bg-black/20` backdrop and the unchanged top-level `--z-dialog-overlay` / `bg-black/80` backdrop in Storybook.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the `nestedInDialog` contract and its desktop-only provider-row call site for correct overlay stacking.
- **Decisions to challenge:** Confirm that an explicit opt-in is preferable to changing or auto-detecting nesting in the shared Dialog primitive.
- **Plausible failures / evidence gaps:** No automated integration test covers the desktop settings host; verification used type checking, static checks, and both visual backdrop states.

### Authoring context

- **User goal / directives:** Fix the reset forecast dialog making the settings background black, keep the change narrow, avoid new tests, and include before/after screenshots.
- **Constraints / non-goals:** Do not refactor shared Dialog behavior or change the mobile settings and session usage presentations.
- **Risk-bearing decisions:** The provider-row entry derives the explicit nested mode from the existing mobile breakpoint and raises only that backdrop to `--z-dialog` with 20% black.
- **Destructive or irreversible behavior:** The change affects presentation only; reverting the single commit restores the prior backdrop behavior without data migration or cleanup.
- **Deliberately not done or tested:** No new automated test was added by request; the shared Dialog primitive and unrelated forecast behavior were left unchanged.
- **Unknowns / confidence:** Confidence is high because both backdrop variants were inspected visually and the changed component passed type, lint, formatting, and public-boundary checks.

<!-- context-handoff:end -->
