### PR TITLE
fix(electron): set macOS development dock icon

### DIFF
--- a/apps/electron/src/main/index.ts
+++ b/apps/electron/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, safeStorage } from 'electron'
 import { electronApp, optimizer } from '@electron-toolkit/utils'
 import dns from 'node:dns'
 import icon from '../../resources/icon.png?asset'
+import macIcon from '../../build/icon-mac.padded.png?asset'
 import { acquireSingleInstanceLock, registerOpenUrlHandler } from './deep-link'
 import { registerLodyProtocolClient } from './protocol-client'
 import { registerIpcServices } from './ipc/register-services'
@@ -153,6 +154,8 @@ if (hasSingleInstanceLock) {
 
 if (hasSingleInstanceLock) {
   void app.whenReady().then(() => {
+    if (process.platform === 'darwin' && !app.isPackaged) app.dock?.setIcon(macIcon)
+
     logDeepLinkDebug('app.whenReady resolved', {
       isDefaultProtocolClient: app.isDefaultProtocolClient(LODY_PROTOCOL),
       protocol: LODY_PROTOCOL


### PR DESCRIPTION
## Related issue

## Problem / pressure

Unpackaged macOS Electron (`pnpm start:local` / `dev:local`) leaves the Dock on Electron's default atom icon. Packaged builds already pick up `build/icon-mac.padded.png` through electron-builder; the development process never calls `app.dock.setIcon`, so the running app does not match the product icon.

## Summary

On Darwin, after `app.whenReady` and only when `!app.isPackaged`, call `app.dock.setIcon` with the existing `build/icon-mac.padded.png` asset. Packaged macOS, Linux, and Windows paths are unchanged.

## Before / after

| Before | After |
| ------ | ----- |
| Unpackaged macOS Dock shows Electron's default atom icon | Unpackaged macOS Dock uses the same padded Lody icon as the packaged app |
| Packaged Dock icon already came from electron-builder | Packaged path untouched (`app.isPackaged` skips the call) |

## Test plan

- Rebased onto current `upstream/main` (`a320b4c`); the patch is still the original three-line change in `apps/electron/src/main/index.ts`.
- Prior session: local Electron build of this change passed; `git diff --check` clean.
- Not re-run after rebase: full `pnpm test:ci` and a packaged macOS build. The rebase only moved the same hunk onto newer `main`; `icon-mac.padded.png` is already on `upstream/main`.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `apps/electron/src/main/index.ts` — the `app.whenReady` Darwin/`!app.isPackaged` `dock.setIcon` call and the `icon-mac.padded.png` import.
- **Decisions to challenge:** using the padded mac icon (packaged artwork) for unpackaged Dock instead of `resources/icon.png`, which windows/tray already use.
- **Plausible failures / evidence gaps:** no automated test asserts Dock artwork; Linux/Windows are gated out but were not launched; `app.dock` is optional-chained so a missing Dock is a no-op.

### Authoring context

- **User goal / directives:** Make the unpackaged macOS Electron Dock icon the Lody product icon instead of Electron's default atom.
- **Constraints / non-goals:** Do not change packaged icons, Linux `.deb` icons, Windows tray/taskbar, or add new image assets.
- **Risk-bearing decisions:** The call is skipped when `app.isPackaged`, so release Dock behavior stays with electron-builder; the asset is an existing build input, not a new file.
- **Destructive or irreversible behavior:** None. The call only sets the live Dock image for this process.
- **Deliberately not done or tested:** No new test for `app.dock.setIcon` (it needs a real macOS Dock); packaged and non-Darwin builds were not re-run after rebase.
- **Unknowns / confidence:** High that packaged macOS is unaffected. Moderate that the padded asset is the right development stand-in versus the smaller `resources/icon.png`.

<!-- context-handoff:end -->
