### PR TITLE
fix(components): align mobile workspace settings

### DIFF
--- a/packages/components/src/components/mobile/AGENTS.md
+++ b/packages/components/src/components/mobile/AGENTS.md
@@ -102,6 +102,9 @@ embedded` lazy-imported from `../tasks/tasks-workspace.tsx` (`embedded`
   card, leaving rows visually glued together. `MobileSettingsSection` renders
   `title`+`actions` on one header line and `description` full-width below it
   (don't squeeze the description into the title column next to wide actions).
+  `workspaceJoinRequestsSlot` already owns its card frame, so wrap it in a
+  `MobileSettingsSection noCard` plus the standard `mx-3` card inset; mounting
+  the slot raw drops both the section rhythm and the shared horizontal edge.
 - Sheets (bottom): `mobile-new-chat-sheet.tsx`,
   `mobile-workspace-switcher-sheet.tsx`, `mobile-create/delete-workspace-sheet`,
   `mobile-worktree-config-sheet.tsx`, `mobile-acp-history-sheet.tsx`,

--- a/packages/components/src/components/mobile/mobile-account-settings.tsx
+++ b/packages/components/src/components/mobile/mobile-account-settings.tsx
@@ -391,7 +391,7 @@ export function MobileAccountSettings({
               ) : (
                 <button
                   type="button"
-                  className="group flex min-w-0 max-w-[60vw] items-center gap-1.5 rounded-md text-right text-[0.95rem] font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-60"
+                  className="group flex min-w-0 max-w-[60vw] items-center gap-1.5 rounded-md text-right text-[0.95rem] font-medium leading-tight text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-60"
                   onClick={beginUserNameEdit}
                   disabled={isSavingUserName}
                   aria-label={t('settings.profile.nameEditLabel')}
@@ -402,7 +402,7 @@ export function MobileAccountSettings({
                   {isSavingUserName ? (
                     <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
                   ) : (
-                    <Pencil className="h-3 w-3 shrink-0 text-muted-foreground/70" />
+                    <Pencil className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" />
                   )}
                 </button>
               )
@@ -492,7 +492,7 @@ export function MobileAccountSettings({
               ) : (
                 <button
                   type="button"
-                  className="group flex min-w-0 max-w-[60vw] items-center gap-1.5 rounded-md text-right text-[0.95rem] font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-60"
+                  className="group flex min-w-0 max-w-[60vw] items-center gap-1.5 rounded-md text-right text-[0.95rem] font-medium leading-tight text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-60"
                   onClick={beginWorkspaceNameEdit}
                   disabled={isRenamingOrganization}
                   aria-label={t('settings.account.workspaceNameEditLabel')}
@@ -501,7 +501,7 @@ export function MobileAccountSettings({
                   {isRenamingOrganization ? (
                     <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
                   ) : (
-                    <Pencil className="h-3 w-3 shrink-0 text-muted-foreground/70" />
+                    <Pencil className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" />
                   )}
                 </button>
               )
@@ -717,7 +717,11 @@ export function MobileAccountSettings({
         </MobileSettingsSection>
       ) : null}
 
-      {isWorkspaceSurface ? workspaceJoinRequestsSlot : null}
+      {isWorkspaceSurface && workspaceJoinRequestsSlot ? (
+        <MobileSettingsSection noCard>
+          <div className="mx-3">{workspaceJoinRequestsSlot}</div>
+        </MobileSettingsSection>
+      ) : null}
 
       {surface === 'account' && canGenerateCliApiKey ? (
         <MobileSettingsSection

--- a/packages/components/src/stories/MobileSettingsPages.stories.tsx
+++ b/packages/components/src/stories/MobileSettingsPages.stories.tsx
@@ -7,6 +7,7 @@ import {
   createCapabilitySet,
   createLocalPlatformProvider,
   createStaticStore,
+  type CloudApi,
 } from '@lody/platform';
 import { PlatformContext } from '@lody/platform/react';
 
@@ -17,8 +18,10 @@ import { MobileAppearanceSettings } from '@/components/mobile/mobile-appearance-
 import { MobileGeneralSettings } from '@/components/mobile/mobile-general-settings';
 import { MobileSettingsLayout } from '@/components/mobile/mobile-settings-layout';
 import { SettingsCategoryList } from '@/components/settings/settings-category-list';
+import { WorkspaceJoinRequestsSettings } from '@/components/settings/workspace-join-requests-settings';
 import { StableSessionContext, type StableSessionValue } from '@/hooks/useStableSession';
 import type { LodyAuthClient } from '@/lib/auth';
+import { cloudOperations, type WorkspaceJoinOwnerState } from '@/lib/cloud-api-operations';
 import { AuthProvider } from '@/providers/convex-provider';
 import { RoutedStory } from './settings-story-shell';
 
@@ -66,8 +69,22 @@ const localStoryPlatform = createLocalPlatformProvider({
     activeWorkspaceId: storyOrganization.id,
   }),
 });
+const storyWorkspaceJoinOwnerState: WorkspaceJoinOwnerState = {
+  activeLink: null,
+  pendingRequests: [],
+  hasMorePendingRequests: false,
+};
+const storyCloudApi = {
+  useQuery: (operation) =>
+    operation.name === cloudOperations.workspaceJoinRequests.getOwnerState.name
+      ? storyWorkspaceJoinOwnerState
+      : undefined,
+  useMutation: () => async () => null,
+  useAction: () => async () => null,
+} as CloudApi;
 const storyPlatform = {
   ...localStoryPlatform,
+  cloudApi: storyCloudApi,
   capabilities: createCapabilitySet([
     ...localStoryPlatform.capabilities.list(),
     'cloudAccount',
@@ -75,6 +92,7 @@ const storyPlatform = {
     'usageAnalytics',
     'billing',
     'bugReport',
+    'teamSharing',
   ]),
 };
 const storyAuthClient = {
@@ -307,32 +325,47 @@ const storyInvitations = [
   },
 ];
 
+function WorkspaceSettingsStory({ showJoinRequests = false }: { showJoinRequests?: boolean }) {
+  return (
+    <MobileAccountSettings
+      surface="workspace"
+      currentUser={storyUser}
+      organization={
+        showJoinRequests
+          ? { ...storyOrganization, name: 'Riverstone Research Workspace' }
+          : storyOrganization
+      }
+      role="owner"
+      hasAdminPermission
+      members={storyMembers}
+      pendingInvitations={showJoinRequests ? [] : storyInvitations}
+      onSignOut={fn()}
+      onInviteMember={async () => null}
+      onRemoveMember={asyncNoop}
+      onUpdateRole={asyncNoop}
+      onCopyInviteLink={asyncNoop}
+      onCancelInvitation={asyncNoop}
+      onLeaveOrganization={asyncNoop}
+      onDeleteOrganization={asyncNoop}
+      onDeleteAccount={asyncNoop}
+      onRenameOrganization={asyncNoop}
+      getInviteLink={() => 'https://example.com/invite/abc'}
+      onUploadAvatar={async () => ''}
+      workspaceJoinRequestsSlot={
+        showJoinRequests ? (
+          <WorkspaceJoinRequestsSettings workspaceId={storyOrganization.id} />
+        ) : undefined
+      }
+    />
+  );
+}
+
 /** Workspace sub-page: name/logo, members, invitations, danger zone. */
 export const Workspace: Story = {
-  args: {
-    title: 'Workspace',
-    children: (
-      <MobileAccountSettings
-        surface="workspace"
-        currentUser={storyUser}
-        organization={storyOrganization}
-        role="owner"
-        hasAdminPermission
-        members={storyMembers}
-        pendingInvitations={storyInvitations}
-        onSignOut={fn()}
-        onInviteMember={async () => null}
-        onRemoveMember={asyncNoop}
-        onUpdateRole={asyncNoop}
-        onCopyInviteLink={asyncNoop}
-        onCancelInvitation={asyncNoop}
-        onLeaveOrganization={asyncNoop}
-        onDeleteOrganization={asyncNoop}
-        onDeleteAccount={asyncNoop}
-        onRenameOrganization={asyncNoop}
-        getInviteLink={() => 'https://example.com/invite/abc'}
-        onUploadAvatar={async () => ''}
-      />
-    ),
-  },
+  args: { title: 'Workspace', children: <WorkspaceSettingsStory /> },
+};
+
+/** Owner workspace with the join-request card and a long editable name. */
+export const WorkspaceJoinRequests: Story = {
+  args: { title: 'Workspace', children: <WorkspaceSettingsStory showJoinRequests /> },
 };

--- a/packages/components/tests/e2e/mobile-workspace-settings-layout.spec.ts
+++ b/packages/components/tests/e2e/mobile-workspace-settings-layout.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test, type Locator } from '@playwright/test';
+
+const STORY_URL =
+  '/iframe.html?id=mobile-mobilesettingspages--workspace-join-requests&viewMode=story&globals=locale:zh_CN;theme:dark';
+
+test.use({
+  hasTouch: true,
+  isMobile: true,
+  viewport: { width: 393, height: 852 },
+});
+
+type ElementBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+async function getVisibleBox(locator: Locator): Promise<ElementBox> {
+  await expect(locator).toBeVisible();
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error('Expected a visible element to have a bounding box');
+  }
+  return box;
+}
+
+test('keeps join requests in the mobile section rhythm and centers the edit icon', async ({
+  page,
+}) => {
+  const response = await page.goto(STORY_URL);
+  expect(response?.ok()).toBeTruthy();
+
+  const workspaceSection = page
+    .getByRole('heading', { level: 2, name: '工作空间' })
+    .locator('xpath=ancestor::section[1]');
+  const membersSection = page
+    .getByRole('heading', { level: 2, name: '成员' })
+    .locator('xpath=ancestor::section[1]');
+  const joinCard = page
+    .getByRole('heading', { level: 3, name: '开放式加入链接' })
+    .locator('xpath=ancestor::section[1]');
+
+  const [workspaceCardBox, membersCardBox, joinCardBox] = await Promise.all([
+    getVisibleBox(workspaceSection.locator(':scope > div')),
+    getVisibleBox(membersSection.locator(':scope > div')),
+    getVisibleBox(joinCard),
+  ]);
+
+  expect(Math.abs(joinCardBox.x - workspaceCardBox.x)).toBeLessThan(0.5);
+  expect(Math.abs(joinCardBox.width - workspaceCardBox.width)).toBeLessThan(0.5);
+  expect(joinCardBox.y - (membersCardBox.y + membersCardBox.height)).toBeCloseTo(20, 5);
+
+  const editButton = page.getByRole('button', { name: '修改工作空间名称' });
+  const [editTextBox, editIconBox] = await Promise.all([
+    getVisibleBox(editButton.locator('span')),
+    getVisibleBox(editButton.locator('svg')),
+  ]);
+  const textCenter = editTextBox.y + editTextBox.height / 2;
+  const iconCenter = editIconBox.y + editIconBox.height / 2;
+
+  expect(editIconBox.width).toBeCloseTo(14, 5);
+  expect(editIconBox.height).toBeCloseTo(14, 5);
+  expect(Math.abs(iconCenter - textCenter)).toBeLessThan(0.5);
+});


### PR DESCRIPTION
## Related issue

Closes #229

## Problem / pressure

The owner-only join-request card was mounted as a raw slot on the mobile workspace settings page. Unlike the surrounding settings sections, it had neither the standard horizontal card inset nor the 20 px section rhythm, so it appeared attached to the member card and stretched to the viewport edge. The 12 px pencil glyph beside editable names also looked vertically undersized relative to the text.

## Summary

- Wrap the self-framed join-request card in a frameless mobile settings section with the standard 12 px card inset.
- Give editable-name buttons a tight line box and use the existing 14 px loading-icon size for their pencil glyphs.
- Add a synthetic Storybook state and a mobile Playwright geometry regression covering the card inset, section gap, and icon centering.
- Record the slot ownership and spacing invariant in the scoped contributor guide.

## Before / after

| Before | After |
| ------ | ----- |
| Join requests touched the preceding card and ran to the viewport edge; the 12 px pencil looked undersized beside the name. | Join requests share the adjacent cards' 12 px inset and sit 20 px below Members; the 14 px pencil is centered on the text line. |

## Test plan

- `pnpm check` on Node 22 (typecheck, lint, full test suites, i18n, import/platform/public-boundary guards).
- `pnpm format`.
- `pnpm --filter @lody/components test` on Node 22: 407 files and 2,928 tests passed.
- Targeted Storybook Playwright spec passed against local Google Chrome at a 393 x 852 touch viewport; CI will use its configured Playwright Chromium.
- Verified the Chinese dark-mode Storybook surface at 393 x 852: cards were x=12/width=369, the Members-to-join gap was 20 px, the pencil was 14 x 14 with matching text/icon centers, and no page errors or error overlay appeared.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the `workspaceJoinRequestsSlot` wrapper in `mobile-account-settings.tsx` and whether the Storybook/Playwright geometry assertions match the intended mobile section contract.
- **Decisions to challenge:** The join-request component keeps ownership of its card frame while its parent supplies only section rhythm and horizontal inset.
- **Plausible failures / evidence gaps:** A real iOS Safari device was not available; evidence uses the shared renderer in Chrome mobile emulation plus deterministic geometry assertions.

### Authoring context

- **User goal / directives:** Fix the visibly incorrect join-request spacing and pencil alignment on narrow mobile workspace settings, demonstrate the result, test it, and submit a PR.
- **Constraints / non-goals:** Keep the change in public shared components; do not change join-link behavior, authorization, backend contracts, or the wider settings design.
- **Risk-bearing decisions:** The identical profile and workspace editable-name controls both receive the 14 px pencil and tight line-height treatment for visual consistency.
- **Destructive or irreversible behavior:** The change is UI-only and reversible; it performs no deletion, migration, overwrite, or external data mutation.
- **Deliberately not done or tested:** Native mobile sources are outside this public repository, so validation targets the repository's mobile web renderer rather than a native app build.
- **Unknowns / confidence:** Minor font rasterization can vary by browser, but flex alignment, exact spacing tokens, Storybook evidence, and the regression test make confidence high.

<!-- context-handoff:end -->
