### PR TITLE
feat(components): expose lightweight join surface

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,6 +11,10 @@
       "import": "./src/router.tsx",
       "types": "./src/router.tsx"
     },
+    "./components/pages/workspace-join-request-surface": {
+      "import": "./src/components/pages/workspace-join-request-surface.tsx",
+      "types": "./src/components/pages/workspace-join-request-surface.tsx"
+    },
     "./atoms/*": {
       "import": "./src/atoms/*.{ts,tsx}",
       "types": "./src/atoms/*.{ts,tsx}"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -11,7 +11,7 @@
       "import": "./src/router.tsx",
       "types": "./src/router.tsx"
     },
-    "./components/pages/workspace-join-request-surface": {
+    "./join": {
       "import": "./src/components/pages/workspace-join-request-surface.tsx",
       "types": "./src/components/pages/workspace-join-request-surface.tsx"
     },

--- a/packages/components/src/AGENTS.md
+++ b/packages/components/src/AGENTS.md
@@ -6,7 +6,9 @@ Parent `AGENTS.md` files also apply.
 
 - Public/auth entry points that bypass the full product router import route-agnostic
   surfaces. Keep host navigation behind callback props so those surfaces do not import
-  the route tree, `RuntimeProvider`, or workspace Flock document implementation.
+  the route tree, `RuntimeProvider`, or workspace Flock document implementation. When
+  an auth transition selects the destination, the host owns both the non-redirecting
+  auth action and navigation so an auth helper cannot discard route-specific state.
 
 ## Keyboard navigation
 

--- a/packages/components/src/AGENTS.md
+++ b/packages/components/src/AGENTS.md
@@ -2,6 +2,12 @@
 
 Parent `AGENTS.md` files also apply.
 
+## Lightweight hosted entries
+
+- Public/auth entry points that bypass the full product router import route-agnostic
+  surfaces. Keep host navigation behind callback props so those surfaces do not import
+  the route tree, `RuntimeProvider`, or workspace Flock document implementation.
+
 ## Keyboard navigation
 
 - Each independently navigable list owns one `FocusScope` and one

--- a/packages/components/src/components/pages/workspace-join-request-surface.tsx
+++ b/packages/components/src/components/pages/workspace-join-request-surface.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import { useCloudMutation, useCloudQuery, usePlatformCapability } from '@lody/platform/react';
 import { useStableSession } from '@/hooks/useStableSession';
 import { cloudOperations } from '@/lib/cloud-api-operations';
-import { useAuthSignOut } from '../../providers/convex-provider';
 import {
   WorkspaceJoinRequestPage,
   type WorkspaceJoinPageState,
@@ -12,6 +11,7 @@ import {
 export interface WorkspaceJoinRequestSurfaceProps {
   token: string;
   onSignInRequested: () => void;
+  onEmailVerificationRequested: () => void;
   onWorkspaceRequested: (workspaceSlug: string | null) => void;
   onHomeRequested: () => void;
 }
@@ -25,11 +25,11 @@ export interface WorkspaceJoinRequestSurfaceProps {
 export function WorkspaceJoinRequestSurface({
   token,
   onSignInRequested,
+  onEmailVerificationRequested,
   onWorkspaceRequested,
   onHomeRequested,
 }: WorkspaceJoinRequestSurfaceProps) {
   const { t } = useTranslation();
-  const signOut = useAuthSignOut();
   const { data: session, isPending: sessionPending } = useStableSession();
   const joinRequestsAvailable = usePlatformCapability('teamSharing');
   const preview = useCloudQuery(cloudOperations.workspaceJoinRequests.getLinkPreview, { token });
@@ -67,12 +67,7 @@ export function WorkspaceJoinRequestSurface({
       errorMessage={errorMessage}
       onReasonChange={setReason}
       onContinue={onSignInRequested}
-      onVerifyEmail={() => {
-        void (async () => {
-          await signOut();
-          onSignInRequested();
-        })();
-      }}
+      onVerifyEmail={onEmailVerificationRequested}
       onSubmit={() => {
         void (async () => {
           setSubmitting(true);

--- a/packages/components/src/components/pages/workspace-join-request-surface.tsx
+++ b/packages/components/src/components/pages/workspace-join-request-surface.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useCloudMutation, useCloudQuery, usePlatformCapability } from '@lody/platform/react';
+import { useStableSession } from '@/hooks/useStableSession';
+import { cloudOperations } from '@/lib/cloud-api-operations';
+import { useAuthSignOut } from '../../providers/convex-provider';
+import {
+  WorkspaceJoinRequestPage,
+  type WorkspaceJoinPageState,
+} from './workspace-join-request-page';
+
+export interface WorkspaceJoinRequestSurfaceProps {
+  token: string;
+  onSignInRequested: () => void;
+  onWorkspaceRequested: (workspaceSlug: string | null) => void;
+  onHomeRequested: () => void;
+}
+
+/**
+ * Route-agnostic join-request flow for lightweight hosted entry points.
+ *
+ * Navigation stays with the host so this surface never imports the product
+ * router, route tree, workspace runtime, or Flock document implementation.
+ */
+export function WorkspaceJoinRequestSurface({
+  token,
+  onSignInRequested,
+  onWorkspaceRequested,
+  onHomeRequested,
+}: WorkspaceJoinRequestSurfaceProps) {
+  const { t } = useTranslation();
+  const signOut = useAuthSignOut();
+  const { data: session, isPending: sessionPending } = useStableSession();
+  const joinRequestsAvailable = usePlatformCapability('teamSharing');
+  const preview = useCloudQuery(cloudOperations.workspaceJoinRequests.getLinkPreview, { token });
+  const submitRequest = useCloudMutation(cloudOperations.workspaceJoinRequests.submitRequest);
+  const [reason, setReason] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const available = preview?.status === 'available' ? preview : null;
+  let state: WorkspaceJoinPageState = 'loading';
+  if (!joinRequestsAvailable || preview?.status === 'unavailable') state = 'unavailable';
+  else if (available && !session?.user) state = 'auth_required';
+  else if (available?.viewer?.alreadyMember) state = 'already_member';
+  else if (available?.viewer && !available.viewer.emailVerified) state = 'verification_required';
+  else if (available?.viewer?.request?.status === 'pending') state = 'pending';
+  else if (available?.viewer?.request?.status === 'approved') state = 'approved';
+  else if (available?.viewer?.request?.status === 'rejected') state = 'rejected';
+  else if (available?.viewer) state = 'form';
+  if (sessionPending) state = 'loading';
+  if (submitting) state = 'submitting';
+  if (errorMessage) state = 'error';
+
+  useEffect(() => {
+    if (available?.viewer?.request?.status === 'rejected' && !reason) {
+      setReason(available.viewer.request.reason);
+    }
+  }, [available?.viewer?.request, reason]);
+
+  return (
+    <WorkspaceJoinRequestPage
+      state={state}
+      workspaceName={available?.workspaceName}
+      currentEmail={session?.user?.email}
+      reason={reason}
+      errorMessage={errorMessage}
+      onReasonChange={setReason}
+      onContinue={onSignInRequested}
+      onVerifyEmail={() => {
+        void (async () => {
+          await signOut();
+          onSignInRequested();
+        })();
+      }}
+      onSubmit={() => {
+        void (async () => {
+          setSubmitting(true);
+          setErrorMessage(null);
+          try {
+            await submitRequest({ token, reason });
+          } catch (error) {
+            console.error('Failed to submit workspace join request:', error);
+            setErrorMessage(t('joinRequest.submitFailed'));
+          } finally {
+            setSubmitting(false);
+          }
+        })();
+      }}
+      onOpenWorkspace={() => onWorkspaceRequested(available?.workspaceSlug ?? null)}
+      onBackHome={onHomeRequested}
+    />
+  );
+}

--- a/packages/components/src/routes/join/$token.tsx
+++ b/packages/components/src/routes/join/$token.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { WorkspaceJoinRequestSurface } from '@/components/pages/workspace-join-request-surface';
+import { signOutWithoutRedirect } from '@/lib/auth';
+import { useAuthClient } from '@/providers/convex-provider';
 
 export const Route = createFileRoute('/join/$token')({
   component: WorkspaceJoinRequestRoute,
@@ -8,12 +10,21 @@ export const Route = createFileRoute('/join/$token')({
 export function WorkspaceJoinRequestRoute() {
   const { token } = Route.useParams();
   const navigate = useNavigate();
+  const authClient = useAuthClient();
+
+  const goToLogin = () => {
+    void navigate({ to: '/login', search: { redirect: `/join/${token}`, view: 'email' } });
+  };
 
   return (
     <WorkspaceJoinRequestSurface
       token={token}
-      onSignInRequested={() => {
-        void navigate({ to: '/login', search: { redirect: `/join/${token}`, view: 'email' } });
+      onSignInRequested={goToLogin}
+      onEmailVerificationRequested={() => {
+        void (async () => {
+          await signOutWithoutRedirect(authClient);
+          goToLogin();
+        })();
       }}
       onWorkspaceRequested={(workspaceSlug) => {
         if (workspaceSlug) {

--- a/packages/components/src/routes/join/$token.tsx
+++ b/packages/components/src/routes/join/$token.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { WorkspaceJoinRequestSurface } from '@/components/pages/workspace-join-request-surface';
-import { signOutWithoutRedirect } from '@/lib/auth';
-import { useAuthClient } from '@/providers/convex-provider';
+import { signOutWithoutRedirect } from '../../lib/auth';
+import { useAuthClient } from '../../providers/convex-provider';
 
 export const Route = createFileRoute('/join/$token')({
   component: WorkspaceJoinRequestRoute,

--- a/packages/components/src/routes/join/$token.tsx
+++ b/packages/components/src/routes/join/$token.tsx
@@ -1,100 +1,31 @@
-import { useEffect, useState } from 'react';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useTranslation } from 'react-i18next';
-import { useStableSession } from '@/hooks/useStableSession';
-import { useCloudMutation, useCloudQuery, usePlatformCapability } from '@lody/platform/react';
-import { useAuthSignOut } from '../../providers/convex-provider';
-import { cloudOperations } from '@/lib/cloud-api-operations';
-import {
-  WorkspaceJoinRequestPage,
-  type WorkspaceJoinPageState,
-} from '@/components/pages/workspace-join-request-page';
+import { WorkspaceJoinRequestSurface } from '@/components/pages/workspace-join-request-surface';
 
 export const Route = createFileRoute('/join/$token')({
   component: WorkspaceJoinRequestRoute,
 });
 
 export function WorkspaceJoinRequestRoute() {
-  const { t } = useTranslation();
   const { token } = Route.useParams();
   const navigate = useNavigate();
-  const signOut = useAuthSignOut();
-  const { data: session, isPending: sessionPending } = useStableSession();
-  const joinRequestsAvailable = usePlatformCapability('teamSharing');
-  const preview = useCloudQuery(cloudOperations.workspaceJoinRequests.getLinkPreview, { token });
-  const submitRequest = useCloudMutation(cloudOperations.workspaceJoinRequests.submitRequest);
-  const [reason, setReason] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-
-  const available = preview?.status === 'available' ? preview : null;
-  let state: WorkspaceJoinPageState = 'loading';
-  if (!joinRequestsAvailable || preview?.status === 'unavailable') state = 'unavailable';
-  else if (available && !session?.user) state = 'auth_required';
-  else if (available?.viewer?.alreadyMember) state = 'already_member';
-  else if (available?.viewer && !available.viewer.emailVerified) state = 'verification_required';
-  else if (available?.viewer?.request?.status === 'pending') state = 'pending';
-  else if (available?.viewer?.request?.status === 'approved') state = 'approved';
-  else if (available?.viewer?.request?.status === 'rejected') state = 'rejected';
-  else if (available?.viewer) state = 'form';
-  if (sessionPending) state = 'loading';
-  if (submitting) state = 'submitting';
-  if (errorMessage) state = 'error';
-
-  useEffect(() => {
-    if (available?.viewer?.request?.status === 'rejected' && !reason) {
-      setReason(available.viewer.request.reason);
-    }
-  }, [available?.viewer?.request, reason]);
-
-  const goToLogin = () => {
-    void navigate({ to: '/login', search: { redirect: `/join/${token}`, view: 'email' } });
-  };
-
-  const openWorkspace = () => {
-    if (available?.workspaceSlug) {
-      void navigate({
-        to: '/$workspaceName/chat',
-        params: { workspaceName: available.workspaceSlug },
-      });
-      return;
-    }
-    void navigate({ to: '/' });
-  };
 
   return (
-    <WorkspaceJoinRequestPage
-      state={state}
-      workspaceName={available?.workspaceName}
-      currentEmail={session?.user?.email}
-      reason={reason}
-      errorMessage={errorMessage}
-      onReasonChange={setReason}
-      onContinue={goToLogin}
-      onVerifyEmail={() => {
-        void (async () => {
-          await signOut();
-          goToLogin();
-        })();
+    <WorkspaceJoinRequestSurface
+      token={token}
+      onSignInRequested={() => {
+        void navigate({ to: '/login', search: { redirect: `/join/${token}`, view: 'email' } });
       }}
-      onSubmit={() => {
-        void (async () => {
-          setSubmitting(true);
-          setErrorMessage(null);
-          try {
-            await submitRequest({ token, reason });
-          } catch (error) {
-            console.error('Failed to submit workspace join request:', error);
-            setErrorMessage(t('joinRequest.submitFailed'));
-          } finally {
-            setSubmitting(false);
-          }
-        })();
-      }}
-      onOpenWorkspace={openWorkspace}
-      onBackHome={() => {
+      onWorkspaceRequested={(workspaceSlug) => {
+        if (workspaceSlug) {
+          void navigate({
+            to: '/$workspaceName/chat',
+            params: { workspaceName: workspaceSlug },
+          });
+          return;
+        }
         void navigate({ to: '/' });
       }}
+      onHomeRequested={() => void navigate({ to: '/' })}
     />
   );
 }

--- a/packages/components/tests/workspace-join-request-route.test.tsx
+++ b/packages/components/tests/workspace-join-request-route.test.tsx
@@ -9,7 +9,11 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
   query: vi.fn(),
   submit: vi.fn(),
-  signOut: vi.fn(),
+  session: null as null | {
+    user: { email: string };
+  },
+  authClient: { id: 'auth-client' },
+  signOutWithoutRedirect: vi.fn(),
 }));
 
 vi.mock('@tanstack/react-router', () => ({
@@ -27,11 +31,15 @@ vi.mock('@lody/platform/react', () => ({
 }));
 
 vi.mock('../src/hooks/useStableSession', () => ({
-  useStableSession: () => ({ data: null, isPending: false }),
+  useStableSession: () => ({ data: mocks.session, isPending: false }),
 }));
 
 vi.mock('../src/providers/convex-provider', () => ({
-  useAuthSignOut: () => mocks.signOut,
+  useAuthClient: () => mocks.authClient,
+}));
+
+vi.mock('../src/lib/auth', () => ({
+  signOutWithoutRedirect: (...args: unknown[]) => mocks.signOutWithoutRedirect(...args),
 }));
 
 import { WorkspaceJoinRequestRoute } from '../src/routes/join/$token';
@@ -43,6 +51,7 @@ import { WorkspaceJoinRequestRoute } from '../src/routes/join/$token';
 describe('WorkspaceJoinRequestRoute', () => {
   afterEach(() => {
     vi.clearAllMocks();
+    mocks.session = null;
   });
 
   it('loads the public preview before authentication and preserves the join URL on sign-in', async () => {
@@ -70,6 +79,45 @@ describe('WorkspaceJoinRequestRoute', () => {
       to: '/login',
       search: { redirect: '/join/open-token', view: 'email' },
     });
+
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  it('signs out without redirect before the host preserves the join URL for verification', async () => {
+    await initI18n('en');
+    mocks.session = { user: { email: 'member@example.com' } };
+    mocks.query.mockReturnValue({
+      status: 'available',
+      workspaceName: 'PKU Research Lab',
+      workspaceSlug: 'pku',
+      expiresAt: 9_000_000_000_000_000,
+      viewer: {
+        emailVerified: false,
+        alreadyMember: false,
+        request: null,
+      },
+    });
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<WorkspaceJoinRequestRoute />);
+    });
+
+    const verifyButton = container.querySelector('button');
+    expect(verifyButton).not.toBeNull();
+    await act(async () => verifyButton?.click());
+
+    expect(mocks.signOutWithoutRedirect).toHaveBeenCalledWith(mocks.authClient);
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: '/login',
+      search: { redirect: '/join/open-token', view: 'email' },
+    });
+    expect(mocks.signOutWithoutRedirect.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.navigate.mock.invocationCallOrder[0]
+    );
 
     await act(async () => root.unmount());
     container.remove();


### PR DESCRIPTION
## Related issue

Internal same-repository change; no intake issue is required.

## Problem / pressure

Hosted `/join/:token` needs to render the join-request flow without importing the full product route tree, workspace runtime, or Flock document implementation. The existing route owned both navigation and all join flow state, so a lightweight hosted entry could not reuse it independently.

## Summary

- Extract the join-request controller into an exported, route-agnostic `WorkspaceJoinRequestSurface`.
- Keep the existing TanStack route as a thin navigation adapter so current SPA behavior is preserved.
- Record the lightweight-entry boundary in the scoped contributor guidance.

This public PR does not change hosted entry dispatch, PostHog, RuntimeProvider, or Flock initialization. The private Web composition can consume the new surface in a follow-up.

## Before / after

| Before | After |
| ------ | ----- |
| Join flow state and navigation were coupled to the full router route. | Join flow state is reusable through callback-based navigation, while the existing route remains behavior-compatible. |

## Test plan

- `pnpm format`
- `pnpm --filter @lody/components typecheck`
- `pnpm --filter @lody/components exec vitest run tests/workspace-join-request-route.test.tsx`
- `pnpm --filter @lody/components exec vitest run tests/session-info-context-actions.test.tsx tests/markdown-streaming-reparse.test.ts --maxWorkers=1 --testTimeout=20000`
- `pnpm lint:i18n`
- `pnpm check:code-collab-imports`
- `pnpm check:platform-boundaries`
- `pnpm check:public-boundary`
- `pnpm check` completed typecheck and lint; its components phase passed 405 of 407 files before two unrelated five-second timeouts. Both timed-out files passed when rerun in isolation above.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Verify that `WorkspaceJoinRequestSurface` preserves the former route state machine and that the route callbacks preserve existing navigation.
- **Decisions to challenge:** Confirm that callback-based host navigation is the smallest public contract needed by lightweight hosted entries.
- **Plausible failures / evidence gaps:** The hosted bundle split cannot be validated in this public repository because the private Web entry is intentionally out of scope.

### Authoring context

- **User goal / directives:** Enable the public join-request flow to be composed by a lightweight online entry without loading the complete application shell.
- **Constraints / non-goals:** Preserve PostHog and current full-App Flock behavior; do not add private Web source or hosted dependencies to the public repository.
- **Risk-bearing decisions:** The extracted surface owns authentication, query, mutation, and display state while navigation is delegated to explicit callbacks.
- **Destructive or irreversible behavior:** No data migration, deletion, overwrite, or irreversible behavior is introduced.
- **Deliberately not done or tested:** Private hosted route dispatch and production bundle measurements remain for the downstream Web composition change.
- **Unknowns / confidence:** Public behavior is covered by the existing route test and type checking; final bundle size depends on the private entry dependency closure.

<!-- context-handoff:end -->