### PR TITLE
fix(components): align sidebar loading skeletons

### DIFF
--- a/packages/components/src/components/session-list.tsx
+++ b/packages/components/src/components/session-list.tsx
@@ -50,7 +50,6 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from '@/ui/context-menu';
-import { Skeleton } from '@/ui/skeleton';
 import type {
   LocalProjectHistoryProvider,
   MachineId,
@@ -88,6 +87,7 @@ import {
   SessionMergeablePill,
   SessionOpenedByTreeRow,
   SessionRowOpenedByMenuItems,
+  SidebarListSkeleton,
   buildSessionRowOpenedByTreeSlot,
 } from '@/components/sidebar-row-shared';
 import { SessionInfoHoverCard } from '@/components/session-info-hover-card';
@@ -279,26 +279,6 @@ export function sessionGroupOverflowsPreview(group: SessionRowGroup): boolean {
   return (
     countOpenedByTreeRoots(group.sessions, SESSION_ROW_OPENED_BY_TREE_ACCESSORS) >
     MAX_VISIBLE_SESSIONS
-  );
-}
-
-function SessionListSkeleton({ className }: { className?: string }) {
-  const rowWidths = ['w-[70%]', 'w-[58%]', 'w-[76%]', 'w-[62%]', 'w-[68%]', 'w-[54%]'];
-  return (
-    <div className={cn('space-y-3', className)}>
-      <div className="space-y-2">
-        <Skeleton className="h-3 w-24" />
-        <div className="space-y-2 rounded-lg border border-border/50 p-2">
-          {rowWidths.map((width, index) => (
-            <div key={index} className="flex items-center gap-2 px-1 py-1.5">
-              <Skeleton className="h-7 w-7 rounded-md" />
-              <Skeleton className={cn('h-3', width)} />
-              <Skeleton className="ml-auto h-3 w-10" />
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
   );
 }
 
@@ -1455,7 +1435,7 @@ export const SessionList = memo(function SessionList({
         {headerAction ? (
           <div className="flex h-7 shrink-0 items-center justify-end">{headerAction}</div>
         ) : null}
-        <SessionListSkeleton className={className} />
+        <SidebarListSkeleton className={className} />
       </div>
     );
   }

--- a/packages/components/src/components/sidebar-row-shared.tsx
+++ b/packages/components/src/components/sidebar-row-shared.tsx
@@ -17,6 +17,7 @@ import type { PrStatus, SessionPullRequestCiState } from '@lody/shared';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/tooltip';
 import { ContextMenuItem, ContextMenuSeparator } from '@/ui/context-menu';
+import { Skeleton } from '@/ui/skeleton';
 import { PR_STATUS_META } from '@/components/sessions/pull-request-badge';
 import { SidebarConfirmArchiveButton } from '@/components/sidebar-confirm-archive-button';
 import { CachedAvatarImg } from '@/components/cached-avatar-img';
@@ -770,6 +771,58 @@ export function SidebarSectionHeader({
         <span className="flex-1" aria-hidden="true" />
       </div>
       {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}
+
+const SIDEBAR_SKELETON_ROW_WIDTHS = [
+  'w-[68%]',
+  'w-[56%]',
+  'w-[74%]',
+  'w-[62%]',
+  'w-[70%]',
+] as const;
+
+/**
+ * Loading state for the sidebar lists. Keep this anatomy in sync with the
+ * real section header and single-line rows: the skeleton is intentionally not
+ * a card, because the loaded rows are flat and use the section's own spacing.
+ */
+export function SidebarListSkeleton({
+  className,
+  showHeaderIcon = true,
+  sectionClassName = 'mb-2.5 last:mb-0',
+}: {
+  className?: string;
+  showHeaderIcon?: boolean;
+  sectionClassName?: string;
+}) {
+  return (
+    <div className={cn('flex flex-col', className)} data-sidebar-loading-skeleton="">
+      <div className={cn('flex flex-col gap-0.5', sectionClassName)}>
+        <div className="group flex h-7 items-center">
+          <div className="relative flex h-7 min-w-0 flex-1 items-center gap-1 rounded-md px-2">
+            {showHeaderIcon ? (
+              <span className="flex h-5 w-5 shrink-0 items-center">
+                <Skeleton className="h-3.5 w-3.5 rounded-sm" />
+              </span>
+            ) : null}
+            <Skeleton className="h-3 w-24" />
+          </div>
+        </div>
+        <div className="flex flex-col gap-px">
+          {SIDEBAR_SKELETON_ROW_WIDTHS.map((width, index) => (
+            <div
+              key={index}
+              className="flex h-7 min-w-0 items-center gap-1.5 rounded-md px-2"
+            >
+              <Skeleton className="h-3.5 w-3.5 shrink-0 rounded-full" />
+              <Skeleton className={cn('h-3 min-w-0', width)} />
+              <Skeleton className="ml-auto h-3 w-8 shrink-0" />
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/components/src/components/sidebar-updated-session-list.tsx
+++ b/packages/components/src/components/sidebar-updated-session-list.tsx
@@ -32,7 +32,6 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from '@/ui/context-menu';
-import { Skeleton } from '@/ui/skeleton';
 import { SwipeActionRow } from '@/components/shared/swipe-action-row';
 import {
   SessionOpenedByTreeRow,
@@ -43,6 +42,7 @@ import {
   SessionRowWorktreeIndicator,
   SidebarRowArchiveButton,
   SidebarRowEndSlot,
+  SidebarListSkeleton,
   SidebarSectionHeader,
   SessionRowOpenedByMenuItems,
   buildSessionRowOpenedByTreeSlot,
@@ -177,34 +177,6 @@ export type SidebarUpdatedContextMenuLabels = {
  */
 function HeaderActionRow({ action }: { action: ReactNode }) {
   return <div className="flex h-7 shrink-0 items-center justify-end">{action}</div>;
-}
-
-function SidebarUpdatedSessionListSkeleton({ className }: { className?: string }) {
-  // Three buckets each with a header and a couple of rows; matches the
-  // SessionListSkeleton density so the two organize modes look the same when
-  // the session list is still loading.
-  const bucketRows: string[][] = [
-    ['w-[68%]', 'w-[58%]', 'w-[74%]'],
-    ['w-[60%]', 'w-[52%]'],
-  ];
-  return (
-    <div className={cn('flex flex-col gap-4', className)}>
-      {bucketRows.map((rows, bucketIndex) => (
-        <div key={bucketIndex} className="space-y-2">
-          <Skeleton className="h-3 w-16" />
-          <div className="space-y-2 rounded-lg border border-border/50 p-2">
-            {rows.map((width, rowIndex) => (
-              <div key={rowIndex} className="flex items-center gap-2 px-1 py-1.5">
-                <Skeleton className="h-7 w-7 rounded-md" />
-                <Skeleton className={cn('h-3', width)} />
-                <Skeleton className="ml-auto h-3 w-10" />
-              </div>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
 }
 
 function parseGitHubPrNumber(url: string): number | null {
@@ -502,7 +474,11 @@ export const SidebarUpdatedSessionList = memo(function SidebarUpdatedSessionList
     return (
       <div className="flex flex-col">
         {headerAction ? <HeaderActionRow action={headerAction} /> : null}
-        <SidebarUpdatedSessionListSkeleton className={className} />
+        <SidebarListSkeleton
+          className={className}
+          showHeaderIcon={false}
+          sectionClassName="mb-4 last:mb-0"
+        />
       </div>
     );
   }

--- a/packages/components/src/components/sidebar-updated-task-list.tsx
+++ b/packages/components/src/components/sidebar-updated-task-list.tsx
@@ -31,7 +31,6 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from '@/ui/context-menu';
-import { Skeleton } from '@/ui/skeleton';
 import { SwipeActionRow } from '@/components/shared/swipe-action-row';
 import {
   SessionPrIcon,
@@ -39,6 +38,7 @@ import {
   SessionRowLeadingSlot,
   SidebarRowArchiveButton,
   SidebarRowEndSlot,
+  SidebarListSkeleton,
   SidebarSectionHeader,
   type SidebarRowKind,
 } from '@/components/sidebar-row-shared';
@@ -137,34 +137,6 @@ export type SidebarUpdatedContextMenuLabels = {
  */
 function HeaderActionRow({ action }: { action: ReactNode }) {
   return <div className="flex h-7 shrink-0 items-center justify-end">{action}</div>;
-}
-
-function SidebarUpdatedTaskListSkeleton({ className }: { className?: string }) {
-  // Three buckets each with a header and a couple of rows; matches the
-  // TaskListSkeleton density so the two organize modes look the same when
-  // the session list is still loading.
-  const bucketRows: string[][] = [
-    ['w-[68%]', 'w-[58%]', 'w-[74%]'],
-    ['w-[60%]', 'w-[52%]'],
-  ];
-  return (
-    <div className={cn('flex flex-col gap-4', className)}>
-      {bucketRows.map((rows, bucketIndex) => (
-        <div key={bucketIndex} className="space-y-2">
-          <Skeleton className="h-3 w-16" />
-          <div className="space-y-2 rounded-lg border border-border/50 p-2">
-            {rows.map((width, rowIndex) => (
-              <div key={rowIndex} className="flex items-center gap-2 px-1 py-1.5">
-                <Skeleton className="h-7 w-7 rounded-md" />
-                <Skeleton className={cn('h-3', width)} />
-                <Skeleton className="ml-auto h-3 w-10" />
-              </div>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
 }
 
 function parseGitHubPrNumber(url: string): number | null {
@@ -406,7 +378,11 @@ export const SidebarUpdatedTaskList = memo(function SidebarUpdatedTaskList({
     return (
       <div className="flex flex-col">
         {headerAction ? <HeaderActionRow action={headerAction} /> : null}
-        <SidebarUpdatedTaskListSkeleton className={className} />
+        <SidebarListSkeleton
+          className={className}
+          showHeaderIcon={false}
+          sectionClassName="mb-4 last:mb-0"
+        />
       </div>
     );
   }

--- a/packages/components/src/components/task-list.tsx
+++ b/packages/components/src/components/task-list.tsx
@@ -51,7 +51,6 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from '@/ui/context-menu';
-import { Skeleton } from '@/ui/skeleton';
 import type {
   LocalProjectHistoryProvider,
   MachineId,
@@ -70,6 +69,7 @@ import {
   SessionRowLeadingSlot,
   SidebarRowArchiveButton,
   SidebarRowEndSlot,
+  SidebarListSkeleton,
   SessionMergeablePill,
 } from '@/components/sidebar-row-shared';
 import { SessionInfoHoverCard } from '@/components/session-info-hover-card';
@@ -191,26 +191,6 @@ export function getVisibleTaskGroupTasks(
   whetherShowFullList: boolean
 ): TaskListTask[] {
   return whetherShowFullList ? group.tasks : group.tasks.slice(0, MAX_VISIBLE_TASKS);
-}
-
-function TaskListSkeleton({ className }: { className?: string }) {
-  const rowWidths = ['w-[70%]', 'w-[58%]', 'w-[76%]', 'w-[62%]', 'w-[68%]', 'w-[54%]'];
-  return (
-    <div className={cn('space-y-3', className)}>
-      <div className="space-y-2">
-        <Skeleton className="h-3 w-24" />
-        <div className="space-y-2 rounded-lg border border-border/50 p-2">
-          {rowWidths.map((width, index) => (
-            <div key={index} className="flex items-center gap-2 px-1 py-1.5">
-              <Skeleton className="h-7 w-7 rounded-md" />
-              <Skeleton className={cn('h-3', width)} />
-              <Skeleton className="ml-auto h-3 w-10" />
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
 }
 
 function normalizeRepoFullName(value: TaskListTask['repoFullName']): string | null {
@@ -1302,7 +1282,7 @@ export const TaskList = memo(function TaskList({
         {headerAction ? (
           <div className="flex h-7 shrink-0 items-center justify-end">{headerAction}</div>
         ) : null}
-        <TaskListSkeleton className={className} />
+        <SidebarListSkeleton className={className} />
       </div>
     );
   }

--- a/packages/components/src/stories/SessionList.stories.tsx
+++ b/packages/components/src/stories/SessionList.stories.tsx
@@ -26,6 +26,7 @@ type TaskListDemoProps = SessionListProps & {
 function TaskListDemo({
   sessions,
   repos,
+  isLoading,
   selectedSessionId,
   containerClassName,
   collapsedOpenedBySessionIds,
@@ -119,6 +120,7 @@ function TaskListDemo({
         <SessionList
           sessions={taskState}
           repos={repoState}
+          isLoading={isLoading}
           chatsCollapsed={chatsCollapsed}
           selectedSessionId={selectedId}
           onSelect={setSelectedId}
@@ -249,6 +251,16 @@ const DEFAULT_ARGS: SessionListProps = {
 
 export const Default: Story = {
   args: DEFAULT_ARGS,
+  render: (args) => <TaskListDemo {...args} />,
+};
+
+export const Loading: Story = {
+  args: {
+    ...DEFAULT_ARGS,
+    sessions: [],
+    repos: [],
+    isLoading: true,
+  },
   render: (args) => <TaskListDemo {...args} />,
 };
 

--- a/packages/components/src/stories/TaskList.stories.tsx
+++ b/packages/components/src/stories/TaskList.stories.tsx
@@ -19,7 +19,13 @@ type TaskListDemoProps = TaskListProps & {
   containerClassName?: string;
 };
 
-function TaskListDemo({ tasks, repos, selectedTaskId, containerClassName }: TaskListDemoProps) {
+function TaskListDemo({
+  tasks,
+  repos,
+  isLoading,
+  selectedTaskId,
+  containerClassName,
+}: TaskListDemoProps) {
   const [selectedId, setSelectedId] = useState<string | null>(selectedTaskId ?? null);
   const [repoState, setRepoState] = useState(repos);
   const [chatsCollapsed, setChatsCollapsed] = useState(false);
@@ -92,6 +98,7 @@ function TaskListDemo({ tasks, repos, selectedTaskId, containerClassName }: Task
       <TaskList
         tasks={taskState}
         repos={repoState}
+        isLoading={isLoading}
         chatsCollapsed={chatsCollapsed}
         selectedTaskId={selectedId}
         onSelect={setSelectedId}
@@ -220,6 +227,16 @@ const DEFAULT_ARGS: TaskListProps = {
 
 export const Default: Story = {
   args: DEFAULT_ARGS,
+  render: (args) => <TaskListDemo {...args} />,
+};
+
+export const Loading: Story = {
+  args: {
+    ...DEFAULT_ARGS,
+    tasks: [],
+    repos: [],
+    isLoading: true,
+  },
   render: (args) => <TaskListDemo {...args} />,
 };
 


### PR DESCRIPTION
## Problem / pressure
The Sidebar loading skeleton no longer matched the compact single-line rows rendered after the Sidebar layout refactor, causing a noticeable layout shift while data loaded.

## Summary
- Centralize the loading skeleton shared by SessionList, TaskList, and both Updated list variants.
- Match the real section headers, row heights, spacing, leading slot, and flat (non-card) surface.
- Add loading stories for SessionList and TaskList.

## Before / after
| Before | After |
| ------ | ----- |
| Bordered card with oversized icons, loose spacing, and multiple Updated buckets | Flat single-line rows with the same geometry as the loaded Sidebar |

## Test plan
- `git diff --check` passed.
- Package typecheck and Prettier checks were attempted but could not start because this embedded worktree has no `node_modules`; `tsgo` and `prettier` were unavailable.

## Review focus
Please verify that the shared skeleton geometry remains aligned with the current row and section-header classes across Workspace and Updated modes.