### PR TITLE
feat(components): add copy action to agent file links

### DIFF
--- a/packages/components/src/components/ai-gui/markdown-renderer.tsx
+++ b/packages/components/src/components/ai-gui/markdown-renderer.tsx
@@ -40,6 +40,7 @@ import {
   isMarkdownAgentFileHref,
   parseMarkdownAgentFileHref,
 } from '@/lib/markdown-agent-file-link';
+import { writeTextToClipboard } from '@/lib/clipboard';
 import { matchWholeFilePath, splitTextIntoFilePathSegments } from '@/lib/linkify-file-paths';
 import {
   normalizeTexMathDelimiters,
@@ -886,35 +887,6 @@ const MERMAID_DIAGRAM_SELECTOR = '[data-streamdown="mermaid"]';
 
 /** Matches a fenced ```mermaid block, so blocks without one skip the observer. */
 const MERMAID_FENCE_PATTERN = /^[ \t]{0,3}(?:`{3,}|~{3,})[ \t]*mermaid\b/mu;
-
-const writeTextToClipboard = async (text: string): Promise<boolean> => {
-  if (!text.trim()) return false;
-
-  try {
-    await navigator.clipboard.writeText(text);
-    return true;
-  } catch {
-    try {
-      const el = document.createElement('textarea');
-      el.value = text;
-      el.style.position = 'fixed';
-      el.style.top = '0';
-      el.style.left = '0';
-      el.style.width = '1px';
-      el.style.height = '1px';
-      el.style.opacity = '0';
-      document.body.appendChild(el);
-      el.focus();
-      el.select();
-      const ok = document.execCommand('copy');
-      document.body.removeChild(el);
-      return ok;
-    } catch {
-      return false;
-    }
-  }
-};
-
 const markdownUrlTransform: UrlTransform = (value, key, node) =>
   isMarkdownAgentFileHref(value) || (key === 'src' && parseTaskImageMarkdownUrl(value))
     ? value
@@ -929,63 +901,93 @@ const AgentFileLink = ({
   children,
   onFilePathClick,
   copyAgentFileLabel,
+  copiedLabel,
   openAgentFileLabel,
 }: {
   href: string;
   children: ReactNode;
   onFilePathClick?: (href: string) => void;
   copyAgentFileLabel: string;
+  copiedLabel: string;
   openAgentFileLabel: string;
 }) => {
   const [didCopy, setDidCopy] = useState(false);
   const hasOpenAction = Boolean(onFilePathClick);
-  const iconPath = parseMarkdownAgentFileHref(href)?.filePath ?? href;
+  const filePath = parseMarkdownAgentFileHref(href)?.filePath ?? href;
 
-  const handleClick = useCallback(async () => {
-    if (onFilePathClick) {
-      onFilePathClick(href);
-      return;
-    }
-
-    const ok = await writeTextToClipboard(href);
+  const handleCopy = useCallback(async () => {
+    const ok = await writeTextToClipboard(filePath);
     if (!ok) return;
 
     setDidCopy(true);
     window.setTimeout(() => setDidCopy(false), 1200);
-  }, [href, onFilePathClick]);
+  }, [filePath]);
 
-  return (
+  const copyButtonContent = didCopy ? (
+    <Check className="h-3 w-3 shrink-0 text-emerald-600" aria-hidden="true" />
+  ) : (
+    <Copy className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
+  );
+
+  const primaryButton = (
     <button
       type="button"
       onClick={() => {
-        void handleClick();
+        if (onFilePathClick) {
+          onFilePathClick(href);
+          return;
+        }
+        void handleCopy();
       }}
       title={href}
-      aria-label={`${hasOpenAction ? openAgentFileLabel : copyAgentFileLabel}: ${href}`}
+      aria-label={`${hasOpenAction ? openAgentFileLabel : copyAgentFileLabel}: ${filePath}`}
       className={cn(
-        'inline-flex max-w-full items-center gap-1 rounded-md border border-border/60 bg-muted/40 px-1.5 py-px align-[-0.15em] font-mono text-[0.92em] leading-tight text-foreground no-underline shadow-none transition-colors',
-        'hover:border-border hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+        'inline-flex min-w-0 max-w-full items-center gap-1 px-1.5 py-px text-foreground transition-colors',
+        'hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
       )}
     >
-      <FileIcon filePath={iconPath} className="h-3.5 w-3.5 shrink-0" />
+      <FileIcon filePath={filePath} className="h-3.5 w-3.5 shrink-0" />
       <span className="min-w-0 truncate">{children}</span>
-      {!hasOpenAction ? (
-        didCopy ? (
-          <Check className="h-3 w-3 shrink-0 text-emerald-600" />
-        ) : (
-          <Copy className="h-3 w-3 shrink-0 text-muted-foreground" />
-        )
-      ) : null}
+      {!hasOpenAction ? copyButtonContent : null}
     </button>
+  );
+
+  return (
+    <span
+      className={cn(
+        'inline-flex max-w-full items-stretch overflow-hidden rounded-md border border-border/60 bg-muted/40 align-[-0.15em] font-mono text-[0.92em] leading-tight no-underline shadow-none transition-colors',
+        'hover:border-border'
+      )}
+    >
+      {primaryButton}
+      {hasOpenAction ? (
+        <button
+          type="button"
+          onClick={() => {
+            void handleCopy();
+          }}
+          title={`${didCopy ? copiedLabel : copyAgentFileLabel}: ${filePath}`}
+          aria-label={`${didCopy ? copiedLabel : copyAgentFileLabel}: ${filePath}`}
+          className={cn(
+            'inline-flex shrink-0 items-center border-l border-border/60 px-1 py-px transition-colors',
+            'hover:bg-muted focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset'
+          )}
+        >
+          {copyButtonContent}
+        </button>
+      ) : null}
+    </span>
   );
 };
 
 const createMarkdownComponents = ({
   copyAgentFileLabel,
+  copiedLabel,
   openAgentFileLabel,
   onAgentFileLinkClick,
 }: {
   copyAgentFileLabel: string;
+  copiedLabel: string;
   openAgentFileLabel: string;
   onAgentFileLinkClick?: (href: string) => void;
 }): Components => ({
@@ -1023,6 +1025,7 @@ const createMarkdownComponents = ({
           href={href}
           onFilePathClick={onAgentFileLinkClick}
           copyAgentFileLabel={copyAgentFileLabel}
+          copiedLabel={copiedLabel}
           openAgentFileLabel={openAgentFileLabel}
         >
           {children}
@@ -1112,6 +1115,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   const searchMatch = useSessionSearchBlock(searchBlockId ?? '');
   const copyCodeLabel = t('common.copyCode', 'Copy code');
   const copyAgentFileLabel = t('sessions.copyAgentFilePath', 'Copy agent file path');
+  const copiedLabel = t('common.copied', 'Copied');
   const openAgentFileLabel = t('sessions.openAgentFile', 'Open agent file');
   const openDiagramLabel = t('sessions.diagramViewer.open', 'Open diagram');
   const [diagramSelection, setDiagramSelection] = useState<MermaidDiagramSelection | null>(null);
@@ -1238,10 +1242,11 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
     () =>
       createMarkdownComponents({
         copyAgentFileLabel,
+        copiedLabel,
         openAgentFileLabel,
         onAgentFileLinkClick,
       }),
-    [copyAgentFileLabel, onAgentFileLinkClick, openAgentFileLabel]
+    [copiedLabel, copyAgentFileLabel, onAgentFileLinkClick, openAgentFileLabel]
   );
 
   const rehypePlugins = useMemo(() => (allowHtml ? [rehypeRaw, rehypeSanitize] : []), [allowHtml]);

--- a/packages/components/src/components/ai-gui/markdown-renderer.tsx
+++ b/packages/components/src/components/ai-gui/markdown-renderer.tsx
@@ -38,6 +38,7 @@ import { DEFAULT_CONVERSATION_FONT_SIZE, tasksFeatureEnabledAtom } from '@/atoms
 import { FileIcon } from '@/components/icons/file-icons';
 import {
   isMarkdownAgentFileHref,
+  normalizeMarkdownAgentFilePath,
   parseMarkdownAgentFileHref,
 } from '@/lib/markdown-agent-file-link';
 import { writeTextToClipboard } from '@/lib/clipboard';
@@ -914,14 +915,15 @@ const AgentFileLink = ({
   const [didCopy, setDidCopy] = useState(false);
   const hasOpenAction = Boolean(onFilePathClick);
   const filePath = parseMarkdownAgentFileHref(href)?.filePath ?? href;
+  const copyFilePath = normalizeMarkdownAgentFilePath(filePath);
 
   const handleCopy = useCallback(async () => {
-    const ok = await writeTextToClipboard(filePath);
+    const ok = await writeTextToClipboard(copyFilePath);
     if (!ok) return;
 
     setDidCopy(true);
     window.setTimeout(() => setDidCopy(false), 1200);
-  }, [filePath]);
+  }, [copyFilePath]);
 
   const copyButtonContent = didCopy ? (
     <Check className="h-3 w-3 shrink-0 text-emerald-600" aria-hidden="true" />

--- a/packages/components/src/stories/MarkdownRenderer.stories.tsx
+++ b/packages/components/src/stories/MarkdownRenderer.stories.tsx
@@ -677,6 +677,11 @@ export const AgentFileLinks: Story = {
   render: (args) => wrap(<MarkdownRenderer {...args} />),
 };
 
+export const AgentFileLinksWithOpenAction: Story = {
+  ...AgentFileLinks,
+  render: (args) => wrap(<MarkdownRenderer {...args} onAgentFileLinkClick={() => undefined} />),
+};
+
 const mermaidPhoneText = [
   'The run below is the shape a keeper agent reports back:',
   '',

--- a/packages/components/tests/markdown-agent-file-chip.test.ts
+++ b/packages/components/tests/markdown-agent-file-chip.test.ts
@@ -28,8 +28,14 @@ const MARKDOWN =
 describe('agent file links in finished turns', () => {
   let root: Root | undefined;
   let container: HTMLDivElement | undefined;
+  const writeText = vi.fn(() => Promise.resolve());
 
   beforeEach(() => {
+    writeText.mockClear();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -66,6 +72,39 @@ describe('agent file links in finished turns', () => {
     // The enumeration commas must not be left dangling next to a hole.
     expect(container?.textContent).toContain(
       '改动落在 README.md、conductor.json、oss-revision.json 三个文件。'
+    );
+  });
+
+  it('keeps opening on the file label and exposes a separate copy-path action', async () => {
+    const onAgentFileLinkClick = vi.fn();
+    await act(async () => {
+      root?.render(
+        createElement(MarkdownRenderer, {
+          text: '[README.md](/srv/workspaces/demo-app/README.md:8)',
+          isStreaming: false,
+          onAgentFileLinkClick,
+        })
+      );
+    });
+
+    const openButton = container?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open agent file: /srv/workspaces/demo-app/README.md"]'
+    );
+    const copyButton = container?.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy agent file path: /srv/workspaces/demo-app/README.md"]'
+    );
+
+    expect(openButton).toBeTruthy();
+    expect(copyButton).toBeTruthy();
+
+    act(() => openButton?.click());
+    expect(onAgentFileLinkClick).toHaveBeenCalledWith('/srv/workspaces/demo-app/README.md:8');
+
+    await act(async () => copyButton?.click());
+    expect(writeText).toHaveBeenCalledWith('/srv/workspaces/demo-app/README.md');
+    expect(onAgentFileLinkClick).toHaveBeenCalledTimes(1);
+    expect(copyButton?.getAttribute('aria-label')).toBe(
+      'Copied: /srv/workspaces/demo-app/README.md'
     );
   });
 });

--- a/packages/components/tests/markdown-agent-file-chip.test.ts
+++ b/packages/components/tests/markdown-agent-file-chip.test.ts
@@ -107,4 +107,27 @@ describe('agent file links in finished turns', () => {
       'Copied: /srv/workspaces/demo-app/README.md'
     );
   });
+
+  it('decodes escaped path characters exactly once when copying', async () => {
+    const onAgentFileLinkClick = vi.fn();
+    const href = '/srv/workspaces/demo-app/docs/My%20File%2520Name.md:8';
+    await act(async () => {
+      root?.render(
+        createElement(MarkdownRenderer, {
+          text: `[icon](${href})`,
+          isStreaming: false,
+          onAgentFileLinkClick,
+        })
+      );
+    });
+
+    const copyButton = [...(container?.querySelectorAll<HTMLButtonElement>('button') ?? [])].find(
+      (button) => button.getAttribute('aria-label')?.startsWith('Copy agent file path:')
+    );
+
+    expect(copyButton).toBeTruthy();
+    await act(async () => copyButton?.click());
+    expect(writeText).toHaveBeenCalledWith('/srv/workspaces/demo-app/docs/My File%20Name.md');
+    expect(onAgentFileLinkClick).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Related issue

Closes #268

## Problem / pressure

Agent file references in session messages already open the referenced file when clicked, but that open action leaves no direct way to copy the path for reuse in a terminal, editor, document, or follow-up prompt.

## Summary

- Preserve the existing open-file action on the file label and add a separate adjacent copy-path button.
- Copy the parsed, safely URL-decoded file path without line-reference suffixes while retaining the original href for opening.
- Reuse the shared clipboard helper, show localized copied feedback, and add focused unit and Storybook coverage.

## Visual explanation

Simple change: the before/after screenshots below show the complete visible interaction; a structural diagram would not add useful review context.

## Before / after

| Before | After |
| ------ | ----- |
| Clicking an agent file chip only opens the file. <img width="732" height="262" alt="image" src="https://github.com/user-attachments/assets/fcd1c8bd-9834-436f-88d3-a66e66b60bd0" /> | The file label still opens the file, while an adjacent button copies its path and briefly confirms success. <img width="1064" height="524" alt="image" src="https://github.com/user-attachments/assets/0f7f278f-a229-4076-90a0-0d3b71a67bab" /> |

## Test plan

- `fnm exec --using=22.23.1 pnpm --filter @lody/components exec vitest run tests/markdown-agent-file-chip.test.ts tests/markdown-agent-file-link.test.ts` — 2 files and 23 tests passed.
- `fnm exec --using=22.23.1 pnpm --filter @lody/components typecheck`.
- `fnm exec --using=22.23.1 pnpm exec oxlint --quiet packages/components/src/components/ai-gui/markdown-renderer.tsx packages/components/src/stories/MarkdownRenderer.stories.tsx packages/components/tests/markdown-agent-file-chip.test.ts`.
- `fnm exec --using=22.23.1 pnpm exec prettier --check packages/components/src/components/ai-gui/markdown-renderer.tsx packages/components/src/stories/MarkdownRenderer.stories.tsx packages/components/tests/markdown-agent-file-chip.test.ts`.
- `fnm exec --using=22.23.1 pnpm run docs check`.
- The full suite and packaged Electron shell were not rerun locally after rebasing; CI owns the broader checks.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check `AgentFileLink` in `markdown-renderer.tsx`, especially the separate open/copy actions and exactly-once URL decoding before clipboard writes.
- **Decisions to challenge:** Confirm that the opener should retain the original href with its line reference while the clipboard receives the decoded path without that suffix.
- **Plausible failures / evidence gaps:** The rebased head has focused component coverage but no packaged Electron run; existing screenshots cover the unchanged visible layout.

### Authoring context

- **User goal / directives:** Keep click-to-open behavior for session file links while adding a direct, discoverable way to copy the underlying file path.
- **Constraints / non-goals:** This change does not add a context menu, a relative-versus-absolute chooser, or alter ordinary external links.
- **Risk-bearing decisions:** URL escapes are decoded safely exactly once for copying, while the opener receives the original href including its line reference.
- **Destructive or irreversible behavior:** The only side effect is a user-initiated clipboard write and a 1.2-second local success state; no data is modified.
- **Deliberately not done or tested:** Dual copy formats and a full packaged Electron run remain outside this focused contribution; CI covers the broader suite.
- **Unknowns / confidence:** Confidence is high from focused path-parser and interaction tests; residual uncertainty is limited to OS-specific clipboard restrictions in packaged builds.

<!-- context-handoff:end -->
