### PR TITLE
feat(components): split public route runtime dependencies

### DIFF
--- a/apps/electron/electron.vite.config.ts
+++ b/apps/electron/electron.vite.config.ts
@@ -1,9 +1,11 @@
 import { execSync } from 'node:child_process'
 import fs from 'node:fs'
 import { resolve } from 'node:path'
+import { gzipSync } from 'node:zlib'
 import { defineConfig } from 'electron-vite'
 import type { Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
+import { tanstackRouter } from '@tanstack/router-plugin/vite'
 import wasm from 'vite-plugin-wasm'
 import tailwindcss from '@tailwindcss/vite'
 import {
@@ -76,6 +78,33 @@ function previewPublicBaseDomainHtmlPlugin(baseDomain: string): Plugin {
   }
 }
 
+/**
+ * Test-only observability for the real Electron renderer Rollup graph. The
+ * artifact is written outside the output directory so production builds never
+ * ship graph metadata.
+ */
+function routeBundleGraphPlugin(outputPath: string): Plugin {
+  return {
+    name: 'lody-route-bundle-graph',
+    apply: 'build',
+    generateBundle(_, bundle) {
+      const chunks = Object.values(bundle).filter((output) => output.type === 'chunk')
+      const graph = {
+        chunks: chunks.map((chunk) => ({
+          fileName: chunk.fileName,
+          facadeModuleId: chunk.facadeModuleId,
+          imports: chunk.imports,
+          dynamicImports: chunk.dynamicImports,
+          moduleIds: chunk.moduleIds,
+          rawBytes: Buffer.byteLength(chunk.code),
+          gzipBytes: gzipSync(chunk.code).byteLength
+        }))
+      }
+      fs.writeFileSync(outputPath, JSON.stringify(graph, null, 2))
+    }
+  }
+}
+
 export default defineConfig(({ mode }) => {
   const buildMode = mode || OSS_BUILD_MODE
   if (buildMode !== OSS_BUILD_MODE) {
@@ -84,6 +113,7 @@ export default defineConfig(({ mode }) => {
 
   const buildEnv = { ...OSS_BUILD_ENV }
   const previewPublicBaseDomain = buildEnv.VITE_PREVIEW_PUBLIC_BASE_DOMAIN
+  const routeBundleGraphOutputPath = process.env.LODY_ROUTE_BUNDLE_GRAPH_PATH
   const viteEnvDefine = {
     ...buildViteEnvDefine(buildEnv),
     'import.meta.env.VITE_PREVIEW_PUBLIC_BASE_DOMAIN': JSON.stringify(previewPublicBaseDomain)
@@ -188,13 +218,23 @@ export default defineConfig(({ mode }) => {
         previewPublicBaseDomainHtmlPlugin(previewPublicBaseDomain),
         tailwindcss(),
         loroCrdtWasmUrlWorkaround(),
+        // The router is consumed from @lody/components source, so this host
+        // (not the package's own Vite config) must transform route modules.
+        // Keep this before React, as required by TanStack Router.
+        tanstackRouter({
+          target: 'react',
+          autoCodeSplitting: true,
+          routesDirectory: resolve(__dirname, '../../packages/components/src/routes'),
+          generatedRouteTree: resolve(__dirname, '../../packages/components/src/routeTree.gen.ts')
+        }),
         react(),
         wasm(),
         // The desktop app must work with no network, so the emoji picker's
         // dataset ships in the bundle instead of being fetched from a CDN.
         emojibaseAssetsPlugin(),
         rendererBundleAliasPlugin(),
-        mermaidLazyBoundaryGuardPlugin()
+        mermaidLazyBoundaryGuardPlugin(),
+        ...(routeBundleGraphOutputPath ? [routeBundleGraphPlugin(routeBundleGraphOutputPath)] : [])
       ]
     }
   }

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/LodyAI/Lody",
   "scripts": {
     "format": "prettier --write .",
-    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test src/system-language-argument.test.mjs src/main/reload-shortcut.test.mjs src/main/onboarding-launch-policy.test.mjs src/main/auto-launch-policy.test.mjs src/main/window-theme.test.mjs src/main/local-platform-snapshot.test.mjs src/main/ipc/ipc-channel-list.test.mjs src/main/services/local-path-launcher-core.test.mjs src/main/services/image-export-core.test.mjs src/main/services/public-browser-state.test.mjs src/main/services/app-updater-metadata.test.mjs src/main/services/loro-data-plane-relay.test.mjs src/renderer/renderer-csp.test.mjs src/renderer/src/auth-callback-transaction.test.mjs src/renderer/src/auth-query-generation.test.mjs src/renderer/src/renderer-error-reporting.test.mjs",
+    "test": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --experimental-strip-types --test src/system-language-argument.test.mjs src/main/reload-shortcut.test.mjs src/main/onboarding-launch-policy.test.mjs src/main/auto-launch-policy.test.mjs src/main/window-theme.test.mjs src/main/local-platform-snapshot.test.mjs src/main/ipc/ipc-channel-list.test.mjs src/main/services/local-path-launcher-core.test.mjs src/main/services/image-export-core.test.mjs src/main/services/public-browser-state.test.mjs src/main/services/app-updater-metadata.test.mjs src/main/services/loro-data-plane-relay.test.mjs src/renderer/renderer-csp.test.mjs src/renderer/route-bundle-graph.test.mjs src/renderer/src/auth-callback-transaction.test.mjs src/renderer/src/auth-query-generation.test.mjs src/renderer/src/renderer-error-reporting.test.mjs",
     "lint": "eslint --cache .",
     "typecheck:node": "tsgo --noEmit -p tsconfig.node.json --composite false",
     "typecheck:web": "tsgo --noEmit -p tsconfig.web.json --composite false",
@@ -58,6 +58,7 @@
     "@lody/configs": "workspace:*",
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/vite": "^4.3.0",
+    "@tanstack/router-plugin": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",

--- a/apps/electron/src/renderer/route-bundle-graph.test.mjs
+++ b/apps/electron/src/renderer/route-bundle-graph.test.mjs
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const electronRoot = resolve(fileURLToPath(new URL('../..', import.meta.url)))
+const repositoryRoot = resolve(electronRoot, '../..')
+const componentsRoot = resolve(repositoryRoot, 'packages/components/src')
+
+function normalizeModuleId(moduleId) {
+  return moduleId.replaceAll('\\', '/')
+}
+
+function isRouteComponentModule(moduleId, routePath) {
+  const normalized = normalizeModuleId(moduleId)
+  return normalized.startsWith(`${routePath}?`) && normalized.includes('tsr-split=')
+}
+
+function getChunkForRoute(chunks, routePath) {
+  const chunk = chunks.find((candidate) =>
+    candidate.moduleIds.some((moduleId) => isRouteComponentModule(moduleId, routePath))
+  )
+  assert.ok(chunk, `expected an emitted component chunk for ${routePath}`)
+  return chunk
+}
+
+function getStaticClosure(chunks, roots) {
+  const chunksByFileName = new Map(chunks.map((chunk) => [chunk.fileName, chunk]))
+  const closure = new Map()
+  const pending = [...roots]
+
+  while (pending.length > 0) {
+    const chunk = pending.pop()
+    if (!chunk || closure.has(chunk.fileName)) continue
+    closure.set(chunk.fileName, chunk)
+    for (const importedFileName of chunk.imports) {
+      pending.push(chunksByFileName.get(importedFileName))
+    }
+  }
+
+  return [...closure.values()]
+}
+
+function hasModule(closure, predicate) {
+  return closure.some((chunk) => chunk.moduleIds.some(predicate))
+}
+
+function summarize(closure) {
+  return {
+    chunks: closure.map((chunk) => chunk.fileName).sort(),
+    rawBytes: closure.reduce((total, chunk) => total + chunk.rawBytes, 0),
+    gzipBytes: closure.reduce((total, chunk) => total + chunk.gzipBytes, 0)
+  }
+}
+
+void test(
+  'the Electron host code-splits public routes away from the workspace runtime graph',
+  { timeout: 300_000 },
+  async () => {
+    const outputDirectory = await mkdtemp(resolve(tmpdir(), 'lody-route-bundle-graph-'))
+    const graphPath = resolve(outputDirectory, 'graph.json')
+
+    try {
+      execFileSync(
+        'pnpm',
+        ['--dir', 'apps/electron', 'exec', 'electron-vite', 'build', '--mode', 'oss'],
+        {
+          cwd: repositoryRoot,
+          env: {
+            ...process.env,
+            LODY_ROUTE_BUNDLE_GRAPH_PATH: graphPath
+          },
+          stdio: 'pipe'
+        }
+      )
+
+      const graph = JSON.parse(await readFile(graphPath, 'utf8'))
+      const entry = graph.chunks.find((chunk) =>
+        chunk.moduleIds.some((moduleId) =>
+          normalizeModuleId(moduleId).endsWith('/src/renderer/src/main.tsx')
+        )
+      )
+      assert.ok(entry, 'expected the renderer entry chunk')
+
+      const joinRoute = getChunkForRoute(graph.chunks, `${componentsRoot}/routes/join/$token.tsx`)
+      const loginRoute = getChunkForRoute(graph.chunks, `${componentsRoot}/routes/login.tsx`)
+      const workspaceRoute = getChunkForRoute(
+        graph.chunks,
+        `${componentsRoot}/routes/$workspaceName.tsx`
+      )
+
+      const publicRoots = [entry]
+      const joinClosure = getStaticClosure(graph.chunks, [...publicRoots, joinRoute])
+      const loginClosure = getStaticClosure(graph.chunks, [...publicRoots, loginRoute])
+      const workspaceClosure = getStaticClosure(graph.chunks, [...publicRoots, workspaceRoute])
+
+      const runtimeProvider = (moduleId) =>
+        normalizeModuleId(moduleId) ===
+        `${componentsRoot.replaceAll('\\', '/')}/providers/runtime-provider.tsx`
+      const workspaceRuntime = (moduleId) =>
+        normalizeModuleId(moduleId) ===
+        `${componentsRoot.replaceAll('\\', '/')}/providers/create-workspace-runtime.ts`
+      const streamsCrdt = (moduleId) =>
+        normalizeModuleId(moduleId).includes('/@loro-dev/streams-crdt/')
+      const flockWasm = (moduleId) => normalizeModuleId(moduleId).includes('/@loro-dev/flock-wasm/')
+
+      for (const [routeName, closure] of [
+        ['join', joinClosure],
+        ['login', loginClosure]
+      ]) {
+        assert.equal(
+          hasModule(closure, runtimeProvider),
+          false,
+          `${routeName} loads RuntimeProvider`
+        )
+        assert.equal(
+          hasModule(closure, workspaceRuntime),
+          false,
+          `${routeName} loads workspace runtime`
+        )
+        assert.equal(hasModule(closure, streamsCrdt), false, `${routeName} loads streams-crdt`)
+        assert.equal(hasModule(closure, flockWasm), false, `${routeName} loads flock-wasm`)
+      }
+
+      assert.equal(hasModule(workspaceClosure, runtimeProvider), true)
+      assert.equal(hasModule(workspaceClosure, workspaceRuntime), true)
+      assert.equal(hasModule(workspaceClosure, streamsCrdt), true)
+      assert.equal(hasModule(workspaceClosure, flockWasm), true)
+
+      console.info(
+        JSON.stringify({
+          join: summarize(joinClosure),
+          login: summarize(loginClosure),
+          workspace: summarize(workspaceClosure)
+        })
+      )
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true })
+    }
+  }
+)

--- a/apps/electron/src/renderer/src/auth.ts
+++ b/apps/electron/src/renderer/src/auth.ts
@@ -9,7 +9,7 @@ import {
   createLodyAuthClient,
   type LodyAuthClient
 } from '@lody/components/lib/auth'
-import { getAppWindowLocation } from '@lody/components/lib'
+import { getAppWindowLocation } from '@lody/components/lib/app-location'
 import { readStoredAuthToken } from '@lody/components/lib/auth-bootstrap'
 import { capturePostHogSingleton } from '@lody/components/lib/mobile-resume-analytics'
 import { persistNativeAuthSessionResult as persistAuthSessionResult } from '@lody/components/lib/native-auth-session-sync'

--- a/apps/electron/src/renderer/src/main.tsx
+++ b/apps/electron/src/renderer/src/main.tsx
@@ -10,7 +10,7 @@ import {
 } from '@lody/components/i18n'
 import { languageAtom } from '@lody/components/atoms/settings'
 import '@lody/components/tailwind/index.css'
-import { jotaiStore } from '@lody/components/lib'
+import { jotaiStore } from '@lody/components/lib/utils'
 import { collectBootDiagnostics, renderBootFailure } from '@lody/components/lib/boot-failure'
 import { installResizeObserverLoopErrorHandler } from '@lody/components/lib/resize-observer'
 import { getIpcServices } from '@lody/components/lib/electron-ipc-client'

--- a/packages/components/src/AGENTS.md
+++ b/packages/components/src/AGENTS.md
@@ -2,13 +2,18 @@
 
 Parent `AGENTS.md` files also apply.
 
-## Lightweight hosted entries
+## Public/auth route boundaries
 
-- Public/auth entry points that bypass the full product router import route-agnostic
-  surfaces. Keep host navigation behind callback props so those surfaces do not import
-  the route tree, `RuntimeProvider`, or workspace Flock document implementation. When
-  an auth transition selects the destination, the host owns both the non-redirecting
-  auth action and navigation so an auth helper cannot discard route-specific state.
+- Public/auth pages remain ordinary TanStack file routes under the product router; do
+  not add a separate React entry, root lifecycle, empty workspace provider, or URL
+  dispatcher for a lightweight page. The global layout may own auth, Cloud API, i18n,
+  and PostHog; `RuntimeProvider` and workspace Flock state begin at the
+  `/$workspaceName` layout.
+- Hosts that consume `@lody/components/router` register the TanStack Router Vite plugin
+  before React with this package's routes directory and generated route tree. Keep a
+  route's component local unless another route truly imports it: the plugin can then
+  emit the component chunk, so a new public/auth route inherits the light closure from
+  its layout without bootstrap changes.
 
 ## Keyboard navigation
 

--- a/packages/components/src/components/AppInitializer.tsx
+++ b/packages/components/src/components/AppInitializer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import i18next from 'i18next';
 import { syncTime, createServerTimeFetcher } from '@lody/shared';
 import { usePlatformCapability } from '@lody/platform/react';
-import { API_BASE_URL } from '../lib';
+import { API_BASE_URL } from '../lib/api-base-url';
 import { commands, registerBuiltInCommands } from '../lib/commands';
 import { rehydrateAvatarMemoryCacheFromPersistent } from '../lib/avatar-cache';
 import { languageAtom } from '../atoms/settings';

--- a/packages/components/src/lib/api-base-url.ts
+++ b/packages/components/src/lib/api-base-url.ts
@@ -1,0 +1,20 @@
+function resolveApiBaseUrl(): string {
+  // `import.meta.env` is a Vite-only global — it's `undefined` under other
+  // bundlers (for example, the marketing preview that reuses these components),
+  // so read it defensively rather than crashing at module evaluation time.
+  const importMetaEnv = (import.meta as { env?: Record<string, string | undefined> }).env;
+  const envValue = importMetaEnv?.VITE_SERVER_URL;
+  if (envValue) return envValue;
+
+  if (typeof window === 'undefined') {
+    return 'https://lody.ai';
+  }
+
+  const hostname = window.location.hostname;
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
+    return 'http://localhost:8787';
+  }
+  return window.location.origin;
+}
+
+export const API_BASE_URL = resolveApiBaseUrl();

--- a/packages/components/src/lib/index.ts
+++ b/packages/components/src/lib/index.ts
@@ -8,28 +8,6 @@ export * from './session-file-provider-view-model';
 export * from './session-file-provider';
 export * from './project-skills-cache';
 export * from './local-project-skills-provider';
-
-function resolveApiBaseUrl(): string {
-  // `import.meta.env` is a Vite-only global — it's `undefined` under other bundlers
-  // (e.g. the Next.js marketing preview that reuses these components), so read it
-  // defensively rather than crashing at module-evaluation time.
-  const importMetaEnv = (import.meta as { env?: Record<string, string | undefined> }).env;
-  const envValue = importMetaEnv?.VITE_SERVER_URL;
-  if (envValue) return envValue;
-
-  if (typeof window === 'undefined') {
-    return 'https://lody.ai';
-  }
-
-  // Web: default to localhost agent in local dev; otherwise assume same-origin deployments.
-  const hostname = window.location.hostname;
-  const isLocalhost = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
-  if (isLocalhost) {
-    return 'http://localhost:8787';
-  }
-  return window.location.origin;
-}
-
-export const API_BASE_URL = resolveApiBaseUrl();
+export { API_BASE_URL } from './api-base-url';
 export const buildAgentPrompt = (prompt: string, agentPrompt = '') =>
   [agentPrompt, prompt].filter((part) => part?.trim()).join('\n\n');

--- a/packages/components/src/providers/runtime-provider.tsx
+++ b/packages/components/src/providers/runtime-provider.tsx
@@ -21,7 +21,7 @@ import {
   runtimeInitializingAtom,
   browserOnlineAtom,
 } from '@/atoms/control-connection';
-import { API_BASE_URL } from '@/lib';
+import { API_BASE_URL } from '@/lib/api-base-url';
 import { getCachedWorkspaceId } from '@/lib/local-storage-cache';
 import { usePostHog } from '@posthog/react';
 import { createWorkspaceRuntime } from './create-workspace-runtime';
@@ -266,7 +266,10 @@ export function RuntimeProvider({ children }: { children: ReactNode }) {
           },
           ...(telemetryEnabled
             ? {
-                onAnalyticsEvent: (event: { name: string; properties?: Record<string, unknown> }) => {
+                onAnalyticsEvent: (event: {
+                  name: string;
+                  properties?: Record<string, unknown>;
+                }) => {
                   capturePostHogEvent(postHogRef.current, event.name, event.properties);
                 },
               }

--- a/packages/components/src/routeTree.gen.ts
+++ b/packages/components/src/routeTree.gen.ts
@@ -9,97 +9,57 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ResetPasswordRouteImport } from './routes/reset-password'
-import { Route as OnboardingRouteImport } from './routes/onboarding'
-import { Route as NotFoundRouteImport } from './routes/notFound'
-import { Route as LoginRouteImport } from './routes/login'
-import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
-import { Route as EmailVerifiedRouteImport } from './routes/email-verified'
-import { Route as DeviceRouteImport } from './routes/device'
-import { Route as CompleteEmailRouteImport } from './routes/complete-email'
-import { Route as AppRouteImport } from './routes/app'
-import { Route as WorkspaceNameRouteImport } from './routes/$workspaceName'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as WorkspaceNameRouteImport } from './routes/$workspaceName'
+import { Route as AppRouteImport } from './routes/app'
+import { Route as CompleteEmailRouteImport } from './routes/complete-email'
+import { Route as DeviceRouteImport } from './routes/device'
+import { Route as EmailVerifiedRouteImport } from './routes/email-verified'
+import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
+import { Route as LoginRouteImport } from './routes/login'
+import { Route as NotFoundRouteImport } from './routes/notFound'
+import { Route as OnboardingRouteImport } from './routes/onboarding'
+import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as WorkspaceNameIndexRouteImport } from './routes/$workspaceName/index'
-import { Route as WorkspaceCreateRouteImport } from './routes/workspace/create'
-import { Route as JoinTokenRouteImport } from './routes/join/$token'
-import { Route as InviteInvitationIdRouteImport } from './routes/invite/$invitationId'
-import { Route as DesktopGithubInstallRouteImport } from './routes/desktop/github-install'
-import { Route as DesktopCheckoutReturnRouteImport } from './routes/desktop/checkout-return'
 import { Route as WorkspaceNameAuthRouteImport } from './routes/$workspaceName/_auth'
-import { Route as WorkspaceNameAuthSettingsRouteImport } from './routes/$workspaceName/_auth/settings'
-import { Route as WorkspaceNameAuthSessionsRouteImport } from './routes/$workspaceName/_auth/sessions'
-import { Route as WorkspaceNameAuthChatRouteImport } from './routes/$workspaceName/_auth/chat'
+import { Route as DesktopCheckoutReturnRouteImport } from './routes/desktop/checkout-return'
+import { Route as DesktopGithubInstallRouteImport } from './routes/desktop/github-install'
+import { Route as InviteInvitationIdRouteImport } from './routes/invite/$invitationId'
+import { Route as JoinTokenRouteImport } from './routes/join/$token'
+import { Route as WorkspaceCreateRouteImport } from './routes/workspace/create'
 import { Route as WorkspaceNameAuthArchiveRouteImport } from './routes/$workspaceName/_auth/archive'
-import { Route as WorkspaceNameAuthTasksIndexRouteImport } from './routes/$workspaceName/_auth/tasks.index'
-import { Route as WorkspaceNameAuthSettingsIndexRouteImport } from './routes/$workspaceName/_auth/settings.index'
-import { Route as WorkspaceNameAuthTasksTaskIdRouteImport } from './routes/$workspaceName/_auth/tasks.$taskId'
-import { Route as WorkspaceNameAuthSettingsWorkspaceRouteImport } from './routes/$workspaceName/_auth/settings/workspace'
-import { Route as WorkspaceNameAuthSettingsStatsRouteImport } from './routes/$workspaceName/_auth/settings/stats'
-import { Route as WorkspaceNameAuthSettingsProjectsRouteImport } from './routes/$workspaceName/_auth/settings/projects'
-import { Route as WorkspaceNameAuthSettingsPreferencesRouteImport } from './routes/$workspaceName/_auth/settings/preferences'
-import { Route as WorkspaceNameAuthSettingsPeopleRouteImport } from './routes/$workspaceName/_auth/settings/people'
-import { Route as WorkspaceNameAuthSettingsMyMachinesRouteImport } from './routes/$workspaceName/_auth/settings/my-machines'
-import { Route as WorkspaceNameAuthSettingsMcpRouteImport } from './routes/$workspaceName/_auth/settings/mcp'
-import { Route as WorkspaceNameAuthSettingsMachinesRouteImport } from './routes/$workspaceName/_auth/settings/machines'
-import { Route as WorkspaceNameAuthSettingsKeyboardShortcutsRouteImport } from './routes/$workspaceName/_auth/settings/keyboard-shortcuts'
-import { Route as WorkspaceNameAuthSettingsGithubRouteImport } from './routes/$workspaceName/_auth/settings/github'
-import { Route as WorkspaceNameAuthSettingsGeneralRouteImport } from './routes/$workspaceName/_auth/settings/general'
-import { Route as WorkspaceNameAuthSettingsDevicesRouteImport } from './routes/$workspaceName/_auth/settings/devices'
-import { Route as WorkspaceNameAuthSettingsBillingRouteImport } from './routes/$workspaceName/_auth/settings/billing'
-import { Route as WorkspaceNameAuthSettingsAppearanceRouteImport } from './routes/$workspaceName/_auth/settings/appearance'
-import { Route as WorkspaceNameAuthSettingsAiUsageRouteImport } from './routes/$workspaceName/_auth/settings/ai-usage'
-import { Route as WorkspaceNameAuthSettingsAgentsRouteImport } from './routes/$workspaceName/_auth/settings/agents'
-import { Route as WorkspaceNameAuthSettingsAgentRolesRouteImport } from './routes/$workspaceName/_auth/settings/agent-roles'
-import { Route as WorkspaceNameAuthSettingsAgentConfigRouteImport } from './routes/$workspaceName/_auth/settings/agent-config'
-import { Route as WorkspaceNameAuthSettingsAccountRouteImport } from './routes/$workspaceName/_auth/settings/account'
-import { Route as WorkspaceNameAuthSettingsAboutRouteImport } from './routes/$workspaceName/_auth/settings/about'
+import { Route as WorkspaceNameAuthChatRouteImport } from './routes/$workspaceName/_auth/chat'
+import { Route as WorkspaceNameAuthSessionsRouteImport } from './routes/$workspaceName/_auth/sessions'
+import { Route as WorkspaceNameAuthSettingsRouteImport } from './routes/$workspaceName/_auth/settings'
 import { Route as WorkspaceNameAuthSessionsSessionIdRouteImport } from './routes/$workspaceName/_auth/sessions/$sessionId'
+import { Route as WorkspaceNameAuthSettingsIndexRouteImport } from './routes/$workspaceName/_auth/settings.index'
+import { Route as WorkspaceNameAuthSettingsAboutRouteImport } from './routes/$workspaceName/_auth/settings/about'
+import { Route as WorkspaceNameAuthSettingsAccountRouteImport } from './routes/$workspaceName/_auth/settings/account'
+import { Route as WorkspaceNameAuthSettingsAgentConfigRouteImport } from './routes/$workspaceName/_auth/settings/agent-config'
+import { Route as WorkspaceNameAuthSettingsAgentRolesRouteImport } from './routes/$workspaceName/_auth/settings/agent-roles'
+import { Route as WorkspaceNameAuthSettingsAgentsRouteImport } from './routes/$workspaceName/_auth/settings/agents'
+import { Route as WorkspaceNameAuthSettingsAiUsageRouteImport } from './routes/$workspaceName/_auth/settings/ai-usage'
+import { Route as WorkspaceNameAuthSettingsAppearanceRouteImport } from './routes/$workspaceName/_auth/settings/appearance'
+import { Route as WorkspaceNameAuthSettingsBillingRouteImport } from './routes/$workspaceName/_auth/settings/billing'
+import { Route as WorkspaceNameAuthSettingsDevicesRouteImport } from './routes/$workspaceName/_auth/settings/devices'
+import { Route as WorkspaceNameAuthSettingsGeneralRouteImport } from './routes/$workspaceName/_auth/settings/general'
+import { Route as WorkspaceNameAuthSettingsGithubRouteImport } from './routes/$workspaceName/_auth/settings/github'
+import { Route as WorkspaceNameAuthSettingsKeyboardShortcutsRouteImport } from './routes/$workspaceName/_auth/settings/keyboard-shortcuts'
+import { Route as WorkspaceNameAuthSettingsMachinesRouteImport } from './routes/$workspaceName/_auth/settings/machines'
+import { Route as WorkspaceNameAuthSettingsMcpRouteImport } from './routes/$workspaceName/_auth/settings/mcp'
+import { Route as WorkspaceNameAuthSettingsMyMachinesRouteImport } from './routes/$workspaceName/_auth/settings/my-machines'
+import { Route as WorkspaceNameAuthSettingsPeopleRouteImport } from './routes/$workspaceName/_auth/settings/people'
+import { Route as WorkspaceNameAuthSettingsPreferencesRouteImport } from './routes/$workspaceName/_auth/settings/preferences'
+import { Route as WorkspaceNameAuthSettingsProjectsRouteImport } from './routes/$workspaceName/_auth/settings/projects'
+import { Route as WorkspaceNameAuthSettingsStatsRouteImport } from './routes/$workspaceName/_auth/settings/stats'
+import { Route as WorkspaceNameAuthSettingsWorkspaceRouteImport } from './routes/$workspaceName/_auth/settings/workspace'
+import { Route as WorkspaceNameAuthTasksIndexRouteImport } from './routes/$workspaceName/_auth/tasks.index'
+import { Route as WorkspaceNameAuthTasksTaskIdRouteImport } from './routes/$workspaceName/_auth/tasks.$taskId'
 import { Route as WorkspaceNameAuthLocalMachineIdLocalProjectIdRouteImport } from './routes/$workspaceName/_auth/local/$machineId/$localProjectId'
 
-const ResetPasswordRoute = ResetPasswordRouteImport.update({
-  id: '/reset-password',
-  path: '/reset-password',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const OnboardingRoute = OnboardingRouteImport.update({
-  id: '/onboarding',
-  path: '/onboarding',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const NotFoundRoute = NotFoundRouteImport.update({
-  id: '/notFound',
-  path: '/notFound',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LoginRoute = LoginRouteImport.update({
-  id: '/login',
-  path: '/login',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
-  id: '/forgot-password',
-  path: '/forgot-password',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const EmailVerifiedRoute = EmailVerifiedRouteImport.update({
-  id: '/email-verified',
-  path: '/email-verified',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DeviceRoute = DeviceRouteImport.update({
-  id: '/device',
-  path: '/device',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const CompleteEmailRoute = CompleteEmailRouteImport.update({
-  id: '/complete-email',
-  path: '/complete-email',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const AppRoute = AppRouteImport.update({
-  id: '/app',
-  path: '/app',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const WorkspaceNameRoute = WorkspaceNameRouteImport.update({
@@ -107,9 +67,49 @@ const WorkspaceNameRoute = WorkspaceNameRouteImport.update({
   path: '/$workspaceName',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const AppRoute = AppRouteImport.update({
+  id: '/app',
+  path: '/app',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CompleteEmailRoute = CompleteEmailRouteImport.update({
+  id: '/complete-email',
+  path: '/complete-email',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DeviceRoute = DeviceRouteImport.update({
+  id: '/device',
+  path: '/device',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EmailVerifiedRoute = EmailVerifiedRouteImport.update({
+  id: '/email-verified',
+  path: '/email-verified',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
+  id: '/forgot-password',
+  path: '/forgot-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NotFoundRoute = NotFoundRouteImport.update({
+  id: '/notFound',
+  path: '/notFound',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OnboardingRoute = OnboardingRouteImport.update({
+  id: '/onboarding',
+  path: '/onboarding',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ResetPasswordRoute = ResetPasswordRouteImport.update({
+  id: '/reset-password',
+  path: '/reset-password',
   getParentRoute: () => rootRouteImport,
 } as any)
 const WorkspaceNameIndexRoute = WorkspaceNameIndexRouteImport.update({
@@ -117,19 +117,13 @@ const WorkspaceNameIndexRoute = WorkspaceNameIndexRouteImport.update({
   path: '/',
   getParentRoute: () => WorkspaceNameRoute,
 } as any)
-const WorkspaceCreateRoute = WorkspaceCreateRouteImport.update({
-  id: '/workspace/create',
-  path: '/workspace/create',
-  getParentRoute: () => rootRouteImport,
+const WorkspaceNameAuthRoute = WorkspaceNameAuthRouteImport.update({
+  id: '/_auth',
+  getParentRoute: () => WorkspaceNameRoute,
 } as any)
-const JoinTokenRoute = JoinTokenRouteImport.update({
-  id: '/join/$token',
-  path: '/join/$token',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const InviteInvitationIdRoute = InviteInvitationIdRouteImport.update({
-  id: '/invite/$invitationId',
-  path: '/invite/$invitationId',
+const DesktopCheckoutReturnRoute = DesktopCheckoutReturnRouteImport.update({
+  id: '/desktop/checkout-return',
+  path: '/desktop/checkout-return',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DesktopGithubInstallRoute = DesktopGithubInstallRouteImport.update({
@@ -137,31 +131,20 @@ const DesktopGithubInstallRoute = DesktopGithubInstallRouteImport.update({
   path: '/desktop/github-install',
   getParentRoute: () => rootRouteImport,
 } as any)
-const DesktopCheckoutReturnRoute = DesktopCheckoutReturnRouteImport.update({
-  id: '/desktop/checkout-return',
-  path: '/desktop/checkout-return',
+const InviteInvitationIdRoute = InviteInvitationIdRouteImport.update({
+  id: '/invite/$invitationId',
+  path: '/invite/$invitationId',
   getParentRoute: () => rootRouteImport,
 } as any)
-const WorkspaceNameAuthRoute = WorkspaceNameAuthRouteImport.update({
-  id: '/_auth',
-  getParentRoute: () => WorkspaceNameRoute,
+const JoinTokenRoute = JoinTokenRouteImport.update({
+  id: '/join/$token',
+  path: '/join/$token',
+  getParentRoute: () => rootRouteImport,
 } as any)
-const WorkspaceNameAuthSettingsRoute =
-  WorkspaceNameAuthSettingsRouteImport.update({
-    id: '/settings',
-    path: '/settings',
-    getParentRoute: () => WorkspaceNameAuthRoute,
-  } as any)
-const WorkspaceNameAuthSessionsRoute =
-  WorkspaceNameAuthSessionsRouteImport.update({
-    id: '/sessions',
-    path: '/sessions',
-    getParentRoute: () => WorkspaceNameAuthRoute,
-  } as any)
-const WorkspaceNameAuthChatRoute = WorkspaceNameAuthChatRouteImport.update({
-  id: '/chat',
-  path: '/chat',
-  getParentRoute: () => WorkspaceNameAuthRoute,
+const WorkspaceCreateRoute = WorkspaceCreateRouteImport.update({
+  id: '/workspace/create',
+  path: '/workspace/create',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const WorkspaceNameAuthArchiveRoute =
   WorkspaceNameAuthArchiveRouteImport.update({
@@ -169,136 +152,33 @@ const WorkspaceNameAuthArchiveRoute =
     path: '/archive',
     getParentRoute: () => WorkspaceNameAuthRoute,
   } as any)
-const WorkspaceNameAuthTasksIndexRoute =
-  WorkspaceNameAuthTasksIndexRouteImport.update({
-    id: '/tasks/',
-    path: '/tasks/',
+const WorkspaceNameAuthChatRoute = WorkspaceNameAuthChatRouteImport.update({
+  id: '/chat',
+  path: '/chat',
+  getParentRoute: () => WorkspaceNameAuthRoute,
+} as any)
+const WorkspaceNameAuthSessionsRoute =
+  WorkspaceNameAuthSessionsRouteImport.update({
+    id: '/sessions',
+    path: '/sessions',
     getParentRoute: () => WorkspaceNameAuthRoute,
+  } as any)
+const WorkspaceNameAuthSettingsRoute =
+  WorkspaceNameAuthSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => WorkspaceNameAuthRoute,
+  } as any)
+const WorkspaceNameAuthSessionsSessionIdRoute =
+  WorkspaceNameAuthSessionsSessionIdRouteImport.update({
+    id: '/$sessionId',
+    path: '/$sessionId',
+    getParentRoute: () => WorkspaceNameAuthSessionsRoute,
   } as any)
 const WorkspaceNameAuthSettingsIndexRoute =
   WorkspaceNameAuthSettingsIndexRouteImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthTasksTaskIdRoute =
-  WorkspaceNameAuthTasksTaskIdRouteImport.update({
-    id: '/tasks/$taskId',
-    path: '/tasks/$taskId',
-    getParentRoute: () => WorkspaceNameAuthRoute,
-  } as any)
-const WorkspaceNameAuthSettingsWorkspaceRoute =
-  WorkspaceNameAuthSettingsWorkspaceRouteImport.update({
-    id: '/workspace',
-    path: '/workspace',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsStatsRoute =
-  WorkspaceNameAuthSettingsStatsRouteImport.update({
-    id: '/stats',
-    path: '/stats',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsProjectsRoute =
-  WorkspaceNameAuthSettingsProjectsRouteImport.update({
-    id: '/projects',
-    path: '/projects',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsPreferencesRoute =
-  WorkspaceNameAuthSettingsPreferencesRouteImport.update({
-    id: '/preferences',
-    path: '/preferences',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsPeopleRoute =
-  WorkspaceNameAuthSettingsPeopleRouteImport.update({
-    id: '/people',
-    path: '/people',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsMyMachinesRoute =
-  WorkspaceNameAuthSettingsMyMachinesRouteImport.update({
-    id: '/my-machines',
-    path: '/my-machines',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsMcpRoute =
-  WorkspaceNameAuthSettingsMcpRouteImport.update({
-    id: '/mcp',
-    path: '/mcp',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsMachinesRoute =
-  WorkspaceNameAuthSettingsMachinesRouteImport.update({
-    id: '/machines',
-    path: '/machines',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsKeyboardShortcutsRoute =
-  WorkspaceNameAuthSettingsKeyboardShortcutsRouteImport.update({
-    id: '/keyboard-shortcuts',
-    path: '/keyboard-shortcuts',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsGithubRoute =
-  WorkspaceNameAuthSettingsGithubRouteImport.update({
-    id: '/github',
-    path: '/github',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsGeneralRoute =
-  WorkspaceNameAuthSettingsGeneralRouteImport.update({
-    id: '/general',
-    path: '/general',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsDevicesRoute =
-  WorkspaceNameAuthSettingsDevicesRouteImport.update({
-    id: '/devices',
-    path: '/devices',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsBillingRoute =
-  WorkspaceNameAuthSettingsBillingRouteImport.update({
-    id: '/billing',
-    path: '/billing',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsAppearanceRoute =
-  WorkspaceNameAuthSettingsAppearanceRouteImport.update({
-    id: '/appearance',
-    path: '/appearance',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsAiUsageRoute =
-  WorkspaceNameAuthSettingsAiUsageRouteImport.update({
-    id: '/ai-usage',
-    path: '/ai-usage',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsAgentsRoute =
-  WorkspaceNameAuthSettingsAgentsRouteImport.update({
-    id: '/agents',
-    path: '/agents',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsAgentRolesRoute =
-  WorkspaceNameAuthSettingsAgentRolesRouteImport.update({
-    id: '/agent-roles',
-    path: '/agent-roles',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsAgentConfigRoute =
-  WorkspaceNameAuthSettingsAgentConfigRouteImport.update({
-    id: '/agent-config',
-    path: '/agent-config',
-    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
-  } as any)
-const WorkspaceNameAuthSettingsAccountRoute =
-  WorkspaceNameAuthSettingsAccountRouteImport.update({
-    id: '/account',
-    path: '/account',
     getParentRoute: () => WorkspaceNameAuthSettingsRoute,
   } as any)
 const WorkspaceNameAuthSettingsAboutRoute =
@@ -307,11 +187,131 @@ const WorkspaceNameAuthSettingsAboutRoute =
     path: '/about',
     getParentRoute: () => WorkspaceNameAuthSettingsRoute,
   } as any)
-const WorkspaceNameAuthSessionsSessionIdRoute =
-  WorkspaceNameAuthSessionsSessionIdRouteImport.update({
-    id: '/$sessionId',
-    path: '/$sessionId',
-    getParentRoute: () => WorkspaceNameAuthSessionsRoute,
+const WorkspaceNameAuthSettingsAccountRoute =
+  WorkspaceNameAuthSettingsAccountRouteImport.update({
+    id: '/account',
+    path: '/account',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsAgentConfigRoute =
+  WorkspaceNameAuthSettingsAgentConfigRouteImport.update({
+    id: '/agent-config',
+    path: '/agent-config',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsAgentRolesRoute =
+  WorkspaceNameAuthSettingsAgentRolesRouteImport.update({
+    id: '/agent-roles',
+    path: '/agent-roles',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsAgentsRoute =
+  WorkspaceNameAuthSettingsAgentsRouteImport.update({
+    id: '/agents',
+    path: '/agents',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsAiUsageRoute =
+  WorkspaceNameAuthSettingsAiUsageRouteImport.update({
+    id: '/ai-usage',
+    path: '/ai-usage',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsAppearanceRoute =
+  WorkspaceNameAuthSettingsAppearanceRouteImport.update({
+    id: '/appearance',
+    path: '/appearance',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsBillingRoute =
+  WorkspaceNameAuthSettingsBillingRouteImport.update({
+    id: '/billing',
+    path: '/billing',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsDevicesRoute =
+  WorkspaceNameAuthSettingsDevicesRouteImport.update({
+    id: '/devices',
+    path: '/devices',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsGeneralRoute =
+  WorkspaceNameAuthSettingsGeneralRouteImport.update({
+    id: '/general',
+    path: '/general',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsGithubRoute =
+  WorkspaceNameAuthSettingsGithubRouteImport.update({
+    id: '/github',
+    path: '/github',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsKeyboardShortcutsRoute =
+  WorkspaceNameAuthSettingsKeyboardShortcutsRouteImport.update({
+    id: '/keyboard-shortcuts',
+    path: '/keyboard-shortcuts',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsMachinesRoute =
+  WorkspaceNameAuthSettingsMachinesRouteImport.update({
+    id: '/machines',
+    path: '/machines',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsMcpRoute =
+  WorkspaceNameAuthSettingsMcpRouteImport.update({
+    id: '/mcp',
+    path: '/mcp',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsMyMachinesRoute =
+  WorkspaceNameAuthSettingsMyMachinesRouteImport.update({
+    id: '/my-machines',
+    path: '/my-machines',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsPeopleRoute =
+  WorkspaceNameAuthSettingsPeopleRouteImport.update({
+    id: '/people',
+    path: '/people',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsPreferencesRoute =
+  WorkspaceNameAuthSettingsPreferencesRouteImport.update({
+    id: '/preferences',
+    path: '/preferences',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsProjectsRoute =
+  WorkspaceNameAuthSettingsProjectsRouteImport.update({
+    id: '/projects',
+    path: '/projects',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsStatsRoute =
+  WorkspaceNameAuthSettingsStatsRouteImport.update({
+    id: '/stats',
+    path: '/stats',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthSettingsWorkspaceRoute =
+  WorkspaceNameAuthSettingsWorkspaceRouteImport.update({
+    id: '/workspace',
+    path: '/workspace',
+    getParentRoute: () => WorkspaceNameAuthSettingsRoute,
+  } as any)
+const WorkspaceNameAuthTasksIndexRoute =
+  WorkspaceNameAuthTasksIndexRouteImport.update({
+    id: '/tasks/',
+    path: '/tasks/',
+    getParentRoute: () => WorkspaceNameAuthRoute,
+  } as any)
+const WorkspaceNameAuthTasksTaskIdRoute =
+  WorkspaceNameAuthTasksTaskIdRouteImport.update({
+    id: '/tasks/$taskId',
+    path: '/tasks/$taskId',
+    getParentRoute: () => WorkspaceNameAuthRoute,
   } as any)
 const WorkspaceNameAuthLocalMachineIdLocalProjectIdRoute =
   WorkspaceNameAuthLocalMachineIdLocalProjectIdRouteImport.update({
@@ -322,7 +322,7 @@ const WorkspaceNameAuthLocalMachineIdLocalProjectIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/$workspaceName': typeof WorkspaceNameAuthRouteWithChildren
+  '/$workspaceName': typeof WorkspaceNameRouteWithChildren
   '/app': typeof AppRoute
   '/complete-email': typeof CompleteEmailRoute
   '/device': typeof DeviceRoute
@@ -631,67 +631,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/reset-password': {
-      id: '/reset-password'
-      path: '/reset-password'
-      fullPath: '/reset-password'
-      preLoaderRoute: typeof ResetPasswordRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/onboarding': {
-      id: '/onboarding'
-      path: '/onboarding'
-      fullPath: '/onboarding'
-      preLoaderRoute: typeof OnboardingRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/notFound': {
-      id: '/notFound'
-      path: '/notFound'
-      fullPath: '/notFound'
-      preLoaderRoute: typeof NotFoundRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/forgot-password': {
-      id: '/forgot-password'
-      path: '/forgot-password'
-      fullPath: '/forgot-password'
-      preLoaderRoute: typeof ForgotPasswordRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/email-verified': {
-      id: '/email-verified'
-      path: '/email-verified'
-      fullPath: '/email-verified'
-      preLoaderRoute: typeof EmailVerifiedRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/device': {
-      id: '/device'
-      path: '/device'
-      fullPath: '/device'
-      preLoaderRoute: typeof DeviceRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/complete-email': {
-      id: '/complete-email'
-      path: '/complete-email'
-      fullPath: '/complete-email'
-      preLoaderRoute: typeof CompleteEmailRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/app': {
-      id: '/app'
-      path: '/app'
-      fullPath: '/app'
-      preLoaderRoute: typeof AppRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$workspaceName': {
@@ -701,11 +645,67 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspaceNameRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/app': {
+      id: '/app'
+      path: '/app'
+      fullPath: '/app'
+      preLoaderRoute: typeof AppRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/complete-email': {
+      id: '/complete-email'
+      path: '/complete-email'
+      fullPath: '/complete-email'
+      preLoaderRoute: typeof CompleteEmailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/device': {
+      id: '/device'
+      path: '/device'
+      fullPath: '/device'
+      preLoaderRoute: typeof DeviceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/email-verified': {
+      id: '/email-verified'
+      path: '/email-verified'
+      fullPath: '/email-verified'
+      preLoaderRoute: typeof EmailVerifiedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/forgot-password': {
+      id: '/forgot-password'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof ForgotPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/notFound': {
+      id: '/notFound'
+      path: '/notFound'
+      fullPath: '/notFound'
+      preLoaderRoute: typeof NotFoundRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/onboarding': {
+      id: '/onboarding'
+      path: '/onboarding'
+      fullPath: '/onboarding'
+      preLoaderRoute: typeof OnboardingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/reset-password': {
+      id: '/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof ResetPasswordRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/$workspaceName/': {
@@ -715,25 +715,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspaceNameIndexRouteImport
       parentRoute: typeof WorkspaceNameRoute
     }
-    '/workspace/create': {
-      id: '/workspace/create'
-      path: '/workspace/create'
-      fullPath: '/workspace/create'
-      preLoaderRoute: typeof WorkspaceCreateRouteImport
-      parentRoute: typeof rootRouteImport
+    '/$workspaceName/_auth': {
+      id: '/$workspaceName/_auth'
+      path: ''
+      fullPath: '/$workspaceName'
+      preLoaderRoute: typeof WorkspaceNameAuthRouteImport
+      parentRoute: typeof WorkspaceNameRoute
     }
-    '/join/$token': {
-      id: '/join/$token'
-      path: '/join/$token'
-      fullPath: '/join/$token'
-      preLoaderRoute: typeof JoinTokenRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/invite/$invitationId': {
-      id: '/invite/$invitationId'
-      path: '/invite/$invitationId'
-      fullPath: '/invite/$invitationId'
-      preLoaderRoute: typeof InviteInvitationIdRouteImport
+    '/desktop/checkout-return': {
+      id: '/desktop/checkout-return'
+      path: '/desktop/checkout-return'
+      fullPath: '/desktop/checkout-return'
+      preLoaderRoute: typeof DesktopCheckoutReturnRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/desktop/github-install': {
@@ -743,32 +736,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DesktopGithubInstallRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/desktop/checkout-return': {
-      id: '/desktop/checkout-return'
-      path: '/desktop/checkout-return'
-      fullPath: '/desktop/checkout-return'
-      preLoaderRoute: typeof DesktopCheckoutReturnRouteImport
+    '/invite/$invitationId': {
+      id: '/invite/$invitationId'
+      path: '/invite/$invitationId'
+      fullPath: '/invite/$invitationId'
+      preLoaderRoute: typeof InviteInvitationIdRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/$workspaceName/_auth': {
-      id: '/$workspaceName/_auth'
-      path: ''
-      fullPath: '/$workspaceName'
-      preLoaderRoute: typeof WorkspaceNameAuthRouteImport
-      parentRoute: typeof WorkspaceNameRoute
+    '/join/$token': {
+      id: '/join/$token'
+      path: '/join/$token'
+      fullPath: '/join/$token'
+      preLoaderRoute: typeof JoinTokenRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/$workspaceName/_auth/settings': {
-      id: '/$workspaceName/_auth/settings'
-      path: '/settings'
-      fullPath: '/$workspaceName/settings'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsRouteImport
-      parentRoute: typeof WorkspaceNameAuthRoute
+    '/workspace/create': {
+      id: '/workspace/create'
+      path: '/workspace/create'
+      fullPath: '/workspace/create'
+      preLoaderRoute: typeof WorkspaceCreateRouteImport
+      parentRoute: typeof rootRouteImport
     }
-    '/$workspaceName/_auth/sessions': {
-      id: '/$workspaceName/_auth/sessions'
-      path: '/sessions'
-      fullPath: '/$workspaceName/sessions'
-      preLoaderRoute: typeof WorkspaceNameAuthSessionsRouteImport
+    '/$workspaceName/_auth/archive': {
+      id: '/$workspaceName/_auth/archive'
+      path: '/archive'
+      fullPath: '/$workspaceName/archive'
+      preLoaderRoute: typeof WorkspaceNameAuthArchiveRouteImport
       parentRoute: typeof WorkspaceNameAuthRoute
     }
     '/$workspaceName/_auth/chat': {
@@ -778,165 +771,32 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspaceNameAuthChatRouteImport
       parentRoute: typeof WorkspaceNameAuthRoute
     }
-    '/$workspaceName/_auth/archive': {
-      id: '/$workspaceName/_auth/archive'
-      path: '/archive'
-      fullPath: '/$workspaceName/archive'
-      preLoaderRoute: typeof WorkspaceNameAuthArchiveRouteImport
+    '/$workspaceName/_auth/sessions': {
+      id: '/$workspaceName/_auth/sessions'
+      path: '/sessions'
+      fullPath: '/$workspaceName/sessions'
+      preLoaderRoute: typeof WorkspaceNameAuthSessionsRouteImport
       parentRoute: typeof WorkspaceNameAuthRoute
     }
-    '/$workspaceName/_auth/tasks/': {
-      id: '/$workspaceName/_auth/tasks/'
-      path: '/tasks'
-      fullPath: '/$workspaceName/tasks/'
-      preLoaderRoute: typeof WorkspaceNameAuthTasksIndexRouteImport
+    '/$workspaceName/_auth/settings': {
+      id: '/$workspaceName/_auth/settings'
+      path: '/settings'
+      fullPath: '/$workspaceName/settings'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsRouteImport
       parentRoute: typeof WorkspaceNameAuthRoute
+    }
+    '/$workspaceName/_auth/sessions/$sessionId': {
+      id: '/$workspaceName/_auth/sessions/$sessionId'
+      path: '/$sessionId'
+      fullPath: '/$workspaceName/sessions/$sessionId'
+      preLoaderRoute: typeof WorkspaceNameAuthSessionsSessionIdRouteImport
+      parentRoute: typeof WorkspaceNameAuthSessionsRoute
     }
     '/$workspaceName/_auth/settings/': {
       id: '/$workspaceName/_auth/settings/'
       path: '/'
       fullPath: '/$workspaceName/settings/'
       preLoaderRoute: typeof WorkspaceNameAuthSettingsIndexRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/tasks/$taskId': {
-      id: '/$workspaceName/_auth/tasks/$taskId'
-      path: '/tasks/$taskId'
-      fullPath: '/$workspaceName/tasks/$taskId'
-      preLoaderRoute: typeof WorkspaceNameAuthTasksTaskIdRouteImport
-      parentRoute: typeof WorkspaceNameAuthRoute
-    }
-    '/$workspaceName/_auth/settings/workspace': {
-      id: '/$workspaceName/_auth/settings/workspace'
-      path: '/workspace'
-      fullPath: '/$workspaceName/settings/workspace'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsWorkspaceRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/stats': {
-      id: '/$workspaceName/_auth/settings/stats'
-      path: '/stats'
-      fullPath: '/$workspaceName/settings/stats'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsStatsRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/projects': {
-      id: '/$workspaceName/_auth/settings/projects'
-      path: '/projects'
-      fullPath: '/$workspaceName/settings/projects'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsProjectsRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/preferences': {
-      id: '/$workspaceName/_auth/settings/preferences'
-      path: '/preferences'
-      fullPath: '/$workspaceName/settings/preferences'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsPreferencesRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/people': {
-      id: '/$workspaceName/_auth/settings/people'
-      path: '/people'
-      fullPath: '/$workspaceName/settings/people'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsPeopleRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/my-machines': {
-      id: '/$workspaceName/_auth/settings/my-machines'
-      path: '/my-machines'
-      fullPath: '/$workspaceName/settings/my-machines'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsMyMachinesRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/mcp': {
-      id: '/$workspaceName/_auth/settings/mcp'
-      path: '/mcp'
-      fullPath: '/$workspaceName/settings/mcp'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsMcpRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/machines': {
-      id: '/$workspaceName/_auth/settings/machines'
-      path: '/machines'
-      fullPath: '/$workspaceName/settings/machines'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsMachinesRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/keyboard-shortcuts': {
-      id: '/$workspaceName/_auth/settings/keyboard-shortcuts'
-      path: '/keyboard-shortcuts'
-      fullPath: '/$workspaceName/settings/keyboard-shortcuts'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsKeyboardShortcutsRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/github': {
-      id: '/$workspaceName/_auth/settings/github'
-      path: '/github'
-      fullPath: '/$workspaceName/settings/github'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsGithubRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/general': {
-      id: '/$workspaceName/_auth/settings/general'
-      path: '/general'
-      fullPath: '/$workspaceName/settings/general'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsGeneralRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/devices': {
-      id: '/$workspaceName/_auth/settings/devices'
-      path: '/devices'
-      fullPath: '/$workspaceName/settings/devices'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsDevicesRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/billing': {
-      id: '/$workspaceName/_auth/settings/billing'
-      path: '/billing'
-      fullPath: '/$workspaceName/settings/billing'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsBillingRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/appearance': {
-      id: '/$workspaceName/_auth/settings/appearance'
-      path: '/appearance'
-      fullPath: '/$workspaceName/settings/appearance'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsAppearanceRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/ai-usage': {
-      id: '/$workspaceName/_auth/settings/ai-usage'
-      path: '/ai-usage'
-      fullPath: '/$workspaceName/settings/ai-usage'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsAiUsageRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/agents': {
-      id: '/$workspaceName/_auth/settings/agents'
-      path: '/agents'
-      fullPath: '/$workspaceName/settings/agents'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsAgentsRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/agent-roles': {
-      id: '/$workspaceName/_auth/settings/agent-roles'
-      path: '/agent-roles'
-      fullPath: '/$workspaceName/settings/agent-roles'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsAgentRolesRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/agent-config': {
-      id: '/$workspaceName/_auth/settings/agent-config'
-      path: '/agent-config'
-      fullPath: '/$workspaceName/settings/agent-config'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsAgentConfigRouteImport
-      parentRoute: typeof WorkspaceNameAuthSettingsRoute
-    }
-    '/$workspaceName/_auth/settings/account': {
-      id: '/$workspaceName/_auth/settings/account'
-      path: '/account'
-      fullPath: '/$workspaceName/settings/account'
-      preLoaderRoute: typeof WorkspaceNameAuthSettingsAccountRouteImport
       parentRoute: typeof WorkspaceNameAuthSettingsRoute
     }
     '/$workspaceName/_auth/settings/about': {
@@ -946,12 +806,152 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WorkspaceNameAuthSettingsAboutRouteImport
       parentRoute: typeof WorkspaceNameAuthSettingsRoute
     }
-    '/$workspaceName/_auth/sessions/$sessionId': {
-      id: '/$workspaceName/_auth/sessions/$sessionId'
-      path: '/$sessionId'
-      fullPath: '/$workspaceName/sessions/$sessionId'
-      preLoaderRoute: typeof WorkspaceNameAuthSessionsSessionIdRouteImport
-      parentRoute: typeof WorkspaceNameAuthSessionsRoute
+    '/$workspaceName/_auth/settings/account': {
+      id: '/$workspaceName/_auth/settings/account'
+      path: '/account'
+      fullPath: '/$workspaceName/settings/account'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsAccountRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/agent-config': {
+      id: '/$workspaceName/_auth/settings/agent-config'
+      path: '/agent-config'
+      fullPath: '/$workspaceName/settings/agent-config'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsAgentConfigRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/agent-roles': {
+      id: '/$workspaceName/_auth/settings/agent-roles'
+      path: '/agent-roles'
+      fullPath: '/$workspaceName/settings/agent-roles'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsAgentRolesRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/agents': {
+      id: '/$workspaceName/_auth/settings/agents'
+      path: '/agents'
+      fullPath: '/$workspaceName/settings/agents'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsAgentsRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/ai-usage': {
+      id: '/$workspaceName/_auth/settings/ai-usage'
+      path: '/ai-usage'
+      fullPath: '/$workspaceName/settings/ai-usage'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsAiUsageRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/appearance': {
+      id: '/$workspaceName/_auth/settings/appearance'
+      path: '/appearance'
+      fullPath: '/$workspaceName/settings/appearance'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsAppearanceRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/billing': {
+      id: '/$workspaceName/_auth/settings/billing'
+      path: '/billing'
+      fullPath: '/$workspaceName/settings/billing'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsBillingRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/devices': {
+      id: '/$workspaceName/_auth/settings/devices'
+      path: '/devices'
+      fullPath: '/$workspaceName/settings/devices'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsDevicesRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/general': {
+      id: '/$workspaceName/_auth/settings/general'
+      path: '/general'
+      fullPath: '/$workspaceName/settings/general'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsGeneralRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/github': {
+      id: '/$workspaceName/_auth/settings/github'
+      path: '/github'
+      fullPath: '/$workspaceName/settings/github'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsGithubRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/keyboard-shortcuts': {
+      id: '/$workspaceName/_auth/settings/keyboard-shortcuts'
+      path: '/keyboard-shortcuts'
+      fullPath: '/$workspaceName/settings/keyboard-shortcuts'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsKeyboardShortcutsRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/machines': {
+      id: '/$workspaceName/_auth/settings/machines'
+      path: '/machines'
+      fullPath: '/$workspaceName/settings/machines'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsMachinesRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/mcp': {
+      id: '/$workspaceName/_auth/settings/mcp'
+      path: '/mcp'
+      fullPath: '/$workspaceName/settings/mcp'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsMcpRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/my-machines': {
+      id: '/$workspaceName/_auth/settings/my-machines'
+      path: '/my-machines'
+      fullPath: '/$workspaceName/settings/my-machines'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsMyMachinesRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/people': {
+      id: '/$workspaceName/_auth/settings/people'
+      path: '/people'
+      fullPath: '/$workspaceName/settings/people'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsPeopleRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/preferences': {
+      id: '/$workspaceName/_auth/settings/preferences'
+      path: '/preferences'
+      fullPath: '/$workspaceName/settings/preferences'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsPreferencesRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/projects': {
+      id: '/$workspaceName/_auth/settings/projects'
+      path: '/projects'
+      fullPath: '/$workspaceName/settings/projects'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsProjectsRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/stats': {
+      id: '/$workspaceName/_auth/settings/stats'
+      path: '/stats'
+      fullPath: '/$workspaceName/settings/stats'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsStatsRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/settings/workspace': {
+      id: '/$workspaceName/_auth/settings/workspace'
+      path: '/workspace'
+      fullPath: '/$workspaceName/settings/workspace'
+      preLoaderRoute: typeof WorkspaceNameAuthSettingsWorkspaceRouteImport
+      parentRoute: typeof WorkspaceNameAuthSettingsRoute
+    }
+    '/$workspaceName/_auth/tasks/': {
+      id: '/$workspaceName/_auth/tasks/'
+      path: '/tasks'
+      fullPath: '/$workspaceName/tasks/'
+      preLoaderRoute: typeof WorkspaceNameAuthTasksIndexRouteImport
+      parentRoute: typeof WorkspaceNameAuthRoute
+    }
+    '/$workspaceName/_auth/tasks/$taskId': {
+      id: '/$workspaceName/_auth/tasks/$taskId'
+      path: '/tasks/$taskId'
+      fullPath: '/$workspaceName/tasks/$taskId'
+      preLoaderRoute: typeof WorkspaceNameAuthTasksTaskIdRouteImport
+      parentRoute: typeof WorkspaceNameAuthRoute
     }
     '/$workspaceName/_auth/local/$machineId/$localProjectId': {
       id: '/$workspaceName/_auth/local/$machineId/$localProjectId'

--- a/packages/components/src/routes/$workspaceName.tsx
+++ b/packages/components/src/routes/$workspaceName.tsx
@@ -27,6 +27,7 @@ import {
 } from '@lody/shared';
 import { isLocalAppPlatform } from '@/lib/app-platform';
 import { WorkspaceRouteTargetProvider } from '../providers/workspace-route-target';
+import { RuntimeProvider } from '../providers/runtime-provider';
 import {
   getLocalWorkspaceSlug,
   useLocalPlatformWorkspacesState,
@@ -98,7 +99,9 @@ function WorkspaceGuardRoute() {
   // runtime effects converge. Descendants use it to reject previous-scope data.
   return (
     <WorkspaceRouteTargetProvider slug={workspaceName}>
-      {isLocalAppPlatform() ? <LocalWorkspaceGuardRoute /> : <CloudWorkspaceGuardRoute />}
+      <RuntimeProvider>
+        {isLocalAppPlatform() ? <LocalWorkspaceGuardRoute /> : <CloudWorkspaceGuardRoute />}
+      </RuntimeProvider>
     </WorkspaceRouteTargetProvider>
   );
 }

--- a/packages/components/src/routes/$workspaceName/_auth/sessions.tsx
+++ b/packages/components/src/routes/$workspaceName/_auth/sessions.tsx
@@ -4,7 +4,7 @@ export const Route = createFileRoute('/$workspaceName/_auth/sessions')({
   component: SessionsRoute,
 });
 
-export function SessionsRoute() {
+function SessionsRoute() {
   const matchRoute = useMatchRoute();
   const { workspaceName } = Route.useParams();
 

--- a/packages/components/src/routes/$workspaceName/_auth/settings.tsx
+++ b/packages/components/src/routes/$workspaceName/_auth/settings.tsx
@@ -37,7 +37,7 @@ function isSettingsListPath(pathname: string, workspaceName: string): boolean {
   return pathname === `/${workspaceName}/settings` || pathname === `/${workspaceName}/settings/`;
 }
 
-export function SettingsLayoutComponent() {
+function SettingsLayoutComponent() {
   const { t } = useTranslation();
   const location = useLocation();
   const navigate = useNavigate();
@@ -122,9 +122,7 @@ export function SettingsLayoutComponent() {
     if (isMobile) return;
     setSettingsModalTab(activeTabId ?? SETTINGS_DEFAULT_TAB);
     setSettingsMachineTarget(
-      typeof locationSearch.machine === 'string'
-        ? (locationSearch.machine as MachineId)
-        : null
+      typeof locationSearch.machine === 'string' ? (locationSearch.machine as MachineId) : null
     );
     setSettingsProjectTarget(
       typeof locationSearch.project === 'string' ? locationSearch.project : null
@@ -175,8 +173,8 @@ export function SettingsLayoutComponent() {
   const mobileTitle = settingsListPage
     ? t('settings.title')
     : activeTab
-    ? t(activeTab.labelKey)
-    : t('settings.title');
+      ? t(activeTab.labelKey)
+      : t('settings.title');
 
   /* Workspace tabbar (本地 / GitHub / Chat / 设置) navigates back to the
      chat landing for the first three tabs; the 设置 tab is a no-op

--- a/packages/components/src/routes/$workspaceName/_auth/settings/billing.tsx
+++ b/packages/components/src/routes/$workspaceName/_auth/settings/billing.tsx
@@ -6,7 +6,7 @@ export const Route = createFileRoute('/$workspaceName/_auth/settings/billing')({
   component: BillingSettingsRoute,
 });
 
-export function BillingSettingsRoute() {
+function BillingSettingsRoute() {
   const { workspaceName } = Route.useParams();
 
   if (isNativeAppShell()) {

--- a/packages/components/src/routes/__root.tsx
+++ b/packages/components/src/routes/__root.tsx
@@ -12,7 +12,6 @@ import { LanguageProvider } from '../i18n';
 import { Toaster } from '@/ui/sonner';
 import { NotFound } from '@/components/not-found';
 import { TooltipProvider } from '@/ui';
-import { RuntimeProvider } from '../providers/runtime-provider';
 import { markStartupNavigationForEagerSync } from '../providers/startup-network-idle';
 import { trackDeferredPostHogPageView } from '../lib/deferred-posthog';
 import { scheduleIdleTask } from '../lib/idle-task';
@@ -214,13 +213,12 @@ function RootApp() {
             <LanguageProvider>
               <>
                 <Toaster />
-                <RuntimeProvider>
-                  {/* Location-driven effects and the Outlet boundary subscribe to
-                      router state in these two small components, so a navigation
-                      no longer re-renders the whole provider stack above. */}
-                  <RootLocationEffects />
-                  <RootOutletBoundary />
-                </RuntimeProvider>
+                {/* Location-driven effects and the Outlet boundary subscribe to
+                    router state in these two small components, so a navigation
+                    no longer re-renders the whole provider stack above. Workspace
+                    runtime ownership starts at the workspace route layout. */}
+                <RootLocationEffects />
+                <RootOutletBoundary />
                 {/* <TanStackRouterDevtools /> */}
               </>
             </LanguageProvider>

--- a/packages/components/src/routes/invite/$invitationId.tsx
+++ b/packages/components/src/routes/invite/$invitationId.tsx
@@ -36,7 +36,7 @@ function isEmailVerificationRequiredError(
  * 接受邀请页面组件
  * 处理工作空间邀请的接受流程
  */
-export function AcceptInvitationComponent() {
+function AcceptInvitationComponent() {
   const { t } = useTranslation();
   const authClient = useAuthClient();
   const signOut = useAuthSignOut();

--- a/packages/components/src/routes/join/$token.tsx
+++ b/packages/components/src/routes/join/$token.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute('/join/$token')({
   component: WorkspaceJoinRequestRoute,
 });
 
-export function WorkspaceJoinRequestRoute() {
+function WorkspaceJoinRequestRoute() {
   const { token } = Route.useParams();
   const navigate = useNavigate();
   const authClient = useAuthClient();

--- a/packages/components/tests/billing-settings-route.test.tsx
+++ b/packages/components/tests/billing-settings-route.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, createElement } from 'react';
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -15,6 +15,7 @@ const originalInnerWidth = window.innerWidth;
 vi.mock('@tanstack/react-router', () => ({
   createFileRoute: () => (options: { component: () => ReactNode }) => ({
     ...options,
+    options,
     useParams: () => routerState,
   }),
   Navigate: (props: Record<string, unknown>) => {
@@ -27,7 +28,9 @@ vi.mock('../src/components/settings/billing-setting', () => ({
   BillingSettingsComponent: () => createElement('p', null, 'billing-settings'),
 }));
 
-import { BillingSettingsRoute } from '../src/routes/$workspaceName/_auth/settings/billing';
+import { Route } from '../src/routes/$workspaceName/_auth/settings/billing';
+
+const BillingSettingsRoute = Route.options.component as ComponentType;
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }

--- a/packages/components/tests/workspace-join-request-route.test.tsx
+++ b/packages/components/tests/workspace-join-request-route.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act } from 'react';
+import type { ComponentType } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { initI18n } from '../src/i18n';
@@ -17,10 +18,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@tanstack/react-router', () => ({
-  createFileRoute: () => (options: Record<string, unknown>) => ({
-    ...options,
-    useParams: () => ({ token: 'open-token' }),
-  }),
+  createFileRoute: () => (options: Record<string, unknown>) => {
+    return {
+      ...options,
+      options,
+      useParams: () => ({ token: 'open-token' }),
+    };
+  },
   useNavigate: () => mocks.navigate,
 }));
 
@@ -42,7 +46,9 @@ vi.mock('../src/lib/auth', () => ({
   signOutWithoutRedirect: (...args: unknown[]) => mocks.signOutWithoutRedirect(...args),
 }));
 
-import { WorkspaceJoinRequestRoute } from '../src/routes/join/$token';
+import { Route } from '../src/routes/join/$token';
+
+const WorkspaceJoinRequestRoute = Route.options.component as ComponentType;
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -492,6 +492,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@7.3.1(@types/node@24.10.12)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.23.7)(yaml@2.8.2))
+      '@tanstack/router-plugin':
+        specifier: 'catalog:'
+        version: 1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@7.3.1(@types/node@24.10.12)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.23.7)(yaml@2.8.2))
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.12
@@ -16909,6 +16912,31 @@ snapshots:
       - supports-color
       - unloader
 
+  '@tanstack/router-plugin@1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@7.3.1(@types/node@24.10.12)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.23.7)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.171.15
+      '@tanstack/router-generator': 1.167.21
+      '@tanstack/router-utils': 1.162.2
+      chokidar: 5.0.0
+      unplugin: 3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@7.3.1(@types/node@24.10.12)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.23.7)(yaml@2.8.2))
+      zod: 4.3.6
+    optionalDependencies:
+      '@tanstack/react-router': 1.170.18(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      vite: 7.3.1(@types/node@24.10.12)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.23.7)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - supports-color
+      - unloader
+    optional: true
+
   '@tanstack/router-plugin@1.168.23(@tanstack/react-router@1.170.18(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.5(@types/node@24.10.12)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.23.7)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
@@ -24786,6 +24814,17 @@ snapshots:
       rolldown: 1.1.5
       rollup: 4.57.1
       vite: 6.4.1(@types/node@24.10.12)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.23.7)(yaml@2.8.2)
+
+  unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@7.3.1(@types/node@24.10.12)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.23.7)(yaml@2.8.2)):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+    optionalDependencies:
+      esbuild: 0.28.1
+      rolldown: 1.1.5
+      rollup: 4.57.1
+      vite: 7.3.1(@types/node@24.10.12)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.23.7)(yaml@2.8.2)
 
   unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.57.1)(vite@8.1.5(@types/node@24.10.12)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.23.7)(yaml@2.8.2)):
     dependencies:


### PR DESCRIPTION
## Related issue

Same-repository branch; no separate Issue is required for intake.

## Problem / pressure

Public and authentication routes shared a root that mounted the workspace runtime. The generated route tree and the Electron host's missing Router transform also left workspace-only dependencies in otherwise lightweight route closures.

## Summary

- Move `RuntimeProvider` ownership from the global root to the workspace route layout; retain authentication, Cloud API, i18n, and PostHog globally.
- Register TanStack Router auto code splitting in the Electron host Vite build before React, and keep split route components local to their modules.
- Replace barrel imports that made Flock reachable from the renderer entry with narrow imports, and add an emitted Rollup closure test with raw/gzip accounting.

## Before / after

| Before | After |
| ------ | ----- |
| `__root -> RuntimeProvider -> create-workspace-runtime -> streams-crdt/flock-wasm` was reachable by every route; the Electron host did not run the Router plugin. | Runtime begins at `/$workspaceName`; the host runs the Router plugin and public/auth route chunks stay free of RuntimeProvider, workspace runtime, streams-crdt, and flock-wasm. |
| Join emitted static closure: 3,483,085 raw bytes / 851,032 gzip bytes. | Join emitted static closure: 2,673,915 raw bytes / 643,088 gzip bytes (−809,170 raw, −207,944 gzip). |

The Join-specific entry proposal is intentionally not used: it would duplicate root lifecycle while leaving the shared root and generated route-tree edges as the systemic source of the closure.

## Test plan

- `pnpm check` (passed: typecheck, lint, tests, host-like Electron/Vite/Rollup graph test, public and platform boundary checks).
- `pnpm format` (passed).
- `pnpm install --lockfile-only --frozen-lockfile` (passed).
- The graph test traverses emitted static imports: Join and Login exclude RuntimeProvider, workspace runtime, streams-crdt, and flock-wasm; a workspace route includes all four. It records the emitted closure and raw/gzip sizes.
- Existing authentication, Join sign-out-before-redirect, PostHog, route navigation, local platform, and Electron tests pass.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Inspect root/workspace provider ownership, host Router plugin ordering, and the emitted-chunk graph test's static-closure traversal.
- **Decisions to challenge:** Confirm that runtime ownership belongs at the workspace layout and that making route components module-local is compatible with all non-route imports.
- **Plausible failures / evidence gaps:** Private Web composition is not in this repository; it needs the same host Router plugin configuration and equivalent closure test in a follow-up private PR.

### Authoring context

- **User goal / directives:** Make ordinary public/auth TanStack routes lightweight without a Join-specific React entry, while preserving workspace behavior and PostHog.
- **Constraints / non-goals:** Do not copy private Web code, remove PostHog, add an empty workspace provider or URL dispatcher, or change Join's sign-out-before-redirect contract.
- **Risk-bearing decisions:** The global root no longer provides workspace runtime; workspace layouts now own it, and the Electron host compiles shared routes through TanStack Router's code-splitting transform.
- **Destructive or irreversible behavior:** None; this is a dependency-boundary and build integration change with no migration or data mutation.
- **Deliberately not done or tested:** The private Web host is outside this public source tree; no private composition was fabricated here.
- **Unknowns / confidence:** High confidence for public Electron/local composition based on full checks and the emitted graph; private host adoption remains a separately scoped follow-up.

<!-- context-handoff:end -->
