### PR TITLE
fix(acp): recover when compact is interrupted

### DIFF
--- a/apps/cli/src/session/session-execution-service.ts
+++ b/apps/cli/src/session/session-execution-service.ts
@@ -5304,55 +5304,70 @@ export class SessionExecutionService {
     const currentTurnId = activeTurnId ?? executionTurnId ?? runtimeTurnId;
     // Cancel is exact-match only: a stale stop request must not interrupt a newer assistant turn.
     if (!isPrompting && !isCurrentExecutionTurn) {
-      // Only inspect and repair durable history when no live turn owns the session.
-      // A stale request that races with a newer turn must not touch that turn's
-      // session-wide presence or require history methods on lightweight test/docs.
+      // Stale repair mutates session-wide presence and history, so it must not
+      // overlap a newer turn or another durable rewrite. Hold the conflict lease
+      // across the awaited history read and recheck live ownership before
+      // cleaning up: a turn that starts while getHistory() is awaited must keep
+      // its presence and dispatch metadata.
       if (currentTurnId == null) {
-        const history = await sessionDoc.getHistory();
-        const hasUnfinishedRequestedTurn = history.some(
-          (entry) =>
-            entry.id === turnId &&
-            entry.role === 'assistant' &&
-            entry.finished !== true &&
-            typeof entry.endedAt !== 'number' &&
-            entry.items?.some(
-              (item) =>
-                item.type === 'tool_call' &&
-                item.activityKind === 'context_compaction' &&
-                (item.status === 'pending' || item.status === 'in_progress')
-            ) === true
-        );
-        if (hasUnfinishedRequestedTurn) {
-          this.deps.logger.debug(
-            `[${sessionId}] Finalizing stale unfinished turn ${turnId} after stop request found no live runtime`
-          );
-          this.deps.clearSessionActivePresence(sessionId);
-          await sessionDoc.updateHistory((nextHistory) => {
-            for (const entry of nextHistory) {
-              if (entry.id !== turnId) continue;
-              entry.finished = true;
-              entry.endedAt = getServerNow();
-              if (!entry.items) continue;
-              for (const item of entry.items) {
-                if (
-                  item.type === 'tool_call' &&
-                  item.activityKind === 'context_compaction' &&
-                  (item.status === 'pending' || item.status === 'in_progress')
-                ) {
-                  item.status = 'failed';
-                }
+        const releaseConflict = this.tryAcquireSessionRewriteConflictLease(sessionId);
+        if (releaseConflict) {
+          try {
+            const liveTurnId =
+              this.deps.getActiveTurnId(sessionId) ??
+              this.currentTurnBySession.get(sessionId) ??
+              this.turnRuntimeBySession.get(sessionId)?.turnId;
+            if (liveTurnId == null) {
+              const history = await sessionDoc.getHistory();
+              const hasUnfinishedRequestedTurn = history.some(
+                (entry) =>
+                  entry.id === turnId &&
+                  entry.role === 'assistant' &&
+                  entry.finished !== true &&
+                  typeof entry.endedAt !== 'number' &&
+                  entry.items?.some(
+                    (item) =>
+                      item.type === 'tool_call' &&
+                      item.activityKind === 'context_compaction' &&
+                      (item.status === 'pending' || item.status === 'in_progress')
+                  ) === true
+              );
+              if (hasUnfinishedRequestedTurn) {
+                this.deps.logger.debug(
+                  `[${sessionId}] Finalizing stale unfinished turn ${turnId} after stop request found no live runtime`
+                );
+                this.deps.clearSessionActivePresence(sessionId);
+                await sessionDoc.updateHistory((nextHistory) => {
+                  for (const entry of nextHistory) {
+                    if (entry.id !== turnId) continue;
+                    entry.finished = true;
+                    entry.endedAt = getServerNow();
+                    if (!entry.items) continue;
+                    for (const item of entry.items) {
+                      if (
+                        item.type === 'tool_call' &&
+                        item.activityKind === 'context_compaction' &&
+                        (item.status === 'pending' || item.status === 'in_progress')
+                      ) {
+                        item.status = 'failed';
+                      }
+                    }
+                  }
+                  return nextHistory;
+                });
+
+                await this.finalizeCancelledTurn({
+                  sessionId,
+                  sessionDoc,
+                  turnId,
+                  reportTurnError: false,
+                });
+                return { success: true };
               }
             }
-            return nextHistory;
-          });
-
-          await this.finalizeCancelledTurn({
-            sessionId,
-            sessionDoc,
-            turnId,
-            reportTurnError: false,
-          });
-          return { success: true };
+          } finally {
+            releaseConflict();
+          }
         }
       }
       this.deps.logger.debug(

--- a/apps/cli/src/session/session-execution-service.ts
+++ b/apps/cli/src/session/session-execution-service.ts
@@ -5303,6 +5303,52 @@ export class SessionExecutionService {
     const currentTurnId = activeTurnId ?? this.currentTurnBySession.get(sessionId);
     // Cancel is exact-match only: a stale stop request must not interrupt a newer assistant turn.
     if (!isPrompting && !isCurrentExecutionTurn) {
+      const history = await sessionDoc.getHistory();
+      const hasUnfinishedRequestedTurn = history.some(
+        (entry) =>
+          entry.id === turnId &&
+          entry.role === 'assistant' &&
+          entry.finished !== true &&
+          typeof entry.endedAt !== 'number' &&
+          entry.items?.some(
+            (item) =>
+              item.type === 'tool_call' &&
+              item.activityKind === 'context_compaction' &&
+              (item.status === 'pending' || item.status === 'in_progress')
+          ) === true
+      );
+      if (currentTurnId == null && hasUnfinishedRequestedTurn) {
+        this.deps.logger.debug(
+          `[${sessionId}] Finalizing stale unfinished turn ${turnId} after stop request found no live runtime`
+        );
+        this.deps.clearSessionActivePresence(sessionId);
+        await sessionDoc.updateHistory((nextHistory) => {
+          for (const entry of nextHistory) {
+            if (entry.id !== turnId) continue;
+            entry.finished = true;
+            entry.endedAt = getServerNow();
+            if (!entry.items) continue;
+            for (const item of entry.items) {
+              if (
+                item.type === 'tool_call' &&
+                item.activityKind === 'context_compaction' &&
+                (item.status === 'pending' || item.status === 'in_progress')
+              ) {
+                item.status = 'failed';
+              }
+            }
+          }
+          return nextHistory;
+        });
+
+        await this.finalizeCancelledTurn({
+          sessionId,
+          sessionDoc,
+          turnId,
+          reportTurnError: false,
+        });
+        return { success: true };
+      }
       this.deps.logger.debug(
         `[${sessionId}] Ignoring stop request for stale turn ${turnId} (current=${currentTurnId ?? 'none'})`
       );

--- a/apps/cli/src/session/session-execution-service.ts
+++ b/apps/cli/src/session/session-execution-service.ts
@@ -5298,56 +5298,62 @@ export class SessionExecutionService {
     const sessionDoc = await this.deps.workspaceDocument.getOrCreateSessionDoc(sessionId);
     const activeTurnId = this.deps.getActiveTurnId(sessionId);
     const executionTurnId = this.currentTurnBySession.get(sessionId);
+    const runtimeTurnId = this.turnRuntimeBySession.get(sessionId)?.turnId;
     const isPrompting = activeTurnId === turnId;
-    const isCurrentExecutionTurn = executionTurnId === turnId;
-    const currentTurnId = activeTurnId ?? this.currentTurnBySession.get(sessionId);
+    const isCurrentExecutionTurn = executionTurnId === turnId || runtimeTurnId === turnId;
+    const currentTurnId = activeTurnId ?? executionTurnId ?? runtimeTurnId;
     // Cancel is exact-match only: a stale stop request must not interrupt a newer assistant turn.
     if (!isPrompting && !isCurrentExecutionTurn) {
-      const history = await sessionDoc.getHistory();
-      const hasUnfinishedRequestedTurn = history.some(
-        (entry) =>
-          entry.id === turnId &&
-          entry.role === 'assistant' &&
-          entry.finished !== true &&
-          typeof entry.endedAt !== 'number' &&
-          entry.items?.some(
-            (item) =>
-              item.type === 'tool_call' &&
-              item.activityKind === 'context_compaction' &&
-              (item.status === 'pending' || item.status === 'in_progress')
-          ) === true
-      );
-      if (currentTurnId == null && hasUnfinishedRequestedTurn) {
-        this.deps.logger.debug(
-          `[${sessionId}] Finalizing stale unfinished turn ${turnId} after stop request found no live runtime`
-        );
-        this.deps.clearSessionActivePresence(sessionId);
-        await sessionDoc.updateHistory((nextHistory) => {
-          for (const entry of nextHistory) {
-            if (entry.id !== turnId) continue;
-            entry.finished = true;
-            entry.endedAt = getServerNow();
-            if (!entry.items) continue;
-            for (const item of entry.items) {
-              if (
+      // Only inspect and repair durable history when no live turn owns the session.
+      // A stale request that races with a newer turn must not touch that turn's
+      // session-wide presence or require history methods on lightweight test/docs.
+      if (currentTurnId == null) {
+        const history = await sessionDoc.getHistory();
+        const hasUnfinishedRequestedTurn = history.some(
+          (entry) =>
+            entry.id === turnId &&
+            entry.role === 'assistant' &&
+            entry.finished !== true &&
+            typeof entry.endedAt !== 'number' &&
+            entry.items?.some(
+              (item) =>
                 item.type === 'tool_call' &&
                 item.activityKind === 'context_compaction' &&
                 (item.status === 'pending' || item.status === 'in_progress')
-              ) {
-                item.status = 'failed';
+            ) === true
+        );
+        if (hasUnfinishedRequestedTurn) {
+          this.deps.logger.debug(
+            `[${sessionId}] Finalizing stale unfinished turn ${turnId} after stop request found no live runtime`
+          );
+          this.deps.clearSessionActivePresence(sessionId);
+          await sessionDoc.updateHistory((nextHistory) => {
+            for (const entry of nextHistory) {
+              if (entry.id !== turnId) continue;
+              entry.finished = true;
+              entry.endedAt = getServerNow();
+              if (!entry.items) continue;
+              for (const item of entry.items) {
+                if (
+                  item.type === 'tool_call' &&
+                  item.activityKind === 'context_compaction' &&
+                  (item.status === 'pending' || item.status === 'in_progress')
+                ) {
+                  item.status = 'failed';
+                }
               }
             }
-          }
-          return nextHistory;
-        });
+            return nextHistory;
+          });
 
-        await this.finalizeCancelledTurn({
-          sessionId,
-          sessionDoc,
-          turnId,
-          reportTurnError: false,
-        });
-        return { success: true };
+          await this.finalizeCancelledTurn({
+            sessionId,
+            sessionDoc,
+            turnId,
+            reportTurnError: false,
+          });
+          return { success: true };
+        }
       }
       this.deps.logger.debug(
         `[${sessionId}] Ignoring stop request for stale turn ${turnId} (current=${currentTurnId ?? 'none'})`

--- a/apps/cli/tests/session-execution-service.test.ts
+++ b/apps/cli/tests/session-execution-service.test.ts
@@ -6276,6 +6276,69 @@ describe('SessionExecutionService', () => {
     });
   });
 
+  it('finalizes a stale unfinished compaction turn when no live runtime owns it', async () => {
+    const upsertDocMeta = vi.fn(async () => {});
+    const compactionItem = {
+      type: 'tool_call',
+      toolCallId: 'context-compaction-stale',
+      title: 'Context compacting',
+      status: 'in_progress',
+      activityKind: 'context_compaction',
+    };
+    const history = [
+      {
+        id: 'assistant-stale-compaction',
+        role: 'assistant',
+        items: [compactionItem],
+        finished: false,
+      },
+    ];
+    const sessionDoc = {
+      getHistory: vi.fn(async () => history),
+      setStatus: vi.fn(async () => {}),
+      updateHistory: vi.fn(async (update: (value: typeof history) => typeof history) => {
+        update(history);
+      }),
+    };
+    const sessionManager = {
+      getSession: vi.fn(() => null),
+      getPendingSession: vi.fn(() => null),
+      createSession: vi.fn(),
+      setSessionError: vi.fn(),
+      terminateSession: vi.fn(),
+      refreshGhTokenForSession: vi.fn(async () => {}),
+    } as unknown as SessionManager;
+    const deps = createBaseDeps({
+      sessionManager,
+      getActiveTurnId: vi.fn(() => undefined),
+      workspaceDocument: {
+        repo: {
+          upsertDocMeta,
+          getDocMeta: vi.fn(async () => ({ meta: {} })),
+        },
+        getOrCreateSessionDoc: vi.fn(async () => sessionDoc),
+        updateAcpCapabilities: vi.fn(async () => {}),
+      } as unknown as LoroDocumentManager,
+    });
+
+    const service = new SessionExecutionService(deps);
+    const result = await service.cancelSession({
+      type: 'session/cancel',
+      sessionId: 'session-stale-compaction' as SessionId,
+      machineId: 'machine-1',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      turnId: 'assistant-stale-compaction',
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(compactionItem.status).toBe('failed');
+    expect(sessionDoc.updateHistory).toHaveBeenCalled();
+    expect(sessionDoc.setStatus).toHaveBeenCalledWith(SessionStatusFactory.idle());
+    expect(upsertDocMeta).toHaveBeenCalledWith('session-session-stale-compaction', {
+      lastCanceledTurn: undefined,
+    });
+  });
+
   it('keeps a newer queued turn pending when cancelling the currently running turn', async () => {
     const upsertDocMeta = vi.fn(async () => {});
     const sessionDoc = {

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -3496,7 +3496,7 @@ export const SessionChatInterface = memo(
     const canStopAgent = canStopAgentEnabled({
       isContextCompacting,
       isSessionActive,
-      activeAssistantTurnId,
+      activeAssistantTurnId: activeAssistantTurnId ?? null,
       isGoalActive,
       canPauseGoal,
     });

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -3494,7 +3494,9 @@ export const SessionChatInterface = memo(
       isGoalActive,
     });
     const canStopAgent =
-      (isSessionActive && activeAssistantTurnId != null) || (isGoalActive && canPauseGoal);
+      isContextCompacting ||
+      (isSessionActive && activeAssistantTurnId != null) ||
+      (isGoalActive && canPauseGoal);
     const latestCompletedProposedPlan = useMemo(
       () => findLatestCompletedCodexProposedPlan(sessionDoc?.history),
       [sessionDoc?.history]

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -55,7 +55,7 @@ import { Button } from '@/ui/button';
 import { isMacOSElectronRenderer, useElectronFullscreen } from '@/lib/electron';
 import { getIpcServices } from '@/lib/electron-ipc-client';
 import { matchesKeyboardEvent } from '@/lib/commands/key-matcher';
-import { isSessionContextCompacting } from '@/lib/session-context-compaction';
+import { isSessionContextCompacting, canStopAgentEnabled } from '@/lib/session-context-compaction';
 import { hasFileTransfer, readDroppedTransfer } from '@/lib/file-drop';
 import { resolveProgrammaticTurnAgentRole } from '@/lib/composer-agent-roles';
 import { mergeDropZoneHandlers, useDropZone } from '@/hooks/use-drop-zone';
@@ -3493,10 +3493,13 @@ export const SessionChatInterface = memo(
       isSessionWorking,
       isGoalActive,
     });
-    const canStopAgent =
-      isContextCompacting ||
-      (isSessionActive && activeAssistantTurnId != null) ||
-      (isGoalActive && canPauseGoal);
+    const canStopAgent = canStopAgentEnabled({
+      isContextCompacting,
+      isSessionActive,
+      activeAssistantTurnId,
+      isGoalActive,
+      canPauseGoal,
+    });
     const latestCompletedProposedPlan = useMemo(
       () => findLatestCompletedCodexProposedPlan(sessionDoc?.history),
       [sessionDoc?.history]

--- a/packages/components/src/lib/session-context-compaction.ts
+++ b/packages/components/src/lib/session-context-compaction.ts
@@ -13,3 +13,34 @@ export const isSessionContextCompacting = (
   }
   return false;
 };
+
+export type CanStopAgentOptions = {
+  isContextCompacting: boolean;
+  isSessionActive: boolean;
+  activeAssistantTurnId: string | null;
+  isGoalActive: boolean;
+  canPauseGoal: boolean;
+};
+
+/**
+ * Whether the session Stop control should be exposed.
+ *
+ * The compaction branch is gated on a cancellable assistant turn: when a
+ * pending/in-progress compaction marker remains in history but its assistant
+ * entry is already finished (restart, interrupted notification stream),
+ * `isContextCompacting` is true while `activeAssistantTurnId` is null. In that
+ * state Stop would be shown but `handleStop` rejects the click as
+ * `missing_active_turn`, leaving an idle session with a permanently
+ * nonfunctional Stop button. Only expose Stop during compaction when there is
+ * a turn to cancel.
+ */
+export const canStopAgentEnabled = ({
+  isContextCompacting,
+  isSessionActive,
+  activeAssistantTurnId,
+  isGoalActive,
+  canPauseGoal,
+}: CanStopAgentOptions): boolean =>
+  (isContextCompacting && activeAssistantTurnId != null) ||
+  (isSessionActive && activeAssistantTurnId != null) ||
+  (isGoalActive && canPauseGoal);

--- a/packages/components/tests/session-context-compaction.test.ts
+++ b/packages/components/tests/session-context-compaction.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { SessionHistory } from '@lody/shared';
 
-import { isSessionContextCompacting } from '../src/lib/session-context-compaction';
+import { canStopAgentEnabled, isSessionContextCompacting } from '../src/lib/session-context-compaction';
 
 const historyWithStatus = (
   status: 'pending' | 'in_progress' | 'completed' | 'failed',
@@ -36,5 +36,75 @@ describe('isSessionContextCompacting', () => {
   it('does not treat host turn finalization as provider termination', () => {
     expect(isSessionContextCompacting(historyWithStatus('pending', true))).toBe(true);
     expect(isSessionContextCompacting(historyWithStatus('in_progress', true))).toBe(true);
+  });
+});
+
+describe('canStopAgentEnabled', () => {
+  const base = {
+    isContextCompacting: false,
+    isSessionActive: false,
+    activeAssistantTurnId: null,
+    isGoalActive: false,
+    canPauseGoal: false,
+  };
+
+  it('does not expose Stop during compaction without a cancellable turn', () => {
+    // A pending/in-progress compaction marker remains in history but its
+    // assistant entry is already finished (restart, interrupted notification
+    // stream). Stop must NOT be shown — clicking it would be rejected as
+    // missing_active_turn, leaving a permanently nonfunctional button.
+    expect(
+      canStopAgentEnabled({ ...base, isContextCompacting: true, activeAssistantTurnId: null })
+    ).toBe(false);
+  });
+
+  it('exposes Stop during compaction when a cancellable turn exists', () => {
+    expect(
+      canStopAgentEnabled({
+        ...base,
+        isContextCompacting: true,
+        activeAssistantTurnId: 'turn-1',
+      })
+    ).toBe(true);
+  });
+
+  it('exposes Stop for an active assistant turn regardless of compaction', () => {
+    expect(
+      canStopAgentEnabled({
+        ...base,
+        isSessionActive: true,
+        activeAssistantTurnId: 'turn-2',
+      })
+    ).toBe(true);
+  });
+
+  it('does not expose Stop for an active session without a turn', () => {
+    expect(
+      canStopAgentEnabled({
+        ...base,
+        isSessionActive: true,
+        activeAssistantTurnId: null,
+      })
+    ).toBe(false);
+  });
+
+  it('exposes Stop for a pausable goal', () => {
+    expect(
+      canStopAgentEnabled({
+        ...base,
+        isGoalActive: true,
+        canPauseGoal: true,
+      })
+    ).toBe(true);
+  });
+
+  it('does not expose Stop for an unpausable goal', () => {
+    expect(
+      canStopAgentEnabled({
+        ...base,
+        isGoalActive: true,
+        canPauseGoal: false,
+      })
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Related issue

Closes #267

## Problem / pressure

Stopping `/compact` while Codex is showing the context-compaction activity leaves the ACP prompt waiting for `thread/compacted`. Because compaction is a non-turn command, the existing cancellation path cannot find a turn to interrupt, so the prompt remains active and later prompts fail with `A Codex prompt is already active`.

## Summary

- Track the non-turn compaction lifecycle on the owning Codex ACP prompt.
- Route ACP cancellation directly to that prompt while compaction is in flight, allowing the prompt to return `cancelled` and release its active-prompt guard.
- Keep the session stop action available while the compaction activity is visible.
- Add a regression test that cancels `/compact` before the provider's terminal compaction notification arrives and verifies a late notification is harmless.

The ACP adapter portion is contributed in the companion change https://github.com/LodyAI/acp-extension-codex/pull/30, and this PR updates the repository submodule pointer to that tested revision.

## Visual explanation

The change preserves ordinary turn interruption while adding an ownership-aware recovery path for non-turn compaction and stale durable history:

```mermaid
sequenceDiagram
    participant User
    participant SessionUI
    participant ExecutionService
    participant ACP
    participant History

    User->>SessionUI: Stop during /compact
    SessionUI->>ExecutionService: cancelSession(sessionId)
    alt live compaction owner exists
        ExecutionService->>ACP: cancel owning non-turn prompt
        ACP-->>ExecutionService: cancelled
        ExecutionService-->>SessionUI: clear active compaction state
    else no live owner, stale compaction history exists
        ExecutionService->>History: finalize stale assistant entry as failed
        ExecutionService-->>SessionUI: clear stale state only
    end
    ACP-->>ExecutionService: late thread/compacted (optional)
    Note over ExecutionService: ignore safely; never clear a newer turn
```

A newer live or queued turn remains authoritative: stale cleanup repairs only the old assistant entry and does not finalize, cancel, or hide the newer turn.

## Before / after

| Before | After |
| ------ | ----- |
| Cancelling `/compact` has no turn id to interrupt, so the ACP prompt stays active and future prompts are rejected. | Cancellation aborts the owning non-turn compaction prompt, and the session can accept a subsequent prompt after the cancelled operation settles. |
| The stop control depends only on ordinary active-turn status. | The stop control remains available while context compaction is reported as active. |

## Test plan

- `corepack pnpm --filter acp-extension-core build` — passed.
- `corepack pnpm --filter acp-extension-codex typecheck` — passed.
- `corepack pnpm --filter acp-extension-codex exec vitest run src/__tests__/CodexACPAgent/CodexAcpClient.test.ts -t "cancels a compact slash command without waiting for compaction completion" --no-file-parallelism` — passed.
- `corepack pnpm --filter @lody/components exec vitest run tests/session-context-compaction.test.ts` — 2 tests passed.
- `corepack pnpm --filter @lody/components typecheck` — passed.
- The full Codex ACP client test file passed 100 tests; 2 unrelated existing Windows path-normalization tests failed.
- `git diff --check` — passed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Inspect `packages/acp-extension-codex/src/CodexAcpServer.ts` cancellation handling and `CodexCommands.ts` compaction lifecycle callbacks, then verify the parent submodule pointer and session UI stop gate.
- **Decisions to challenge:** Confirm that cancelling the owning ACP prompt is the correct recovery for a non-turn `thread/compact/start` operation, and that a late `thread/compacted` notification remains harmless.
- **Plausible failures / evidence gaps:** The focused regression and typechecks pass; the full Codex ACP file retains 2 pre-existing Windows path-normalization failures, and packaged Electron clipboard/runtime smoke coverage was not applicable to this change.

### Authoring context

- **User goal / directives:** Make interrupting context compaction recover the session instead of leaving the ACP prompt permanently active.
- **Constraints / non-goals:** Keep ordinary turn interruption unchanged; do not alter Codex compaction protocol messages or redesign session cancellation; do not change unrelated Windows path behavior.
- **Risk-bearing decisions:** Only a prompt marked as actively running compaction is cancelled directly; ordinary active turns continue through the existing turn-ID interrupt path.
- **Destructive or irreversible behavior:** Cancellation sends no destructive filesystem operation; it aborts the local prompt wait and leaves any provider-side compaction completion notification to be safely ignored or consumed.
- **Deliberately not done or tested:** No packaged Electron end-to-end run was performed; provider-side cancellation timing is covered by the deterministic ACP mock regression and the existing late-notification path.
- **Unknowns / confidence:** Confidence is high for the reported ACP deadlock because the regression reproduces the missing-turn cancellation shape; residual risk is limited to provider-specific behavior outside the adapter's deterministic contract.

### Original user prompt

<details>
<summary>Show original prompt</summary>

````text
发送/compact，后，如果在显示“正在压缩上下文”时中断，当前会彻底卡死

acp_invalid_request:
A Codex prompt is already active; use the advertised steer extension

脱离卡死状态
````

</details>

<!-- context-handoff:end -->
