### PR TITLE
fix(electron): report update install failures instead of success

### DIFF
--- a/apps/electron/src/main/services/app-updater-service.ts
+++ b/apps/electron/src/main/services/app-updater-service.ts
@@ -1,3 +1,5 @@
+import { appendFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { app, BrowserWindow } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import type {
@@ -42,6 +44,25 @@ function readVersionPrereleaseChannel(version: string): string | undefined {
   return normalized
 }
 
+// electron-updater defaults to `console`, and a packaged desktop app has no
+// terminal attached, so every install failure it reports is lost. Keep the
+// updater's own log next to the app data instead.
+function createUpdaterLogger() {
+  const logPath = join(app.getPath('userData'), 'updater.log')
+  const write = (level: string, message: unknown): void => {
+    try {
+      appendFileSync(logPath, `${new Date().toISOString()} [${level}] ${String(message)}\n`)
+    } catch {
+      // Logging must never break the update flow.
+    }
+  }
+  return {
+    info: (message: unknown) => write('info', message),
+    warn: (message: unknown) => write('warn', message),
+    error: (message: unknown) => write('error', message)
+  }
+}
+
 export class AppUpdaterService {
   private state: ElectronUpdaterState = {
     phase: 'idle',
@@ -70,6 +91,7 @@ export class AppUpdaterService {
       return
     }
 
+    autoUpdater.logger = createUpdaterLogger()
     autoUpdater.autoDownload = true
     autoUpdater.autoInstallOnAppQuit = false
 
@@ -154,6 +176,18 @@ export class AppUpdaterService {
       // Ensure macOS close handlers don't hide windows and block updater-triggered quit.
       setAppQuitting(true)
       autoUpdater.quitAndInstall(false, true)
+      // electron-updater reports install failures through its `error` event and
+      // returns normally, so a plain `ok: true` here would leave the renderer
+      // spinning on an install that never started. The event listener is
+      // synchronous, so a failure is already recorded in state by now.
+      const stateAfterInstall = this.getState()
+      if (stateAfterInstall.phase === 'error') {
+        setAppQuitting(false)
+        return {
+          ok: false,
+          error: stateAfterInstall.error ?? 'update_install_failed'
+        }
+      }
       return { ok: true }
     } catch (error) {
       setAppQuitting(false)


### PR DESCRIPTION
## Related issue

Closes #277

## Problem / pressure

`AppUpdaterService.quitAndInstall` returned `{ ok: true }` whenever `autoUpdater.quitAndInstall()` did not throw. It never throws on a failed install: in electron-updater 6.x `BaseUpdater.quitAndInstall()` returns `void`, and `install()` catches its own errors and routes them to `dispatchError`.

So a failed install reached the renderer as a success. `about-setting.tsx` only clears its spinner on `!result.ok`, so `isInstalling` stayed `true` for the rest of the session; the next 30-minute check cleared the transient `error` phase, re-emitted `update-downloaded` from the cached file, and re-rendered the "Update and restart" button already disabled and spinning. The user is left on an old version with a dead button and no error text.

Two smaller consequences of the same path: `setAppQuitting(true)` was only reverted inside the `catch` branch, so a silent failure left the app permanently believing it was quitting; and with no `autoUpdater.logger` set, electron-updater logged to `console`, which a packaged app discards, so the installer stderr explaining the failure was unrecoverable.

## Summary

- `quitAndInstall` reads the recorded phase after the synchronous `autoUpdater.quitAndInstall()` call. `dispatchError` emits `error` synchronously, so the listener has already written the failure to state by the time the call returns; the IPC result now carries `ok: false` and the real message.
- `setAppQuitting(false)` is restored on that path, so an install that never started does not leave the app in quitting state.
- `autoUpdater.logger` writes to `updater.log` under `app.getPath('userData')` via `appendFileSync`, wrapped in `try/catch` so logging can never break the update flow. No new dependency.

## Before / after

| Before | After |
| ------ | ----- |
| A failed install returns `{ ok: true }`; the install button stays disabled with a spinner for the rest of the session and shows no reason. | A failed install returns `{ ok: false }` with the error message; the button becomes actionable again. |
| `setAppQuitting(true)` leaks on the silent-failure path. | Restored whenever the install did not start. |
| electron-updater logs to `console`, which a packaged app sends nowhere. | The updater keeps `userData/updater.log`, so the installer's own failure reason survives. |

## Test plan

Run from a clean standalone clone with submodules initialised.

- `pnpm install --frozen-lockfile` — clean.
- `pnpm --filter @lody/electron typecheck` (`tsgo`, node and web projects) — passes.
- `oxlint` and `prettier --check` on the changed file — clean.
- `apps/electron` test suite — 53/53 pass.

Skipped, with reasons. Full `pnpm check` does not complete in my environment for three reasons unrelated to this change; I reproduced all three with this change stashed:

1. `packages/acp-extension-dsh` fails `tsc` with `TS2352` on a `ReadableStream` conversion, which blocks `prepare:acp-adapters` before typecheck begins.
2. Root `pnpm lint` (`oxlint --type-aware`) is `SIGKILL`ed while starting `tsgolint` — out of memory on this machine.
3. `src/main/services/loro-data-plane-relay.test.mjs` cannot run: the electron binary did not download here.

CI is green on `main` at `c7d905b`, so these are local. I also did not exercise the new failure branch in a packaged build; it is reasoned from the electron-updater sources rather than observed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `apps/electron/src/main/services/app-updater-service.ts` — whether reading `this.getState().phase` immediately after the synchronous `autoUpdater.quitAndInstall()` is a sound failure signal, and whether `setAppQuitting(false)` is restored on exactly the right path.
- **Decisions to challenge:** inferring failure from updater state instead of an explicit signal, since electron-updater exposes none; and writing `userData/updater.log` with `appendFileSync` and no rotation rather than adding an `electron-log` dependency.
- **Plausible failures / evidence gaps:** if an install error is ever dispatched asynchronously the check misses it and still reports success; `install()` also returns `false` without dispatching an error when its `quitAndInstallCalled` guard trips, which this change still reports as `ok`; and no automated test covers the new branch.

### Authoring context

- **User goal / directives:** A user asked why their Linux desktop update kept getting stuck; the investigation found this defect, and they asked for it to be fixed and contributed upstream.
- **Constraints / non-goals:** Keep the change inside the Electron main updater service, add no dependency, and do not alter electron-updater's install strategy or the renderer; diagnosing why the reporter's own `dpkg` step failed is out of scope.
- **Risk-bearing decisions:** Treating a post-call `error` phase as proof the install did not start, and restoring `setAppQuitting(false)` on that path — a wrong reading there would abort a quit that should have proceeded.
- **Destructive or irreversible behavior:** None. The log file is append-only under `userData` and its writes are swallowed on failure; no migration, deletion, or state rewrite is involved, and the recovery path only relaxes a flag.
- **Deliberately not done or tested:** No unit test, because the module imports `electron` at the top level and the repository's pattern for testable main logic is a separate `-core` module, which is disproportionate for a four-line branch; no log rotation; and the error text is not newly surfaced in the About panel beyond its existing error state.
- **Unknowns / confidence:** High confidence in the defect and the fix, both read from this repository and the bundled electron-updater sources; the residual unknown is why the original install failed, which is unrecoverable precisely because of the missing logger this PR adds.

<!-- context-handoff:end -->
