### PR TITLE
chore: upgrade built-in Claude Code to 2.1.258

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@agentclientprotocol/sdk": "catalog:",
-    "@anthropic-ai/claude-agent-sdk": "0.3.251",
+    "@anthropic-ai/claude-agent-sdk": "0.3.258",
     "@better-auth/api-key": "catalog:",
     "@convex-dev/better-auth": "catalog:",
     "@lody/cli-supervisor": "workspace:*",

--- a/apps/cli/src/agent/claude-runtime-manifest.json
+++ b/apps/cli/src/agent/claude-runtime-manifest.json
@@ -1,47 +1,47 @@
 {
   "name": "claude-code",
-  "sdkVersion": "0.3.251",
-  "version": "2.1.251",
+  "sdkVersion": "0.3.258",
+  "version": "2.1.258",
   "artifacts": {
     "darwin-arm64": {
-      "fileName": "anthropic-ai-claude-agent-sdk-darwin-arm64-0.3.251.tar.zst",
-      "sha256": "536a3755844d168b87250af3ee6e3dd103391305514f28abe564f91a5aa856ee",
-      "size": 71945899
+      "fileName": "anthropic-ai-claude-agent-sdk-darwin-arm64-0.3.258.tar.zst",
+      "sha256": "dd01a1ae8868c41ac7755e89fa4fc087d28e265b6d7ab122c18317dfd7023ed2",
+      "size": 73550133
     },
     "darwin-x64": {
-      "fileName": "anthropic-ai-claude-agent-sdk-darwin-x64-0.3.251.tar.zst",
-      "sha256": "68e88be76d4399d1dea054d9dbbf7106c393578fa1fa5714c9a8890b6ff3213c",
-      "size": 75692035
+      "fileName": "anthropic-ai-claude-agent-sdk-darwin-x64-0.3.258.tar.zst",
+      "sha256": "f46392ec768822fca40d61f6986d7d293a42b3ee5820b0c1a6c14bee474fdb02",
+      "size": 77362894
     },
     "linux-arm64": {
-      "fileName": "anthropic-ai-claude-agent-sdk-linux-arm64-0.3.251.tar.zst",
-      "sha256": "92e61ffb31b8beae919beb6a9458f4a376067bf25d4df7e5c8fe29b84ed1edaa",
-      "size": 81951594
+      "fileName": "anthropic-ai-claude-agent-sdk-linux-arm64-0.3.258.tar.zst",
+      "sha256": "b2df6e0ac548e348a1609d5cba8c1c22c8f4f98b9a3ab54f5ce2082ff96db0f2",
+      "size": 83313235
     },
     "linux-x64": {
-      "fileName": "anthropic-ai-claude-agent-sdk-linux-x64-0.3.251.tar.zst",
-      "sha256": "9e51358bb06885a29c0cdcaff6ffbbed47718e3210b8e92ae074802440a46dd3",
-      "size": 81994218
+      "fileName": "anthropic-ai-claude-agent-sdk-linux-x64-0.3.258.tar.zst",
+      "sha256": "ea9bfd7a1cfe218b9c9451450401d654711787bf1972b8a22d3b5f7b495a73f8",
+      "size": 83414920
     },
     "linux-arm64-musl": {
-      "fileName": "anthropic-ai-claude-agent-sdk-linux-arm64-musl-0.3.251.tar.zst",
-      "sha256": "bfad7556c20b01776c2205898c7f76a31448e42b7c2e7254476d25aac9c0d84c",
-      "size": 80166022
+      "fileName": "anthropic-ai-claude-agent-sdk-linux-arm64-musl-0.3.258.tar.zst",
+      "sha256": "9293b47fd63fa6f368fe0a9fa2930fd6963e6108e65b34584f854919df7f227b",
+      "size": 81542174
     },
     "linux-x64-musl": {
-      "fileName": "anthropic-ai-claude-agent-sdk-linux-x64-musl-0.3.251.tar.zst",
-      "sha256": "143efe291c6cd6501681fff2930c58c9eeeef5f924dded6b340e84a9e069e1d1",
-      "size": 80324347
+      "fileName": "anthropic-ai-claude-agent-sdk-linux-x64-musl-0.3.258.tar.zst",
+      "sha256": "ba0e031ff3266f41d73a28effc25d4334d992891b0495542ca7cf3b2a75632c8",
+      "size": 81733248
     },
     "win32-arm64": {
-      "fileName": "anthropic-ai-claude-agent-sdk-win32-arm64-0.3.251.tar.zst",
-      "sha256": "0d70dd262d40b39fe354e3b7c0e5a1b3a4895beef2692509a3830511ff184023",
-      "size": 81916953
+      "fileName": "anthropic-ai-claude-agent-sdk-win32-arm64-0.3.258.tar.zst",
+      "sha256": "13cd9e1ad2958bc8dbaaf908362852136b63f8ce4f452beade38d0323a40774d",
+      "size": 83257894
     },
     "win32-x64": {
-      "fileName": "anthropic-ai-claude-agent-sdk-win32-x64-0.3.251.tar.zst",
-      "sha256": "db8bcee96e0f0bc42b01977c1897977c204d5cee07464656ec49fa44d31014aa",
-      "size": 84974808
+      "fileName": "anthropic-ai-claude-agent-sdk-win32-x64-0.3.258.tar.zst",
+      "sha256": "ae93d318561a4c069d7074726d345224b588e1b3b0a6955b604f6a06ec0c3195",
+      "size": 86357676
     }
   }
 }

--- a/packages/components/tests/acp-selector-options.test.ts
+++ b/packages/components/tests/acp-selector-options.test.ts
@@ -639,7 +639,12 @@ describe('buildAcpSelectorOptions', () => {
       machine: machineWithCapabilities({}),
     });
 
-    expect(selectors.map((selector) => selector.configId)).toEqual(['mode', 'model', 'effort']);
+    expect(selectors.map((selector) => selector.configId)).toEqual([
+      'mode',
+      'model',
+      'effort',
+      'fast',
+    ]);
   });
 
   it('hides max and ultra for other Codex models and falls back to medium', () => {

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -600,7 +600,7 @@ const CLAUDE_STATIC_MODES: StaticBuiltinAcpCapabilities['modes'] = [
   },
   {
     id: 'default',
-    name: 'Default',
+    name: 'Manual',
     description: 'Standard behavior, prompts for dangerous operations',
   },
   {
@@ -618,6 +618,11 @@ const CLAUDE_STATIC_MODES: StaticBuiltinAcpCapabilities['modes'] = [
     name: "Don't Ask",
     description: "Don't prompt for permissions, deny if not pre-approved",
   },
+  {
+    id: 'bypassPermissions',
+    name: 'Bypass Permissions',
+    description: 'Bypass all permission checks',
+  },
 ];
 
 /**
@@ -632,9 +637,9 @@ const CLAUDE_STATIC_MODES: StaticBuiltinAcpCapabilities['modes'] = [
  * - `render: 'icon'` + `tone: 'neutral'`: a notable but non-risky mode
  *   (read-only, accept-edits, plan) — plain indicator.
  * - `render: 'icon'` + `tone: 'warning'`: a mode that changes the safety model —
- *   Codex `agent-full-access` (Full access) OR Claude `dontAsk` (Don't Ask /
- *   skip permissions, which drops the human out of the approval loop) — amber so
- *   the risk is visible at a glance.
+ *   Codex `agent-full-access` (Full access), Claude `dontAsk` (Don't Ask /
+ *   skip permissions), or Claude `bypassPermissions` (bypass all checks) — amber
+ *   so the risk is visible at a glance.
  * - `render: 'auto-label'`: show the literal short text "Auto" (Claude auto and
  *   Codex agent-auto-review route approval prompts to a reviewing model, so a
  *   short name fits better than a glyph).
@@ -677,6 +682,8 @@ export function classifyPermissionModeFace(modeId: string | null | undefined): P
     case 'dontAsk':
       // "Don't Ask" skips the human approval prompt — flag it like full access.
       return { kind: 'deny', tone: 'warning', render: 'icon' };
+    case 'bypassPermissions':
+      return { kind: 'full-access', tone: 'warning', render: 'icon' };
     case 'yolo':
     case 'always-approve':
       return { kind: 'full-access', tone: 'warning', render: 'icon' };
@@ -690,28 +697,28 @@ export function classifyPermissionModeFace(modeId: string | null | undefined): P
 const CLAUDE_STATIC_MODELS: StaticBuiltinAcpCapabilities['models'] = [
   {
     modelId: 'default',
-    name: 'Default',
-    description: 'Claude Code default model',
+    name: 'Default (recommended)',
+    description: 'Opus (1M context)',
   },
   {
-    modelId: 'opus',
-    name: 'Opus',
-    description: 'Claude Opus',
+    modelId: 'opus[1m]',
+    name: 'Opus (1M context)',
+    description: 'Opus 5 with 1M context · Best for everyday, complex tasks',
   },
   {
-    modelId: 'claude-fable-5[1m]',
+    modelId: 'claude-fable-5-1[1m]',
     name: 'Fable',
-    description: 'Claude Fable 5 with 1M context',
+    description: 'Fable 5.1 · Most capable for your hardest and longest-running tasks',
   },
   {
     modelId: 'sonnet',
     name: 'Sonnet',
-    description: 'Claude Sonnet',
+    description: 'Sonnet 5 · Efficient for routine tasks',
   },
   {
     modelId: 'haiku',
     name: 'Haiku',
-    description: 'Claude Haiku',
+    description: 'Haiku 4.5 · Fastest for quick answers',
   },
 ];
 
@@ -754,7 +761,18 @@ const CLAUDE_STATIC_CONFIG_OPTIONS: AcpConfigOptionSummary[] = [
       { value: 'low', name: 'Low' },
       { value: 'medium', name: 'Medium' },
       { value: 'high', name: 'High' },
+      { value: 'xhigh', name: 'Xhigh' },
+      { value: 'max', name: 'Max' },
     ],
+  },
+  {
+    id: 'fast',
+    name: 'Fast mode',
+    description: 'Faster responses on supported models',
+    category: 'model_config',
+    type: 'boolean',
+    currentValue: false,
+    options: [],
   },
 ];
 

--- a/packages/shared/tests/ai-claude.test.ts
+++ b/packages/shared/tests/ai-claude.test.ts
@@ -3,18 +3,62 @@ import { describe, expect, it } from 'vitest';
 import { getStaticBuiltinAcpCapabilities } from '../src/ai';
 
 describe('builtin Claude shared contract', () => {
-  it('uses the exact Fable option value exposed by the Claude ACP runtime', () => {
+  it('matches the modes and models exposed by Claude Code 2.1.258', () => {
     const capabilities = getStaticBuiltinAcpCapabilities('builtin', 'claude');
 
-    expect(capabilities?.models).toContainEqual({
-      modelId: 'claude-fable-5[1m]',
-      name: 'Fable',
-      description: 'Claude Fable 5 with 1M context',
-    });
+    expect(capabilities?.modes.map(({ id, name }) => ({ id, name }))).toEqual([
+      { id: 'auto', name: 'Auto' },
+      { id: 'default', name: 'Manual' },
+      { id: 'acceptEdits', name: 'Accept Edits' },
+      { id: 'plan', name: 'Plan Mode' },
+      { id: 'dontAsk', name: "Don't Ask" },
+      { id: 'bypassPermissions', name: 'Bypass Permissions' },
+    ]);
+    expect(capabilities?.models).toEqual([
+      {
+        modelId: 'default',
+        name: 'Default (recommended)',
+        description: 'Opus (1M context)',
+      },
+      {
+        modelId: 'opus[1m]',
+        name: 'Opus (1M context)',
+        description: 'Opus 5 with 1M context · Best for everyday, complex tasks',
+      },
+      {
+        modelId: 'claude-fable-5-1[1m]',
+        name: 'Fable',
+        description: 'Fable 5.1 · Most capable for your hardest and longest-running tasks',
+      },
+      {
+        modelId: 'sonnet',
+        name: 'Sonnet',
+        description: 'Sonnet 5 · Efficient for routine tasks',
+      },
+      {
+        modelId: 'haiku',
+        name: 'Haiku',
+        description: 'Haiku 4.5 · Fastest for quick answers',
+      },
+    ]);
+  });
+
+  it('matches the default model config options exposed to boolean-capable clients', () => {
+    const capabilities = getStaticBuiltinAcpCapabilities('builtin', 'claude');
+    const options = capabilities?.configOptions ?? [];
+
+    expect(options.map((option) => option.id)).toEqual(['mode', 'model', 'effort', 'fast']);
     expect(
-      capabilities?.configOptions
-        .find((option) => option.id === 'model')
-        ?.options.find((option) => option.name === 'Fable')?.value
-    ).toBe('claude-fable-5[1m]');
+      options.find((option) => option.id === 'effort')?.options.map(({ value }) => value)
+    ).toEqual(['default', 'low', 'medium', 'high', 'xhigh', 'max']);
+    expect(options.find((option) => option.id === 'fast')).toEqual({
+      id: 'fast',
+      name: 'Fast mode',
+      description: 'Faster responses on supported models',
+      category: 'model_config',
+      type: 'boolean',
+      currentValue: false,
+      options: [],
+    });
   });
 });

--- a/packages/shared/tests/permission-mode-face.test.ts
+++ b/packages/shared/tests/permission-mode-face.test.ts
@@ -34,6 +34,11 @@ describe('classifyPermissionModeFace', () => {
       tone: 'warning',
       render: 'icon',
     });
+    expect(classifyPermissionModeFace('bypassPermissions')).toEqual({
+      kind: 'full-access',
+      tone: 'warning',
+      render: 'icon',
+    });
   });
 
   it('renders model-reviewed approval modes as a short text label, neutral tone', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,8 +213,8 @@ importers:
         specifier: 'catalog:'
         version: 1.3.0(zod@4.3.6)
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.251
-        version: 0.3.251(@anthropic-ai/sdk@0.117.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.258
+        version: 0.3.258(@anthropic-ai/sdk@0.117.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@better-auth/api-key':
         specifier: 'catalog:'
         version: 1.5.5(patch_hash=ba3020ffdebafda4df4a616ccbcdb40c0101374c9fe08e0a8f87c5c96102f054)(@better-auth/core@1.5.5(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260317.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.11)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(better-auth@1.5.5(f00b050de135afaee0bf8a26fdaa86ac))
@@ -550,8 +550,8 @@ importers:
         specifier: 1.3.0
         version: 1.3.0(zod@4.3.6)
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.251
-        version: 0.3.251(@anthropic-ai/sdk@0.117.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
+        specifier: 0.3.258
+        version: 0.3.258(@anthropic-ai/sdk@0.117.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       acp-extension-core:
         specifier: workspace:*
         version: link:../acp-extension-core
@@ -1568,48 +1568,48 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.251':
-    resolution: {integrity: sha512-C23h+Dbddcc4gai95+lhm4/94am2IOq+bf3IdEDDS7EPqDQqajo2s5q1/ZSwq9rOc0RJLT7Ws72ZCzYJh67KSg==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.258':
+    resolution: {integrity: sha512-Hrhzc9WVGSid+DghdTcpVr/8fyXnTD6KeSlDpKx6Wru47J/Nq7RTYiZJt+cex+O2ehaHMEcuYEgoqJ3K/X9NlA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.251':
-    resolution: {integrity: sha512-HrLnb3ggk+vMbymUvbosgPmxWp4W6Ot+0mNVjoBYDn5OZrTV3C3LRtbWf7jwcGyKMcg0xJf0AqiudQ2BRrlr8A==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.258':
+    resolution: {integrity: sha512-AVqxGX4988J5cS+TMqIzH85+sbsLhJu5Ou9TIALcO/v2Z9ze8GK4vX2ydAYvU/SRnjTvEaiITX+Xcm5afP1IbQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.251':
-    resolution: {integrity: sha512-RTUf7TPBUkQ6oV3pDkEdcD47I0uH0ZpvmZlXHnrLGznFqyLr+7XHupOxUMJD0Jwm9v5qeqpNiPAYB0dL4RYiHg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.258':
+    resolution: {integrity: sha512-I/BLt2vdvqK2B2px526U1lw7Rv+SI+Ld22+wLwu8gLRQk5SYhSW9dmMYEO+GCeF7vQzfzJvMQ4IzbbY+aSGACg==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.251':
-    resolution: {integrity: sha512-3E27F5j82EWOyEniRW7crmo0jWYYQmPDdP52jWq6Y6aytiyYIdUFMEGZZ6chVHNlZiU7GsjTa3teKk2xlQ68lQ==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.258':
+    resolution: {integrity: sha512-Jj3K1Ip7WpyMouZCjd7kgV3KswUBF62WAnyG0iaYvKZJvXgYKbIAkjcQ2F2Rx5ZuRUNWAVncE9LeHmdIdx78VQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.251':
-    resolution: {integrity: sha512-SzXrdy7jjrjJIuTG+VMRAY0YZ3G/8w21WuhAozwnvnEUAPo6NDv6lgFinu7NO8J6CPE+MK2sGze6JeCF+ljgUg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.258':
+    resolution: {integrity: sha512-sM7GzRyrOpFhwMn2Ng8nLiWK6cc04uCEu3Zh9mrJS2r3iQu1TryHKoPTjc2Ip0N75sHmwhNodgoRs8NtG1Gkkw==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.251':
-    resolution: {integrity: sha512-qCD87XPjcNM1u4ukqmcgpHDl3Y6l+cW8j7kPzH91Y5yLBYJ5xYZA2KtJ7AYNEPOteVyOGJw/efmva0S8CRr0fg==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.258':
+    resolution: {integrity: sha512-2MJeFVJM/3xwZASP3yn2OuQ9RHIoS30DC/B7oG1XPYcbToPLH4QIfCPLWbSQfqCdp+NEBupLMM9BWpDz4s8Q0g==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.251':
-    resolution: {integrity: sha512-FH1ZLcyc97ie3h7CSlIxA1ppXILgf0V8sFQrWnHyKBrthJXQkMHXhsTq9OZV/2KhXslNf2hTe0gHpZ1nCL1Gmg==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.258':
+    resolution: {integrity: sha512-n/Vf6oXAo9EZVSSM5+9d+8dFrUrX9cbgSHK/1njkvykWAN5xsfBbikJYqwhbW84GCYkpXYM+gGNZe23h0fHldw==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.251':
-    resolution: {integrity: sha512-/jmtFIvfF0UFMxSZ8WV2Aus8aGA3+8Ft6AHvWuBJkY5jM2ubfqi6GnBjKCAL831TTllp2rKZlViANtWWRBvpvg==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.258':
+    resolution: {integrity: sha512-UDbXE6n37ZMUogVVYEWX901NNmbyXUv1VvGYN/vfOiIWKUJXCAypam71dBlYFhlAhVX28qCd64w+pTZDYQfYQA==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.251':
-    resolution: {integrity: sha512-DqSi8mH2tQYRlVV0G+lJnQ/WbjJZ/a+8cJ3vPuYoqh8esIIvXHm1ZOXV1UPGsFYRnbBytEoiSGitguEXd+sQ+Q==}
+  '@anthropic-ai/claude-agent-sdk@0.3.258':
+    resolution: {integrity: sha512-RxJ5fSPCGCxX5qO/b4IPXhldvtLHeYBAzTUJ4eOzO+gTrepZQSDmwSlQD6nnoEquKGJzOMHCjhdEtBfDjbDWUg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
@@ -12457,44 +12457,44 @@ snapshots:
       package-manager-detector: 1.6.0
       tinyexec: 1.2.4
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.251':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.251':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.251':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.251':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.251':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.251':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.251':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.251':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.258':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.251(@anthropic-ai/sdk@0.117.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.3.258(@anthropic-ai/sdk@0.117.1(zod@4.3.6))(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.117.1(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.251
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.251
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.251
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.251
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.251
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.251
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.251
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.251
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.258
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.258
 
   '@anthropic-ai/sdk@0.117.1(zod@4.3.6)':
     dependencies:


### PR DESCRIPTION
## Related issue

## Problem / pressure

Lody's built-in Claude Code runtime was pinned to Claude Agent SDK `0.3.251` and Claude Code `2.1.251`, while the current official release is SDK `0.3.258` with runtime `2.1.258`. The code pins, production artifacts, and first-render capability defaults must move together so fresh installs do not reference unavailable binaries or show stale model and run configuration choices.

## Summary

- update the CLI and workspace lockfile to `@anthropic-ai/claude-agent-sdk@0.3.258`
- update the Claude runtime manifest to Claude Code `2.1.258` with regenerated SHA-256 and byte-size pins for all eight supported platforms
- advance the Claude ACP gitlink to the merged `main` commit from [LodyAI/acp-extension-claude#23](https://github.com/LodyAI/acp-extension-claude/pull/23)
- upload all eight immutable runtime archives and verify them through the public client download API
- probe the authenticated `2.1.258` runtime through ACP and sync the static first-render modes, model choices, effort levels, and boolean Fast mode option
- render the new `bypassPermissions` mode with the existing full-access warning treatment

## Before / after

| Before | After |
| ------ | ----- |
| Built-in Claude Code used SDK `0.3.251` / runtime `2.1.251`. | Built-in Claude Code uses SDK `0.3.258` / runtime `2.1.258`. |
| The `2.1.258` platform archives were not available on the production runtime channel. | All eight platform archives return HTTP 200 with manifest-matching byte sizes; production R2 readback also matched SHA-256 and size. |
| Static Claude capabilities omitted Bypass Permissions, Fast mode, `xhigh`/`max`, and advertised stale model ids and labels. | Static first-render capabilities match the runtime's current Default/Opus/Fable/Sonnet/Haiku choices and default-model config options; live model switches still use the agent's model-specific response. |

## Test plan

- authenticated local ACP probe against Claude Code `2.1.258`: `initialize`, `session/new`, then `session/set_config_option` across every advertised model; no prompt was sent
- verified runtime lifecycle capabilities including session fork/list/resume/close/delete, Lody steering/tasks/subagents/goal/compaction metadata, image/context prompts, HTTP/SSE MCP, and auth logout
- verified model-specific config behavior: Default/Opus expose effort plus boolean Fast mode; Fable/Sonnet expose effort without Fast mode; Haiku exposes neither and omits Auto mode
- `npm run build` in `packages/acp-extension-claude`
- `npm run test:run` in `packages/acp-extension-claude` — 813 passed, 20 skipped
- `npm run check` in `packages/acp-extension-claude`
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter lody exec vitest run src/agent/managed-agent-runtime.test.ts` — 21 passed
- `corepack pnpm --filter lody prepare:acp-adapters`
- `corepack pnpm --filter lody typecheck`
- `pnpm exec vitest run tests/ai-claude.test.ts tests/permission-mode-face.test.ts` in `packages/shared` — 7 passed
- `pnpm check` — passed
- production R2 readback — 8/8 artifacts matched SHA-256 and byte size
- public runtime API HEAD verification — 8/8 returned HTTP 200 with manifest-matching `Content-Length`

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check that `apps/cli/package.json`, both lockfiles, the Claude gitlink, and `claude-runtime-manifest.json` all describe SDK `0.3.258` and runtime `2.1.258` consistently; compare `packages/shared/src/ai.ts` with the runtime probe contract.
- **Decisions to challenge:** Confirm that all eight platform artifacts are derived from the exact optional package versions, that retaining older immutable runtime objects preserves rollback behavior, and that static config represents the Default model while runtime refresh remains authoritative after model switches.
- **Plausible failures / evidence gaps:** The child ACP PR is merged and this PR pins its squash commit. Capability discovery used the real authenticated runtime but deliberately did not send a provider prompt.

### Authoring context

- **User goal / directives:** Upgrade the built-in Claude Code version to the latest release, complete the matching binary upload, test its capabilities, and update Lody's default Claude model and config choices.
- **Constraints / non-goals:** Keep the existing managed-runtime download design and all supported platforms; do not delete prior runtime objects or change authentication behavior. Static capabilities are first-render fallback only and must not replace dynamic per-model ACP responses.
- **Risk-bearing decisions:** Code pins were updated only after all eight production objects passed canonical R2 readback. Capability defaults were copied from an authenticated ACP session, and `bypassPermissions` is visibly classified as full access.
- **Destructive or irreversible behavior:** Eight new immutable R2 objects were added under the `2.1.258` version prefix; no existing object was overwritten or deleted.
- **Deliberately not done or tested:** No Claude prompt or model completion was sent; the live test stopped at capability discovery and config switching.
- **Unknowns / confidence:** Confidence is high in dependency, packaging, download, adapter compatibility, and the advertised configuration contract; provider-side completion behavior remains external.

<!-- context-handoff:end -->
