### PR TITLE
fix(components): restore mobile settings source

### DIFF
--- a/packages/components/src/components/chat/chat-landing.tsx
+++ b/packages/components/src/components/chat/chat-landing.tsx
@@ -80,6 +80,7 @@ import { docMetaCacheReadyAtom, sessionMetaCountAtom } from '@/atoms/doc-meta';
 import { localProbeAttemptedAtom, localProbeResultAtom } from '@/atoms/local-probe';
 import { lodyPresenceNowMsAtom, lodyPresenceStatesAtom } from '@/atoms/presence';
 import { buildAgentPrompt } from '@/lib';
+import { getAppCurrentPathWithSearch } from '@/lib/app-location';
 import { isImeComposingKeyboardEvent } from '@/lib/ime';
 import { useNavigate } from '@tanstack/react-router';
 import { activeWorkspaceRuntimeAtom, authTokenAtom, runtimeAtom } from '@/atoms/runtime';
@@ -6415,6 +6416,7 @@ function WorkspaceChatLanding({
             void navigate({
               to: '/$workspaceName/settings',
               params: { workspaceName: workspaceSlug },
+              search: { from: getAppCurrentPathWithSearch() },
             });
           }}
           /* New-chat chip opens the bottom-sheet composer. Stays on the

--- a/packages/components/src/components/mobile/AGENTS.md
+++ b/packages/components/src/components/mobile/AGENTS.md
@@ -105,6 +105,10 @@ embedded` lazy-imported from `../tasks/tasks-workspace.tsx` (`embedded`
   `workspaceJoinRequestsSlot` already owns its card frame, so wrap it in a
   `MobileSettingsSection noCard` plus the standard `mx-3` card inset; mounting
   the slot raw drops both the section rhythm and the shared horizontal edge.
+  Opening the mobile Settings route from workspace home carries the complete
+  in-app path in `from`. Nested settings Back returns to the settings list;
+  top-level Back restores that validated source path (including the Projects
+  Local/GitHub query) and uses context-free Chat only as the direct-entry fallback.
 - Sheets (bottom): `mobile-new-chat-sheet.tsx`,
   `mobile-workspace-switcher-sheet.tsx`, `mobile-create/delete-workspace-sheet`,
   `mobile-worktree-config-sheet.tsx`, `mobile-acp-history-sheet.tsx`,

--- a/packages/components/src/lib/settings-navigation.ts
+++ b/packages/components/src/lib/settings-navigation.ts
@@ -1,19 +1,29 @@
-export type SettingsBackDestination = 'settings-list' | 'chat';
+export type SettingsBackDestination =
+  | { kind: 'settings-list' }
+  | { kind: 'source'; to: string }
+  | { kind: 'chat' };
 
 type GetSettingsBackDestinationOptions = {
   isMobile: boolean;
   settingsListPage: boolean;
+  from?: string;
 };
 
 export function getSettingsBackDestination({
   isMobile,
   settingsListPage,
+  from,
 }: GetSettingsBackDestinationOptions): SettingsBackDestination {
   if (isMobile && !settingsListPage) {
-    return 'settings-list';
+    return { kind: 'settings-list' };
   }
 
-  return 'chat';
+  const source = resolveSettingsCloseTo(from);
+  if (source) {
+    return { kind: 'source', to: source };
+  }
+
+  return { kind: 'chat' };
 }
 
 /** Whether `pathname` is anywhere inside the workspace's settings section. */

--- a/packages/components/src/routes/$workspaceName/_auth/settings.tsx
+++ b/packages/components/src/routes/$workspaceName/_auth/settings.tsx
@@ -61,6 +61,7 @@ export function SettingsLayoutComponent() {
     isMobile &&
     (activeTabId === 'agents' || activeTabId === 'machines') &&
     hasAgentConfigMachineParam;
+  const settingsFrom = (location.search as { from?: string }).from;
 
   const handleBack = useCallback(() => {
     if (isMobileMachineDetail) {
@@ -79,9 +80,10 @@ export function SettingsLayoutComponent() {
     const destination = getSettingsBackDestination({
       isMobile,
       settingsListPage,
+      from: settingsFrom,
     });
 
-    if (destination === 'settings-list') {
+    if (destination.kind === 'settings-list') {
       void navigate({
         to: '/$workspaceName/settings',
         params: { workspaceName },
@@ -91,16 +93,28 @@ export function SettingsLayoutComponent() {
       return;
     }
 
-    // Settings exits back to the new session landing instead of browser history.
+    if (destination.kind === 'source') {
+      void navigate({ to: destination.to });
+      return;
+    }
+
+    // A direct settings entry has no source to restore.
     void navigate({
       to: '/$workspaceName/chat',
       params: { workspaceName },
     });
-  }, [activeTabId, isMobile, isMobileMachineDetail, navigate, settingsListPage, workspaceName]);
+  }, [
+    activeTabId,
+    isMobile,
+    isMobileMachineDetail,
+    navigate,
+    settingsFrom,
+    settingsListPage,
+    workspaceName,
+  ]);
 
   // Close (exit) settings entirely — back to where it was opened from (the `from` search
   // param, preserved across tabs) or the chat landing. Used by ⌘, (toggle) and Esc.
-  const settingsFrom = (location.search as { from?: string }).from;
   const handleCloseSettings = useCallback(() => {
     const closeTo = resolveSettingsCloseTo(settingsFrom);
     if (closeTo) {

--- a/packages/components/tests/settings-navigation.test.ts
+++ b/packages/components/tests/settings-navigation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { getSettingsBackDestination, resolveSettingsCloseTo } from '../src/lib/settings-navigation';
+
+describe('settings navigation', () => {
+  it('restores the full source path when leaving the top-level mobile settings page', () => {
+    expect(
+      getSettingsBackDestination({
+        isMobile: true,
+        settingsListPage: true,
+        from: '/acme/chat?context=local&machine=machine-1&project=project-1',
+      })
+    ).toEqual({
+      kind: 'source',
+      to: '/acme/chat?context=local&machine=machine-1&project=project-1',
+    });
+
+    expect(
+      getSettingsBackDestination({
+        isMobile: true,
+        settingsListPage: true,
+        from: '/acme/chat?context=github&repo=LodyAI%2FLody',
+      })
+    ).toEqual({
+      kind: 'source',
+      to: '/acme/chat?context=github&repo=LodyAI%2FLody',
+    });
+  });
+
+  it('returns nested mobile settings pages to the settings list first', () => {
+    expect(
+      getSettingsBackDestination({
+        isMobile: true,
+        settingsListPage: false,
+        from: '/acme/chat?context=local',
+      })
+    ).toEqual({ kind: 'settings-list' });
+  });
+
+  it('falls back to chat when the source is absent or unsafe', () => {
+    expect(getSettingsBackDestination({ isMobile: true, settingsListPage: true })).toEqual({
+      kind: 'chat',
+    });
+    expect(
+      getSettingsBackDestination({
+        isMobile: true,
+        settingsListPage: true,
+        from: '//example.com/phishing',
+      })
+    ).toEqual({ kind: 'chat' });
+  });
+
+  it('accepts only absolute in-app source paths', () => {
+    expect(resolveSettingsCloseTo('/acme/chat?context=local')).toBe('/acme/chat?context=local');
+    expect(resolveSettingsCloseTo('https://example.com')).toBeNull();
+    expect(resolveSettingsCloseTo('//example.com')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Related issue

Closes #263

## Problem / pressure

Mobile workspace Settings discarded the source query when opened from Projects, and the top-level Back action always navigated to context-free Chat. A Settings round trip therefore changed Projects / Local or Projects / GitHub into the Chat tab.

## Summary

- Carry the complete current in-app path in the Settings `from` search parameter when mobile workspace home opens Settings.
- Make top-level Settings Back restore a validated source path while preserving the existing nested-settings-to-list behavior and direct-entry Chat fallback.
- Add focused Local, GitHub, nested-page, missing-source, and unsafe-source regression coverage.
- Record the mobile Settings navigation invariant in the scoped contributor guidance.

## Before / after

| Before | After |
| ------ | ----- |
| Settings Back from Projects / Local or Projects / GitHub opened context-free Chat. | Settings Back restores the exact originating Projects context and query. |
| Nested Settings Back returned to the Settings list. | Nested Settings Back still returns to the Settings list before leaving Settings. |

## Test plan

- `npx --yes vitest@3.2.4 run --config /tmp/lody-vitest.config.mjs` — 4 tests passed.
- `npx --yes oxlint@1.61.0 <changed TypeScript files>` — 0 errors; 7 pre-existing warnings in `chat-landing.tsx`.
- `git diff --check upstream/main...HEAD` — passed.
- Full workspace typecheck and test suite were not run because this checkout has no `corepack`, `pnpm`, or installed workspace dependencies; PR CI should run the canonical checks.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check `chat-landing.tsx`, `settings.tsx`, and `settings-navigation.ts` for preservation and restoration of the full mobile Projects source URL.
- **Decisions to challenge:** Verify that nested Settings Back must outrank the saved source while top-level Back may restore any validated in-app absolute path.
- **Plausible failures / evidence gaps:** The focused pure tests pass, but the full router integration and workspace suite were left to CI because dependencies are unavailable in this checkout.

### Authoring context

- **User goal / directives:** Fix Issue #263 after a maintainer requested the PR so mobile Settings returns users to their selected Projects context.
- **Constraints / non-goals:** Keep the change in public shared components, preserve nested Settings behavior, and avoid private native-shell changes.
- **Risk-bearing decisions:** Store the full current path in `from` and accept only absolute non-protocol-relative in-app paths before restoring it.
- **Destructive or irreversible behavior:** None; navigation state only, with context-free Chat retained as the recovery fallback.
- **Deliberately not done or tested:** No native-shell changes or broad workspace tests; the isolated regression suite and lint completed locally, with canonical checks delegated to CI.
- **Unknowns / confidence:** High confidence in route decision logic; remaining uncertainty is limited to end-to-end rendering in the unavailable native mobile shell.

<!-- context-handoff:end -->
