### PR TITLE
fix(acp): pick the reasoning-effort ladder from the selected model

### DIFF
--- a/apps/cli/src/agent/AGENTS.md
+++ b/apps/cli/src/agent/AGENTS.md
@@ -14,14 +14,10 @@ context/acp-agent-edit-evidence.md; adapter repos: [apps/cli/AGENTS.md](../../AG
   provider-neutral.
 - Builtin Grok must default `clientCapabilities.terminal` to false.
 - Send the driving turn's config on every session establishment as `_meta.lody.sessionConfig`;
-  provider-specific startup translation belongs in the ACP adapter. Adapters may publish
-  per-model reasoning-effort ladders on the session response as
-  `_meta.lody.modelReasoningEfforts`; capability normalization merges that map into the cached
-  `modelReasoningEfforts`, together with the legacy `model[effort]` id derivation for builtin
-  Codex only — other agents use the same brackets for unrelated variants (Claude's `opus[1m]`
-  is a context window). Vendor model `_meta` never enters the CLI.
-  `session/set_config_option` stays the live-session switch, and a successful selection becomes
-  a later replacement's startup state.
+  provider-specific startup translation belongs in the ACP adapter. `session/set_config_option`
+  stays the live-session switch, and a successful selection becomes a later replacement's
+  startup state.
+- Cache session `_meta.lody.modelReasoningEfforts`; Codex `model[effort]` only.
 - Config projections must consume agent-confirmed state from session setup and
   `set_config_option` responses, not only `config_option_update` notifications. A
   present `configOptions` — empty array included — is an authoritative full snapshot; only an

--- a/apps/cli/src/agent/AGENTS.md
+++ b/apps/cli/src/agent/AGENTS.md
@@ -14,9 +14,14 @@ context/acp-agent-edit-evidence.md; adapter repos: [apps/cli/AGENTS.md](../../AG
   provider-neutral.
 - Builtin Grok must default `clientCapabilities.terminal` to false.
 - Send the driving turn's config on every session establishment as `_meta.lody.sessionConfig`;
-  provider-specific startup translation belongs in the ACP adapter. `session/set_config_option`
-  stays the live-session switch, and a successful selection becomes a later replacement's
-  startup state.
+  provider-specific startup translation belongs in the ACP adapter. Adapters may publish
+  per-model reasoning-effort ladders on the session response as
+  `_meta.lody.modelReasoningEfforts`; capability normalization merges that map into the cached
+  `modelReasoningEfforts`, together with the legacy `model[effort]` id derivation for builtin
+  Codex only — other agents use the same brackets for unrelated variants (Claude's `opus[1m]`
+  is a context window). Vendor model `_meta` never enters the CLI.
+  `session/set_config_option` stays the live-session switch, and a successful selection becomes
+  a later replacement's startup state.
 - Config projections must consume agent-confirmed state from session setup and
   `set_config_option` responses, not only `config_option_update` notifications. A
   present `configOptions` — empty array included — is an authoritative full snapshot; only an

--- a/apps/cli/src/agent/README.md
+++ b/apps/cli/src/agent/README.md
@@ -157,7 +157,12 @@ installed reusable runtime, and blocks on `ensureCurrentRuntime()` only when no 
 installed. `ManagedRuntimeUpdateCoordinator` serially downloads stale targets in the
 background and never hot-swaps a running ACP process. Real session creation also normalizes
 its `NewSessionResponse` through `acp-capability-normalization.ts`; the session execution
-service schedules a non-blocking cache update before the first prompt.
+service schedules a non-blocking cache update before the first prompt. Adapters may publish
+per-model reasoning-effort ladders on that session response as
+`_meta.lody.modelReasoningEfforts`. Normalization merges the map into the cached
+`modelReasoningEfforts`, together with the legacy `model[effort]` id derivation for builtin
+Codex only — other agents use the same brackets for unrelated variants (Claude's `opus[1m]`
+is a context window). Vendor model `_meta` never enters the CLI.
 
 ### Session titles
 

--- a/apps/cli/src/agent/acp-capabilities.ts
+++ b/apps/cli/src/agent/acp-capabilities.ts
@@ -92,6 +92,7 @@ export async function fetchAcpCapabilities(
       ...normalizeAcpSessionCapabilities(sessionResponse, {
         sessionFork: client.supportsSessionFork?.() === true,
         acknowledgedSteer: client.supportsAcknowledgedSteer(),
+        agent: { cliType, agentType },
       }),
       capabilitySourceVersion,
     };

--- a/apps/cli/src/agent/acp-capability-normalization.ts
+++ b/apps/cli/src/agent/acp-capability-normalization.ts
@@ -146,12 +146,53 @@ type AcpSessionCapabilitiesResponse = {
     availableModes?: Array<{ id: string; name: string; description?: string | null }> | null;
   } | null;
   configOptions?: SessionConfigOption[] | null;
+  /** Session-response meta; adapters publish Lody-owned contracts here. */
+  _meta?: Record<string, unknown> | null;
 };
+
+const zLodySessionResponseMeta = z.object({
+  _meta: z
+    .object({
+      lody: z
+        .object({
+          modelReasoningEfforts: z.record(z.string(), z.array(z.string())),
+        })
+        .nullish(),
+    })
+    .nullish(),
+});
+
+/**
+ * Per-model reasoning-effort ladders an adapter published under the Lody-owned
+ * "_meta.lody" session-response namespace (the Grok adapter does; agents that
+ * publish no per-model information have none and stay undefined).
+ */
+export function readLodyModelReasoningEfforts(
+  sessionResponse: unknown
+): Record<string, string[]> | undefined {
+  const parsed = zLodySessionResponseMeta.safeParse(sessionResponse);
+  const map = parsed.success ? parsed.data._meta?.lody?.modelReasoningEfforts : undefined;
+  return map && Object.keys(map).length > 0 ? map : undefined;
+}
+
+/**
+ * Only builtin Codex encodes reasoning effort into its legacy model ids
+ * (`gpt-5.6-sol[xhigh]`). Other agents use the same bracket syntax for
+ * unrelated variants — Claude's `opus[1m]` is a context window — so the
+ * legacy derivation must not read those as effort ladders.
+ */
+const usesCodexModelEffortIds = (agent?: { cliType: string; agentType: string }): boolean =>
+  agent?.cliType === 'builtin' && agent.agentType === 'codex';
 
 /** Extract cacheable capabilities from a real ACP new/load/resume session response. */
 export function normalizeAcpSessionCapabilities(
   sessionResponse: AcpSessionCapabilitiesResponse,
-  lifecycleCapabilities: { sessionFork?: boolean; acknowledgedSteer?: boolean } = {}
+  lifecycleCapabilities: {
+    sessionFork?: boolean;
+    acknowledgedSteer?: boolean;
+    /** The agent that answered; decides whether legacy `model[effort]` ids apply. */
+    agent?: { cliType: string; agentType: string };
+  } = {}
 ): AcpCapabilitiesResult {
   const modes = (sessionResponse.modes?.availableModes ?? []).map((mode) => ({
     id: mode.id,
@@ -169,12 +210,15 @@ export function normalizeAcpSessionCapabilities(
   const models = modelsFromConfigOptions.length > 0 ? modelsFromConfigOptions : legacyModels;
   const availableCommands = readSessionAvailableCommands(sessionResponse);
   // `configOptions` only describes the model that is current right now — agents
-  // rebuild the effort/fast options on every model switch. The legacy model list
-  // is the only place some agents (Codex) expose every `model[effort]`
-  // combination, so keep reading it even when configOptions supersede it.
-  const modelReasoningEfforts = deriveModelReasoningEffortsFromLegacyModelIds(
-    legacyModels.map((model) => model.modelId)
-  );
+  // rebuild the effort/fast options on every model switch. Two sources expose
+  // the model-independent view: the legacy `model[effort]` list (Codex) and the
+  // Lody "_meta.lody" map the adapter translates vendor metadata into (Grok).
+  const modelReasoningEfforts = {
+    ...readLodyModelReasoningEfforts(sessionResponse),
+    ...(usesCodexModelEffortIds(lifecycleCapabilities.agent)
+      ? deriveModelReasoningEffortsFromLegacyModelIds(legacyModels.map((model) => model.modelId))
+      : undefined),
+  };
 
   return {
     modes,
@@ -183,6 +227,6 @@ export function normalizeAcpSessionCapabilities(
     availableCommands,
     sessionFork: lifecycleCapabilities.sessionFork === true,
     acknowledgedSteer: lifecycleCapabilities.acknowledgedSteer === true,
-    ...(modelReasoningEfforts ? { modelReasoningEfforts } : {}),
+    ...(Object.keys(modelReasoningEfforts).length > 0 ? { modelReasoningEfforts } : {}),
   };
 }

--- a/apps/cli/src/session/session.ts
+++ b/apps/cli/src/session/session.ts
@@ -658,6 +658,7 @@ export class Session extends EventEmitter<SessionEvents> implements ISession {
         acpCapabilities = normalizeAcpSessionCapabilities(started.sessionResponse, {
           sessionFork: started.client.supportsSessionFork(),
           acknowledgedSteer: started.client.supportsAcknowledgedSteer(),
+          agent: { cliType: this.config.agentCliType, agentType: this.config.agentType },
         });
       } catch (error) {
         // The agent process died before startup completed (the startup monitor

--- a/apps/cli/tests/acp-capability-normalization.test.ts
+++ b/apps/cli/tests/acp-capability-normalization.test.ts
@@ -72,7 +72,9 @@ describe('ACP capability normalization', () => {
   });
 
   it('recovers per-model reasoning efforts the config options cannot express', () => {
-    const capabilities = normalizeAcpSessionCapabilities(codexSessionResponse);
+    const capabilities = normalizeAcpSessionCapabilities(codexSessionResponse, {
+      agent: { cliType: 'builtin', agentType: 'codex' },
+    });
 
     // configOptions still win for the model list itself (clean model ids).
     expect(capabilities.models.map((model) => model.modelId)).toEqual([
@@ -85,6 +87,28 @@ describe('ACP capability normalization', () => {
       'gpt-5.6-sol': ['low', 'xhigh'],
       'gpt-5.4-mini': ['low'],
     });
+  });
+
+  it("does not read another agent's bracketed model ids as effort ladders", () => {
+    /* Claude lists context-window variants with the same bracket syntax Codex
+       uses for effort (`opus[1m]`); reading them as a ladder would rebuild
+       Claude's effort picker to the sole value `1m`. */
+    const capabilities = normalizeAcpSessionCapabilities(
+      {
+        modes: { availableModes: [] },
+        models: {
+          currentModelId: 'opus',
+          availableModels: [
+            { modelId: 'opus', name: 'Opus' },
+            { modelId: 'opus[1m]', name: 'Opus (1M context)' },
+          ],
+        },
+      },
+      { agent: { cliType: 'builtin', agentType: 'claude' } }
+    );
+
+    expect(capabilities.modelReasoningEfforts).toBeUndefined();
+    expect(capabilities.models.map((model) => model.modelId)).toEqual(['opus', 'opus[1m]']);
   });
 
   it('omits the breakdown for agents that do not publish model/effort combinations', () => {
@@ -107,6 +131,47 @@ describe('ACP capability normalization', () => {
 
     expect(capabilities.modelReasoningEfforts).toBeUndefined();
     expect(capabilities.models.map((model) => model.modelId)).toEqual(['opus', 'sonnet']);
+  });
+
+  it('reads the Lody per-model reasoning-effort map published on the session response meta', () => {
+    const capabilities = normalizeAcpSessionCapabilities({
+      modes: { availableModes: [] },
+      configOptions: [
+        {
+          id: 'model',
+          name: 'Model',
+          category: 'model',
+          type: 'select',
+          currentValue: 'grok-4.6',
+          options: [
+            { value: 'grok-4.6', name: 'Grok 4.6' },
+            { value: 'grok-4.5', name: 'Grok 4.5' },
+          ],
+        },
+      ],
+      _meta: {
+        lody: {
+          modelReasoningEfforts: {
+            'grok-4.6': ['xhigh', 'high', 'medium', 'low'],
+            'grok-4.5': ['high', 'medium', 'low'],
+          },
+        },
+      },
+    });
+
+    expect(capabilities.modelReasoningEfforts).toEqual({
+      'grok-4.6': ['xhigh', 'high', 'medium', 'low'],
+      'grok-4.5': ['high', 'medium', 'low'],
+    });
+  });
+
+  it('ignores a malformed Lody reasoning-effort map', () => {
+    const capabilities = normalizeAcpSessionCapabilities({
+      modes: { availableModes: [] },
+      _meta: { lody: { modelReasoningEfforts: { 'grok-4.6': 'xhigh' } } },
+    });
+
+    expect(capabilities.modelReasoningEfforts).toBeUndefined();
   });
 
   it('preserves acknowledged steering support discovered from the live client', () => {

--- a/packages/components/src/components/chat/chat-landing.tsx
+++ b/packages/components/src/components/chat/chat-landing.tsx
@@ -1685,14 +1685,18 @@ function WorkspaceChatLanding({
     machine: selectedMachine,
   });
   const { modeOptions, modelOptions, configOptionSelectors } = selectorOptions;
-  const { selectedModeId, selectedModelId, configOptionValues } =
-    useResolvedAcpSessionConfigSelection(sessionConfigSelection, selectorOptions, {
-      cliType: selectedConfig?.cliType,
-      agentType: selectedConfig?.agentType,
-    });
+  const {
+    selectedModeId,
+    selectedModelId,
+    configOptionValues,
+    configOptionSelectors: resolvedConfigOptionSelectors,
+  } = useResolvedAcpSessionConfigSelection(sessionConfigSelection, selectorOptions, {
+    cliType: selectedConfig?.cliType,
+    agentType: selectedConfig?.agentType,
+  });
   const dispatchConfigOptionValues = useMemo(
-    () => filterAcpSessionConfigOptionValues(configOptionValues, configOptionSelectors),
-    [configOptionSelectors, configOptionValues]
+    () => filterAcpSessionConfigOptionValues(configOptionValues, resolvedConfigOptionSelectors),
+    [configOptionValues, resolvedConfigOptionSelectors]
   );
   const selectedRateLimits =
     selectedConfig &&
@@ -1794,15 +1798,20 @@ function WorkspaceChatLanding({
       return;
     }
     setPendingRecentRunConfig(null);
-    if (
+    const appliedModelId =
       pendingRecentRunConfig.modelId &&
       modelOptions.some((option) => option.value === pendingRecentRunConfig.modelId)
-    ) {
-      setSelectedModelName(pendingRecentRunConfig.modelId);
+        ? pendingRecentRunConfig.modelId
+        : undefined;
+    if (appliedModelId) {
+      setSelectedModelName(appliedModelId);
     }
     for (const { configId, value } of resolveApplicableConfigOptionValues(
       pendingRecentRunConfig,
-      configOptionSelectors
+      configOptionSelectors,
+      // The selectors still describe the model this entry replaces, so its
+      // effort must not be validated against the outgoing model's ladder.
+      { switchesModel: appliedModelId !== undefined && appliedModelId !== selectedModelId }
     )) {
       handleConfigOptionChange(configId, value);
     }
@@ -1813,6 +1822,7 @@ function WorkspaceChatLanding({
     modelOptions,
     pendingRecentRunConfig,
     selectedAgent,
+    selectedModelId,
     sessionConfigSelection.edits.model,
     setSelectedModelName,
   ]);

--- a/packages/components/src/components/sessions/draft-session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/draft-session-chat-interface.tsx
@@ -262,6 +262,7 @@ export const DraftSessionChatInterface = memo(
         machineFlockRows,
         modeOptions,
         modelOptions,
+        modelReasoningEfforts,
         sessionMachine,
       } = useSessionAcpSelectorContext({
         machineId: parentSession.machineId,
@@ -280,6 +281,7 @@ export const DraftSessionChatInterface = memo(
           defaultModelId,
           modeOptions,
           modelOptions,
+          modelReasoningEfforts,
         }),
         [
           capabilityAuthority,
@@ -288,16 +290,21 @@ export const DraftSessionChatInterface = memo(
           defaultModelId,
           modeOptions,
           modelOptions,
+          modelReasoningEfforts,
         ]
       );
-      const { selectedModeId, selectedModelId, configOptionValues } =
-        useResolvedAcpSessionConfigSelection(sessionConfigSelection, selectorOptions, {
-          cliType: draft.cliType,
-          agentType: draft.agentType,
-        });
+      const {
+        selectedModeId,
+        selectedModelId,
+        configOptionValues,
+        configOptionSelectors: resolvedConfigOptionSelectors,
+      } = useResolvedAcpSessionConfigSelection(sessionConfigSelection, selectorOptions, {
+        cliType: draft.cliType,
+        agentType: draft.agentType,
+      });
       const dispatchConfigOptionValues = useMemo(
-        () => filterAcpSessionConfigOptionValues(configOptionValues, configOptionSelectors),
-        [configOptionSelectors, configOptionValues]
+        () => filterAcpSessionConfigOptionValues(configOptionValues, resolvedConfigOptionSelectors),
+        [configOptionValues, resolvedConfigOptionSelectors]
       );
       const thinkEffortSelector = useMemo(
         () =>

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -2131,6 +2131,7 @@ export const SessionChatInterface = memo(
       machineFlockRows,
       modeOptions,
       modelOptions,
+      modelReasoningEfforts,
       sessionMachine,
     } = useSessionAcpSelectorContext({
       machineId: session.machineId,
@@ -2149,6 +2150,7 @@ export const SessionChatInterface = memo(
         defaultModelId,
         modeOptions,
         modelOptions,
+        modelReasoningEfforts,
       }),
       [
         capabilityAuthority,
@@ -2157,6 +2159,7 @@ export const SessionChatInterface = memo(
         defaultModelId,
         modeOptions,
         modelOptions,
+        modelReasoningEfforts,
       ]
     );
     const { selectedModeId, selectedModelId, configOptionValues } =

--- a/packages/components/src/components/settings/agent-role-editor-dialog.tsx
+++ b/packages/components/src/components/settings/agent-role-editor-dialog.tsx
@@ -120,6 +120,10 @@ export function AgentRoleEditorDialog({
           configId: selectedAgentConfig.id,
           cliType: selectedAgentConfig.cliType,
           agentType: selectedAgentConfig.agentType,
+          // A Role pins its model: the effort ladder must follow the model
+          // being edited, not the probe-time current one, so the picker and
+          // the compatibility check agree on the same ladder.
+          selectedModelId: editor?.value.modelId ?? null,
           runtimeOverrides: selectedAgentConfig.runtimeOverrides,
           machine: selectedMachineId ? (machines.get(selectedMachineId) ?? null) : null,
         }

--- a/packages/components/src/components/shared/acp-selector-options.ts
+++ b/packages/components/src/components/shared/acp-selector-options.ts
@@ -189,6 +189,8 @@ export type AcpSelectorOptions = {
   defaultModelId: string | null;
   /** Dynamic config option selectors for agents with configOptions (e.g. thought_level). */
   configOptionSelectors: AcpConfigOptionSelector[];
+  /** Per-model reasoning-effort ladders when the capability source publishes them. */
+  modelReasoningEfforts: Record<string, string[]> | undefined;
 };
 
 export type AcpSelectorTarget = {
@@ -210,11 +212,12 @@ export type AcpSelectorTarget = {
 type ResolvedConfigOptions = {
   authority: AcpCapabilityAuthority;
   configOptions?: AcpConfigOptionSummary[];
+  modelReasoningEfforts: Record<string, string[]> | undefined;
 };
 
 const resolveConfigOptions = (target?: AcpSelectorTarget): ResolvedConfigOptions => {
   if (!target?.cliType || !target.agentType) {
-    return { authority: 'unavailable' };
+    return { authority: 'unavailable', modelReasoningEfforts: undefined };
   }
 
   if (target.configId) {
@@ -222,8 +225,9 @@ const resolveConfigOptions = (target?: AcpSelectorTarget): ResolvedConfigOptions
     const capability = target.machine?.acpCapabilities?.[key];
     if (isAcpCapabilityCacheEntryCurrentForRuntimeOverrides(capability, target.runtimeOverrides)) {
       const authority = getAcpCapabilityCacheEntryAuthority(capability, target.runtimeOverrides);
+      const modelReasoningEfforts = capability.modelReasoningEfforts;
       if (capability.configOptions?.length) {
-        return { authority, configOptions: capability.configOptions };
+        return { authority, configOptions: capability.configOptions, modelReasoningEfforts };
       }
       // Fallback: synthesize configOptions from legacy modes/models.
       const synthesized: AcpConfigOptionSummary[] = [];
@@ -257,6 +261,7 @@ const resolveConfigOptions = (target?: AcpSelectorTarget): ResolvedConfigOptions
       return {
         authority,
         configOptions: synthesized.length > 0 ? synthesized : undefined,
+        modelReasoningEfforts,
       };
     }
   }
@@ -267,8 +272,12 @@ const resolveConfigOptions = (target?: AcpSelectorTarget): ResolvedConfigOptions
     target.runtimeOverrides
   );
   return staticCapabilities
-    ? { authority: 'provisional', configOptions: staticCapabilities.configOptions }
-    : { authority: 'unavailable' };
+    ? {
+        authority: 'provisional',
+        configOptions: staticCapabilities.configOptions,
+        modelReasoningEfforts: staticCapabilities.modelReasoningEfforts,
+      }
+    : { authority: 'unavailable', modelReasoningEfforts: undefined };
 };
 
 export const stripRecommended = (text: string): string => text.replace(/\s*\(recommended\)/gi, '');
@@ -355,7 +364,7 @@ const resolveSelectedModelId = (
   return typeof modelOption?.currentValue === 'string' ? modelOption.currentValue : undefined;
 };
 
-export const normalizeCodexReasoningEffortSelectors = (
+const normalizeCodexReasoningEffortSelectors = (
   selectors: AcpConfigOptionSelector[],
   target?: Pick<AcpSelectorTarget, 'cliType' | 'agentType' | 'selectedModelId'>
 ): AcpConfigOptionSelector[] => {
@@ -393,6 +402,72 @@ export const normalizeCodexReasoningEffortSelectors = (
       return selector;
     }
     return { ...selector, options, currentValue };
+  });
+};
+
+const reasoningEffortOptionLabel = (value: string): string =>
+  value === 'xhigh' ? 'X-High' : value.charAt(0).toUpperCase() + value.slice(1);
+
+/**
+ * Rebuilds a thought-level selector's options from the selected model's own
+ * effort ladder. The probed config option list describes only the model that
+ * was current at probe time; agents that publish a per-model map
+ * (`modelReasoningEfforts`) get a picker that follows the model instead of
+ * serving that stale list for every model (LodyAI/Lody#149). A model the
+ * map does not cover keeps the probe-time list — the adapter owns the wire
+ * and rejects unsupported efforts with a visible warning, so the UI does
+ * not duplicate that guard.
+ *
+ * The map is a FALLBACK, never an override: an agent that already adapts the
+ * ladder to the model itself owns that behavior. Codex hands off to its
+ * hand-maintained tiers above (its probed list omits the extended ones), and
+ * Claude's adapter rebuilds its effort option from the model's own
+ * `supportedEffortLevels` on every switch, so it publishes no map and this
+ * path stays inert for it. This is the one entry point; the per-agent split
+ * lives here rather than at every call site.
+ */
+export const normalizeReasoningEffortSelectors = (
+  selectors: AcpConfigOptionSelector[],
+  options: {
+    cliType?: AcpSelectorTarget['cliType'];
+    agentType?: AcpSelectorTarget['agentType'];
+    modelReasoningEfforts?: Record<string, string[]>;
+    selectedModelId?: string | null;
+  }
+): AcpConfigOptionSelector[] => {
+  if (options.cliType === 'builtin' && options.agentType?.toLowerCase() === 'codex') {
+    return normalizeCodexReasoningEffortSelectors(selectors, {
+      cliType: options.cliType,
+      agentType: options.agentType,
+      selectedModelId: options.selectedModelId ?? undefined,
+    });
+  }
+  const map = options.modelReasoningEfforts;
+  const selectedModelId = options.selectedModelId;
+  if (!map || !selectedModelId) {
+    return selectors;
+  }
+  const targetEfforts = map[selectedModelId];
+  if (!targetEfforts || targetEfforts.length === 0) {
+    return selectors;
+  }
+  return selectors.map((selector) => {
+    if (selector.type !== 'select' || !isThoughtLevelSelector(selector)) {
+      return selector;
+    }
+    return {
+      ...selector,
+      options: targetEfforts.map((value) => ({
+        value,
+        label: reasoningEffortOptionLabel(value),
+        description: undefined,
+      })),
+      currentValue: targetEfforts.includes(selector.currentValue)
+        ? selector.currentValue
+        : targetEfforts.includes('medium')
+          ? 'medium'
+          : (targetEfforts[0] ?? ''),
+    };
   });
 };
 
@@ -496,7 +571,8 @@ const resolveDefaultModeId = (
  * For React components, prefer useAcpSelectorOptions hook instead.
  */
 export const buildAcpSelectorOptions = (target?: AcpSelectorTarget): AcpSelectorOptions => {
-  const { authority: capabilityAuthority, configOptions } = resolveConfigOptions(target);
+  const { authority: capabilityAuthority, configOptions, modelReasoningEfforts } =
+    resolveConfigOptions(target);
   // Custom providers are arbitrary ACP agents just like registry agents: their
   // modes/models come from the capability probe (configOptions), not the
   // builtin tables.
@@ -516,15 +592,14 @@ export const buildAcpSelectorOptions = (target?: AcpSelectorTarget): AcpSelector
     (option) => option.category === 'model' && option.type === 'select'
   );
 
-  const allSelectors = normalizeCodexReasoningEffortSelectors(
+  const allSelectors = normalizeReasoningEffortSelectors(
     buildConfigOptionSelectors(configOptions, target, capabilityAuthority),
-    target
-      ? {
-          cliType: target.cliType,
-          agentType: target.agentType,
-          selectedModelId: resolveSelectedModelId(configOptions, target),
-        }
-      : undefined
+    {
+      cliType: target?.cliType,
+      agentType: target?.agentType,
+      modelReasoningEfforts,
+      selectedModelId: target ? resolveSelectedModelId(configOptions, target) : undefined,
+    }
   );
   const configOptionSelectors = allSelectors.filter((selector) => {
     const category = selector.category ?? '';
@@ -545,6 +620,7 @@ export const buildAcpSelectorOptions = (target?: AcpSelectorTarget): AcpSelector
     defaultModelId:
       typeof modelConfigOption?.currentValue === 'string' ? modelConfigOption.currentValue : null,
     configOptionSelectors,
+    modelReasoningEfforts,
   };
 };
 
@@ -555,15 +631,14 @@ export const buildAcpSelectorOptions = (target?: AcpSelectorTarget): AcpSelector
 export const buildAllConfigOptionSelectors = (
   target?: AcpSelectorTarget
 ): AcpConfigOptionSelector[] => {
-  const { authority, configOptions } = resolveConfigOptions(target);
-  return normalizeCodexReasoningEffortSelectors(
+  const { authority, configOptions, modelReasoningEfforts } = resolveConfigOptions(target);
+  return normalizeReasoningEffortSelectors(
     buildConfigOptionSelectors(configOptions, target, authority),
-    target
-      ? {
-          cliType: target.cliType,
-          agentType: target.agentType,
-          selectedModelId: resolveSelectedModelId(configOptions, target),
-        }
-      : undefined
+    {
+      cliType: target?.cliType,
+      agentType: target?.agentType,
+      modelReasoningEfforts,
+      selectedModelId: target ? resolveSelectedModelId(configOptions, target) : undefined,
+    }
   );
 };

--- a/packages/components/src/hooks/use-session-agent-role.ts
+++ b/packages/components/src/hooks/use-session-agent-role.ts
@@ -266,17 +266,23 @@ export function useSessionAgentRole({
       setSelectionOverride({ roleId, basedOnTurnKeys: effectiveKnownTurnKeys });
 
       const { modelId, modeId, configOptionValues: pinned } = role.runConfig;
-      if (modelId && modelOptions.some((option) => option.value === modelId)) {
-        onModelChange?.(modelId);
+      const appliedModelId =
+        modelId && modelOptions.some((option) => option.value === modelId) ? modelId : undefined;
+      if (appliedModelId) {
+        onModelChange?.(appliedModelId);
       }
       if (modeId && modeOptions.some((option) => option.value === modeId)) {
         onModeChange?.(modeId);
       }
       // An option this agent dropped, or whose value it no longer offers, is
       // skipped rather than forced back in — through the same filter every
-      // other surface applies to remembered values.
+      // other surface applies to remembered values. A Role that also pins a
+      // different model is the exception: the selectors describe the outgoing
+      // model, whose ladder must not decide the pinned effort.
       for (const [configId, value] of Object.entries(
-        filterAcpSessionConfigOptionValues(pinned, configOptionSelectors)
+        filterAcpSessionConfigOptionValues(pinned, configOptionSelectors, {
+          switchesModel: appliedModelId !== undefined && appliedModelId !== selectedModelId,
+        })
       )) {
         onConfigOptionChange?.(configId, value);
       }
@@ -291,6 +297,7 @@ export function useSessionAgentRole({
       onConfigOptionChange,
       onModeChange,
       onModelChange,
+      selectedModelId,
       setSelectionOverride,
     ]
   );

--- a/packages/components/src/lib/acp-session-config-selection.ts
+++ b/packages/components/src/lib/acp-session-config-selection.ts
@@ -1,7 +1,8 @@
 import type { AcpCapabilityAuthority, AcpConfigOptionValue } from '@lody/shared';
 import {
   isConfigOptionValueValid,
-  normalizeCodexReasoningEffortSelectors,
+  isThoughtLevelSelector,
+  normalizeReasoningEffortSelectors,
   type AcpConfigOptionSelector,
   type AcpSelectorTarget,
 } from '@/components/shared/acp-selector-options';
@@ -165,12 +166,16 @@ export type AcpSessionSelectorOptionsInput = {
   defaultModeId: string | null;
   defaultModelId: string | null;
   configOptionSelectors: AcpConfigOptionSelector[];
+  /** Per-model reasoning-effort ladders when the capability source publishes them. */
+  modelReasoningEfforts: Record<string, string[]> | undefined;
 };
 
 export type ResolvedAcpSessionConfigSelection = {
   selectedModeId: string | null;
   selectedModelId: string | null;
   configOptionValues: Record<string, AcpConfigOptionValue>;
+  /** Selectors re-normalized for the RESOLVED model; dispatch filtering must use these, not the candidate-model input ones. */
+  configOptionSelectors: AcpConfigOptionSelector[];
 };
 
 const isSelectValueValid = (
@@ -235,6 +240,7 @@ export const resolveAcpSessionConfigSelection = (
     defaultModeId,
     defaultModelId,
     configOptionSelectors,
+    modelReasoningEfforts,
   } = selectorOptions;
 
   const selectedModeId = resolveSelectField(
@@ -253,13 +259,15 @@ export const resolveAcpSessionConfigSelection = (
     defaultModelId,
     capabilityAuthority
   );
-  const selectors = target
-    ? normalizeCodexReasoningEffortSelectors(configOptionSelectors, {
-        cliType: target.cliType,
-        agentType: target.agentType,
-        selectedModelId,
-      })
-    : configOptionSelectors;
+  let selectors = configOptionSelectors;
+  if (target) {
+    selectors = normalizeReasoningEffortSelectors(selectors, {
+      cliType: target.cliType,
+      agentType: target.agentType,
+      modelReasoningEfforts,
+      selectedModelId,
+    });
+  }
 
   const runtimeTable = runtimePreferences?.configOptionValues;
   const baseTable = runtimeTable ?? preferences.configOptionValues ?? {};
@@ -304,16 +312,39 @@ export const resolveAcpSessionConfigSelection = (
     }
   }
 
-  return { selectedModeId, selectedModelId, configOptionValues };
+  return {
+    selectedModeId,
+    selectedModelId,
+    configOptionValues,
+    configOptionSelectors: selectors,
+  };
 };
 
+/**
+ * Keeps the values the given selectors still offer.
+ *
+ * `switchesModel` says the caller applies these values together with a new
+ * model. Reasoning effort is per model and the selectors still describe the
+ * OUTGOING one, so validating the effort here would drop a value the incoming
+ * model does offer (Grok 4.5 has no `xhigh`, Grok 4.6 does). It passes through
+ * instead, and the selection resolution re-validates it against the resolved
+ * model.
+ */
 export const filterAcpSessionConfigOptionValues = (
   values: Record<string, AcpConfigOptionValue> | undefined,
-  selectors: readonly AcpConfigOptionSelector[]
+  selectors: readonly AcpConfigOptionSelector[],
+  options: { switchesModel?: boolean } = {}
 ): Record<string, AcpConfigOptionValue> => {
   const filtered: Record<string, AcpConfigOptionValue> = {};
   for (const selector of selectors) {
     const value = values?.[selector.configId];
+    if (value === undefined) {
+      continue;
+    }
+    if (options.switchesModel === true && isThoughtLevelSelector(selector)) {
+      filtered[selector.configId] = value;
+      continue;
+    }
     if (isConfigOptionValueValid(selector, value)) {
       filtered[selector.configId] = value;
     }

--- a/packages/components/src/lib/recent-run-configs.ts
+++ b/packages/components/src/lib/recent-run-configs.ts
@@ -3,6 +3,7 @@ import { getAgentRoleEmoji, type AgentConfigMeta, type AgentRole } from '@lody/s
 import type { RecentRunConfigItem } from '@/components/sessions/recent-run-config-menu-group';
 import {
   isConfigOptionValueValid,
+  isThoughtLevelSelector,
   resolveConfigOptionValue,
   resolveOnOffConfigOptionEnabled,
   resolvePlanModeSelectorEnabled,
@@ -295,16 +296,25 @@ export function buildRecentRunConfigItems({
  * The config-option values of a record that are still valid for the agent's
  * current selectors. An option the provider dropped (or whose value it no
  * longer offers) is skipped rather than forced back in.
+ *
+ * `switchesModel` says the record also moves the model. The selectors still
+ * describe the OUTGOING model, and reasoning effort is per model, so validating
+ * the recorded effort against them would drop a value the incoming model does
+ * offer (Grok 4.5's ladder has no `xhigh`, Grok 4.6's does). It is taken
+ * verbatim instead; the selection resolution re-validates it against the
+ * resolved model.
  */
 export function resolveApplicableConfigOptionValues(
   record: Pick<RecentRunConfigRecord, 'configOptionValues'>,
-  configOptionSelectors: ReadonlyArray<AcpConfigOptionSelector>
+  configOptionSelectors: ReadonlyArray<AcpConfigOptionSelector>,
+  options: { switchesModel?: boolean } = {}
 ): Array<{ configId: string; value: AcpConfigOptionValue }> {
   const applicable: Array<{ configId: string; value: AcpConfigOptionValue }> = [];
   for (const selector of configOptionSelectors) {
     const value = record.configOptionValues[selector.configId];
     if (value === undefined) continue;
-    if (!isConfigOptionValueValid(selector, value)) continue;
+    const modelDependent = options.switchesModel === true && isThoughtLevelSelector(selector);
+    if (!modelDependent && !isConfigOptionValueValid(selector, value)) continue;
     applicable.push({ configId: selector.configId, value });
   }
   return applicable;

--- a/packages/components/src/stories/AgentRoleForm.stories.tsx
+++ b/packages/components/src/stories/AgentRoleForm.stories.tsx
@@ -19,6 +19,7 @@ const selectorOptions: AcpSelectorOptions = {
   capabilityAuthority: 'authoritative',
   defaultModeId: 'default',
   defaultModelId: 'gpt-5.6-sol',
+  modelReasoningEfforts: undefined,
   modeOptions: [
     { value: 'default', label: 'Default' },
     { value: 'plan', label: 'Plan' },

--- a/packages/components/tests/acp-selector-options.test.ts
+++ b/packages/components/tests/acp-selector-options.test.ts
@@ -8,7 +8,7 @@ import {
 import {
   buildAcpSelectorOptions,
   buildAllConfigOptionSelectors,
-  normalizeCodexReasoningEffortSelectors,
+  normalizeReasoningEffortSelectors,
   resolvePlanModeSelectorEnabled,
   togglePlanModeSelectorValue,
   type AcpConfigOptionSelector,
@@ -60,6 +60,55 @@ const codexModelAndReasoningOptions = (
     options: reasoningOptions,
   },
 ];
+
+/**
+ * A runtime-probed builtin Grok cache entry: the model option and flat
+ * thought-level list measured at probe time, plus the per-model ladder map
+ * the adapter publishes.
+ */
+const grokMachineWithLadderProbe = ({
+  currentModelId,
+  models,
+  currentEffort,
+  effortOptions,
+  modelReasoningEfforts,
+}: {
+  currentModelId: string;
+  models: Array<{ modelId: string; name: string }>;
+  currentEffort: string;
+  effortOptions: Array<{ value: string; name: string }>;
+  modelReasoningEfforts: Record<string, string[]>;
+}) =>
+  machineWithCapabilities({
+    [agentConfigId]: {
+      cliType: 'builtin',
+      agentType: 'grok',
+      cacheVersion: ACP_CAPABILITY_CACHE_VERSION,
+      provenance: 'runtime',
+      modes: [],
+      models: [],
+      configOptions: [
+        {
+          id: 'model',
+          name: 'Model',
+          category: 'model',
+          type: 'select',
+          currentValue: currentModelId,
+          options: models.map((model) => ({ value: model.modelId, name: model.name })),
+        },
+        {
+          id: 'reasoning_effort',
+          name: 'Reasoning Effort',
+          category: 'thought_level',
+          type: 'select',
+          currentValue: currentEffort,
+          options: effortOptions,
+        },
+      ],
+      modelReasoningEfforts,
+      fetchedAt: 1,
+    },
+  });
 
 describe('buildAcpSelectorOptions', () => {
   it('synthesizes registry model selectors when a stale cache stores empty config options', () => {
@@ -598,6 +647,161 @@ describe('buildAcpSelectorOptions', () => {
     });
   });
 
+  it('rebuilds the Grok thought-level ladder for the selected model, not the probed one', () => {
+    /* The capability probe measured the thought-level list while a model with
+       a `high`/`low`/`max` ladder was current; selecting Grok 4.6 must restore
+       its own ladder instead of the probed one (LodyAI/Lody#149). */
+    const grokMachineWithProbedKimiLadder = grokMachineWithLadderProbe({
+      currentModelId: 'kimi-k3-256k',
+      models: [
+        { modelId: 'grok-4.6', name: 'Grok 4.6' },
+        { modelId: 'grok-4.5', name: 'Grok 4.5' },
+        { modelId: 'kimi-k3-256k', name: 'Kimi K3 256K' },
+      ],
+      currentEffort: 'high',
+      effortOptions: [
+        { value: 'high', name: 'High' },
+        { value: 'low', name: 'Low' },
+        { value: 'max', name: 'Max' },
+      ],
+      modelReasoningEfforts: {
+        'grok-4.6': ['xhigh', 'high', 'medium', 'low'],
+        'grok-4.5': ['high', 'medium', 'low'],
+        'kimi-k3-256k': ['high', 'low', 'max'],
+      },
+    });
+
+    const options46 = buildAcpSelectorOptions({
+      configId: agentConfigId,
+      cliType: 'builtin',
+      agentType: 'grok',
+      selectedModelId: 'grok-4.6',
+      machine: grokMachineWithProbedKimiLadder,
+    });
+    const selector46 = options46.configOptionSelectors.find(
+      (candidate) => candidate.configId === 'reasoning_effort'
+    );
+    expect(selector46?.options).toEqual([
+      { value: 'xhigh', label: 'X-High', description: undefined },
+      { value: 'high', label: 'High', description: undefined },
+      { value: 'medium', label: 'Medium', description: undefined },
+      { value: 'low', label: 'Low', description: undefined },
+    ]);
+    expect(selector46?.currentValue).toBe('high');
+
+    const options45 = buildAcpSelectorOptions({
+      configId: agentConfigId,
+      cliType: 'builtin',
+      agentType: 'grok',
+      selectedModelId: 'grok-4.5',
+      machine: grokMachineWithProbedKimiLadder,
+    });
+    expect(
+      options45.configOptionSelectors
+        .find((candidate) => candidate.configId === 'reasoning_effort')
+        ?.options.map((option) => option.value)
+    ).toEqual(['high', 'medium', 'low']);
+  });
+
+  it('falls back to medium rather than the highest target-model tier', () => {
+    /* The probed model's current effort (`max`) is invalid for Grok 4.6,
+       whose ladder starts at `xhigh`: the fallback must pick the neutral
+       tier instead of silently defaulting the next turn to maximum effort. */
+    const options = buildAcpSelectorOptions({
+      configId: agentConfigId,
+      cliType: 'builtin',
+      agentType: 'grok',
+      selectedModelId: 'grok-4.6',
+      machine: grokMachineWithLadderProbe({
+        currentModelId: 'kimi-k3-256k',
+        models: [
+          { modelId: 'grok-4.6', name: 'Grok 4.6' },
+          { modelId: 'kimi-k3-256k', name: 'Kimi K3 256K' },
+        ],
+        currentEffort: 'max',
+        effortOptions: [
+          { value: 'high', name: 'High' },
+          { value: 'low', name: 'Low' },
+          { value: 'max', name: 'Max' },
+        ],
+        modelReasoningEfforts: {
+          'grok-4.6': ['xhigh', 'high', 'medium', 'low'],
+        },
+      }),
+    });
+
+    const selector = options.configOptionSelectors.find(
+      (candidate) => candidate.configId === 'reasoning_effort'
+    );
+    expect(selector?.currentValue).toBe('medium');
+  });
+
+  it('follows the static Grok per-model ladders before any probe', () => {
+    const options = buildAcpSelectorOptions({
+      configId: agentConfigId,
+      cliType: 'builtin',
+      agentType: 'grok',
+      selectedModelId: 'grok-4.5',
+      machine: machineWithCapabilities({}),
+    });
+
+    expect(
+      options.configOptionSelectors
+        .find((candidate) => candidate.configId === 'reasoning_effort')
+        ?.options.map((option) => option.value)
+    ).toEqual(['high', 'medium', 'low']);
+  });
+
+  it('keeps the Codex hardcoded tiers richer than a synthesized map rebuild', () => {
+    /* When the Codex cache carries a per-model map richer than the probed
+       thought-level list (the probe ran under a lesser model), the map-driven
+       rebuild would synthesize label-only `max`/`ultra` and the hardcoded
+       normalizer would then skip its described options. Codex stays on its
+       hardcoded path so the described tiers keep winning. */
+    const options = buildAcpSelectorOptions({
+      configId: agentConfigId,
+      cliType: 'builtin',
+      agentType: 'codex',
+      selectedModelId: 'gpt-5.6-sol',
+      machine: machineWithCapabilities({
+        [agentConfigId]: {
+          cliType: 'builtin',
+          agentType: 'codex',
+          cacheVersion: ACP_CAPABILITY_CACHE_VERSION,
+          provenance: 'runtime',
+          modes: [],
+          models: [],
+          configOptions: codexModelAndReasoningOptions('medium', [
+            { value: 'low', name: 'low' },
+            { value: 'medium', name: 'medium' },
+          ]),
+          modelReasoningEfforts: {
+            'gpt-5.6-sol': ['low', 'medium', 'max', 'ultra'],
+          },
+          fetchedAt: 1,
+        },
+      }),
+    });
+
+    expect(
+      options.configOptionSelectors.find((candidate) => candidate.configId === 'reasoning_effort')
+        ?.options
+    ).toEqual([
+      { value: 'low', label: 'low', description: undefined },
+      { value: 'medium', label: 'medium', description: undefined },
+      {
+        value: 'max',
+        label: 'Max',
+        description: 'Maximum reasoning depth for the hardest problems',
+      },
+      {
+        value: 'ultra',
+        label: 'Ultra',
+        description: 'Maximum reasoning with automatic task delegation',
+      },
+    ]);
+  });
+
   it('does not use static or default cached builtin capabilities when a runtime override is set', () => {
     const options = buildAcpSelectorOptions({
       configId: agentConfigId,
@@ -832,14 +1036,14 @@ describe('buildAcpSelectorOptions', () => {
     };
 
     expect(
-      normalizeCodexReasoningEffortSelectors([reasoningSelector], {
+      normalizeReasoningEffortSelectors([reasoningSelector], {
         cliType: 'builtin',
         agentType: 'claude',
         selectedModelId: 'gpt-5.6-sol',
       })
     ).toEqual([reasoningSelector]);
     expect(
-      normalizeCodexReasoningEffortSelectors([customSelector], {
+      normalizeReasoningEffortSelectors([customSelector], {
         cliType: 'builtin',
         agentType: 'codex',
         selectedModelId: 'gpt-5.6-sol',

--- a/packages/components/tests/acp-session-config-selection.test.ts
+++ b/packages/components/tests/acp-session-config-selection.test.ts
@@ -293,6 +293,63 @@ describe('ACP session config derivation', () => {
     expect(resolved.configOptionValues.reasoning_effort).toBe('medium');
   });
 
+  it('returns the resolved-model selectors so dispatch filtering keeps resolved-valid values', () => {
+    /* The resolver keeps `xhigh` for the resolved 4.6, but the caller's
+       candidate-4.5 selector would drop it at dispatch. The resolved selectors
+       must travel with the values so filtering follows the model the turn
+       will actually run on. */
+    const staleGrokReasoningSelector = {
+      configId: 'reasoning_effort',
+      label: 'Reasoning effort',
+      type: 'select' as const,
+      currentValue: 'high',
+      options: [
+        { value: 'high', label: 'High' },
+        { value: 'medium', label: 'Medium' },
+        { value: 'low', label: 'Low' },
+      ],
+    };
+    const resolved = resolveAcpSessionConfigSelection(
+      {
+        edits: emptyEdits,
+        preferences: {
+          modelId: 'grok-4.5',
+          configOptionValues: { reasoning_effort: 'xhigh' },
+        },
+      },
+      {
+        capabilityAuthority: 'authoritative',
+        modeOptions: [],
+        modelOptions: [{ value: 'grok-4.6', label: '4.6' }],
+        defaultModeId: null,
+        defaultModelId: 'grok-4.6',
+        configOptionSelectors: [staleGrokReasoningSelector],
+        modelReasoningEfforts: {
+          'grok-4.6': ['xhigh', 'high', 'medium', 'low'],
+        },
+      },
+      { cliType: 'builtin', agentType: 'grok' }
+    );
+    expect(resolved.selectedModelId).toBe('grok-4.6');
+    expect(resolved.configOptionValues.reasoning_effort).toBe('xhigh');
+    expect(
+      resolved.configOptionSelectors
+        ?.find((selector) => selector.configId === 'reasoning_effort')
+        ?.options.map((option) => option.value)
+    ).toEqual(['xhigh', 'high', 'medium', 'low']);
+    expect(
+      filterAcpSessionConfigOptionValues(
+        resolved.configOptionValues,
+        resolved.configOptionSelectors ?? []
+      ).reasoning_effort
+    ).toBe('xhigh');
+    expect(
+      filterAcpSessionConfigOptionValues(resolved.configOptionValues, [
+        staleGrokReasoningSelector,
+      ]).reasoning_effort
+    ).toBeUndefined();
+  });
+
   it('builds unvalidated candidates from the same chain', () => {
     expect(
       buildAcpSessionConfigCandidates({
@@ -332,6 +389,36 @@ describe('ACP session config derivation', () => {
         selectors
       )
     ).toEqual({});
+  });
+
+  it('lets a pinned effort through when the same pick moves the model', () => {
+    const selectors = [
+      {
+        configId: 'reasoning_effort',
+        label: 'Reasoning',
+        category: 'thought_level' as const,
+        type: 'select' as const,
+        currentValue: 'high',
+        options: [
+          { value: 'high', label: 'High' },
+          { value: 'low', label: 'Low' },
+        ],
+      },
+      {
+        configId: 'collaboration_mode',
+        label: 'Collaboration mode',
+        type: 'select' as const,
+        currentValue: 'default',
+        options: [{ value: 'default', label: 'Default' }],
+      },
+    ];
+    const pinned = { reasoning_effort: 'xhigh', collaboration_mode: 'invalid' };
+    // These selectors belong to the model being left behind; only the effort is
+    // model-dependent, so everything else is still validated against them.
+    expect(filterAcpSessionConfigOptionValues(pinned, selectors, { switchesModel: true })).toEqual({
+      reasoning_effort: 'xhigh',
+    });
+    expect(filterAcpSessionConfigOptionValues(pinned, selectors)).toEqual({});
   });
 });
 

--- a/packages/components/tests/recent-run-configs.test.ts
+++ b/packages/components/tests/recent-run-configs.test.ts
@@ -183,6 +183,18 @@ describe('applying a record to the current selectors', () => {
     ).toEqual([{ configId: 'reasoning_effort', value: 'high' }]);
   });
 
+  it('keeps the recorded effort when the entry also moves the model', () => {
+    // The selectors still carry the outgoing model's ladder, so `xhigh` is not
+    // theirs to reject — the incoming model may well offer it.
+    expect(
+      resolveApplicableConfigOptionValues(
+        { configOptionValues: { reasoning_effort: 'xhigh', gone: 'x' } },
+        [reasoning],
+        { switchesModel: true }
+      )
+    ).toEqual([{ configId: 'reasoning_effort', value: 'xhigh' }]);
+  });
+
   it('describes the selection the way the run-config trigger reads it', () => {
     const face = describeRunConfigSelection({
       modelOptions: [{ value: 'opus', label: 'Opus 5' }],

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -393,6 +393,8 @@ export type StaticBuiltinAcpCapabilities = {
   modes: Array<{ id: string; name: string; description?: string }>;
   models: Array<{ modelId: string; name: string; description?: string }>;
   configOptions: AcpConfigOptionSummary[];
+  /** Per-model reasoning-effort ladders, mirroring the cached runtime map. */
+  modelReasoningEfforts?: Record<string, string[]>;
 };
 
 /** Codex mode that routes approval requests to a model reviewer subagent. */
@@ -910,6 +912,10 @@ const STATIC_BUILTIN_ACP_CAPABILITIES: Record<BuiltinAgentType, StaticBuiltinAcp
     modes: GROK_STATIC_MODES,
     models: GROK_STATIC_MODELS,
     configOptions: GROK_STATIC_CONFIG_OPTIONS,
+    modelReasoningEfforts: {
+      'grok-4.6': ['xhigh', 'high', 'medium', 'low'],
+      'grok-4.5': ['high', 'medium', 'low'],
+    },
   },
   deepseek: {
     modes: DEEPSEEK_HARNESS_PERMISSION_MODES.map((mode) => ({ ...mode })),
@@ -929,6 +935,16 @@ const cloneStaticCapabilities = (
   modes: capabilities.modes.map((mode) => ({ ...mode })),
   models: capabilities.models.map((model) => ({ ...model })),
   configOptions: capabilities.configOptions.map(cloneConfigOption),
+  ...(capabilities.modelReasoningEfforts
+    ? {
+        modelReasoningEfforts: Object.fromEntries(
+          Object.entries(capabilities.modelReasoningEfforts).map(([modelId, efforts]) => [
+            modelId,
+            [...efforts],
+          ])
+        ),
+      }
+    : {}),
 });
 
 /**

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -277,7 +277,11 @@ export type AcpCommandSummary = {
 };
 
 // Bump when cached ACP probes need to be invalidated across clients.
-export const ACP_CAPABILITY_CACHE_VERSION = 6;
+// 7: entries probed before the legacy `model[effort]` derivation became
+// Codex-only carry a bogus ladder for every agent that spells other variants
+// with the same brackets — a Claude probe stored `{ opus: ['1m'] }` — and the
+// per-model effort picker would rebuild that model's ladder from it.
+export const ACP_CAPABILITY_CACHE_VERSION = 7;
 
 export type AcpCapabilityAuthority = 'unavailable' | 'provisional' | 'authoritative';
 


### PR DESCRIPTION
## Related issue

Closes #149

## Problem / pressure

The reasoning-effort picker showed one flat list — the ladder measured for whatever model was current at probe time — for every model. Selecting Grok 4.6 while the probe had run under a model with a `high`/`low`/`max` ladder hid `medium`/`xhigh` and offered `max`, which xAI rejects with `400 Invalid reasoning effort`. Grok 4.5 and 4.6 differ the same way (`xhigh` only on 4.6). The Grok adapter kept one flat ladder and never rebuilt it on model change, and nothing carried a model-independent view to the UI.

## Summary

- Grok adapter (LodyAI/acp-extension-grok#11): rebuilds the ladder from the selected model on every change, translates the runtime `model_changed` notification into `config_option_update`, and publishes the per-model view as `_meta.lody.modelReasoningEfforts` on the session response. The root gitlink is bumped after that PR merges, per the runtime-upgrade convention from #201.
- CLI: capability normalization reads that map into the capability cache, merged with the existing legacy `model[effort]` derivation — now scoped to builtin Codex, because Claude uses the same brackets for context windows (`opus[1m]`). `ACP_CAPABILITY_CACHE_VERSION` goes to 7, because an entry probed before that guard stored a bogus ladder for every agent that spells other variants with the same brackets (a Claude probe left `{ opus: ['1m'] }`), and the picker would now rebuild that model's ladder from it. `summarizeAgentRunConfigCapabilities` and `resolveAgentRunConfigSelection` already consume the map, so MCP options and dispatch validation pick it up unchanged.
- UI: `normalizeReasoningEffortSelectors` rebuilds the thought-level selector from the selected model's ladder, in the selector builders and again in the selection resolution so it follows an authoritatively resolved model. Applying a whole saved configuration (a recent run config or a Role) that also moves the model passes its effort through unvalidated, because the selectors still describe the outgoing model; the selection resolution re-validates it against the resolved one. It is a fallback, never an override — Codex's hand-maintained extended tiers and Claude's adapter-side rebuild keep their own paths, and a model the map does not cover keeps the probe-time list, since the adapter owns the wire and rejects an unsupported effort with a visible warning.

## Before / after

| Before                                                                     | After                                                       |
| -------------------------------------------------------------------------- | ----------------------------------------------------------- |
| Picker shows the probed model's ladder for every model                     | Picker shows the selected model's ladder                    |
| Grok 4.6 picker under a foreign probe: `high`/`low`/`max`                   | `xhigh`/`high`/`medium`/`low`                                |
| Effort validated against the probed model's ladder                         | Validated against the selected model's ladder               |
| MCP `lody_session_create_options` reports one flat `reasoningEffortValues`  | Adds per-model `models[].reasoningEffortValues`             |

## Test plan

- `packages/acp-extension-grok`: `npm test` — 39 passing (model-switch rebuild, effort validation against the selected model, published meta).
- `apps/cli`: `npx vitest run tests/acp-capability-normalization.test.ts src/mcp/lody-mcp-server.test.ts src/commands/session.test.ts` — passing.
- `packages/components`: `npx vitest run tests/acp-selector-options.test.ts tests/acp-session-config-selection.test.ts tests/session-config-selection-oscillation.test.tsx tests/agent-role-form.test.ts tests/recent-run-configs.test.ts` — passing (the two localStorage failures in `recent-run-configs` reproduce on a clean checkout). `packages/shared`: full run, 995 passing.
- Repo-wide `pnpm typecheck`, `pnpm lint`, `pnpm lint:i18n`, `check:code-collab-imports`, `check:platform-boundaries`, `check:public-boundary` — pass. Full `test:ci` was not run; the known environment-related component failures reproduce on a clean checkout without this change.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `normalizeReasoningEffortSelectors` in `packages/components/src/components/shared/acp-selector-options.ts`, and the zod-scoped `_meta.lody` read plus Codex-only legacy merge in `apps/cli/src/agent/acp-capability-normalization.ts`.
- **Decisions to challenge:** the map is fallback-only, because Codex and Claude already adapt the ladder per model themselves and must not be overridden; the cache-version bump, which drops every entry (builtins fall back to their static tables, registry agents to no selectors) until the next probe; a model absent from the map keeps the probe-time list instead of losing the control.
- **Plausible failures / evidence gaps:** the runtime half ships only once grok#11 merges and the gitlink follows; the `_meta.lody.modelReasoningEfforts` contract is documented in AGENTS.md rather than declared in acp-extension-core — say the word if you prefer it in core.

### Authoring context

- **User goal / directives:** fix #149 as agreed with the maintainer on the issue — take the ladder from the selected model, not the probed one — keeping the change small and preferring deletions.
- **Constraints / non-goals:** Codex and Claude keep their existing per-model handling; vendor model `_meta` must not leak into Lody business code; the adapter's startup `sessionConfig` translation is untouched.
- **Risk-bearing decisions:** an effort invalid for the selected model falls back to the neutral `medium` rather than the ladder's first (most expensive) entry; an uncovered model keeps the probe-time list and relies on the adapter's rejection warning.
- **Destructive or irreversible behavior:** the cache-version bump discards cached probe results; they are re-derived by the next probe and no user data is touched.
- **Deliberately not done or tested:** UI-side withdrawal of the control for uncovered models was tried during review and rolled back (it needed a four-branch rule plus a measured-model pipeline to duplicate a guard the adapter already owns); registry/custom agents select models through `configOptionValues`, which the resolver does not read, and none publishes the map today; no end-to-end Grok run on a real machine.
- **Unknowns / confidence:** high for the cache and picker layers, unit-tested at each seam with fixtures from the issue; the adapter half depends on grok#11 merging first.

<!-- context-handoff:end -->
