### PR TITLE
fix(components): attach SVG images as files

### DIFF
--- a/packages/components/src/lib/file-drop.ts
+++ b/packages/components/src/lib/file-drop.ts
@@ -1,9 +1,15 @@
+import { SESSION_IMAGE_ALLOWED_MIME_TYPES } from '@lody/shared';
+
 type FileTransferItem = Pick<DataTransferItem, 'kind' | 'getAsFile'>;
 type FileDropDataTransfer = {
   types?: ArrayLike<string> | Iterable<string>;
   items?: ArrayLike<FileTransferItem> | Iterable<FileTransferItem>;
   files?: ArrayLike<File> | Iterable<File>;
 };
+
+const supportedImageMimeTypes = new Set<string>(SESSION_IMAGE_ALLOWED_MIME_TYPES);
+const isSupportedImage = (file: File): boolean =>
+  supportedImageMimeTypes.has(file.type.trim().toLowerCase());
 
 const toArray = <T>(value: ArrayLike<T> | Iterable<T> | null | undefined): T[] => {
   if (!value) {
@@ -38,7 +44,11 @@ export const getFilesFromDataTransfer = (
 
 export const splitImageAndFileAttachments = (
   files: File[]
-): { images: File[]; attachments: File[] } => ({
-  images: files.filter((file) => file.type.startsWith('image/')),
-  attachments: files.filter((file) => !file.type.startsWith('image/')),
-});
+): { images: File[]; attachments: File[] } => {
+  return {
+    images: files.filter(isSupportedImage),
+    // Image MIME types unsupported by the image upload path (for example
+    // SVG) remain valid general file attachments instead of being rejected.
+    attachments: files.filter((file) => !isSupportedImage(file)),
+  };
+};

--- a/packages/components/tests/file-drop.test.ts
+++ b/packages/components/tests/file-drop.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { splitImageAndFileAttachments } from '../src/lib/file-drop';
 
 describe('splitImageAndFileAttachments', () => {
-  it('routes picker selections by MIME type rather than filename', () => {
+  it('routes picker selections by supported image MIME type rather than filename', () => {
     const imageWithTextExtension = new File(['image'], 'preview.txt', { type: 'image/png' });
     const fileWithImageExtension = new File(['document'], 'report.png', {
       type: 'application/pdf',
@@ -20,6 +20,17 @@ describe('splitImageAndFileAttachments', () => {
     ).toEqual({
       images: [imageWithTextExtension],
       attachments: [fileWithImageExtension, fileWithoutMime],
+    });
+  });
+
+  it('routes SVG images to general file attachments', () => {
+    const svg = new File(['<svg xmlns="http://www.w3.org/2000/svg"/>'], 'diagram.svg', {
+      type: 'image/svg+xml',
+    });
+
+    expect(splitImageAndFileAttachments([svg])).toEqual({
+      images: [],
+      attachments: [svg],
     });
   });
 });


### PR DESCRIPTION
## Related issue

Closes #290

## Problem / pressure

The composer routed every `image/*` MIME type through the raster image uploader, while that uploader accepts only PNG, JPEG, WebP, and GIF. Dragging an SVG therefore selected a path that was guaranteed to reject it, even though the general file attachment path supports SVG.

## Summary

- Classify image attachments against the shared raster MIME allowlist.
- Route SVG and other unsupported image MIME types to general file attachments.
- Add a regression test for `image/svg+xml` while preserving MIME-based routing for supported raster images.

## Before / after

| Before | After |
| ------ | ----- |
| Dragging an SVG shows an unsupported-format error and adds nothing. | Dragging an SVG adds it as a general file attachment. |

## Test plan

- `corepack pnpm --filter @lody/components exec vitest run tests/file-drop.test.ts`
- `corepack pnpm --filter @lody/components typecheck`
- `corepack pnpm exec prettier --check packages/components/src/lib/file-drop.ts packages/components/tests/file-drop.test.ts`

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check `file-drop.ts` classification against the shared image MIME contract and the SVG regression in `file-drop.test.ts`.
- **Decisions to challenge:** Confirm that every image MIME unsupported by the raster uploader should fall back to a general file, rather than special-casing SVG.
- **Plausible failures / evidence gaps:** Browser-provided MIME values remain advisory; files with no MIME already follow the general file path, while full end-to-end drag UI automation is left to CI or manual preview.

### Authoring context

- **User goal / directives:** Allow an SVG dragged into the Lody composer to be attached at least as a regular file and publish the focused fix through a fork PR.
- **Constraints / non-goals:** Keep raster image behavior unchanged and do not add SVG to thumbnail decoding, image schemas, or image upload endpoints.
- **Risk-bearing decisions:** The fallback applies to every MIME type outside the shared raster allowlist, matching the general file path's no-format-rejection contract.
- **Destructive or irreversible behavior:** The change performs no migration, deletion, overwrite, or external data mutation; reverting the single commit restores prior routing.
- **Deliberately not done or tested:** No new SVG image rendering path was added; validation covers routing, component typing, and formatting rather than the complete workspace suite.
- **Unknowns / confidence:** Confidence is high because all composer entry points share this splitter; remaining uncertainty is limited to platform-specific MIME reporting, whose empty-type case already falls back to files.

<!-- context-handoff:end -->
