### PR TITLE
fix(electron): allow fake-IP proxy answers in the public browser

### DIFF
--- a/apps/electron/src/main/services/public-browser-service.ts
+++ b/apps/electron/src/main/services/public-browser-service.ts
@@ -6,7 +6,7 @@ import {
   type ElectronPublicBrowserResult,
   type ElectronPublicBrowserState
 } from '@lody/shared/electron-ipc'
-import { classifyBrowserHostname, parseBrowserAddress } from '@lody/shared/browser-url'
+import { classifyResolvedBrowserAddress, parseBrowserAddress } from '@lody/shared/browser-url'
 import { formatUnknownError } from '../utils'
 import { isNavigationAbortError, mergePublicBrowserState } from './public-browser-state'
 
@@ -54,7 +54,7 @@ const resolvePublicHostname = async (browserSession: Session, hostname: string):
     throw new Error(`Unable to resolve public browser host: ${hostname}`)
   }
   const blocked = endpoints.find(
-    (endpoint) => classifyBrowserHostname(endpoint.address) !== 'public'
+    (endpoint) => classifyResolvedBrowserAddress(endpoint.address) !== 'public'
   )
   if (blocked) {
     throw new Error(`Public browser blocked a non-public destination: ${blocked.address}`)

--- a/packages/components/src/components/sessions/AGENTS.md
+++ b/packages/components/src/components/sessions/AGENTS.md
@@ -242,6 +242,10 @@ Session conversation page chain:
   capability (Electron `WebContentsView` today); loopback/private targets use Managed Preview and
   are the only pages eligible for Visual Annotation. Never fall back from a missing public engine
   to iframe, system browser, CLI, Preview Gateway, or a different Machine RPC plane.
+  The public engine resolves every hostname and rejects non-public answers (DNS rebinding), with
+  one deliberate exception: a public name resolving into RFC 2544 `198.18.0.0/15` is a fake-IP
+  proxy's synthetic answer (Clash, Surge, sing-box, Shadowrocket) and is allowed via
+  `classifyResolvedBrowserAddress`; a literal `198.18.x.x` address stays prohibited.
   The composer info-bar Browser action is an explicit candidate-navigation request, not merely a
   panel-open action. It opens the reported candidate even when another page is already visible.
   That click IS the approval for that exact target: a remote route creates (or replaces) its tunnel

--- a/packages/shared/src/browser-url.ts
+++ b/packages/shared/src/browser-url.ts
@@ -48,14 +48,16 @@ const stripIpv6Brackets = (host: string): string => {
     : normalized;
 };
 
-const parseIpv4 = (host: string): [number, number, number, number] | null => {
+type Ipv4Octets = [number, number, number, number];
+
+const parseIpv4 = (host: string): Ipv4Octets | null => {
   const parts = host.split('.');
   if (parts.length !== 4) return null;
   const octets = parts.map((part) => Number(part));
   if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
     return null;
   }
-  return octets as [number, number, number, number];
+  return octets as Ipv4Octets;
 };
 
 const parseIpv6 = (host: string): number[] | null => {
@@ -83,12 +85,14 @@ const parseIpv6 = (host: string): number[] | null => {
   return [...left, ...Array.from({ length: 8 - left.length - right.length }, () => 0), ...right];
 };
 
-const classifyIpv4 = ([first, second, third, fourth]: [
-  number,
-  number,
-  number,
-  number,
-]): BrowserTargetClass => {
+// RFC 2544 benchmarking range 198.18.0.0/15. It is never globally routed, so a literal
+// address stays prohibited, but fake-IP proxies (Clash, Surge, sing-box, Shadowrocket)
+// answer every DNS query from this range and then intercept the connection by domain.
+const isBenchmarkingIpv4 = ([first, second]: Ipv4Octets): boolean =>
+  first === 198 && (second === 18 || second === 19);
+
+const classifyIpv4 = (octets: Ipv4Octets): BrowserTargetClass => {
+  const [first, second, third, fourth] = octets;
   if (first === 127) return 'loopback';
   if (first === 10 || (first === 172 && second >= 16 && second <= 31)) return 'private-lan';
   if (first === 192 && second === 168) return 'private-lan';
@@ -100,11 +104,20 @@ const classifyIpv4 = ([first, second, third, fourth]: [
     (first === 169 && second === 254) ||
     (first === 192 && second === 0 && third === 0) ||
     (first === 192 && second === 0 && third === 2) ||
-    (first === 198 && (second === 18 || second === 19)) ||
+    isBenchmarkingIpv4(octets) ||
     (first === 198 && second === 51 && third === 100) ||
     (first === 203 && second === 0 && third === 113) ||
     (first === 255 && second === 255 && third === 255 && fourth === 255);
   return prohibited ? 'prohibited' : 'public';
+};
+
+const mappedIpv4 = (segments: number[]): Ipv4Octets | null => {
+  if (!segments.slice(0, 5).every((segment) => segment === 0) || segments[5] !== 0xffff) {
+    return null;
+  }
+  const high = segments[6] ?? 0;
+  const low = segments[7] ?? 0;
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff];
 };
 
 const classifyIpv6 = (segments: number[]): BrowserTargetClass => {
@@ -112,11 +125,8 @@ const classifyIpv6 = (segments: number[]): BrowserTargetClass => {
   if (segments.slice(0, 7).every((segment) => segment === 0) && segments[7] === 1) {
     return 'loopback';
   }
-  if (segments.slice(0, 5).every((segment) => segment === 0) && segments[5] === 0xffff) {
-    const high = segments[6] ?? 0;
-    const low = segments[7] ?? 0;
-    return classifyIpv4([high >> 8, high & 0xff, low >> 8, low & 0xff]);
-  }
+  const mapped = mappedIpv4(segments);
+  if (mapped) return classifyIpv4(mapped);
   const first = segments[0] ?? 0;
   if ((first & 0xfe00) === 0xfc00) return 'private-lan';
   if ((first & 0xffc0) === 0xfe80 || (first & 0xff00) === 0xff00) return 'prohibited';
@@ -133,6 +143,20 @@ export const classifyBrowserHostname = (hostname: string): BrowserTargetClass =>
   const ipv6 = parseIpv6(host);
   if (ipv6) return classifyIpv6(ipv6);
   return 'public';
+};
+
+/**
+ * Classifies an address that the resolver returned for a public hostname, as opposed to a
+ * hostname the user typed. The only difference from `classifyBrowserHostname` is 198.18.0.0/15:
+ * a public name resolving there is a fake-IP proxy's synthetic answer, and the connection to it
+ * is intercepted by that proxy and forwarded by domain, so it is treated as public. A literal
+ * 198.18.x.x address is still prohibited because nothing legitimate lives in that range.
+ */
+export const classifyResolvedBrowserAddress = (address: string): BrowserTargetClass => {
+  const host = stripIpv6Brackets(address);
+  const ipv4 = parseIpv4(host) ?? mappedIpv4(parseIpv6(host) ?? []);
+  if (ipv4 && isBenchmarkingIpv4(ipv4)) return 'public';
+  return classifyBrowserHostname(address);
 };
 
 const parseWithDefaultScheme = (input: string): URL => {

--- a/packages/shared/tests/browser-url.test.ts
+++ b/packages/shared/tests/browser-url.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   BrowserAddressError,
   classifyBrowserHostname,
+  classifyResolvedBrowserAddress,
   formatPreviewTargetUrl,
   parseBrowserAddress,
 } from '../src/browser-url';
@@ -69,6 +70,34 @@ describe('classifyBrowserHostname', () => {
   it('treats local DNS names as managed targets', () => {
     expect(classifyBrowserHostname('devbox.local')).toBe('private-lan');
     expect(classifyBrowserHostname('host.docker.internal')).toBe('private-lan');
+  });
+
+  it('prohibits literal RFC 2544 benchmarking addresses', () => {
+    expect(classifyBrowserHostname('198.18.3.75')).toBe('prohibited');
+    expect(classifyBrowserHostname('198.19.255.1')).toBe('prohibited');
+    expect(() => parseBrowserAddress('http://198.18.3.75/')).toThrow(BrowserAddressError);
+  });
+});
+
+describe('classifyResolvedBrowserAddress', () => {
+  it.each(['198.18.0.1', '198.18.3.75', '198.19.255.254', '[::ffff:c612:34b]'])(
+    'accepts %s as a fake-IP proxy answer for a public hostname',
+    (address) => {
+      expect(classifyResolvedBrowserAddress(address)).toBe('public');
+    }
+  );
+
+  it.each([
+    ['127.0.0.1', 'loopback'],
+    ['10.0.0.8', 'private-lan'],
+    ['[::ffff:c0a8:101]', 'private-lan'],
+    ['169.254.169.254', 'prohibited'],
+    ['198.17.255.255', 'public'],
+    ['198.20.0.0', 'public'],
+    ['198.51.100.7', 'prohibited'],
+    ['[fe80::1]', 'prohibited'],
+  ])('still classifies resolved %s as %s', (address, targetClass) => {
+    expect(classifyResolvedBrowserAddress(address)).toBe(targetClass);
   });
 });
 


### PR DESCRIPTION
## Related issue

Closes #298

## Problem / pressure

The public browser resolves every hostname before navigating and rejects any answer that is not a public address, which defeats DNS rebinding against loopback, private LAN, link-local, and cloud-metadata targets. Fake-IP proxies (Clash / Clash Verge, Surge, sing-box, Shadowrocket in `fake-ip` DNS mode) answer every DNS query from the RFC 2544 benchmarking range `198.18.0.0/15` and intercept the connection by domain. That range is on the prohibited list, so with such a proxy active every public site fails with `Public browser blocked a non-public destination: 198.18.x.x`. Fake-IP mode is the default for several of these tools, so the public browser is unusable for a large group of users while their proxy is on.

## Summary

- Add `classifyResolvedBrowserAddress` in `packages/shared/src/browser-url.ts`. It classifies an address the resolver returned for a public hostname and differs from `classifyBrowserHostname` only for `198.18.0.0/15`, which it treats as public. IPv4-mapped IPv6 answers are unwrapped the same way.
- `PublicBrowserService.resolvePublicHostname` now uses the resolved-address classifier, so the navigation, `webRequest`, and WebSocket policy paths all accept fake-IP answers while still blocking every other non-public range.
- Literal `198.18.x.x` addresses typed into the address bar or used as a page subresource remain prohibited; `classifyBrowserHostname` and `parseBrowserAddress` are unchanged for them.
- Shared the IPv4-mapped IPv6 unwrapping between `classifyIpv6` and the new classifier instead of duplicating it.
- Tests cover the `/15` boundary, the mapped-IPv6 form, and that loopback, private LAN, link-local, metadata, and documentation ranges are still blocked when resolved.
- Recorded the exception next to the dual-engine invariant in `packages/components/src/components/sessions/AGENTS.md`.

## Before / after

| Before | After |
| ------ | ----- |
| With a fake-IP proxy on, `https://example.com` in the Session Browser fails with `Public browser blocked a non-public destination: 198.18.3.75`. | The page loads; the proxy intercepts the `198.18.x.x` connection and forwards it by domain as it does for every other application. |
| A hostname resolving to `127.0.0.1`, `10.x`, `169.254.169.254`, or `198.51.100.x` is blocked. | Unchanged: still blocked. |
| Typing `http://198.18.3.75/` is rejected as a reserved address. | Unchanged: still rejected. |

## Test plan

- `pnpm --filter @lody/shared exec vitest run tests/browser-url.test.ts`: 36 passed, including the new `classifyResolvedBrowserAddress` cases and the literal-address prohibition case.
- `pnpm --filter @lody/shared typecheck` and `pnpm --filter @lody/electron typecheck` (node and web): clean.
- `oxlint --type-aware` on the changed files: no errors; the remaining warnings are pre-existing lines not touched here. `eslint` in `apps/electron` on the changed service: clean.
- `pnpm --filter @lody/electron test`: 54 passed.
- `pnpm check:public-boundary`: passed. `prettier --check` on the changed files: clean.
- Skipped: the full `pnpm check` (root typecheck and the complete test matrix) and a manual desktop run behind a live fake-IP proxy. The behavior change is fully covered by the shared unit tests; the Electron service change is a one-symbol swap on a code path that cannot run under `node --test` because it imports `electron`.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `packages/shared/src/browser-url.ts` (`classifyResolvedBrowserAddress`, `isBenchmarkingIpv4`, `mappedIpv4`) and the single call-site change in `apps/electron/src/main/services/public-browser-service.ts`; confirm every path that checks resolver answers goes through `resolvePublicHostname`.
- **Decisions to challenge:** exempting the whole `198.18.0.0/15` instead of the more common `198.18.0.0/16` (sing-box defaults to the `/15`); keeping the exemption resolver-only rather than also allowing literal addresses; not adding a user-facing hint about fake-IP proxies in the error message.
- **Plausible failures / evidence gaps:** a network that illegitimately uses `198.18.0.0/15` for internal hosts would now be reachable via DNS rebinding when no fake-IP proxy is active; not verified against a live fake-IP proxy in the desktop app, only via unit tests of the classifier.

### Authoring context

- **User goal / directives:** make the public browser work behind fake-IP proxies by treating `198.18.0.0/15` differently from other reserved ranges, and open a PR that explains why.
- **Constraints / non-goals:** keep the DNS-rebinding guard for every other range; keep literal reserved addresses prohibited; no changes to Managed Preview, the dual-engine routing, or the error UI.
- **Risk-bearing decisions:** narrowing the security policy for one non-globally-routed range; the exemption is resolver-only and documented as a deliberate exception in the sessions `AGENTS.md`.
- **Destructive or irreversible behavior:** none; no data, migration, or configuration changes.
- **Deliberately not done or tested:** no live fake-IP desktop run and no full-root `pnpm check`; the classifier is exhaustively unit tested and the service change is a one-symbol swap on a typechecked path.
- **Unknowns / confidence:** high confidence in the classifier; moderate residual risk only for networks that misuse the benchmarking range internally, which is uncommon and already outside the range's specification.

<!-- context-handoff:end -->
