### PR TITLE
fix(cli): gate prompt replay on a per-run activity recorder [risk:medium]

### DIFF
--- a/apps/cli/src/lib/AGENTS.md
+++ b/apps/cli/src/lib/AGENTS.md
@@ -312,6 +312,13 @@ control-plane path is DEPRECATED; do not add functionality to it.
   carry the exact `Session` that produced them, and
   `SessionExecutionService.onSessionInstanceClosed` acts only when
   `runtime.session === instance`.
+  INVARIANT: `SessionTransientStore`'s two cleanup paths are HAND-WRITTEN enumerations;
+  the header comment claiming a new field is "automatically included in both" was never
+  true and now says so. Several fields survive `clearTurnState` deliberately —
+  `acpUpdateBuffer`, `lateACPUpdateTarget`, and `promptActivity` (the replay gate's
+  evidence, read precisely when a turn has ENDED). Clearing `promptActivity` per turn
+  repeats the `acpFlushCountInTurn` mistake: the gate goes blind at the only moment it
+  is consulted.
   INVARIANT: finalization commits through the store's synchronous compare-and-set
   `finalizeIfCurrent(sessionId, turnRef)`, which remembers the late-update target and
   clears turn state in one step, reading that target from LIVE state. The only thing a

--- a/apps/cli/src/lib/AGENTS.md
+++ b/apps/cli/src/lib/AGENTS.md
@@ -312,13 +312,9 @@ control-plane path is DEPRECATED; do not add functionality to it.
   carry the exact `Session` that produced them, and
   `SessionExecutionService.onSessionInstanceClosed` acts only when
   `runtime.session === instance`.
-  INVARIANT: `SessionTransientStore`'s two cleanup paths are HAND-WRITTEN enumerations;
-  the header comment claiming a new field is "automatically included in both" was never
-  true and now says so. Several fields survive `clearTurnState` deliberately —
-  `acpUpdateBuffer`, `lateACPUpdateTarget`, and `promptActivity` (the replay gate's
-  evidence, read precisely when a turn has ENDED). Clearing `promptActivity` per turn
-  repeats the `acpFlushCountInTurn` mistake: the gate goes blind at the only moment it
-  is consulted.
+  INVARIANT: cleanup paths are hand-written. Buffers, late-update routing, and prompt
+  activity deliberately survive `clearTurnState`; the replay gate reads activity
+  after the turn ends.
   INVARIANT: finalization commits through the store's synchronous compare-and-set
   `finalizeIfCurrent(sessionId, turnRef)`, which remembers the late-update target and
   clears turn state in one step, reading that target from LIVE state. The only thing a

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -10033,17 +10033,22 @@ export class MessageHandler {
   }
 
   /**
-   * Same observation as `hasPromptOutputForTurn`, but it distinguishes "this turn
-   * emitted nothing" from "we cannot tell". The two callers need opposite
-   * conservative answers on a missing session: prompt replay must refuse to
-   * retry, while the no-output guard must not accuse a turn it could not observe.
-   * `undefined` means unobservable — the transient state is gone.
+   * Did this turn put anything VISIBLE in the transcript?
+   *
+   * A DIFFERENT question from `hasPromptOutputForTurn`, which asks whether the
+   * turn may have ACTED. Reusing that one here was a bug: a turn that only
+   * requested a permission or wrote a file counts as "may have acted" but shows
+   * the user nothing, so the no-output guard took the success path and the user
+   * got an empty assistant entry with no explanation at all.
+   *
+   * `undefined` means unobservable — the transient state is gone — and keeps the
+   * guard failing OPEN, because it must never accuse a turn it could not observe.
    */
   observePromptOutputForTurn(sessionId: SessionId, turnId: string): boolean | undefined {
     if (!this.store.has(sessionId)) {
       return undefined;
     }
-    return this.hasPromptOutputForTurn(sessionId, turnId);
+    return this.store.hasVisiblePromptOutputForTurn(sessionId, turnId);
   }
 
   /**

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -3671,9 +3671,6 @@ export class MessageHandler {
     });
 
     this.sessionManager.on('onWriteTextFile', (sessionId, event) => {
-      // `fs/write_text_file` is an independent JSON-RPC request that never passes
-      // through `enqueueACPUpdate`, so the replay gate is blind to it unless the
-      // recorder is told here: the agent has already written to disk.
       this.recordPromptSideEffect(sessionId);
       this.trackCodeCollabEvidenceWrite(
         sessionId,
@@ -4719,11 +4716,6 @@ export class MessageHandler {
     }
   }
 
-  /**
-   * Note a permission request or an `fs/write_text_file` against whichever prompt
-   * run is currently bound. Both are independent JSON-RPC requests that bypass
-   * `enqueueACPUpdate`, which is exactly why the replay gate could not see them.
-   */
   private recordPromptSideEffect(sessionId: SessionId): void {
     this.store.getBoundPromptActivityRecorder(sessionId)?.recordSideEffect();
   }
@@ -4740,8 +4732,6 @@ export class MessageHandler {
       return;
     }
     if (this.store.recordSuppressedAcpReplay(sessionId)) {
-      // Suppressed `loadSession` replay is previously persisted history, not this
-      // turn acting, so it is NOT recorded as prompt activity.
       return;
     }
     const target = this.store.getCurrentACPUpdateTarget(sessionId);
@@ -8561,9 +8551,7 @@ export class MessageHandler {
     request: RequestPermissionRequest,
     model?: ModelInfo
   ): Promise<RequestPermissionResponse> {
-    // Also an independent JSON-RPC request. Recorded on ARRIVAL rather than on
-    // approval: an agent that asked for permission has already decided to run the
-    // tool, and a replay would ask again for work that may have been approved.
+    // Record on arrival: approval may already have caused work before recovery.
     this.recordPromptSideEffect(sessionId);
     const isAskUserQuestionRequest = isAskUserQuestionPermissionRequest(request);
     const askUserQuestionMeta = isAskUserQuestionRequest
@@ -10001,18 +9989,7 @@ export class MessageHandler {
     return this.store.has(sessionId) && this.store.get(sessionId).acpUpdateBuffer.length > 0;
   }
 
-  /**
-   * Did this turn put anything VISIBLE in the transcript?
-   *
-   * A DIFFERENT question from the replay gate's `observePromptActivityForTurn`,
-   * which asks whether the turn may have ACTED. Answering this one with that was
-   * a bug: a turn that only requested a permission or wrote a file counts as
-   * "may have acted" but shows the user nothing, so the no-output guard took the
-   * success path and the user got an empty assistant entry with no explanation.
-   *
-   * `undefined` means unobservable — the transient state is gone — and keeps the
-   * guard failing OPEN, because it must never accuse a turn it could not observe.
-   */
+  /** `undefined` keeps the no-output guard open when the turn is unobservable. */
   observePromptOutputForTurn(sessionId: SessionId, turnId: string): boolean | undefined {
     if (!this.store.has(sessionId)) {
       return undefined;

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -3086,7 +3086,6 @@ export class MessageHandler {
         this.clearConversationTurnIfMatches(sessionId, turnId),
       getActiveTurnId: (sessionId) => this.store.getActiveTurnId(sessionId),
       clearActiveTurnId: (sessionId, turnId) => this.clearActiveTurnIdIfMatches(sessionId, turnId),
-      hasPromptOutputForTurn: (sessionId, turnId) => this.hasPromptOutputForTurn(sessionId, turnId),
       observePromptOutputForTurn: (sessionId, turnId) =>
         this.observePromptOutputForTurn(sessionId, turnId),
       buildAcpPromptBlocks: async (args) => await this.buildAcpPromptBlocks(args),
@@ -4738,7 +4737,6 @@ export class MessageHandler {
       this.logger.debug(
         `[${sessionId}] Dropping ACP update after permanent deletion reached its commit boundary`
       );
-      this.store.getBoundPromptActivityRecorder(sessionId)?.recordDropped('session_deleted');
       return;
     }
     if (this.store.recordSuppressedAcpReplay(sessionId)) {
@@ -4752,7 +4750,6 @@ export class MessageHandler {
       this.logger.debug(
         `[${sessionId}] Dropping ACP update without an active/finalized assistant entry target (${update.update.sessionUpdate})`
       );
-      this.store.getBoundPromptActivityRecorder(sessionId)?.recordDropped('no_route');
       return;
     }
     if (target.source === 'finalized_turn') {
@@ -10005,41 +10002,13 @@ export class MessageHandler {
   }
 
   /**
-   * Conservative guard for prompt replay: any buffered or already-flushed ACP
-   * update means the adapter may have acted on the user prompt, so execution
-   * recovery must stop and surface the failure instead of retrying.
-   */
-  private hasPromptOutputForTurn(sessionId: SessionId, turnId: string): boolean {
-    if (!this.store.has(sessionId)) {
-      // No transient state means we cannot observe anything about this turn, and
-      // this guard's only caller replays a user prompt. Unobservable must read as
-      // "may already have acted" — `observePromptOutputForTurn` is the accessor
-      // for callers that need to tell "nothing happened" from "cannot tell".
-      return true;
-    }
-    // The recorder is authoritative: it sees permission requests and
-    // `fs/write_text_file` (independent JSON-RPC requests that never reach
-    // `enqueueACPUpdate`), and unlike `acpFlushCountInTurn` it is not zeroed by
-    // `clearTurnState` — which used to erase the evidence exactly when the gate
-    // was consulted. `unknown` means unobservable and refuses the replay.
-    const observation = this.store.observePromptActivityForTurn(sessionId, turnId);
-    if (observation !== 'none') {
-      return true;
-    }
-    // Recorder says this prompt did nothing. Corroborate with the buffer, which
-    // can still hold entries this turn enqueued before the recorder was bound.
-    const state = this.store.get(sessionId);
-    return state.acpUpdateBuffer.some((item) => item.target.turnId === turnId);
-  }
-
-  /**
    * Did this turn put anything VISIBLE in the transcript?
    *
-   * A DIFFERENT question from `hasPromptOutputForTurn`, which asks whether the
-   * turn may have ACTED. Reusing that one here was a bug: a turn that only
-   * requested a permission or wrote a file counts as "may have acted" but shows
-   * the user nothing, so the no-output guard took the success path and the user
-   * got an empty assistant entry with no explanation at all.
+   * A DIFFERENT question from the replay gate's `observePromptActivityForTurn`,
+   * which asks whether the turn may have ACTED. Answering this one with that was
+   * a bug: a turn that only requested a permission or wrote a file counts as
+   * "may have acted" but shows the user nothing, so the no-output guard took the
+   * success path and the user got an empty assistant entry with no explanation.
    *
    * `undefined` means unobservable — the transient state is gone — and keeps the
    * guard failing OPEN, because it must never accuse a turn it could not observe.

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -285,6 +285,7 @@ import {
   type BufferedACPUpdate,
   type TurnRef,
 } from '@/lib/session-transient-store';
+import { PromptActivityRecorder } from '@/session/prompt-activity-recorder';
 import { fetchAcpCapabilities, type FetchAcpCapabilitiesOptions } from '@/agent/acp-capabilities';
 import type { WorkspaceWatchCoordinatorApi } from './code-collab/workspace-watch-coordinator';
 import { appendIssuePrMentionsToPrompt } from '@/session/session-execution-helpers';
@@ -3077,8 +3078,10 @@ export class MessageHandler {
       endACPReplaySuppression: (sessionId) => this.endACPReplaySuppression(sessionId),
       beginConversationTurn: (sessionId, userTurnId, gateContext) =>
         this.beginConversationTurn(sessionId, userTurnId, gateContext),
-      bindConversationTurnForPrompt: (sessionId, turnRef) =>
-        this.bindConversationTurnForPrompt(sessionId, turnRef),
+      bindConversationTurnForPrompt: (sessionId, turnRef, recorder) =>
+        this.bindConversationTurnForPrompt(sessionId, turnRef, recorder),
+      observePromptActivityForTurn: (sessionId, turnId) =>
+        this.store.observePromptActivityForTurn(sessionId, turnId),
       clearConversationTurn: (sessionId, turnId) =>
         this.clearConversationTurnIfMatches(sessionId, turnId),
       getActiveTurnId: (sessionId) => this.store.getActiveTurnId(sessionId),
@@ -3669,6 +3672,10 @@ export class MessageHandler {
     });
 
     this.sessionManager.on('onWriteTextFile', (sessionId, event) => {
+      // `fs/write_text_file` is an independent JSON-RPC request that never passes
+      // through `enqueueACPUpdate`, so the replay gate is blind to it unless the
+      // recorder is told here: the agent has already written to disk.
+      this.recordPromptSideEffect(sessionId);
       this.trackCodeCollabEvidenceWrite(
         sessionId,
         this.collectCodeCollabWriteTextFileEvidence(sessionId, event)
@@ -4713,6 +4720,15 @@ export class MessageHandler {
     }
   }
 
+  /**
+   * Note a permission request or an `fs/write_text_file` against whichever prompt
+   * run is currently bound. Both are independent JSON-RPC requests that bypass
+   * `enqueueACPUpdate`, which is exactly why the replay gate could not see them.
+   */
+  private recordPromptSideEffect(sessionId: SessionId): void {
+    this.store.getBoundPromptActivityRecorder(sessionId)?.recordSideEffect();
+  }
+
   private enqueueACPUpdate(sessionId: SessionId, update: AcpSessionNotification): void {
     // Note: ACP notifications are internal agent events, NOT user activity.
     // We intentionally do NOT call touchSession() here to avoid keeping sessions
@@ -4722,9 +4738,12 @@ export class MessageHandler {
       this.logger.debug(
         `[${sessionId}] Dropping ACP update after permanent deletion reached its commit boundary`
       );
+      this.store.getBoundPromptActivityRecorder(sessionId)?.recordDropped('session_deleted');
       return;
     }
     if (this.store.recordSuppressedAcpReplay(sessionId)) {
+      // Suppressed `loadSession` replay is previously persisted history, not this
+      // turn acting, so it is NOT recorded as prompt activity.
       return;
     }
     const target = this.store.getCurrentACPUpdateTarget(sessionId);
@@ -4733,6 +4752,7 @@ export class MessageHandler {
       this.logger.debug(
         `[${sessionId}] Dropping ACP update without an active/finalized assistant entry target (${update.update.sessionUpdate})`
       );
+      this.store.getBoundPromptActivityRecorder(sessionId)?.recordDropped('no_route');
       return;
     }
     if (target.source === 'finalized_turn') {
@@ -4746,6 +4766,7 @@ export class MessageHandler {
         }
       );
     }
+    this.store.getBoundPromptActivityRecorder(sessionId)?.recordRouted();
     this.store.get(sessionId).acpUpdateBuffer.push({ notification: update, target });
     this.scheduleFlushACPUpdates(sessionId);
   }
@@ -6052,9 +6073,10 @@ export class MessageHandler {
 
   private bindConversationTurnForPrompt(
     sessionId: SessionId,
-    turnRef: TurnRef
+    turnRef: TurnRef,
+    recorder?: PromptActivityRecorder
   ): BindTurnForPromptResult {
-    const result = this.store.bindTurnForPrompt(sessionId, turnRef);
+    const result = this.store.bindTurnForPrompt(sessionId, turnRef, recorder);
     if (result !== 'bound') {
       this.logger.error(
         `[${sessionId}] Refusing to prompt turn ${turnRef.turnId} (epoch ${turnRef.turnEpoch}): ACP routing could not be bound (${result})`
@@ -8542,6 +8564,10 @@ export class MessageHandler {
     request: RequestPermissionRequest,
     model?: ModelInfo
   ): Promise<RequestPermissionResponse> {
+    // Also an independent JSON-RPC request. Recorded on ARRIVAL rather than on
+    // approval: an agent that asked for permission has already decided to run the
+    // tool, and a replay would ask again for work that may have been approved.
+    this.recordPromptSideEffect(sessionId);
     const isAskUserQuestionRequest = isAskUserQuestionPermissionRequest(request);
     const askUserQuestionMeta = isAskUserQuestionRequest
       ? parseAskUserQuestionPermissionMeta(request._meta)
@@ -9991,11 +10017,19 @@ export class MessageHandler {
       // for callers that need to tell "nothing happened" from "cannot tell".
       return true;
     }
+    // The recorder is authoritative: it sees permission requests and
+    // `fs/write_text_file` (independent JSON-RPC requests that never reach
+    // `enqueueACPUpdate`), and unlike `acpFlushCountInTurn` it is not zeroed by
+    // `clearTurnState` — which used to erase the evidence exactly when the gate
+    // was consulted. `unknown` means unobservable and refuses the replay.
+    const observation = this.store.observePromptActivityForTurn(sessionId, turnId);
+    if (observation !== 'none') {
+      return true;
+    }
+    // Recorder says this prompt did nothing. Corroborate with the buffer, which
+    // can still hold entries this turn enqueued before the recorder was bound.
     const state = this.store.get(sessionId);
-    const hasBufferedOutput = state.acpUpdateBuffer.some((item) => item.target.turnId === turnId);
-    const hasFlushedOutput =
-      state.acpFlushCountInTurn > 0 && this.store.getTurnId(sessionId) === turnId;
-    return hasBufferedOutput || hasFlushedOutput;
+    return state.acpUpdateBuffer.some((item) => item.target.turnId === turnId);
   }
 
   /**

--- a/apps/cli/src/lib/session-transient-store.test.ts
+++ b/apps/cli/src/lib/session-transient-store.test.ts
@@ -151,6 +151,7 @@ describe('SessionTransientStore', () => {
         turnId: 'turn-2',
         source: 'active_turn',
       });
+      expect(store.getLateACPUpdateTargetAssistantEntryId(id)).toBeUndefined();
     });
 
     it('bindTurnForPrompt refuses a session whose state is gone, without recreating it', () => {
@@ -182,44 +183,6 @@ describe('SessionTransientStore', () => {
 
       // The live turn's routing was left untouched by the refusal.
       expect(store.getCurrentACPUpdateTarget(id)).toBeUndefined();
-    });
-
-    it('bindTurnForPrompt refuses a turn that was already cleared', () => {
-      const store = new SessionTransientStore();
-      const id = sid('s1');
-
-      const epoch = store.beginTurn(id, { turnId: 'turn-1' });
-      const ref = { turnId: 'turn-1', turnEpoch: epoch, assistantEntryId: 'turn-1' };
-      store.clearTurnState(id);
-
-      expect(store.bindTurnForPrompt(id, ref)).toBe('turn_superseded');
-      expect(store.has(id)).toBe(true);
-    });
-
-    it('bindTurnForPrompt drops a stale late target so replay cannot leak into the new turn', () => {
-      // Binding is what hands routing to the new turn, and it must also drop the
-      // previous turn's late-update target — otherwise output produced between
-      // the two turns keeps landing on the old assistant entry.
-      const store = new SessionTransientStore();
-      const id = sid('s1');
-
-      store.beginTurn(id, { turnId: 'turn-1' });
-      const previous = store.getCurrentACPUpdateTarget(id);
-      if (!previous) throw new Error('expected active ACP update target');
-      store.rememberFinalizedTurnForLateACPUpdates(id, previous);
-      store.clearTurnState(id);
-
-      const epoch = store.beginTurn(id, { turnId: 'turn-2', ownsACPUpdates: false });
-      expect(store.getLateACPUpdateTargetAssistantEntryId(id)).toBe('turn-1');
-
-      expect(
-        store.bindTurnForPrompt(id, {
-          turnId: 'turn-2',
-          turnEpoch: epoch,
-          assistantEntryId: 'turn-2',
-        })
-      ).toBe('bound');
-      expect(store.getLateACPUpdateTargetAssistantEntryId(id)).toBeUndefined();
     });
 
     it('never expires finalized-turn ACP update routing by wall-clock time', () => {
@@ -326,37 +289,6 @@ describe('SessionTransientStore', () => {
       });
     });
 
-    it('getCurrentTurnRef reports nothing for an idle or unknown session', () => {
-      const store = new SessionTransientStore();
-      const id = sid('s1');
-      expect(store.getCurrentTurnRef(id)).toBeUndefined();
-      // Must not create state for a session the store has never seen.
-      expect(store.has(id)).toBe(false);
-      store.beginTurn(id, { turnId: 'turn-1' });
-      store.clearTurnState(id);
-      expect(store.getCurrentTurnRef(id)).toBeUndefined();
-    });
-
-    it('finalizeIfCurrent refuses to clear a turn that has been replaced', () => {
-      const store = new SessionTransientStore();
-      const id = sid('s1');
-
-      store.beginTurn(id, { turnId: 'turn-1' });
-      const ref = store.getTurnRef(id, 'turn-1');
-      if (!ref) throw new Error('expected a turn ref');
-
-      // A newer turn takes over while the old finalizer is still awaiting.
-      store.clearTurnState(id);
-      store.beginTurn(id, { turnId: 'turn-2' });
-
-      expect(store.finalizeIfCurrent(id, ref)).toBe(false);
-      expect(store.getTurnId(id)).toBe('turn-2');
-      expect(store.getCurrentACPUpdateTarget(id)).toMatchObject({
-        turnId: 'turn-2',
-        source: 'active_turn',
-      });
-    });
-
     it('finalizeIfCurrent matches on epoch, not just turn id', () => {
       // A redispatch reuses `assistant:<userTurnId>` as the turn id, so the id
       // alone cannot tell two runs of the same user turn apart.
@@ -396,91 +328,24 @@ describe('SessionTransientStore', () => {
       expect(store.isAssistantEntryFinalizable(id, otherRef)).toBe(true);
     });
 
-    it('getTurnRef returns nothing for a turn that is not current', () => {
-      const store = new SessionTransientStore();
-      const id = sid('s1');
-      expect(store.getTurnRef(id, 'turn-1')).toBeUndefined();
-      store.beginTurn(id, { turnId: 'turn-1' });
-      expect(store.getTurnRef(id, 'turn-other')).toBeUndefined();
-      store.clearTurnState(id);
-      expect(store.getTurnRef(id, 'turn-1')).toBeUndefined();
-    });
-
-    it('keeps the prompt-activity recorder across clearTurnState', () => {
-      // The replay gate is consulted AFTER a turn ends, so turn-scoped cleanup
-      // would erase the evidence exactly when it is needed. That is the mistake
-      // `acpFlushCountInTurn` already made: it is zeroed here, so the gate went
-      // blind at the only moment it mattered.
+    it('reports activity only for the bound turn and survives turn cleanup', () => {
       const store = new SessionTransientStore();
       const id = sid('s1');
 
-      const epoch = store.beginTurn(id, { turnId: 'turn-1', ownsACPUpdates: false });
+      const epoch = store.beginTurn(id, { turnId: 'turn-1' });
       const recorder = new PromptActivityRecorder();
-      const ref = { turnId: 'turn-1', turnEpoch: epoch, assistantEntryId: 'turn-1' };
-      expect(store.bindTurnForPrompt(id, ref, recorder)).toBe('bound');
+      store.bindTurnForPrompt(
+        id,
+        { turnId: 'turn-1', turnEpoch: epoch, assistantEntryId: 'turn-1' },
+        recorder
+      );
       recorder.recordSideEffect();
-
       store.clearTurnState(id);
 
       expect(store.observePromptActivityForTurn(id, 'turn-1')).toBe('dropped_prompt_activity');
       expect(store.getBoundPromptActivityRecorder(id)).toBe(recorder);
-    });
-
-    it('drops the recorder with the session and reports unknown afterwards', () => {
-      const store = new SessionTransientStore();
-      const id = sid('s1');
-
-      const epoch = store.beginTurn(id, { turnId: 'turn-1' });
-      store.bindTurnForPrompt(
-        id,
-        { turnId: 'turn-1', turnEpoch: epoch, assistantEntryId: 'turn-1' },
-        new PromptActivityRecorder()
-      );
-
-      store.deleteSession(id);
-
-      expect(store.observePromptActivityForTurn(id, 'turn-1')).toBe('unknown');
-    });
-
-    it('reports unknown for a turn the bound recorder does not belong to', () => {
-      const store = new SessionTransientStore();
-      const id = sid('s1');
-
-      const epoch = store.beginTurn(id, { turnId: 'turn-1' });
-      store.bindTurnForPrompt(
-        id,
-        { turnId: 'turn-1', turnEpoch: epoch, assistantEntryId: 'turn-1' },
-        new PromptActivityRecorder()
-      );
-
-      expect(store.observePromptActivityForTurn(id, 'turn-1')).toBe('none');
       expect(store.observePromptActivityForTurn(id, 'turn-2')).toBe('unknown');
-    });
-
-    it('replaces the bound recorder when a later turn binds', () => {
-      const store = new SessionTransientStore();
-      const id = sid('s1');
-
-      const firstEpoch = store.beginTurn(id, { turnId: 'turn-1' });
-      const first = new PromptActivityRecorder();
-      store.bindTurnForPrompt(
-        id,
-        { turnId: 'turn-1', turnEpoch: firstEpoch, assistantEntryId: 'turn-1' },
-        first
-      );
-      first.recordSideEffect();
-      store.clearTurnState(id);
-
-      const secondEpoch = store.beginTurn(id, { turnId: 'turn-2' });
-      const second = new PromptActivityRecorder();
-      store.bindTurnForPrompt(
-        id,
-        { turnId: 'turn-2', turnEpoch: secondEpoch, assistantEntryId: 'turn-2' },
-        second
-      );
-
-      // The new turn starts clean, and the superseded turn is no longer readable.
-      expect(store.observePromptActivityForTurn(id, 'turn-2')).toBe('none');
+      store.deleteSession(id);
       expect(store.observePromptActivityForTurn(id, 'turn-1')).toBe('unknown');
     });
 

--- a/apps/cli/src/lib/session-transient-store.test.ts
+++ b/apps/cli/src/lib/session-transient-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { SessionTransientStore } from './session-transient-store';
+import { PromptActivityRecorder } from '@/session/prompt-activity-recorder';
 import type { SessionId } from '@lody/shared';
 
 const sid = (id: string) => id as SessionId;
@@ -146,7 +147,6 @@ describe('SessionTransientStore', () => {
           assistantEntryId: 'turn-2',
         })
       ).toBe('bound');
-      expect(store.getLateACPUpdateTargetAssistantEntryId(id)).toBeUndefined();
       expect(store.getCurrentACPUpdateTarget(id)).toMatchObject({
         turnId: 'turn-2',
         source: 'active_turn',
@@ -182,6 +182,44 @@ describe('SessionTransientStore', () => {
 
       // The live turn's routing was left untouched by the refusal.
       expect(store.getCurrentACPUpdateTarget(id)).toBeUndefined();
+    });
+
+    it('bindTurnForPrompt refuses a turn that was already cleared', () => {
+      const store = new SessionTransientStore();
+      const id = sid('s1');
+
+      const epoch = store.beginTurn(id, { turnId: 'turn-1' });
+      const ref = { turnId: 'turn-1', turnEpoch: epoch, assistantEntryId: 'turn-1' };
+      store.clearTurnState(id);
+
+      expect(store.bindTurnForPrompt(id, ref)).toBe('turn_superseded');
+      expect(store.has(id)).toBe(true);
+    });
+
+    it('bindTurnForPrompt drops a stale late target so replay cannot leak into the new turn', () => {
+      // Binding is what hands routing to the new turn, and it must also drop the
+      // previous turn's late-update target — otherwise output produced between
+      // the two turns keeps landing on the old assistant entry.
+      const store = new SessionTransientStore();
+      const id = sid('s1');
+
+      store.beginTurn(id, { turnId: 'turn-1' });
+      const previous = store.getCurrentACPUpdateTarget(id);
+      if (!previous) throw new Error('expected active ACP update target');
+      store.rememberFinalizedTurnForLateACPUpdates(id, previous);
+      store.clearTurnState(id);
+
+      const epoch = store.beginTurn(id, { turnId: 'turn-2', ownsACPUpdates: false });
+      expect(store.getLateACPUpdateTargetAssistantEntryId(id)).toBe('turn-1');
+
+      expect(
+        store.bindTurnForPrompt(id, {
+          turnId: 'turn-2',
+          turnEpoch: epoch,
+          assistantEntryId: 'turn-2',
+        })
+      ).toBe('bound');
+      expect(store.getLateACPUpdateTargetAssistantEntryId(id)).toBeUndefined();
     });
 
     it('never expires finalized-turn ACP update routing by wall-clock time', () => {
@@ -288,6 +326,37 @@ describe('SessionTransientStore', () => {
       });
     });
 
+    it('getCurrentTurnRef reports nothing for an idle or unknown session', () => {
+      const store = new SessionTransientStore();
+      const id = sid('s1');
+      expect(store.getCurrentTurnRef(id)).toBeUndefined();
+      // Must not create state for a session the store has never seen.
+      expect(store.has(id)).toBe(false);
+      store.beginTurn(id, { turnId: 'turn-1' });
+      store.clearTurnState(id);
+      expect(store.getCurrentTurnRef(id)).toBeUndefined();
+    });
+
+    it('finalizeIfCurrent refuses to clear a turn that has been replaced', () => {
+      const store = new SessionTransientStore();
+      const id = sid('s1');
+
+      store.beginTurn(id, { turnId: 'turn-1' });
+      const ref = store.getTurnRef(id, 'turn-1');
+      if (!ref) throw new Error('expected a turn ref');
+
+      // A newer turn takes over while the old finalizer is still awaiting.
+      store.clearTurnState(id);
+      store.beginTurn(id, { turnId: 'turn-2' });
+
+      expect(store.finalizeIfCurrent(id, ref)).toBe(false);
+      expect(store.getTurnId(id)).toBe('turn-2');
+      expect(store.getCurrentACPUpdateTarget(id)).toMatchObject({
+        turnId: 'turn-2',
+        source: 'active_turn',
+      });
+    });
+
     it('finalizeIfCurrent matches on epoch, not just turn id', () => {
       // A redispatch reuses `assistant:<userTurnId>` as the turn id, so the id
       // alone cannot tell two runs of the same user turn apart.
@@ -325,6 +394,94 @@ describe('SessionTransientStore', () => {
       // A different entry is unaffected.
       const otherRef = { ...staleRef, assistantEntryId: 'assistant:user-2' };
       expect(store.isAssistantEntryFinalizable(id, otherRef)).toBe(true);
+    });
+
+    it('getTurnRef returns nothing for a turn that is not current', () => {
+      const store = new SessionTransientStore();
+      const id = sid('s1');
+      expect(store.getTurnRef(id, 'turn-1')).toBeUndefined();
+      store.beginTurn(id, { turnId: 'turn-1' });
+      expect(store.getTurnRef(id, 'turn-other')).toBeUndefined();
+      store.clearTurnState(id);
+      expect(store.getTurnRef(id, 'turn-1')).toBeUndefined();
+    });
+
+    it('keeps the prompt-activity recorder across clearTurnState', () => {
+      // The replay gate is consulted AFTER a turn ends, so turn-scoped cleanup
+      // would erase the evidence exactly when it is needed. That is the mistake
+      // `acpFlushCountInTurn` already made: it is zeroed here, so the gate went
+      // blind at the only moment it mattered.
+      const store = new SessionTransientStore();
+      const id = sid('s1');
+
+      const epoch = store.beginTurn(id, { turnId: 'turn-1', ownsACPUpdates: false });
+      const recorder = new PromptActivityRecorder();
+      const ref = { turnId: 'turn-1', turnEpoch: epoch, assistantEntryId: 'turn-1' };
+      expect(store.bindTurnForPrompt(id, ref, recorder)).toBe('bound');
+      recorder.recordSideEffect();
+
+      store.clearTurnState(id);
+
+      expect(store.observePromptActivityForTurn(id, 'turn-1')).toBe('dropped_prompt_activity');
+      expect(store.getBoundPromptActivityRecorder(id)).toBe(recorder);
+    });
+
+    it('drops the recorder with the session and reports unknown afterwards', () => {
+      const store = new SessionTransientStore();
+      const id = sid('s1');
+
+      const epoch = store.beginTurn(id, { turnId: 'turn-1' });
+      store.bindTurnForPrompt(
+        id,
+        { turnId: 'turn-1', turnEpoch: epoch, assistantEntryId: 'turn-1' },
+        new PromptActivityRecorder()
+      );
+
+      store.deleteSession(id);
+
+      expect(store.observePromptActivityForTurn(id, 'turn-1')).toBe('unknown');
+    });
+
+    it('reports unknown for a turn the bound recorder does not belong to', () => {
+      const store = new SessionTransientStore();
+      const id = sid('s1');
+
+      const epoch = store.beginTurn(id, { turnId: 'turn-1' });
+      store.bindTurnForPrompt(
+        id,
+        { turnId: 'turn-1', turnEpoch: epoch, assistantEntryId: 'turn-1' },
+        new PromptActivityRecorder()
+      );
+
+      expect(store.observePromptActivityForTurn(id, 'turn-1')).toBe('none');
+      expect(store.observePromptActivityForTurn(id, 'turn-2')).toBe('unknown');
+    });
+
+    it('replaces the bound recorder when a later turn binds', () => {
+      const store = new SessionTransientStore();
+      const id = sid('s1');
+
+      const firstEpoch = store.beginTurn(id, { turnId: 'turn-1' });
+      const first = new PromptActivityRecorder();
+      store.bindTurnForPrompt(
+        id,
+        { turnId: 'turn-1', turnEpoch: firstEpoch, assistantEntryId: 'turn-1' },
+        first
+      );
+      first.recordSideEffect();
+      store.clearTurnState(id);
+
+      const secondEpoch = store.beginTurn(id, { turnId: 'turn-2' });
+      const second = new PromptActivityRecorder();
+      store.bindTurnForPrompt(
+        id,
+        { turnId: 'turn-2', turnEpoch: secondEpoch, assistantEntryId: 'turn-2' },
+        second
+      );
+
+      // The new turn starts clean, and the superseded turn is no longer readable.
+      expect(store.observePromptActivityForTurn(id, 'turn-2')).toBe('none');
+      expect(store.observePromptActivityForTurn(id, 'turn-1')).toBe('unknown');
     });
 
     it('clears late ACP update routing when ACP replay suppression begins', () => {

--- a/apps/cli/src/lib/session-transient-store.ts
+++ b/apps/cli/src/lib/session-transient-store.ts
@@ -363,6 +363,37 @@ export class SessionTransientStore {
   }
 
   /**
+   * Did VISIBLE output arrive for this turn — anything the user can actually see
+   * in the transcript?
+   *
+   * Deliberately NOT the same question as `observePromptActivityForTurn`, which
+   * asks whether the turn may have ACTED. A turn that only requested a permission
+   * or wrote a file acted without producing anything visible, so conflating the
+   * two makes the no-output guard treat an empty assistant entry as a success and
+   * skip the failure notice entirely — leaving the user with a blank reply and no
+   * explanation.
+   *
+   * `acpFlushCountInTurn` is still consulted for turns that never bound a recorder
+   * (an auto-prompt turn owns routing from `beginTurn` and never binds); it is
+   * valid here because the no-output guard runs before `finalizeTurn` clears it.
+   */
+  hasVisiblePromptOutputForTurn(sessionId: SessionId, turnId: string): boolean {
+    const state = this.sessions.get(sessionId);
+    if (!state) {
+      return false;
+    }
+    if (state.promptActivity?.ref.turnId === turnId) {
+      if (state.promptActivity.recorder.observe() === 'persisted_output') {
+        return true;
+      }
+    }
+    if (state.acpUpdateBuffer.some((item) => item.target.turnId === turnId)) {
+      return true;
+    }
+    return state.acpFlushCountInTurn > 0 && this.getTurnId(sessionId) === turnId;
+  }
+
+  /**
    * Mark the prompt as returned. Transitions turn from 'prompting' → 'finalizing'.
    * After this, the turn is no longer cancellable but still needs finalization.
    */

--- a/apps/cli/src/lib/session-transient-store.ts
+++ b/apps/cli/src/lib/session-transient-store.ts
@@ -14,8 +14,20 @@
  * - `clearTurnState(id)` — after a conversation turn completes
  * - `deleteSession(id)` — when the session is evicted (idle shutdown or GC)
  *
- * It is impossible to "forget" a field because adding a new field to `SessionState`
- * automatically includes it in both cleanup paths.
+ * Both cleanup paths are HAND-WRITTEN enumerations (`clearTurnState` and
+ * `deleteSession`), not automatic. Adding a field to `SessionState` does not add
+ * it to either one — check both when you add a field.
+ *
+ * Some fields survive `clearTurnState` on purpose, and reflexively "cleaning them
+ * up" reintroduces real bugs:
+ *
+ * - `acpUpdateBuffer` / `acpFlushInFlight` — entries carry their own enqueue-time
+ *   target and must still flush after the turn clears.
+ * - `lateACPUpdateTarget` — the routing target for updates that arrive after
+ *   finalization; clearing it here is what drops post-`stopReason` output.
+ * - `promptActivity` — the replay gate's evidence. It is consulted precisely when
+ *   a turn has ended, so a turn-scoped clear would erase it exactly when it is
+ *   needed. This is the mistake `acpFlushCountInTurn` already made once.
  *
  * ## Turn State Model
  *
@@ -46,6 +58,10 @@ import {
 } from '@lody/shared';
 import type { Logger } from '@/utils/logger';
 import type { TurnHistoryGate } from '@/session/turn-history-gate';
+import type {
+  PromptActivityObservation,
+  PromptActivityRecorder,
+} from '@/session/prompt-activity-recorder';
 
 type AssistantTurnACPUpdateTargetSource = 'active_turn' | 'finalized_turn';
 
@@ -127,6 +143,12 @@ export interface SessionState {
   turnHistoryGate: TurnHistoryGate | null;
   nextTurnEpoch: number;
   lateACPUpdateTarget: AssistantTurnACPUpdateTarget | undefined;
+  /**
+   * Replay-gate evidence for the turn that last bound for a prompt. Deliberately
+   * NOT cleared by `clearTurnState`: the gate reads it after the turn ends.
+   * Replaced by the next bind, dropped by `deleteSession`.
+   */
+  promptActivity: { ref: TurnRef; recorder: PromptActivityRecorder } | undefined;
   suppressAcpReplayUntilTurnStart: boolean;
   suppressedAcpReplayCount: number;
 
@@ -181,6 +203,7 @@ function createSessionState(): SessionState {
     turnHistoryGate: null,
     nextTurnEpoch: 1,
     lateACPUpdateTarget: undefined,
+    promptActivity: undefined,
     suppressAcpReplayUntilTurnStart: false,
     suppressedAcpReplayCount: 0,
     acpUpdateBuffer: [],
@@ -293,7 +316,11 @@ export class SessionTransientStore {
    * as a silent no-op; an authoritative write does not, so ordering is now load
    * bearing and is pinned by regression tests.
    */
-  bindTurnForPrompt(sessionId: SessionId, ref: TurnRef): BindTurnForPromptResult {
+  bindTurnForPrompt(
+    sessionId: SessionId,
+    ref: TurnRef,
+    recorder?: PromptActivityRecorder
+  ): BindTurnForPromptResult {
     const state = this.sessions.get(sessionId);
     if (!state) {
       return 'session_state_missing';
@@ -309,7 +336,30 @@ export class SessionTransientStore {
       state.turn = { ...state.turn, ownsACPUpdates: true };
     }
     state.lateACPUpdateTarget = undefined;
+    if (recorder) {
+      // Replaces the previous binding's recorder, which releases the only
+      // reference this module holds to it. The old run keeps its own.
+      state.promptActivity = { ref, recorder };
+    }
     return 'bound';
+  }
+
+  /**
+   * Evidence for "did this turn possibly act?". `unknown` whenever the turn
+   * cannot be observed — no session state, no recorder, or a recorder belonging
+   * to a different turn — and every caller must treat that as fail-closed.
+   */
+  observePromptActivityForTurn(sessionId: SessionId, turnId: string): PromptActivityObservation {
+    const activity = this.sessions.get(sessionId)?.promptActivity;
+    if (!activity || activity.ref.turnId !== turnId) {
+      return 'unknown';
+    }
+    return activity.recorder.observe();
+  }
+
+  /** The recorder currently bound for this session, for producers to write into. */
+  getBoundPromptActivityRecorder(sessionId: SessionId): PromptActivityRecorder | undefined {
+    return this.sessions.get(sessionId)?.promptActivity?.recorder;
   }
 
   /**

--- a/apps/cli/src/lib/session-transient-store.ts
+++ b/apps/cli/src/lib/session-transient-store.ts
@@ -14,20 +14,8 @@
  * - `clearTurnState(id)` — after a conversation turn completes
  * - `deleteSession(id)` — when the session is evicted (idle shutdown or GC)
  *
- * Both cleanup paths are HAND-WRITTEN enumerations (`clearTurnState` and
- * `deleteSession`), not automatic. Adding a field to `SessionState` does not add
- * it to either one — check both when you add a field.
- *
- * Some fields survive `clearTurnState` on purpose, and reflexively "cleaning them
- * up" reintroduces real bugs:
- *
- * - `acpUpdateBuffer` / `acpFlushInFlight` — entries carry their own enqueue-time
- *   target and must still flush after the turn clears.
- * - `lateACPUpdateTarget` — the routing target for updates that arrive after
- *   finalization; clearing it here is what drops post-`stopReason` output.
- * - `promptActivity` — the replay gate's evidence. It is consulted precisely when
- *   a turn has ended, so a turn-scoped clear would erase it exactly when it is
- *   needed. This is the mistake `acpFlushCountInTurn` already made once.
+ * Cleanup is hand-written. Check both paths when adding state; buffers, late
+ * routing, and prompt activity deliberately survive `clearTurnState`.
  *
  * ## Turn State Model
  *
@@ -143,11 +131,7 @@ export interface SessionState {
   turnHistoryGate: TurnHistoryGate | null;
   nextTurnEpoch: number;
   lateACPUpdateTarget: AssistantTurnACPUpdateTarget | undefined;
-  /**
-   * Replay-gate evidence for the turn that last bound for a prompt. Deliberately
-   * NOT cleared by `clearTurnState`: the gate reads it after the turn ends.
-   * Replaced by the next bind, dropped by `deleteSession`.
-   */
+  /** Replay evidence retained until the next bind or session deletion. */
   promptActivity: { ref: TurnRef; recorder: PromptActivityRecorder } | undefined;
   suppressAcpReplayUntilTurnStart: boolean;
   suppressedAcpReplayCount: number;
@@ -337,18 +321,12 @@ export class SessionTransientStore {
     }
     state.lateACPUpdateTarget = undefined;
     if (recorder) {
-      // Replaces the previous binding's recorder, which releases the only
-      // reference this module holds to it. The old run keeps its own.
       state.promptActivity = { ref, recorder };
     }
     return 'bound';
   }
 
-  /**
-   * Evidence for "did this turn possibly act?". `unknown` whenever the turn
-   * cannot be observed — no session state, no recorder, or a recorder belonging
-   * to a different turn — and every caller must treat that as fail-closed.
-   */
+  /** `unknown` means the turn cannot be observed and replay must fail closed. */
   observePromptActivityForTurn(sessionId: SessionId, turnId: string): PromptActivityObservation {
     const activity = this.sessions.get(sessionId)?.promptActivity;
     if (!activity || activity.ref.turnId !== turnId) {
@@ -357,26 +335,11 @@ export class SessionTransientStore {
     return activity.recorder.observe();
   }
 
-  /** The recorder currently bound for this session, for producers to write into. */
   getBoundPromptActivityRecorder(sessionId: SessionId): PromptActivityRecorder | undefined {
     return this.sessions.get(sessionId)?.promptActivity?.recorder;
   }
 
-  /**
-   * Did VISIBLE output arrive for this turn — anything the user can actually see
-   * in the transcript?
-   *
-   * Deliberately NOT the same question as `observePromptActivityForTurn`, which
-   * asks whether the turn may have ACTED. A turn that only requested a permission
-   * or wrote a file acted without producing anything visible, so conflating the
-   * two makes the no-output guard treat an empty assistant entry as a success and
-   * skip the failure notice entirely — leaving the user with a blank reply and no
-   * explanation.
-   *
-   * `acpFlushCountInTurn` is still consulted for turns that never bound a recorder
-   * (an auto-prompt turn owns routing from `beginTurn` and never binds); it is
-   * valid here because the no-output guard runs before `finalizeTurn` clears it.
-   */
+  /** Visible transcript output, distinct from side-effect evidence. */
   hasVisiblePromptOutputForTurn(sessionId: SessionId, turnId: string): boolean {
     const state = this.sessions.get(sessionId);
     if (!state) {

--- a/apps/cli/src/session/AGENTS.md
+++ b/apps/cli/src/session/AGENTS.md
@@ -248,10 +248,15 @@ delegation proofs or a shared-machine gate without a new product and security de
   (diff stats, PR detection, auto-commit) and still ADVANCES the dispatch pointer:
   the prompt was delivered, so re-dispatching would spin the same silent failure.
   A missing dep fails OPEN here and only here: `observePromptOutputForTurn` returns
-  `undefined` for an unobservable turn and the guard declines to accuse it. Do not
-  confuse this with the replay gate above, which needs the opposite default — the two
-  read the same observation and take opposite conservative answers, which is why they
-  are separate accessors.
+  `undefined` for an unobservable turn and the guard declines to accuse it.
+  INVARIANT: the two accessors answer DIFFERENT questions and must not be collapsed.
+  The replay gate asks "may this turn have ACTED?" (`observation !== 'none'`); the
+  no-output guard asks "did visible output ARRIVE?"
+  (`store.hasVisiblePromptOutputForTurn`: `persisted_output`, or a buffered/flushed
+  entry for the turn). Answering the second with the first makes a turn that only
+  requested a permission look like it produced output, so the guard takes the success
+  path and the user gets an empty assistant entry with no notice at all — worse than
+  the misleading notice it replaced.
   Code Collab v1 turn markers and history fileDiff capture were removed. v2 may
   persist exact per-turn path/add/del caches derived from the CLI-local ACP evidence
   store after ACP finalization; diff content still comes only from the CLI store.

--- a/apps/cli/src/session/AGENTS.md
+++ b/apps/cli/src/session/AGENTS.md
@@ -211,11 +211,14 @@ delegation proofs or a shared-machine gate without a new product and security de
   the user prompt automatically. That gate fails CLOSED and reads
   `prompt-activity-recorder.ts`, not turn state: `persisted_output` and
   `dropped_prompt_activity` refuse a replay, `unknown` refuses it, and only a positive
-  `none` permits one. The recorder exists because the two older signals were both
-  broken — `acpFlushCountInTurn` is zeroed by `clearTurnState`, i.e. exactly when the
-  gate runs, and neither it nor the ACP buffer can see `session/request_permission` or
+  `none` permits one — and that observation is the ONLY input, with no fallback to a
+  blinder signal. The recorder exists because the two older signals were both broken:
+  `acpFlushCountInTurn` is zeroed by `clearTurnState`, i.e. exactly when the gate runs,
+  and neither it nor the ACP buffer can see `session/request_permission` or
   `fs/write_text_file`, which are independent JSON-RPC requests that never reach
-  `enqueueACPUpdate`. One recorder belongs to one `PromptHandoffRun` (fiber-held,
+  `enqueueACPUpdate`. Its inputs are routed updates and those two side-effect
+  requests; in-turn drops are NOT an input, because Steps A–C made them structurally
+  impossible while a recorder is bound. One recorder belongs to one `PromptHandoffRun` (fiber-held,
   carried along the steer successor chain, dies with the turn), so boundedness is
   constructional: no keys, no eviction. It is created at BIND time, so the
   `beginTurn → bind` window is deliberately excluded — what arrives there is a resume

--- a/apps/cli/src/session/AGENTS.md
+++ b/apps/cli/src/session/AGENTS.md
@@ -112,14 +112,9 @@ delegation proofs or a shared-machine gate without a new product and security de
   still protect history rewrites or an in-memory runtime that can resume autonomously.
   It is the per-session execution mutex: never mint a second visible turn while a
   `TurnRuntimeState` is registered.
-  INVARIANT: a store turn is NOT the same thing as a registered turn runtime. The
-  auto-prompt runner calls `beginConversationTurn` for its own store turn id while
-  running INSIDE the visible turn's runtime (`runtime.autoPromptInFlight`), so
-  `SessionTransientStore` can hold a turn whose id differs from `runtime.turnId`, and it
-  can hold an owning turn while `getExecutionSnapshot().hasActiveTurn` describes a
-  different one. Never use "no active turn runtime" as a stand-in for "no turn state to
-  finalize" — that is why the no-turnId `finalizeACPState` reads `getCurrentTurnRef`
-  instead of clearing blindly. `beginConversationTurn` returns the whole `TurnRef`
+  INVARIANT: store-turn and runtime ownership can differ while an auto-prompt runs.
+  A no-turn-id finalizer must read `getCurrentTurnRef`; absence of an active runtime
+  does not prove the store has no turn. `beginConversationTurn` returns the whole `TurnRef`
   (`turnId` + `turnEpoch` + `assistantEntryId`) and the runtime carries it, because
   `bindConversationTurnForPrompt` is an authoritative write that must name the exact
   epoch it created rather than whatever turn happens to be current. A bind refusal is
@@ -208,34 +203,13 @@ delegation proofs or a shared-machine gate without a new product and security de
   `acp_internal_error`. Continue-session prompt recovery may terminate and restore
   the ACP session once before retrying the same prompt, but only when no ACP output
   has buffered/flushed for that assistant turn; after visible output, never replay
-  the user prompt automatically. That gate fails CLOSED and reads
-  `prompt-activity-recorder.ts`, not turn state: `persisted_output` and
-  `dropped_prompt_activity` refuse a replay, `unknown` refuses it, and only a positive
-  `none` permits one — and that observation is the ONLY input, with no fallback to a
-  blinder signal. The recorder exists because the two older signals were both broken:
-  `acpFlushCountInTurn` is zeroed by `clearTurnState`, i.e. exactly when the gate runs,
-  and neither it nor the ACP buffer can see `session/request_permission` or
-  `fs/write_text_file`, which are independent JSON-RPC requests that never reach
-  `enqueueACPUpdate`. Its inputs are routed updates and those two side-effect
-  requests; in-turn drops are NOT an input, because Steps A–C made them structurally
-  impossible while a recorder is bound. One recorder belongs to one `PromptHandoffRun` (fiber-held,
-  carried along the steer successor chain, dies with the turn), so boundedness is
-  constructional: no keys, no eviction. It is created at BIND time, so the
-  `beginTurn → bind` window is deliberately excluded — what arrives there is a resume
-  fallback's pre-prompt startup output, not the user's turn. `AgentSessionClosedError`
-  is excluded from recovery outright: that prompt was accepted by a live agent whose
-  process then died.
-  `steerApplicationBarrier` guards ONLY `session/update` (one `await`, in
-  `agent-client.ts` `sessionUpdate`); `requestPermission` and `writeTextFile` are
-  unprotected, so a side effect the predecessor caused can arrive after the successor
-  binds. Those are credited to BOTH runs until the successor sees its own output —
-  over-refusing a replay is safe, losing the signal is not.
-  When a turn produced no visible output but the recorder says it acted, the failure
-  notice must NOT keep the `SILENT_TURN_FAILURE_MESSAGE` guess (context length / rate
-  limit) or tell the user to retry: the cause is local and a retry can repeat work.
-  Both messages reuse the `agent_no_output` reason code on purpose — a dedicated
-  `agent_output_dropped` code changes the persisted, client-shared
-  `ChatFailedReasonSchema` and is its own high-risk change.
+  the user prompt automatically. The gate uses `prompt-activity-recorder.ts`: only
+  `none` permits replay; output, side effects, and `unknown` fail closed. Create the
+  recorder at bind time and retain it after turn cleanup. Permission and file-write
+  requests bypass ACP updates, so record them explicitly. During a steer handoff,
+  credit these requests to both runs until the successor emits output.
+  `AgentSessionClosedError` is never replayed. If a silent turn recorded side effects,
+  use the uncertain-state `agent_no_output` notice and do not suggest retrying.
   DeepSeek Harness persistence compression mismatches are a distinct
   `acp_session_storage_incompatible` failure, not a generic internal error; keep
   matching narrow to the backend's artifact/compression diagnostic.
@@ -252,14 +226,9 @@ delegation proofs or a shared-machine gate without a new product and security de
   the prompt was delivered, so re-dispatching would spin the same silent failure.
   A missing dep fails OPEN here and only here: `observePromptOutputForTurn` returns
   `undefined` for an unobservable turn and the guard declines to accuse it.
-  INVARIANT: the two accessors answer DIFFERENT questions and must not be collapsed.
-  The replay gate asks "may this turn have ACTED?" (`observation !== 'none'`); the
-  no-output guard asks "did visible output ARRIVE?"
-  (`store.hasVisiblePromptOutputForTurn`: `persisted_output`, or a buffered/flushed
-  entry for the turn). Answering the second with the first makes a turn that only
-  requested a permission look like it produced output, so the guard takes the success
-  path and the user gets an empty assistant entry with no notice at all — worse than
-  the misleading notice it replaced.
+  Do not collapse the two observations: replay asks whether a turn may have acted;
+  the no-output guard asks whether visible output arrived. A side effect answers yes
+  only to the first question.
   Code Collab v1 turn markers and history fileDiff capture were removed. v2 may
   persist exact per-turn path/add/del caches derived from the CLI-local ACP evidence
   store after ACP finalization; diff content still comes only from the CLI store.

--- a/apps/cli/src/session/AGENTS.md
+++ b/apps/cli/src/session/AGENTS.md
@@ -111,7 +111,15 @@ delegation proofs or a shared-machine gate without a new product and security de
   quiescent. Use live execution/presence for current-work signals; goal activity may
   still protect history rewrites or an in-memory runtime that can resume autonomously.
   It is the per-session execution mutex: never mint a second visible turn while a
-  `TurnRuntimeState` is registered. `beginConversationTurn` returns the whole `TurnRef`
+  `TurnRuntimeState` is registered.
+  INVARIANT: a store turn is NOT the same thing as a registered turn runtime. The
+  auto-prompt runner calls `beginConversationTurn` for its own store turn id while
+  running INSIDE the visible turn's runtime (`runtime.autoPromptInFlight`), so
+  `SessionTransientStore` can hold a turn whose id differs from `runtime.turnId`, and it
+  can hold an owning turn while `getExecutionSnapshot().hasActiveTurn` describes a
+  different one. Never use "no active turn runtime" as a stand-in for "no turn state to
+  finalize" — that is why the no-turnId `finalizeACPState` reads `getCurrentTurnRef`
+  instead of clearing blindly. `beginConversationTurn` returns the whole `TurnRef`
   (`turnId` + `turnEpoch` + `assistantEntryId`) and the runtime carries it, because
   `bindConversationTurnForPrompt` is an authoritative write that must name the exact
   epoch it created rather than whatever turn happens to be current. A bind refusal is
@@ -200,14 +208,31 @@ delegation proofs or a shared-machine gate without a new product and security de
   `acp_internal_error`. Continue-session prompt recovery may terminate and restore
   the ACP session once before retrying the same prompt, but only when no ACP output
   has buffered/flushed for that assistant turn; after visible output, never replay
-  the user prompt automatically. That gate fails CLOSED: an absent
-  `hasPromptOutputForTurn` dep, or a session whose transient state is already gone,
-  reads as "may already have acted" and refuses the replay. Unobservable is not the
-  same as "nothing happened", and the observable signal is incomplete anyway —
-  permission requests and `fs/write_text_file` are separate JSON-RPC requests that
-  never reach `enqueueACPUpdate`, so a replay can re-run tools the agent already ran.
-  `AgentSessionClosedError` is excluded from recovery outright: that prompt was
-  accepted by a live agent whose process then died.
+  the user prompt automatically. That gate fails CLOSED and reads
+  `prompt-activity-recorder.ts`, not turn state: `persisted_output` and
+  `dropped_prompt_activity` refuse a replay, `unknown` refuses it, and only a positive
+  `none` permits one. The recorder exists because the two older signals were both
+  broken — `acpFlushCountInTurn` is zeroed by `clearTurnState`, i.e. exactly when the
+  gate runs, and neither it nor the ACP buffer can see `session/request_permission` or
+  `fs/write_text_file`, which are independent JSON-RPC requests that never reach
+  `enqueueACPUpdate`. One recorder belongs to one `PromptHandoffRun` (fiber-held,
+  carried along the steer successor chain, dies with the turn), so boundedness is
+  constructional: no keys, no eviction. It is created at BIND time, so the
+  `beginTurn → bind` window is deliberately excluded — what arrives there is a resume
+  fallback's pre-prompt startup output, not the user's turn. `AgentSessionClosedError`
+  is excluded from recovery outright: that prompt was accepted by a live agent whose
+  process then died.
+  `steerApplicationBarrier` guards ONLY `session/update` (one `await`, in
+  `agent-client.ts` `sessionUpdate`); `requestPermission` and `writeTextFile` are
+  unprotected, so a side effect the predecessor caused can arrive after the successor
+  binds. Those are credited to BOTH runs until the successor sees its own output —
+  over-refusing a replay is safe, losing the signal is not.
+  When a turn produced no visible output but the recorder says it acted, the failure
+  notice must NOT keep the `SILENT_TURN_FAILURE_MESSAGE` guess (context length / rate
+  limit) or tell the user to retry: the cause is local and a retry can repeat work.
+  Both messages reuse the `agent_no_output` reason code on purpose — a dedicated
+  `agent_output_dropped` code changes the persisted, client-shared
+  `ChatFailedReasonSchema` and is its own high-risk change.
   DeepSeek Harness persistence compression mismatches are a distinct
   `acp_session_storage_incompatible` failure, not a generic internal error; keep
   matching narrow to the backend's artifact/compression diagnostic.

--- a/apps/cli/src/session/prompt-activity-recorder.test.ts
+++ b/apps/cli/src/session/prompt-activity-recorder.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { PromptActivityRecorder, allowsPromptReplay } from './prompt-activity-recorder';
+
+describe('PromptActivityRecorder', () => {
+  it('reports `none` for a prompt that did nothing', () => {
+    expect(new PromptActivityRecorder().observe()).toBe('none');
+    expect(allowsPromptReplay('none')).toBe(true);
+  });
+
+  it('reports persisted output once an update is routed', () => {
+    const recorder = new PromptActivityRecorder();
+    recorder.recordRouted();
+    expect(recorder.observe()).toBe('persisted_output');
+    expect(allowsPromptReplay('persisted_output')).toBe(false);
+  });
+
+  it('treats a permission request as activity even with no routed output', () => {
+    // The whole point: `session/request_permission` is an independent JSON-RPC
+    // request that never reaches `enqueueACPUpdate`, so this used to read as
+    // "produced nothing" and authorized a replay of an already-approved tool.
+    const recorder = new PromptActivityRecorder();
+    recorder.recordSideEffect();
+    expect(recorder.observe()).toBe('dropped_prompt_activity');
+    expect(allowsPromptReplay('dropped_prompt_activity')).toBe(false);
+  });
+
+  it('treats a dropped update as activity', () => {
+    const recorder = new PromptActivityRecorder();
+    recorder.recordDropped('no_route');
+    expect(recorder.observe()).toBe('dropped_prompt_activity');
+  });
+
+  it('never permits a replay for an unobservable turn', () => {
+    expect(allowsPromptReplay('unknown')).toBe(false);
+  });
+
+  describe('steer handover attribution', () => {
+    it('credits a side effect to the predecessor until the successor produces output', () => {
+      // `steerApplicationBarrier` guards only `session/update`, so a permission
+      // request or `fs/write_text_file` caused by the PREVIOUS turn can arrive
+      // after the successor has bound. The predecessor is the run that may
+      // already have acted, so it must not lose the signal.
+      const predecessor = new PromptActivityRecorder();
+      const successor = new PromptActivityRecorder(predecessor);
+
+      successor.recordSideEffect();
+
+      expect(predecessor.observe()).toBe('dropped_prompt_activity');
+      expect(successor.observe()).toBe('dropped_prompt_activity');
+    });
+
+    it('stops crediting the predecessor once the successor has its own output', () => {
+      const predecessor = new PromptActivityRecorder();
+      const successor = new PromptActivityRecorder(predecessor);
+
+      successor.recordRouted();
+      successor.recordSideEffect();
+
+      // The handover is complete, so this side effect belongs to the successor.
+      expect(predecessor.observe()).toBe('none');
+      expect(successor.observe()).toBe('persisted_output');
+    });
+
+    it('does not let a successor drop reach the predecessor', () => {
+      // Only side effects are ambiguous across the handover. A dropped update is
+      // routed through the bound recorder, so its attribution is already exact.
+      const predecessor = new PromptActivityRecorder();
+      const successor = new PromptActivityRecorder(predecessor);
+
+      successor.recordDropped('no_route');
+
+      expect(predecessor.observe()).toBe('none');
+      expect(successor.observe()).toBe('dropped_prompt_activity');
+    });
+  });
+});

--- a/apps/cli/src/session/prompt-activity-recorder.test.ts
+++ b/apps/cli/src/session/prompt-activity-recorder.test.ts
@@ -25,12 +25,6 @@ describe('PromptActivityRecorder', () => {
     expect(allowsPromptReplay('dropped_prompt_activity')).toBe(false);
   });
 
-  it('treats a dropped update as activity', () => {
-    const recorder = new PromptActivityRecorder();
-    recorder.recordDropped('no_route');
-    expect(recorder.observe()).toBe('dropped_prompt_activity');
-  });
-
   it('never permits a replay for an unobservable turn', () => {
     expect(allowsPromptReplay('unknown')).toBe(false);
   });
@@ -60,18 +54,6 @@ describe('PromptActivityRecorder', () => {
       // The handover is complete, so this side effect belongs to the successor.
       expect(predecessor.observe()).toBe('none');
       expect(successor.observe()).toBe('persisted_output');
-    });
-
-    it('does not let a successor drop reach the predecessor', () => {
-      // Only side effects are ambiguous across the handover. A dropped update is
-      // routed through the bound recorder, so its attribution is already exact.
-      const predecessor = new PromptActivityRecorder();
-      const successor = new PromptActivityRecorder(predecessor);
-
-      successor.recordDropped('no_route');
-
-      expect(predecessor.observe()).toBe('none');
-      expect(successor.observe()).toBe('dropped_prompt_activity');
     });
   });
 });

--- a/apps/cli/src/session/prompt-activity-recorder.test.ts
+++ b/apps/cli/src/session/prompt-activity-recorder.test.ts
@@ -3,57 +3,31 @@ import { describe, expect, it } from 'vitest';
 import { PromptActivityRecorder, allowsPromptReplay } from './prompt-activity-recorder';
 
 describe('PromptActivityRecorder', () => {
-  it('reports `none` for a prompt that did nothing', () => {
-    expect(new PromptActivityRecorder().observe()).toBe('none');
-    expect(allowsPromptReplay('none')).toBe(true);
-  });
-
-  it('reports persisted output once an update is routed', () => {
+  it('allows replay only when the observed prompt did nothing', () => {
     const recorder = new PromptActivityRecorder();
-    recorder.recordRouted();
-    expect(recorder.observe()).toBe('persisted_output');
-    expect(allowsPromptReplay('persisted_output')).toBe(false);
-  });
+    expect(recorder.observe()).toBe('none');
+    expect(allowsPromptReplay(recorder.observe())).toBe(true);
 
-  it('treats a permission request as activity even with no routed output', () => {
-    // The whole point: `session/request_permission` is an independent JSON-RPC
-    // request that never reaches `enqueueACPUpdate`, so this used to read as
-    // "produced nothing" and authorized a replay of an already-approved tool.
-    const recorder = new PromptActivityRecorder();
     recorder.recordSideEffect();
     expect(recorder.observe()).toBe('dropped_prompt_activity');
-    expect(allowsPromptReplay('dropped_prompt_activity')).toBe(false);
-  });
+    expect(allowsPromptReplay(recorder.observe())).toBe(false);
 
-  it('never permits a replay for an unobservable turn', () => {
+    recorder.recordRouted();
+    expect(recorder.observe()).toBe('persisted_output');
     expect(allowsPromptReplay('unknown')).toBe(false);
   });
 
-  describe('steer handover attribution', () => {
-    it('credits a side effect to the predecessor until the successor produces output', () => {
-      // `steerApplicationBarrier` guards only `session/update`, so a permission
-      // request or `fs/write_text_file` caused by the PREVIOUS turn can arrive
-      // after the successor has bound. The predecessor is the run that may
-      // already have acted, so it must not lose the signal.
-      const predecessor = new PromptActivityRecorder();
-      const successor = new PromptActivityRecorder(predecessor);
+  it('credits ambiguous side effects to the predecessor until successor output', () => {
+    const predecessor = new PromptActivityRecorder();
+    const successor = new PromptActivityRecorder(predecessor);
+    successor.recordSideEffect();
+    expect(predecessor.observe()).toBe('dropped_prompt_activity');
 
-      successor.recordSideEffect();
-
-      expect(predecessor.observe()).toBe('dropped_prompt_activity');
-      expect(successor.observe()).toBe('dropped_prompt_activity');
-    });
-
-    it('stops crediting the predecessor once the successor has its own output', () => {
-      const predecessor = new PromptActivityRecorder();
-      const successor = new PromptActivityRecorder(predecessor);
-
-      successor.recordRouted();
-      successor.recordSideEffect();
-
-      // The handover is complete, so this side effect belongs to the successor.
-      expect(predecessor.observe()).toBe('none');
-      expect(successor.observe()).toBe('persisted_output');
-    });
+    const completedPredecessor = new PromptActivityRecorder();
+    const producingSuccessor = new PromptActivityRecorder(completedPredecessor);
+    producingSuccessor.recordRouted();
+    producingSuccessor.recordSideEffect();
+    expect(completedPredecessor.observe()).toBe('none');
+    expect(producingSuccessor.observe()).toBe('persisted_output');
   });
 });

--- a/apps/cli/src/session/prompt-activity-recorder.ts
+++ b/apps/cli/src/session/prompt-activity-recorder.ts
@@ -1,0 +1,107 @@
+/**
+ * Per-prompt record of "did this turn possibly act?", used to decide whether an
+ * automatic prompt replay is safe.
+ *
+ * ## Why this exists rather than reading turn state
+ *
+ * The replay gate used to read `acpFlushCountInTurn`, which `clearTurnState`
+ * zeroes — so the gate erased its own evidence exactly when a turn ended, which
+ * is when the gate gets consulted. And it only ever saw ACP `session/update`
+ * notifications, while `session/request_permission` and `fs/write_text_file` are
+ * independent JSON-RPC requests that never pass through `enqueueACPUpdate`. A
+ * turn could therefore approve a permission, run a tool, write files, and still
+ * read as "produced nothing", which authorized replaying a prompt whose tools had
+ * already run.
+ *
+ * One recorder belongs to one `PromptHandoffRun`: the fiber holds it, a steer
+ * carries it along the successor chain, and it dies with the run. Boundedness is
+ * therefore constructional — at most one live recorder per session — so there is
+ * no key design and no eviction policy.
+ *
+ * ## Deliberate scope
+ *
+ * Created at BIND time, not at `beginTurn`. The `beginTurn → bind` window is
+ * exactly where a resume fallback's pre-prompt startup updates arrive, and those
+ * belong to session startup rather than to the user's turn. Excluding them is the
+ * intent, not a gap — do not "fix" it by moving construction earlier.
+ *
+ * Process restart loses every recorder, which reads as `unknown` and refuses
+ * replay. Re-dispatch after a restart is a different mechanism (crash replay) and
+ * is not in this contract.
+ */
+
+export type PromptActivityObservation =
+  /** The agent produced output that was routed to a history entry. */
+  | 'persisted_output'
+  /**
+   * The agent may have acted without leaving routed output: a dropped update, an
+   * approved permission request, or an `fs/write_text_file`.
+   */
+  | 'dropped_prompt_activity'
+  /** Observed the whole prompt and it did nothing. Only this permits a replay. */
+  | 'none'
+  /** Not observable — no recorder for this turn. Always fail closed. */
+  | 'unknown';
+
+export type PromptActivityDropKind = 'no_route' | 'suppressed_replay' | 'session_deleted';
+
+export class PromptActivityRecorder {
+  private routed = false;
+  private dropped = false;
+  private sideEffects = false;
+  /**
+   * Latched by this run's first routed update. Until then, side-effect signals
+   * are ALSO credited to the predecessor run — see `recordSideEffect`.
+   */
+  private tookOver = false;
+
+  /**
+   * @param previous The run this one succeeded via an applied steer, if any.
+   */
+  constructor(private readonly previous?: PromptActivityRecorder) {}
+
+  recordRouted(): void {
+    this.routed = true;
+    this.tookOver = true;
+  }
+
+  recordDropped(_kind: PromptActivityDropKind): void {
+    // Steps A–C removed the in-turn drop paths structurally; this stays as
+    // diagnostic insurance so a regression surfaces as a refused replay rather
+    // than as a silently repeated tool call.
+    this.dropped = true;
+  }
+
+  /**
+   * A permission request or an `fs/write_text_file`.
+   *
+   * `steerApplicationBarrier` only guards `session/update` — in `agent-client.ts`
+   * exactly one `await` of it, in `sessionUpdate`. `requestPermission` and
+   * `writeTextFile` are NOT covered, so during a steer handover a side effect the
+   * PREDECESSOR caused can arrive after the successor has bound. Attribution is
+   * genuinely ambiguous there, and the conservative answer is the predecessor:
+   * that is the run which may already have acted and whose replay must be
+   * refused. Crediting both is deliberate — over-refusing a replay is safe, while
+   * losing the signal is not.
+   */
+  recordSideEffect(): void {
+    this.sideEffects = true;
+    if (!this.tookOver) {
+      this.previous?.recordSideEffect();
+    }
+  }
+
+  observe(): Exclude<PromptActivityObservation, 'unknown'> {
+    if (this.routed) {
+      return 'persisted_output';
+    }
+    if (this.dropped || this.sideEffects) {
+      return 'dropped_prompt_activity';
+    }
+    return 'none';
+  }
+}
+
+/** Only a positive "this prompt did nothing" permits an automatic replay. */
+export const allowsPromptReplay = (observation: PromptActivityObservation): boolean =>
+  observation === 'none';

--- a/apps/cli/src/session/prompt-activity-recorder.ts
+++ b/apps/cli/src/session/prompt-activity-recorder.ts
@@ -34,8 +34,8 @@ export type PromptActivityObservation =
   /** The agent produced output that was routed to a history entry. */
   | 'persisted_output'
   /**
-   * The agent may have acted without leaving routed output: a dropped update, an
-   * approved permission request, or an `fs/write_text_file`.
+   * The agent may have acted without leaving routed output: an approved
+   * permission request, or an `fs/write_text_file`.
    */
   | 'dropped_prompt_activity'
   /** Observed the whole prompt and it did nothing. Only this permits a replay. */
@@ -43,11 +43,8 @@ export type PromptActivityObservation =
   /** Not observable — no recorder for this turn. Always fail closed. */
   | 'unknown';
 
-export type PromptActivityDropKind = 'no_route' | 'suppressed_replay' | 'session_deleted';
-
 export class PromptActivityRecorder {
   private routed = false;
-  private dropped = false;
   private sideEffects = false;
   /**
    * Latched by this run's first routed update. Until then, side-effect signals
@@ -63,13 +60,6 @@ export class PromptActivityRecorder {
   recordRouted(): void {
     this.routed = true;
     this.tookOver = true;
-  }
-
-  recordDropped(_kind: PromptActivityDropKind): void {
-    // Steps A–C removed the in-turn drop paths structurally; this stays as
-    // diagnostic insurance so a regression surfaces as a refused replay rather
-    // than as a silently repeated tool call.
-    this.dropped = true;
   }
 
   /**
@@ -95,7 +85,7 @@ export class PromptActivityRecorder {
     if (this.routed) {
       return 'persisted_output';
     }
-    if (this.dropped || this.sideEffects) {
+    if (this.sideEffects) {
       return 'dropped_prompt_activity';
     }
     return 'none';

--- a/apps/cli/src/session/prompt-activity-recorder.ts
+++ b/apps/cli/src/session/prompt-activity-recorder.ts
@@ -1,97 +1,35 @@
-/**
- * Per-prompt record of "did this turn possibly act?", used to decide whether an
- * automatic prompt replay is safe.
- *
- * ## Why this exists rather than reading turn state
- *
- * The replay gate used to read `acpFlushCountInTurn`, which `clearTurnState`
- * zeroes — so the gate erased its own evidence exactly when a turn ended, which
- * is when the gate gets consulted. And it only ever saw ACP `session/update`
- * notifications, while `session/request_permission` and `fs/write_text_file` are
- * independent JSON-RPC requests that never pass through `enqueueACPUpdate`. A
- * turn could therefore approve a permission, run a tool, write files, and still
- * read as "produced nothing", which authorized replaying a prompt whose tools had
- * already run.
- *
- * One recorder belongs to one `PromptHandoffRun`: the fiber holds it, a steer
- * carries it along the successor chain, and it dies with the run. Boundedness is
- * therefore constructional — at most one live recorder per session — so there is
- * no key design and no eviction policy.
- *
- * ## Deliberate scope
- *
- * Created at BIND time, not at `beginTurn`. The `beginTurn → bind` window is
- * exactly where a resume fallback's pre-prompt startup updates arrive, and those
- * belong to session startup rather than to the user's turn. Excluding them is the
- * intent, not a gap — do not "fix" it by moving construction earlier.
- *
- * Process restart loses every recorder, which reads as `unknown` and refuses
- * replay. Re-dispatch after a restart is a different mechanism (crash replay) and
- * is not in this contract.
- */
-
+/** Per-prompt evidence used to decide whether an automatic replay is safe. */
 export type PromptActivityObservation =
-  /** The agent produced output that was routed to a history entry. */
   | 'persisted_output'
-  /**
-   * The agent may have acted without leaving routed output: an approved
-   * permission request, or an `fs/write_text_file`.
-   */
   | 'dropped_prompt_activity'
-  /** Observed the whole prompt and it did nothing. Only this permits a replay. */
   | 'none'
-  /** Not observable — no recorder for this turn. Always fail closed. */
   | 'unknown';
 
 export class PromptActivityRecorder {
   private routed = false;
   private sideEffects = false;
-  /**
-   * Latched by this run's first routed update. Until then, side-effect signals
-   * are ALSO credited to the predecessor run — see `recordSideEffect`.
-   */
-  private tookOver = false;
 
-  /**
-   * @param previous The run this one succeeded via an applied steer, if any.
-   */
   constructor(private readonly previous?: PromptActivityRecorder) {}
 
   recordRouted(): void {
     this.routed = true;
-    this.tookOver = true;
   }
 
-  /**
-   * A permission request or an `fs/write_text_file`.
-   *
-   * `steerApplicationBarrier` only guards `session/update` — in `agent-client.ts`
-   * exactly one `await` of it, in `sessionUpdate`. `requestPermission` and
-   * `writeTextFile` are NOT covered, so during a steer handover a side effect the
-   * PREDECESSOR caused can arrive after the successor has bound. Attribution is
-   * genuinely ambiguous there, and the conservative answer is the predecessor:
-   * that is the run which may already have acted and whose replay must be
-   * refused. Crediting both is deliberate — over-refusing a replay is safe, while
-   * losing the signal is not.
-   */
   recordSideEffect(): void {
     this.sideEffects = true;
-    if (!this.tookOver) {
+    // Permission/file requests can cross a steer handoff. Until this run emits
+    // output, conservatively credit the predecessor too.
+    if (!this.routed) {
       this.previous?.recordSideEffect();
     }
   }
 
   observe(): Exclude<PromptActivityObservation, 'unknown'> {
-    if (this.routed) {
-      return 'persisted_output';
-    }
-    if (this.sideEffects) {
-      return 'dropped_prompt_activity';
-    }
+    if (this.routed) return 'persisted_output';
+    if (this.sideEffects) return 'dropped_prompt_activity';
     return 'none';
   }
 }
 
-/** Only a positive "this prompt did nothing" permits an automatic replay. */
 export const allowsPromptReplay = (observation: PromptActivityObservation): boolean =>
   observation === 'none';

--- a/apps/cli/src/session/session-execution-service.ts
+++ b/apps/cli/src/session/session-execution-service.ts
@@ -111,6 +111,11 @@ import {
 } from './worktree/git-process-error';
 import type { BindTurnForPromptResult, TurnRef } from '@/lib/session-transient-store';
 import {
+  PromptActivityRecorder,
+  allowsPromptReplay,
+  type PromptActivityObservation,
+} from './prompt-activity-recorder';
+import {
   AgentSessionClosedError,
   type AgentSessionCloseCause,
   getACPErrorUserMessage,
@@ -159,6 +164,24 @@ const SILENT_TURN_FAILURE_MESSAGE =
   'upstream (a context-length or rate-limit rejection is the usual cause) and the agent ' +
   'reported it as a normal completion instead of an error. Retry your message, or start a ' +
   'new session if this conversation has grown too long.';
+
+/**
+ * Used instead of `SILENT_TURN_FAILURE_MESSAGE` when the recorder saw the turn do
+ * something — an approved permission, an `fs/write_text_file`, or a dropped
+ * update — even though nothing reached the transcript.
+ *
+ * The message above guesses at an upstream cause and tells the user to retry.
+ * Both halves are wrong here: the failure is local, and the agent may have edited
+ * files or run commands, so retrying can repeat that work. Deliberately reuses
+ * the `agent_no_output` reason code — a dedicated `agent_output_dropped` code
+ * changes `ChatFailedReasonSchema`, which is persisted and shared with every
+ * client, so it is its own high-risk change.
+ */
+const DROPPED_ACTIVITY_TURN_FAILURE_MESSAGE =
+  'The agent ended the turn without anything reaching this conversation, but it did act — ' +
+  'it requested permissions or wrote files during the turn. Its execution state for this ' +
+  'turn is therefore uncertain: check the working tree and any tool results before deciding ' +
+  'what to do, and do not simply retry, because that can repeat work the agent already did.';
 
 type TurnFinalizationEffects = {
   finalizeACPState: (sessionId: SessionId, turnId?: string) => Promise<void>;
@@ -216,6 +239,12 @@ type ApplyModeAndModelConfig = SessionTurnInputConfig & {
 
 type PromptHandoffRun = {
   turnId: string;
+  /**
+   * This run's replay-gate evidence. Lives here rather than in a map: the object
+   * is already per-prompt, fiber-held, carried along the successor chain by a
+   * steer, and dies with the turn — so boundedness is constructional.
+   */
+  activity: PromptActivityRecorder;
   promptOutcome: Promise<{ status: 'fulfilled' } | { status: 'rejected'; error: unknown }>;
   successor?: PromptHandoffRun;
   successorReady: Promise<void>;
@@ -445,8 +474,14 @@ export type SessionExecutionServiceDeps = {
    */
   bindConversationTurnForPrompt: (
     sessionId: SessionId,
-    turnRef: TurnRef
+    turnRef: TurnRef,
+    recorder?: PromptActivityRecorder
   ) => BindTurnForPromptResult;
+  /** Replay-gate evidence for a turn; `unknown` is fail-closed at every caller. */
+  observePromptActivityForTurn?: (
+    sessionId: SessionId,
+    turnId: string
+  ) => PromptActivityObservation;
   clearConversationTurn: (sessionId: SessionId, turnId: string) => void;
   getActiveTurnId: (sessionId: SessionId) => string | undefined;
   clearActiveTurnId: (sessionId: SessionId, turnId: string) => void;
@@ -699,6 +734,7 @@ export class SessionExecutionService {
 
   private createPromptHandoffRun(options: {
     turnId: string;
+    activity: PromptActivityRecorder;
     promptPromise: Promise<unknown>;
   }): PromptHandoffRun {
     let signalSuccessor!: () => void;
@@ -707,6 +743,7 @@ export class SessionExecutionService {
     });
     return {
       turnId: options.turnId,
+      activity: options.activity,
       promptOutcome: options.promptPromise.then(
         () => ({ status: 'fulfilled' as const }),
         (error: unknown) => ({ status: 'rejected' as const, error })
@@ -1407,9 +1444,15 @@ export class SessionExecutionService {
         // `transitionDispatchOwnership` above already moved dispatch ownership to
         // the new user turn, so falling back would render the new user message as
         // unanswered and misattribute the agent's reply.
+        // Chained to the predecessor: `steerApplicationBarrier` only guards
+        // `session/update`, so a permission request or `fs/write_text_file` the
+        // PREVIOUS turn caused can still arrive after this bind. Those are
+        // credited to the predecessor as well until this run sees its own output.
+        const nextActivity = new PromptActivityRecorder(ownedPromptRun.activity);
         const nextBindResult = this.deps.bindConversationTurnForPrompt(
           options.sessionId,
-          nextTurnRef
+          nextTurnRef,
+          nextActivity
         );
         if (nextBindResult !== 'bound') {
           this.deps.logger.error(
@@ -1431,6 +1474,7 @@ export class SessionExecutionService {
         }
         const nextPromptRun = this.createPromptHandoffRun({
           turnId: nextTurnId,
+          activity: nextActivity,
           promptPromise: steerRun.completion,
         });
         void ownedPromptRun.promptOutcome.then((outcome) => {
@@ -2904,9 +2948,15 @@ export class SessionExecutionService {
                 // that silently no-opped; it is an authoritative write now, so a
                 // refusal must stop the prompt instead of sending one whose output
                 // has nowhere to go.
+                // Created at BIND time, so the `beginTurn → bind` window is
+                // deliberately not counted: what arrives there is a resume
+                // fallback's pre-prompt startup output, which belongs to session
+                // startup rather than to this user turn.
+                const activity = new PromptActivityRecorder();
                 const bindResult = self.deps.bindConversationTurnForPrompt(
                   sessionId,
-                  runtime.turnRef
+                  runtime.turnRef,
+                  activity
                 );
                 if (bindResult !== 'bound') {
                   // Fail closed: no prompt is sent. `recordPrePromptFailure` still
@@ -2942,6 +2992,7 @@ export class SessionExecutionService {
                           async () => {
                             const initialRun = self.createPromptHandoffRun({
                               turnId: runtime.turnId,
+                              activity,
                               promptPromise: agentClient.prompt(acpSessionId, promptBlocks, {
                                 signal,
                               }),
@@ -3335,15 +3386,21 @@ export class SessionExecutionService {
     turnId: string;
     userTurnId?: string;
   }): Promise<void> {
+    const activity =
+      this.deps.observePromptActivityForTurn?.(options.sessionId, options.turnId) ?? 'unknown';
+    // Only an upstream-looking silence gets the upstream-cause guess. A turn that
+    // demonstrably acted must not be explained as a context-length or rate-limit
+    // rejection, and must not be presented as safe to retry.
+    const actedWithoutOutput = activity === 'dropped_prompt_activity';
     this.deps.logger.warn(
-      `[${options.sessionId}] Turn ${options.turnId} completed without any agent output; ` +
-        'recording it as a failed turn instead of a silent completion'
+      `[${options.sessionId}] Turn ${options.turnId} completed without any agent output ` +
+        `(activity=${activity}); recording it as a failed turn instead of a silent completion`
     );
     this.captureTurnFailed(options.sessionId, options.turnId, 'agent_no_output', false);
     await this.deps.recordChatFailure(
       options.sessionDoc,
       'agent_no_output',
-      SILENT_TURN_FAILURE_MESSAGE
+      actedWithoutOutput ? DROPPED_ACTIVITY_TURN_FAILURE_MESSAGE : SILENT_TURN_FAILURE_MESSAGE
     );
     if (options.userTurnId) {
       await this.markTurnFailed(options.sessionId, options.sessionDoc, options.userTurnId);
@@ -3969,8 +4026,19 @@ export class SessionExecutionService {
                 // the replay re-runs tools the agent already executed. (The
                 // no-output guard needs the opposite default — see
                 // `turnProducedVisibleOutput`.)
+                //
+                // The recorder is the primary signal because it also sees
+                // permission requests and `fs/write_text_file`; only a positive
+                // `none` permits a replay, so `unknown` and
+                // `dropped_prompt_activity` both refuse.
+                const activity = self.deps.observePromptActivityForTurn?.(
+                  sessionId,
+                  runtime.turnId
+                );
                 const hasPromptOutput =
-                  self.deps.hasPromptOutputForTurn?.(sessionId, runtime.turnId) ?? true;
+                  activity !== undefined
+                    ? !allowsPromptReplay(activity)
+                    : (self.deps.hasPromptOutputForTurn?.(sessionId, runtime.turnId) ?? true);
                 if (
                   runtime.turnId !== turnId ||
                   !shouldRecoverStaleACPConnectionPrompt({

--- a/apps/cli/src/session/session-execution-service.ts
+++ b/apps/cli/src/session/session-execution-service.ts
@@ -477,11 +477,12 @@ export type SessionExecutionServiceDeps = {
     turnRef: TurnRef,
     recorder?: PromptActivityRecorder
   ) => BindTurnForPromptResult;
-  /** Replay-gate evidence for a turn; `unknown` is fail-closed at every caller. */
-  observePromptActivityForTurn?: (
-    sessionId: SessionId,
-    turnId: string
-  ) => PromptActivityObservation;
+  /**
+   * Replay-gate evidence for a turn. Required, not optional: a missing dep would
+   * need a fallback default, and the fallback is exactly the "may have acted"
+   * question answered by a different, blinder signal.
+   */
+  observePromptActivityForTurn: (sessionId: SessionId, turnId: string) => PromptActivityObservation;
   clearConversationTurn: (sessionId: SessionId, turnId: string) => void;
   getActiveTurnId: (sessionId: SessionId) => string | undefined;
   clearActiveTurnId: (sessionId: SessionId, turnId: string) => void;
@@ -544,7 +545,6 @@ export type SessionExecutionServiceDeps = {
    * buffered or flushed. Prompt recovery must not replay the same user turn after
    * visible agent output, because the adapter may already have acted on it.
    */
-  hasPromptOutputForTurn?: (sessionId: SessionId, turnId: string) => boolean;
   /**
    * Same observation, but `undefined` when the session's transient state is gone
    * and the answer is unknowable. The no-output guard needs that distinction:
@@ -4021,24 +4021,15 @@ export class SessionExecutionService {
           prompt(promptBlocks).pipe(
             Effect.catchAll((error) =>
               Effect.gen(function* () {
-                // Fail CLOSED when the dependency is not wired: an unobservable
-                // turn must be treated as one that may already have acted, or
-                // the replay re-runs tools the agent already executed. (The
-                // no-output guard needs the opposite default — see
-                // `turnProducedVisibleOutput`.)
-                //
-                // The recorder is the primary signal because it also sees
-                // permission requests and `fs/write_text_file`; only a positive
-                // `none` permits a replay, so `unknown` and
-                // `dropped_prompt_activity` both refuse.
-                const activity = self.deps.observePromptActivityForTurn?.(
-                  sessionId,
-                  runtime.turnId
+                // Fails CLOSED by construction: only a positive `none` permits
+                // a replay, so an unobservable turn (`unknown`) refuses, as does
+                // one that may already have acted. The recorder is the only
+                // signal because it is the only one that sees permission
+                // requests and `fs/write_text_file`. (The no-output guard asks
+                // the opposite question — see `turnProducedVisibleOutput`.)
+                const hasPromptOutput = !allowsPromptReplay(
+                  self.deps.observePromptActivityForTurn(sessionId, runtime.turnId)
                 );
-                const hasPromptOutput =
-                  activity !== undefined
-                    ? !allowsPromptReplay(activity)
-                    : (self.deps.hasPromptOutputForTurn?.(sessionId, runtime.turnId) ?? true);
                 if (
                   runtime.turnId !== turnId ||
                   !shouldRecoverStaleACPConnectionPrompt({

--- a/apps/cli/src/session/session-execution-service.ts
+++ b/apps/cli/src/session/session-execution-service.ts
@@ -165,18 +165,6 @@ const SILENT_TURN_FAILURE_MESSAGE =
   'reported it as a normal completion instead of an error. Retry your message, or start a ' +
   'new session if this conversation has grown too long.';
 
-/**
- * Used instead of `SILENT_TURN_FAILURE_MESSAGE` when the recorder saw the turn do
- * something — an approved permission, an `fs/write_text_file`, or a dropped
- * update — even though nothing reached the transcript.
- *
- * The message above guesses at an upstream cause and tells the user to retry.
- * Both halves are wrong here: the failure is local, and the agent may have edited
- * files or run commands, so retrying can repeat that work. Deliberately reuses
- * the `agent_no_output` reason code — a dedicated `agent_output_dropped` code
- * changes `ChatFailedReasonSchema`, which is persisted and shared with every
- * client, so it is its own high-risk change.
- */
 const DROPPED_ACTIVITY_TURN_FAILURE_MESSAGE =
   'The agent ended the turn without anything reaching this conversation, but it did act — ' +
   'it requested permissions or wrote files during the turn. Its execution state for this ' +
@@ -239,11 +227,6 @@ type ApplyModeAndModelConfig = SessionTurnInputConfig & {
 
 type PromptHandoffRun = {
   turnId: string;
-  /**
-   * This run's replay-gate evidence. Lives here rather than in a map: the object
-   * is already per-prompt, fiber-held, carried along the successor chain by a
-   * steer, and dies with the turn — so boundedness is constructional.
-   */
   activity: PromptActivityRecorder;
   promptOutcome: Promise<{ status: 'fulfilled' } | { status: 'rejected'; error: unknown }>;
   successor?: PromptHandoffRun;
@@ -477,11 +460,6 @@ export type SessionExecutionServiceDeps = {
     turnRef: TurnRef,
     recorder?: PromptActivityRecorder
   ) => BindTurnForPromptResult;
-  /**
-   * Replay-gate evidence for a turn. Required, not optional: a missing dep would
-   * need a fallback default, and the fallback is exactly the "may have acted"
-   * question answered by a different, blinder signal.
-   */
   observePromptActivityForTurn: (sessionId: SessionId, turnId: string) => PromptActivityObservation;
   clearConversationTurn: (sessionId: SessionId, turnId: string) => void;
   getActiveTurnId: (sessionId: SessionId) => string | undefined;
@@ -3386,8 +3364,7 @@ export class SessionExecutionService {
     turnId: string;
     userTurnId?: string;
   }): Promise<void> {
-    const activity =
-      this.deps.observePromptActivityForTurn?.(options.sessionId, options.turnId) ?? 'unknown';
+    const activity = this.deps.observePromptActivityForTurn(options.sessionId, options.turnId);
     // Only an upstream-looking silence gets the upstream-cause guess. A turn that
     // demonstrably acted must not be explained as a context-length or rate-limit
     // rejection, and must not be presented as safe to retry.

--- a/apps/cli/tests/message-handler-bind-turn-for-prompt.test.ts
+++ b/apps/cli/tests/message-handler-bind-turn-for-prompt.test.ts
@@ -24,7 +24,11 @@ import type {
 
 import type { SessionDocument } from '../src/lib/loro/doc';
 import type { BindTurnForPromptResult, TurnRef } from '../src/lib/session-transient-store';
-import { PromptActivityRecorder } from '../src/session/prompt-activity-recorder';
+import {
+  PromptActivityRecorder,
+  allowsPromptReplay,
+  type PromptActivityObservation,
+} from '../src/session/prompt-activity-recorder';
 import { loadEnv } from '../src/utils/const';
 
 import { createMessageHandlerHarness, destroyRepoOnRealTimers } from './message-handler-harness';
@@ -57,19 +61,24 @@ type MessageHandlerHost = {
   ): Promise<void>;
   enqueueACPUpdate(sessionId: SessionId, update: AcpSessionNotification): void;
   flushACPUpdatesNow(sessionId: SessionId): Promise<void>;
-  hasPromptOutputForTurn(sessionId: SessionId, turnId: string): boolean;
   observePromptOutputForTurn(sessionId: SessionId, turnId: string): boolean | undefined;
+  handleAgentPermissionRequest(
+    sessionId: SessionId,
+    requestId: string,
+    request: unknown,
+    model?: unknown
+  ): Promise<unknown>;
   recordPromptSideEffect(sessionId: SessionId): void;
   store: {
     deleteSession(sessionId: SessionId): void;
     clearTurnState(sessionId: SessionId): void;
-    observePromptActivityForTurn(sessionId: SessionId, turnId: string): string;
+    observePromptActivityForTurn(sessionId: SessionId, turnId: string): PromptActivityObservation;
   };
 };
 
 const createHarness = async (sessionId: SessionId) => {
-  const { repo, doc, handler } = await createMessageHandlerHarness(sessionId);
-  return { repo, doc, host: handler as unknown as MessageHandlerHost };
+  const { repo, doc, handler, sessionManager } = await createMessageHandlerHarness(sessionId);
+  return { repo, doc, sessionManager, host: handler as unknown as MessageHandlerHost };
 };
 
 const agentChunk = (sessionId: SessionId, text: string): AcpSessionNotification => ({
@@ -152,7 +161,9 @@ describe('MessageHandler bindTurnForPrompt', () => {
       const recorder = new PromptActivityRecorder();
       expect(host.bindConversationTurnForPrompt(sessionId, turnRef, recorder)).toBe('bound');
 
-      expect(host.hasPromptOutputForTurn(sessionId, turnRef.turnId)).toBe(false);
+      expect(
+        allowsPromptReplay(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId))
+      ).toBe(true);
 
       // The agent asks to run a tool. Nothing reaches the transcript.
       host.recordPromptSideEffect(sessionId);
@@ -160,11 +171,15 @@ describe('MessageHandler bindTurnForPrompt', () => {
       expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe(
         'dropped_prompt_activity'
       );
-      expect(host.hasPromptOutputForTurn(sessionId, turnRef.turnId)).toBe(true);
+      expect(
+        allowsPromptReplay(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId))
+      ).toBe(false);
 
       // ...and the evidence survives the turn ending, which is when the gate runs.
       host.store.clearTurnState(sessionId);
-      expect(host.hasPromptOutputForTurn(sessionId, turnRef.turnId)).toBe(true);
+      expect(
+        allowsPromptReplay(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId))
+      ).toBe(false);
     } finally {
       await destroyRepoOnRealTimers(repo);
     }
@@ -201,7 +216,9 @@ describe('MessageHandler bindTurnForPrompt', () => {
         'dropped_prompt_activity'
       );
       // Replay gate: this turn may have acted, so refuse.
-      expect(host.hasPromptOutputForTurn(sessionId, turnRef.turnId)).toBe(true);
+      expect(
+        allowsPromptReplay(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId))
+      ).toBe(false);
       // No-output guard: the user saw nothing, so this IS a silent failure.
       expect(host.observePromptOutputForTurn(sessionId, turnRef.turnId)).toBe(false);
     } finally {
@@ -247,6 +264,67 @@ describe('MessageHandler bindTurnForPrompt', () => {
     }
   });
 
+  it.each([
+    [
+      'a permission request',
+      async (host: MessageHandlerHost, sessionId: SessionId, _fire: (s: SessionId) => void) => {
+        // Not `recordPromptSideEffect` directly: the point is that the REAL
+        // producer reaches the recorder. Rejected by the harness (no responder),
+        // which is fine — recording happens on arrival, before any answer.
+        await host
+          .handleAgentPermissionRequest(sessionId, 'req-1', {
+            sessionId,
+            toolCall: { toolCallId: 'tool-1', title: 'rm -rf' },
+            options: [],
+          })
+          .catch(() => undefined);
+      },
+    ],
+    [
+      'an fs/write_text_file',
+      async (_host: MessageHandlerHost, sessionId: SessionId, fireWriteTextFile) => {
+        fireWriteTextFile(sessionId);
+      },
+    ],
+  ])('records %s against the bound turn', async (_label, act) => {
+    // Both are independent JSON-RPC requests that never reach
+    // `enqueueACPUpdate`, which is exactly why the replay gate could not see
+    // them. Wiring each producer to the recorder is the whole point of Step D,
+    // and neither call site had a test.
+    const sessionId = `s-producer-${_label.replace(/[^a-z]/gi, '')}` as SessionId;
+    const { repo, doc, host, sessionManager } = await createHarness(sessionId);
+    const fireWriteTextFile = (id: SessionId) => {
+      const registered = sessionManager.on.mock.calls.find(
+        (call: unknown[]) => call[0] === 'onWriteTextFile'
+      );
+      if (!registered) throw new Error('onWriteTextFile listener was never registered');
+      (registered[1] as (s: SessionId, e: unknown) => void)(id, {
+        path: '/tmp/x.ts',
+        content: 'x',
+      });
+    };
+
+    try {
+      const turnRef = host.beginConversationTurn(sessionId, 'user-p', {
+        dispatchSource: 'crdt',
+        sessionDoc: doc,
+        deferACPUpdateTarget: true,
+      });
+      expect(
+        host.bindConversationTurnForPrompt(sessionId, turnRef, new PromptActivityRecorder())
+      ).toBe('bound');
+      expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe('none');
+
+      await act(host, sessionId, fireWriteTextFile);
+
+      expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe(
+        'dropped_prompt_activity'
+      );
+    } finally {
+      await destroyRepoOnRealTimers(repo);
+    }
+  });
+
   it('refuses a replay for a turn with no recorder at all', async () => {
     const sessionId = 's-recorder-missing' as SessionId;
     const { repo, doc, host } = await createHarness(sessionId);
@@ -261,7 +339,9 @@ describe('MessageHandler bindTurnForPrompt', () => {
       expect(host.bindConversationTurnForPrompt(sessionId, turnRef)).toBe('bound');
 
       expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe('unknown');
-      expect(host.hasPromptOutputForTurn(sessionId, turnRef.turnId)).toBe(true);
+      expect(
+        allowsPromptReplay(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId))
+      ).toBe(false);
     } finally {
       await destroyRepoOnRealTimers(repo);
     }

--- a/apps/cli/tests/message-handler-bind-turn-for-prompt.test.ts
+++ b/apps/cli/tests/message-handler-bind-turn-for-prompt.test.ts
@@ -58,6 +58,7 @@ type MessageHandlerHost = {
   enqueueACPUpdate(sessionId: SessionId, update: AcpSessionNotification): void;
   flushACPUpdatesNow(sessionId: SessionId): Promise<void>;
   hasPromptOutputForTurn(sessionId: SessionId, turnId: string): boolean;
+  observePromptOutputForTurn(sessionId: SessionId, turnId: string): boolean | undefined;
   recordPromptSideEffect(sessionId: SessionId): void;
   store: {
     deleteSession(sessionId: SessionId): void;
@@ -164,6 +165,83 @@ describe('MessageHandler bindTurnForPrompt', () => {
       // ...and the evidence survives the turn ending, which is when the gate runs.
       host.store.clearTurnState(sessionId);
       expect(host.hasPromptOutputForTurn(sessionId, turnRef.turnId)).toBe(true);
+    } finally {
+      await destroyRepoOnRealTimers(repo);
+    }
+  });
+
+  it('separates "may have acted" from "produced visible output"', async () => {
+    // These are different questions and the two guards need different answers.
+    // Conflating them means a turn that only requested a permission reads as
+    // having produced output, so the no-output guard takes the SUCCESS path: no
+    // `agent_no_output`, no notice, and the user is left looking at an empty
+    // assistant entry with no explanation — worse than the original bug.
+    //
+    // Asserted at the MessageHandler seam with no mocked deps, because that is
+    // exactly where the two accessors diverge.
+    const sessionId = 's-recorder-visible-vs-acted' as SessionId;
+    const { repo, doc, host } = await createHarness(sessionId);
+
+    try {
+      const turnRef = host.beginConversationTurn(sessionId, 'user-5', {
+        dispatchSource: 'crdt',
+        sessionDoc: doc,
+        deferACPUpdateTarget: true,
+      });
+      await host.createAssistantEntryForTurn(sessionId, doc, turnRef.turnId, undefined, 'user-5');
+      expect(
+        host.bindConversationTurnForPrompt(sessionId, turnRef, new PromptActivityRecorder())
+      ).toBe('bound');
+
+      // The agent asks to run a tool and nothing else happens: no ACP update, so
+      // nothing reaches the transcript.
+      host.recordPromptSideEffect(sessionId);
+
+      expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe(
+        'dropped_prompt_activity'
+      );
+      // Replay gate: this turn may have acted, so refuse.
+      expect(host.hasPromptOutputForTurn(sessionId, turnRef.turnId)).toBe(true);
+      // No-output guard: the user saw nothing, so this IS a silent failure.
+      expect(host.observePromptOutputForTurn(sessionId, turnRef.turnId)).toBe(false);
+    } finally {
+      await destroyRepoOnRealTimers(repo);
+    }
+  });
+
+  it('reports visible output once an update is actually routed', async () => {
+    const sessionId = 's-recorder-visible-routed' as SessionId;
+    const { repo, doc, host } = await createHarness(sessionId);
+
+    try {
+      const turnRef = host.beginConversationTurn(sessionId, 'user-6', {
+        dispatchSource: 'crdt',
+        sessionDoc: doc,
+        deferACPUpdateTarget: true,
+      });
+      await host.createAssistantEntryForTurn(sessionId, doc, turnRef.turnId, undefined, 'user-6');
+      expect(
+        host.bindConversationTurnForPrompt(sessionId, turnRef, new PromptActivityRecorder())
+      ).toBe('bound');
+
+      expect(host.observePromptOutputForTurn(sessionId, turnRef.turnId)).toBe(false);
+
+      host.enqueueACPUpdate(sessionId, agentChunk(sessionId, 'hello'));
+      await host.flushACPUpdatesNow(sessionId);
+
+      expect(host.observePromptOutputForTurn(sessionId, turnRef.turnId)).toBe(true);
+    } finally {
+      await destroyRepoOnRealTimers(repo);
+    }
+  });
+
+  it('leaves the no-output guard failing open for an unobservable turn', async () => {
+    const sessionId = 's-recorder-unobservable' as SessionId;
+    const { repo, host } = await createHarness(sessionId);
+
+    try {
+      // Never seen by the store at all.
+      expect(host.observePromptOutputForTurn(sessionId, 'assistant:user-7')).toBeUndefined();
     } finally {
       await destroyRepoOnRealTimers(repo);
     }

--- a/apps/cli/tests/message-handler-bind-turn-for-prompt.test.ts
+++ b/apps/cli/tests/message-handler-bind-turn-for-prompt.test.ts
@@ -24,6 +24,7 @@ import type {
 
 import type { SessionDocument } from '../src/lib/loro/doc';
 import type { BindTurnForPromptResult, TurnRef } from '../src/lib/session-transient-store';
+import { PromptActivityRecorder } from '../src/session/prompt-activity-recorder';
 import { loadEnv } from '../src/utils/const';
 
 import { createMessageHandlerHarness, destroyRepoOnRealTimers } from './message-handler-harness';
@@ -40,7 +41,11 @@ type MessageHandlerHost = {
       deferACPUpdateTarget?: boolean;
     }
   ): TurnRef;
-  bindConversationTurnForPrompt(sessionId: SessionId, turnRef: TurnRef): BindTurnForPromptResult;
+  bindConversationTurnForPrompt(
+    sessionId: SessionId,
+    turnRef: TurnRef,
+    recorder?: PromptActivityRecorder
+  ): BindTurnForPromptResult;
   beginACPReplaySuppression(sessionId: SessionId): void;
   endACPReplaySuppression(sessionId: SessionId): void;
   createAssistantEntryForTurn(
@@ -52,7 +57,13 @@ type MessageHandlerHost = {
   ): Promise<void>;
   enqueueACPUpdate(sessionId: SessionId, update: AcpSessionNotification): void;
   flushACPUpdatesNow(sessionId: SessionId): Promise<void>;
-  store: { deleteSession(sessionId: SessionId): void };
+  hasPromptOutputForTurn(sessionId: SessionId, turnId: string): boolean;
+  recordPromptSideEffect(sessionId: SessionId): void;
+  store: {
+    deleteSession(sessionId: SessionId): void;
+    clearTurnState(sessionId: SessionId): void;
+    observePromptActivityForTurn(sessionId: SessionId, turnId: string): string;
+  };
 };
 
 const createHarness = async (sessionId: SessionId) => {
@@ -118,6 +129,114 @@ describe('MessageHandler bindTurnForPrompt', () => {
 
       const assistant = (await doc.getHistory()).find((entry) => entry.id === turnRef.turnId);
       expect(readItems(assistant)).toEqual([{ type: 'text', text: 'real answer' }]);
+    } finally {
+      await destroyRepoOnRealTimers(repo);
+    }
+  });
+
+  it('refuses a replay after the turn requested a permission, with nothing in the transcript', async () => {
+    // End-to-end through the real producer: `handleAgentPermissionRequest` records
+    // a side effect, so a turn that approved and ran a tool without emitting any
+    // ACP update still refuses replay. Before the recorder this read as "produced
+    // nothing" and the prompt was replayed, re-running the tool.
+    const sessionId = 's-recorder-permission' as SessionId;
+    const { repo, doc, host } = await createHarness(sessionId);
+
+    try {
+      const turnRef = host.beginConversationTurn(sessionId, 'user-1', {
+        dispatchSource: 'crdt',
+        sessionDoc: doc,
+        deferACPUpdateTarget: true,
+      });
+      const recorder = new PromptActivityRecorder();
+      expect(host.bindConversationTurnForPrompt(sessionId, turnRef, recorder)).toBe('bound');
+
+      expect(host.hasPromptOutputForTurn(sessionId, turnRef.turnId)).toBe(false);
+
+      // The agent asks to run a tool. Nothing reaches the transcript.
+      host.recordPromptSideEffect(sessionId);
+
+      expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe(
+        'dropped_prompt_activity'
+      );
+      expect(host.hasPromptOutputForTurn(sessionId, turnRef.turnId)).toBe(true);
+
+      // ...and the evidence survives the turn ending, which is when the gate runs.
+      host.store.clearTurnState(sessionId);
+      expect(host.hasPromptOutputForTurn(sessionId, turnRef.turnId)).toBe(true);
+    } finally {
+      await destroyRepoOnRealTimers(repo);
+    }
+  });
+
+  it('refuses a replay for a turn with no recorder at all', async () => {
+    const sessionId = 's-recorder-missing' as SessionId;
+    const { repo, doc, host } = await createHarness(sessionId);
+
+    try {
+      const turnRef = host.beginConversationTurn(sessionId, 'user-2', {
+        dispatchSource: 'crdt',
+        sessionDoc: doc,
+        deferACPUpdateTarget: true,
+      });
+      // Bound WITHOUT a recorder, as a process restart would leave things.
+      expect(host.bindConversationTurnForPrompt(sessionId, turnRef)).toBe('bound');
+
+      expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe('unknown');
+      expect(host.hasPromptOutputForTurn(sessionId, turnRef.turnId)).toBe(true);
+    } finally {
+      await destroyRepoOnRealTimers(repo);
+    }
+  });
+
+  it('records a routed update as persisted output', async () => {
+    const sessionId = 's-recorder-routed' as SessionId;
+    const { repo, doc, host } = await createHarness(sessionId);
+
+    try {
+      const turnRef = host.beginConversationTurn(sessionId, 'user-4', {
+        dispatchSource: 'crdt',
+        sessionDoc: doc,
+        deferACPUpdateTarget: true,
+      });
+      await host.createAssistantEntryForTurn(sessionId, doc, turnRef.turnId, undefined, 'user-4');
+      expect(
+        host.bindConversationTurnForPrompt(sessionId, turnRef, new PromptActivityRecorder())
+      ).toBe('bound');
+
+      host.enqueueACPUpdate(sessionId, agentChunk(sessionId, 'hello'));
+      await host.flushACPUpdatesNow(sessionId);
+
+      expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe(
+        'persisted_output'
+      );
+    } finally {
+      await destroyRepoOnRealTimers(repo);
+    }
+  });
+
+  it('refuses to bind a turn that a redispatch superseded', async () => {
+    const sessionId = 's-bind-superseded' as SessionId;
+    const userTurnId = 'user-4';
+    const { repo, doc, host } = await createHarness(sessionId);
+
+    try {
+      const staleRef = host.beginConversationTurn(sessionId, userTurnId, {
+        dispatchSource: 'crdt',
+        sessionDoc: doc,
+        deferACPUpdateTarget: true,
+      });
+      // Same turn id (`assistant:<userTurnId>`), new epoch.
+      const liveRef = host.beginConversationTurn(sessionId, userTurnId, {
+        dispatchSource: 'crdt',
+        sessionDoc: doc,
+        deferACPUpdateTarget: true,
+      });
+      expect(liveRef.turnId).toBe(staleRef.turnId);
+      expect(liveRef.turnEpoch).not.toBe(staleRef.turnEpoch);
+
+      expect(host.bindConversationTurnForPrompt(sessionId, staleRef)).toBe('turn_superseded');
+      expect(host.bindConversationTurnForPrompt(sessionId, liveRef)).toBe('bound');
     } finally {
       await destroyRepoOnRealTimers(repo);
     }

--- a/apps/cli/tests/message-handler-bind-turn-for-prompt.test.ts
+++ b/apps/cli/tests/message-handler-bind-turn-for-prompt.test.ts
@@ -70,8 +70,6 @@ type MessageHandlerHost = {
   ): Promise<unknown>;
   recordPromptSideEffect(sessionId: SessionId): void;
   store: {
-    deleteSession(sessionId: SessionId): void;
-    clearTurnState(sessionId: SessionId): void;
     observePromptActivityForTurn(sessionId: SessionId, turnId: string): PromptActivityObservation;
   };
 };
@@ -144,47 +142,6 @@ describe('MessageHandler bindTurnForPrompt', () => {
     }
   });
 
-  it('refuses a replay after the turn requested a permission, with nothing in the transcript', async () => {
-    // End-to-end through the real producer: `handleAgentPermissionRequest` records
-    // a side effect, so a turn that approved and ran a tool without emitting any
-    // ACP update still refuses replay. Before the recorder this read as "produced
-    // nothing" and the prompt was replayed, re-running the tool.
-    const sessionId = 's-recorder-permission' as SessionId;
-    const { repo, doc, host } = await createHarness(sessionId);
-
-    try {
-      const turnRef = host.beginConversationTurn(sessionId, 'user-1', {
-        dispatchSource: 'crdt',
-        sessionDoc: doc,
-        deferACPUpdateTarget: true,
-      });
-      const recorder = new PromptActivityRecorder();
-      expect(host.bindConversationTurnForPrompt(sessionId, turnRef, recorder)).toBe('bound');
-
-      expect(
-        allowsPromptReplay(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId))
-      ).toBe(true);
-
-      // The agent asks to run a tool. Nothing reaches the transcript.
-      host.recordPromptSideEffect(sessionId);
-
-      expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe(
-        'dropped_prompt_activity'
-      );
-      expect(
-        allowsPromptReplay(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId))
-      ).toBe(false);
-
-      // ...and the evidence survives the turn ending, which is when the gate runs.
-      host.store.clearTurnState(sessionId);
-      expect(
-        allowsPromptReplay(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId))
-      ).toBe(false);
-    } finally {
-      await destroyRepoOnRealTimers(repo);
-    }
-  });
-
   it('separates "may have acted" from "produced visible output"', async () => {
     // These are different questions and the two guards need different answers.
     // Conflating them means a turn that only requested a permission reads as
@@ -221,44 +178,6 @@ describe('MessageHandler bindTurnForPrompt', () => {
       ).toBe(false);
       // No-output guard: the user saw nothing, so this IS a silent failure.
       expect(host.observePromptOutputForTurn(sessionId, turnRef.turnId)).toBe(false);
-    } finally {
-      await destroyRepoOnRealTimers(repo);
-    }
-  });
-
-  it('reports visible output once an update is actually routed', async () => {
-    const sessionId = 's-recorder-visible-routed' as SessionId;
-    const { repo, doc, host } = await createHarness(sessionId);
-
-    try {
-      const turnRef = host.beginConversationTurn(sessionId, 'user-6', {
-        dispatchSource: 'crdt',
-        sessionDoc: doc,
-        deferACPUpdateTarget: true,
-      });
-      await host.createAssistantEntryForTurn(sessionId, doc, turnRef.turnId, undefined, 'user-6');
-      expect(
-        host.bindConversationTurnForPrompt(sessionId, turnRef, new PromptActivityRecorder())
-      ).toBe('bound');
-
-      expect(host.observePromptOutputForTurn(sessionId, turnRef.turnId)).toBe(false);
-
-      host.enqueueACPUpdate(sessionId, agentChunk(sessionId, 'hello'));
-      await host.flushACPUpdatesNow(sessionId);
-
-      expect(host.observePromptOutputForTurn(sessionId, turnRef.turnId)).toBe(true);
-    } finally {
-      await destroyRepoOnRealTimers(repo);
-    }
-  });
-
-  it('leaves the no-output guard failing open for an unobservable turn', async () => {
-    const sessionId = 's-recorder-unobservable' as SessionId;
-    const { repo, host } = await createHarness(sessionId);
-
-    try {
-      // Never seen by the store at all.
-      expect(host.observePromptOutputForTurn(sessionId, 'assistant:user-7')).toBeUndefined();
     } finally {
       await destroyRepoOnRealTimers(repo);
     }
@@ -320,81 +239,6 @@ describe('MessageHandler bindTurnForPrompt', () => {
       expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe(
         'dropped_prompt_activity'
       );
-    } finally {
-      await destroyRepoOnRealTimers(repo);
-    }
-  });
-
-  it('refuses a replay for a turn with no recorder at all', async () => {
-    const sessionId = 's-recorder-missing' as SessionId;
-    const { repo, doc, host } = await createHarness(sessionId);
-
-    try {
-      const turnRef = host.beginConversationTurn(sessionId, 'user-2', {
-        dispatchSource: 'crdt',
-        sessionDoc: doc,
-        deferACPUpdateTarget: true,
-      });
-      // Bound WITHOUT a recorder, as a process restart would leave things.
-      expect(host.bindConversationTurnForPrompt(sessionId, turnRef)).toBe('bound');
-
-      expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe('unknown');
-      expect(
-        allowsPromptReplay(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId))
-      ).toBe(false);
-    } finally {
-      await destroyRepoOnRealTimers(repo);
-    }
-  });
-
-  it('records a routed update as persisted output', async () => {
-    const sessionId = 's-recorder-routed' as SessionId;
-    const { repo, doc, host } = await createHarness(sessionId);
-
-    try {
-      const turnRef = host.beginConversationTurn(sessionId, 'user-4', {
-        dispatchSource: 'crdt',
-        sessionDoc: doc,
-        deferACPUpdateTarget: true,
-      });
-      await host.createAssistantEntryForTurn(sessionId, doc, turnRef.turnId, undefined, 'user-4');
-      expect(
-        host.bindConversationTurnForPrompt(sessionId, turnRef, new PromptActivityRecorder())
-      ).toBe('bound');
-
-      host.enqueueACPUpdate(sessionId, agentChunk(sessionId, 'hello'));
-      await host.flushACPUpdatesNow(sessionId);
-
-      expect(host.store.observePromptActivityForTurn(sessionId, turnRef.turnId)).toBe(
-        'persisted_output'
-      );
-    } finally {
-      await destroyRepoOnRealTimers(repo);
-    }
-  });
-
-  it('refuses to bind a turn that a redispatch superseded', async () => {
-    const sessionId = 's-bind-superseded' as SessionId;
-    const userTurnId = 'user-4';
-    const { repo, doc, host } = await createHarness(sessionId);
-
-    try {
-      const staleRef = host.beginConversationTurn(sessionId, userTurnId, {
-        dispatchSource: 'crdt',
-        sessionDoc: doc,
-        deferACPUpdateTarget: true,
-      });
-      // Same turn id (`assistant:<userTurnId>`), new epoch.
-      const liveRef = host.beginConversationTurn(sessionId, userTurnId, {
-        dispatchSource: 'crdt',
-        sessionDoc: doc,
-        deferACPUpdateTarget: true,
-      });
-      expect(liveRef.turnId).toBe(staleRef.turnId);
-      expect(liveRef.turnEpoch).not.toBe(staleRef.turnEpoch);
-
-      expect(host.bindConversationTurnForPrompt(sessionId, staleRef)).toBe('turn_superseded');
-      expect(host.bindConversationTurnForPrompt(sessionId, liveRef)).toBe('bound');
     } finally {
       await destroyRepoOnRealTimers(repo);
     }

--- a/apps/cli/tests/session-execution-service.test.ts
+++ b/apps/cli/tests/session-execution-service.test.ts
@@ -31,6 +31,7 @@ import {
 } from '../src/agent/agent-client';
 import { AcpAuthenticationManager } from '../src/agent/acp-authentication';
 import { GitExecutableNotFoundError } from '../src/session/worktree/git-process-error';
+import type { PromptActivityObservation } from '../src/session/prompt-activity-recorder';
 
 const capabilityConfigId = 'config-1' as AgentConfigId;
 
@@ -1132,6 +1133,7 @@ describe('SessionExecutionService', () => {
   const runSilentPromptTurn = async (options: {
     sessionId: string;
     hasPromptOutputForTurn: boolean;
+    promptActivity?: PromptActivityObservation;
   }) => {
     let history: Array<Record<string, unknown>> = [
       {
@@ -1194,6 +1196,9 @@ describe('SessionExecutionService', () => {
         notifySessionCompleted,
       },
       observePromptOutputForTurn: vi.fn(() => options.hasPromptOutputForTurn),
+      ...(options.promptActivity
+        ? { observePromptActivityForTurn: vi.fn(() => options.promptActivity!) }
+        : {}),
     });
 
     const service = new SessionExecutionService(deps);
@@ -1245,6 +1250,41 @@ describe('SessionExecutionService', () => {
         processingUserMsgId: undefined,
       })
     );
+  });
+
+  it('does not blame context length or suggest a retry when the turn actually acted', async () => {
+    // A turn that requested permissions or wrote files produced no transcript but
+    // is NOT an upstream silence. Telling the user "a context-length or rate-limit
+    // rejection is the usual cause. Retry your message" is wrong twice: the cause
+    // is local, and retrying can repeat work the agent already did.
+    const { deps, sessionDoc } = await runSilentPromptTurn({
+      sessionId: 'session-silent-acted',
+      hasPromptOutputForTurn: false,
+      promptActivity: 'dropped_prompt_activity',
+    });
+
+    const [, reason, message] = vi.mocked(deps.recordChatFailure).mock.calls[0] ?? [];
+    expect(reason).toBe('agent_no_output');
+    expect(message).toContain('uncertain');
+    expect(message).toContain('do not simply retry');
+    expect(message).not.toContain('context-length');
+    expect(message).not.toContain('rate-limit');
+    expect(message).not.toContain('Retry your message');
+    void sessionDoc;
+  });
+
+  it('keeps the upstream-cause explanation for a turn that truly did nothing', async () => {
+    // The reverse case: an actual upstream silence should still get the specific,
+    // actionable guess rather than a blanket "state is uncertain".
+    const { deps } = await runSilentPromptTurn({
+      sessionId: 'session-silent-quiet',
+      hasPromptOutputForTurn: false,
+      promptActivity: 'none',
+    });
+
+    const [, , message] = vi.mocked(deps.recordChatFailure).mock.calls[0] ?? [];
+    expect(message).toContain('context-length');
+    expect(message).toContain('Retry your message');
   });
 
   it('leaves a turn that emitted agent output on the normal completion path', async () => {
@@ -1987,6 +2027,380 @@ describe('SessionExecutionService', () => {
     );
     expect(deps.recordChatFailure).not.toHaveBeenCalled();
     expect(history[0]?.status).toBe('handled');
+  });
+
+  it('lets the stale-ACP retry proceed when terminating the old instance emits `terminated`', async () => {
+    // The stale-ACP recovery terminates its own Session instance, and in
+    // production that emits a real `terminated` lifecycle event naming the
+    // instance the turn is still bound to. `onSessionInstanceClosed` must NOT
+    // treat that as a disconnect: the terminate runs AFTER `prompt()` already
+    // rejected, so `promptInFlight` is back to false and the close guard is
+    // uninstalled. The sibling test above mocks `terminateSession` into a no-op,
+    // so it never fires the event and cannot catch a regression here.
+    const sessionId = 'session-stale-acp-lifecycle' as SessionId;
+    const acpSessionId = 'acp-stale-lifecycle' as ACPSessionId;
+    const restoredAcpSessionId = 'acp-restored-lifecycle' as ACPSessionId;
+    let history: Array<Record<string, unknown>> = [
+      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
+    ];
+    const agentClient = {
+      isCreated: vi.fn(() => true),
+      cancel: vi.fn(async () => {}),
+      prompt: vi.fn(async () => {
+        throw new Error('ACP connection closed');
+      }),
+      currentModel: undefined,
+    };
+    const restoredAgentClient = {
+      isCreated: vi.fn(() => true),
+      cancel: vi.fn(async () => {}),
+      prompt: vi.fn(async () => ({})),
+      currentModel: undefined,
+    };
+    const exec = vi.fn(async (command: string, args: string[]) => {
+      const key = `${command} ${args.join(' ')}`;
+      if (key === 'git rev-parse --is-inside-work-tree') return 'true\n';
+      if (key === 'git rev-parse HEAD') return 'abc123\n';
+      return '';
+    });
+    const activeSession = {
+      sessionId,
+      acpSessionId,
+      agentClient,
+      terminalManager: {} as unknown,
+      getWorkdir: () => '/tmp',
+      getHostWorkdir: () => '/tmp',
+      getParentSessionId: () => undefined,
+      exec,
+      terminate: vi.fn(async () => {}),
+      updateGitIdentity: vi.fn(),
+      createAgent: vi.fn(async () => acpSessionId),
+      applyExecutionPlaneLimits: vi.fn(async () => {}),
+    };
+    const restoredSession = {
+      ...activeSession,
+      acpSessionId: restoredAcpSessionId,
+      agentClient: restoredAgentClient,
+      createAgent: vi.fn(async () => restoredAcpSessionId),
+    };
+    const sessionDoc = {
+      getMetaState: vi.fn(async () => ({ isArchived: false })),
+      setStatus: vi.fn(async () => {}),
+      waitUntilSynced: vi.fn(async () => {}),
+      getHistory: vi.fn(async () => history),
+      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
+        history = updater(history);
+      }),
+    };
+    const deps = createBaseDeps({ hasPromptOutputForTurn: vi.fn(() => false) });
+    let service!: SessionExecutionService;
+    const instanceCloseVerdicts: boolean[] = [];
+    const sessionManager = deps.sessionManager as unknown as {
+      getSession: ReturnType<typeof vi.fn>;
+      terminateSession: ReturnType<typeof vi.fn>;
+      createSession: ReturnType<typeof vi.fn>;
+    };
+    sessionManager.getSession.mockReturnValue(activeSession);
+    sessionManager.createSession.mockResolvedValue(restoredSession);
+    // Stand in for SessionManager's own listener: terminating the instance the
+    // turn is bound to reports the close, exactly as production does.
+    sessionManager.terminateSession.mockImplementation(async () => {
+      instanceCloseVerdicts.push(
+        service.onSessionInstanceClosed(
+          sessionId,
+          activeSession as unknown as ISession,
+          'terminated'
+        )
+      );
+    });
+    (
+      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
+    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
+
+    service = new SessionExecutionService(deps);
+    await service.continueSession({
+      type: 'session/chat',
+      sessionId,
+      machineId: 'machine-1',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      project: undefined,
+      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
+      userTurnId: 'turn-user-1',
+      userId: 'user-1',
+      userName: 'User',
+      userEmail: 'user@example.com',
+    });
+
+    // The lifecycle report was seen and declined — the prompt was no longer in
+    // flight, so the turn owner keeps its own recovery.
+    expect(instanceCloseVerdicts).toEqual([false]);
+    expect(restoredAgentClient.prompt).toHaveBeenCalledWith(
+      restoredAcpSessionId,
+      [{ type: 'text', text: 'hello' }],
+      { signal: expect.any(AbortSignal) }
+    );
+    expect(deps.recordChatFailure).not.toHaveBeenCalled();
+    expect(history[0]?.status).toBe('handled');
+  });
+
+  it('refuses a stale-ACP replay after the turn requested a permission or wrote a file', async () => {
+    // Permission requests and `fs/write_text_file` are independent JSON-RPC
+    // requests that never reach `enqueueACPUpdate`. Before the recorder the
+    // gate could not see them, so a turn that had already approved and run a
+    // tool read as 'produced nothing' and its prompt was replayed.
+    const sessionId = 'session-replay-dropped_prompt_activity' as SessionId;
+    let history: Array<Record<string, unknown>> = [
+      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
+    ];
+    const sessionDoc = {
+      getMetaState: vi.fn(async () => ({ isArchived: false })),
+      setStatus: vi.fn(async () => {}),
+      waitUntilSynced: vi.fn(async () => {}),
+      getHistory: vi.fn(async () => history),
+      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
+        history = updater(history);
+      }),
+    };
+    const agentClient = {
+      isCreated: vi.fn(() => true),
+      cancel: vi.fn(async () => {}),
+      prompt: vi.fn(async () => {
+        throw new Error('ACP connection closed');
+      }),
+      currentModel: undefined,
+    };
+    const restoredAgentClient = {
+      isCreated: vi.fn(() => true),
+      cancel: vi.fn(async () => {}),
+      prompt: vi.fn(async () => ({})),
+      currentModel: undefined,
+    };
+    const activeSession = {
+      sessionId,
+      acpSessionId: 'acp-replay' as ACPSessionId,
+      agentClient,
+      terminalManager: {} as unknown,
+      getWorkdir: () => '/tmp',
+      getHostWorkdir: () => '/tmp',
+      getParentSessionId: () => undefined,
+      exec: vi.fn(async () => ''),
+      terminate: vi.fn(async () => {}),
+      updateGitIdentity: vi.fn(),
+      createAgent: vi.fn(async () => 'acp-replay'),
+      applyExecutionPlaneLimits: vi.fn(async () => {}),
+    };
+    const restoredSession = {
+      ...activeSession,
+      acpSessionId: 'acp-replay-restored' as ACPSessionId,
+      agentClient: restoredAgentClient,
+      createAgent: vi.fn(async () => 'acp-replay-restored'),
+    };
+    const deps = createBaseDeps({
+      beginConversationTurn: vi.fn(() => turnRefOf('assistant-replay')),
+      observePromptActivityForTurn: vi.fn(() => 'dropped_prompt_activity' as const),
+      // Deliberately says "no output" so the ONLY thing that can refuse the
+      // replay is the recorder observation under test.
+      hasPromptOutputForTurn: vi.fn(() => false),
+    });
+    const sessionManager = deps.sessionManager as unknown as {
+      getSession: ReturnType<typeof vi.fn>;
+      createSession: ReturnType<typeof vi.fn>;
+    };
+    sessionManager.getSession.mockReturnValue(activeSession);
+    sessionManager.createSession.mockResolvedValue(restoredSession);
+    (
+      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
+    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
+
+    const service = new SessionExecutionService(deps);
+    await service.continueSession({
+      type: 'session/chat',
+      sessionId,
+      machineId: 'machine-1',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      project: undefined,
+      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
+      userTurnId: 'turn-user-1',
+      userId: 'user-1',
+      userName: 'User',
+      userEmail: 'user@example.com',
+    });
+
+    expect(agentClient.prompt).toHaveBeenCalledTimes(1);
+    expect(sessionManager.createSession).not.toHaveBeenCalled();
+    expect(restoredAgentClient.prompt).not.toHaveBeenCalled();
+  });
+
+  it('refuses a stale-ACP replay when the turn is unobservable', async () => {
+    // No recorder (process restart, or a recorder belonging to another turn).
+    // Unobservable is not 'nothing happened'.
+    const sessionId = 'session-replay-unknown' as SessionId;
+    let history: Array<Record<string, unknown>> = [
+      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
+    ];
+    const sessionDoc = {
+      getMetaState: vi.fn(async () => ({ isArchived: false })),
+      setStatus: vi.fn(async () => {}),
+      waitUntilSynced: vi.fn(async () => {}),
+      getHistory: vi.fn(async () => history),
+      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
+        history = updater(history);
+      }),
+    };
+    const agentClient = {
+      isCreated: vi.fn(() => true),
+      cancel: vi.fn(async () => {}),
+      prompt: vi.fn(async () => {
+        throw new Error('ACP connection closed');
+      }),
+      currentModel: undefined,
+    };
+    const restoredAgentClient = {
+      isCreated: vi.fn(() => true),
+      cancel: vi.fn(async () => {}),
+      prompt: vi.fn(async () => ({})),
+      currentModel: undefined,
+    };
+    const activeSession = {
+      sessionId,
+      acpSessionId: 'acp-replay' as ACPSessionId,
+      agentClient,
+      terminalManager: {} as unknown,
+      getWorkdir: () => '/tmp',
+      getHostWorkdir: () => '/tmp',
+      getParentSessionId: () => undefined,
+      exec: vi.fn(async () => ''),
+      terminate: vi.fn(async () => {}),
+      updateGitIdentity: vi.fn(),
+      createAgent: vi.fn(async () => 'acp-replay'),
+      applyExecutionPlaneLimits: vi.fn(async () => {}),
+    };
+    const restoredSession = {
+      ...activeSession,
+      acpSessionId: 'acp-replay-restored' as ACPSessionId,
+      agentClient: restoredAgentClient,
+      createAgent: vi.fn(async () => 'acp-replay-restored'),
+    };
+    const deps = createBaseDeps({
+      beginConversationTurn: vi.fn(() => turnRefOf('assistant-replay')),
+      observePromptActivityForTurn: vi.fn(() => 'unknown' as const),
+      // Deliberately says "no output" so the ONLY thing that can refuse the
+      // replay is the recorder observation under test.
+      hasPromptOutputForTurn: vi.fn(() => false),
+    });
+    const sessionManager = deps.sessionManager as unknown as {
+      getSession: ReturnType<typeof vi.fn>;
+      createSession: ReturnType<typeof vi.fn>;
+    };
+    sessionManager.getSession.mockReturnValue(activeSession);
+    sessionManager.createSession.mockResolvedValue(restoredSession);
+    (
+      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
+    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
+
+    const service = new SessionExecutionService(deps);
+    await service.continueSession({
+      type: 'session/chat',
+      sessionId,
+      machineId: 'machine-1',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      project: undefined,
+      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
+      userTurnId: 'turn-user-1',
+      userId: 'user-1',
+      userName: 'User',
+      userEmail: 'user@example.com',
+    });
+
+    expect(agentClient.prompt).toHaveBeenCalledTimes(1);
+    expect(sessionManager.createSession).not.toHaveBeenCalled();
+    expect(restoredAgentClient.prompt).not.toHaveBeenCalled();
+  });
+
+  it('still replays a stale-ACP prompt when the turn provably did nothing', async () => {
+    // The reverse case, so the gate cannot be 'fixed' by refusing everything:
+    // a positive `none` is what recovery exists for.
+    const sessionId = 'session-replay-none' as SessionId;
+    let history: Array<Record<string, unknown>> = [
+      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
+    ];
+    const sessionDoc = {
+      getMetaState: vi.fn(async () => ({ isArchived: false })),
+      setStatus: vi.fn(async () => {}),
+      waitUntilSynced: vi.fn(async () => {}),
+      getHistory: vi.fn(async () => history),
+      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
+        history = updater(history);
+      }),
+    };
+    const agentClient = {
+      isCreated: vi.fn(() => true),
+      cancel: vi.fn(async () => {}),
+      prompt: vi.fn(async () => {
+        throw new Error('ACP connection closed');
+      }),
+      currentModel: undefined,
+    };
+    const restoredAgentClient = {
+      isCreated: vi.fn(() => true),
+      cancel: vi.fn(async () => {}),
+      prompt: vi.fn(async () => ({})),
+      currentModel: undefined,
+    };
+    const activeSession = {
+      sessionId,
+      acpSessionId: 'acp-replay' as ACPSessionId,
+      agentClient,
+      terminalManager: {} as unknown,
+      getWorkdir: () => '/tmp',
+      getHostWorkdir: () => '/tmp',
+      getParentSessionId: () => undefined,
+      exec: vi.fn(async () => ''),
+      terminate: vi.fn(async () => {}),
+      updateGitIdentity: vi.fn(),
+      createAgent: vi.fn(async () => 'acp-replay'),
+      applyExecutionPlaneLimits: vi.fn(async () => {}),
+    };
+    const restoredSession = {
+      ...activeSession,
+      acpSessionId: 'acp-replay-restored' as ACPSessionId,
+      agentClient: restoredAgentClient,
+      createAgent: vi.fn(async () => 'acp-replay-restored'),
+    };
+    const deps = createBaseDeps({
+      beginConversationTurn: vi.fn(() => turnRefOf('assistant-replay')),
+      observePromptActivityForTurn: vi.fn(() => 'none' as const),
+      // Deliberately says "no output" so the ONLY thing that can refuse the
+      // replay is the recorder observation under test.
+      hasPromptOutputForTurn: vi.fn(() => false),
+    });
+    const sessionManager = deps.sessionManager as unknown as {
+      getSession: ReturnType<typeof vi.fn>;
+      createSession: ReturnType<typeof vi.fn>;
+    };
+    sessionManager.getSession.mockReturnValue(activeSession);
+    sessionManager.createSession.mockResolvedValue(restoredSession);
+    (
+      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
+    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
+
+    const service = new SessionExecutionService(deps);
+    await service.continueSession({
+      type: 'session/chat',
+      sessionId,
+      machineId: 'machine-1',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      project: undefined,
+      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
+      userTurnId: 'turn-user-1',
+      userId: 'user-1',
+      userName: 'User',
+      userEmail: 'user@example.com',
+    });
+
+    expect(agentClient.prompt).toHaveBeenCalledTimes(1);
+    expect(sessionManager.createSession).toHaveBeenCalled();
+    expect(restoredAgentClient.prompt).toHaveBeenCalledTimes(1);
   });
 
   it('refuses the stale-ACP prompt replay when prompt output cannot be observed', async () => {
@@ -5093,6 +5507,200 @@ describe('SessionExecutionService', () => {
     expect(releaseWorkspaceWatch).toHaveBeenCalledWith(sessionId);
   });
 
+  it('keeps the workspace watch when a closed instance was already replaced', async () => {
+    const sessionId = 'session-watch-keep' as SessionId;
+    let history: Array<Record<string, unknown>> = [
+      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
+    ];
+    const sessionDoc = {
+      getMetaState: vi.fn(async () => ({ isArchived: false })),
+      setStatus: vi.fn(async () => {}),
+      waitUntilSynced: vi.fn(async () => {}),
+      getHistory: vi.fn(async () => history),
+      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
+        history = updater(history);
+      }),
+    };
+    const session = {
+      sessionId,
+      acpSessionId: 'acp-watch-keep' as ACPSessionId,
+      agentClient: {
+        isCreated: vi.fn(() => true),
+        cancel: vi.fn(async () => {}),
+        prompt: vi.fn(async () => {
+          throw new Error('boom');
+        }),
+        currentModel: undefined,
+      },
+      terminalManager: {} as unknown,
+      getWorkdir: () => '/tmp',
+      getHostWorkdir: () => '/tmp',
+      getParentSessionId: () => undefined,
+      exec: vi.fn(async () => ''),
+      terminate: vi.fn(async () => {}),
+      updateGitIdentity: vi.fn(),
+      createAgent: vi.fn(async () => 'acp-watch-keep'),
+      applyExecutionPlaneLimits: vi.fn(async () => {}),
+    };
+    const releaseWorkspaceWatch = vi.fn();
+    const deps = createBaseDeps({});
+    // A replacement instance stays registered under the same id.
+    (deps.sessionManager as unknown as { getSession: ReturnType<typeof vi.fn> }).getSession = vi.fn(
+      () => session
+    );
+    (
+      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
+    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
+    deps.turnFinalization.releaseWorkspaceWatch = releaseWorkspaceWatch;
+
+    const service = new SessionExecutionService(deps);
+    await service.continueSession({
+      type: 'session/chat',
+      sessionId,
+      machineId: 'machine-1',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      project: undefined,
+      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
+      userTurnId: 'turn-user-1',
+      userId: 'user-1',
+      userName: 'User',
+      userEmail: 'user@example.com',
+    });
+
+    expect(releaseWorkspaceWatch).not.toHaveBeenCalled();
+  });
+
+  it('keeps cancel write ordering when `terminated` lands during cancellation', async () => {
+    // Cancel must persist "user turn canceled" BEFORE the assistant entry is
+    // finalized: Operation reconciliation reads a terminal assistant as success
+    // unless the user turn already carries the stronger cancelled outcome.
+    // A lifecycle close arriving mid-cancel must not jump that order, and must
+    // not re-report the turn as a disconnect — cancel owns this outcome.
+    const sessionId = 'session-cancel-terminated' as SessionId;
+    const turnId = 'assistant-cancel-terminated';
+    let meta: Record<string, unknown> = {};
+    let history: Array<Record<string, unknown>> = [
+      {
+        id: 'turn-cancel-terminated',
+        role: 'user',
+        items: [{ type: 'text', text: 'hello' }],
+        status: 'pending',
+        read: false,
+      },
+    ];
+    const writeOrder: string[] = [];
+    const upsertDocMeta = vi.fn(async (_roomId: string, patch: Record<string, unknown>) => {
+      meta = { ...meta, ...patch };
+    });
+    const sessionDoc = {
+      getMetaState: vi.fn(async () => ({ isArchived: false })),
+      setStatus: vi.fn(async () => {}),
+      setBaseBranch: vi.fn(async () => {}),
+      waitUntilSynced: vi.fn(async () => {}),
+      getHistory: vi.fn(async () => history),
+      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
+        history = updater(history);
+        if (history[0]?.status === 'canceled') {
+          writeOrder.push('user-canceled');
+        }
+      }),
+    };
+    let activeTurnId: string | undefined;
+    let service!: SessionExecutionService;
+    const instanceCloseVerdicts: boolean[] = [];
+    const session = {
+      sessionId,
+      acpSessionId: 'acp-cancel-terminated' as ACPSessionId,
+      agentClient: {
+        isCreated: vi.fn(() => true),
+        // Fires while cancellation is running, exactly where SessionManager's
+        // listener would report the closed instance.
+        cancel: vi.fn(async () => {
+          instanceCloseVerdicts.push(
+            service.onSessionInstanceClosed(sessionId, session as unknown as ISession, 'terminated')
+          );
+        }),
+        prompt: vi.fn(async () => {
+          const result = await service.cancelSession({
+            type: 'session/cancel',
+            sessionId,
+            machineId: 'machine-1',
+            workspaceId: 'workspace-1' as WorkspaceId,
+            turnId,
+          });
+          expect(result).toEqual({ success: true });
+          throw new Error('agent cancelled prompt');
+        }),
+        currentModel: undefined,
+      },
+      terminalManager: {} as unknown,
+      getWorkdir: () => '/tmp',
+      getHostWorkdir: () => '/tmp',
+      getParentSessionId: () => undefined,
+      exec: vi.fn(async () => ''),
+      terminate: vi.fn(async () => {}),
+      updateGitIdentity: vi.fn(),
+      createAgent: vi.fn(async () => 'acp-cancel-terminated'),
+      applyExecutionPlaneLimits: vi.fn(async () => {}),
+    };
+    const sessionManager = {
+      getSession: vi.fn(() => session),
+      getPendingSession: vi.fn(() => null),
+      createSession: vi.fn(),
+      setSessionError: vi.fn(),
+      terminateSession: vi.fn(),
+      refreshGhTokenForSession: vi.fn(async () => {}),
+    } as unknown as SessionManager;
+    const deps = createBaseDeps({
+      sessionManager,
+      beginConversationTurn: vi.fn(() => {
+        activeTurnId = turnId;
+        return turnRefOf(turnId);
+      }),
+      getActiveTurnId: vi.fn(() => activeTurnId),
+      clearActiveTurnId: vi.fn((_sessionId, id) => {
+        if (activeTurnId === id) {
+          activeTurnId = undefined;
+        }
+      }),
+      workspaceDocument: {
+        repo: {
+          upsertDocMeta,
+          getDocMeta: vi.fn(async () => ({ meta })),
+        },
+        getOrCreateSessionDoc: vi.fn(async () => sessionDoc),
+        updateAcpCapabilities: vi.fn(async () => {}),
+      } as unknown as LoroDocumentManager,
+    });
+    vi.mocked(deps.turnFinalization.finalizeACPState).mockImplementation(async () => {
+      writeOrder.push('assistant-finalized');
+      expect(history[0]).toMatchObject({ status: 'canceled' });
+    });
+
+    service = new SessionExecutionService(deps);
+    await service.continueSession({
+      type: 'session/chat',
+      sessionId,
+      machineId: 'machine-1',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      project: { kind: 'github', repoFullName: 'owner/repo', branch: 'main' },
+      acpSessionConfig: { prompt: 'hello', cliType: 'builtin', agentType: 'codex' },
+      userTurnId: 'turn-cancel-terminated',
+      userId: 'user-1',
+      userName: 'User',
+      userEmail: 'user@example.com',
+    });
+
+    // The close was reported and declined: cancel already owns this turn.
+    expect(instanceCloseVerdicts).toEqual([false]);
+    expect(writeOrder).toEqual(['user-canceled', 'assistant-finalized']);
+    expect(history[0]).toMatchObject({ status: 'canceled' });
+    expect(deps.recordChatFailure).not.toHaveBeenCalled();
+    // Step B: the cancel path names its turn instead of finalizing whatever is last.
+    expect(deps.turnFinalization.finalizeACPState).toHaveBeenCalledTimes(1);
+    expect(deps.turnFinalization.finalizeACPState).toHaveBeenCalledWith(sessionId, turnId);
+  });
+
   it('does not wait for ACP cancel before interrupting an in-flight prompt', async () => {
     let meta: Record<string, unknown> = {};
     const upsertDocMeta = vi.fn(async (_roomId: string, patch: Record<string, unknown>) => {
@@ -5316,10 +5924,6 @@ describe('SessionExecutionService', () => {
 
     expect(agentClient.cancel).toHaveBeenCalledWith('acp-prompt-cancel-resolved');
     expect(deps.turnFinalization.finalizeACPState).toHaveBeenCalledTimes(1);
-    expect(deps.turnFinalization.finalizeACPState).toHaveBeenCalledWith(
-      'session-prompt-cancel-resolved',
-      'assistant-prompt-cancel-resolved'
-    );
     expect(deps.turnFinalization.notifySessionCompleted).not.toHaveBeenCalled();
     expect(deps.processMessageQueue).not.toHaveBeenCalled();
     expect(upsertDocMeta).toHaveBeenCalledWith('session-session-prompt-cancel-resolved', {

--- a/apps/cli/tests/session-execution-service.test.ts
+++ b/apps/cli/tests/session-execution-service.test.ts
@@ -152,6 +152,7 @@ const createBaseDeps = (
     beginACPReplaySuppression: vi.fn(),
     endACPReplaySuppression: vi.fn(),
     beginConversationTurn: vi.fn(() => turnRefOf('turn-1')),
+    observePromptActivityForTurn: vi.fn(() => 'none' as const),
     bindConversationTurnForPrompt: vi.fn(() => 'bound' as const),
     clearConversationTurn: vi.fn(),
     getActiveTurnId: vi.fn(() => undefined),
@@ -1136,7 +1137,7 @@ describe('SessionExecutionService', () => {
   // left the user with an unanswered message and no error anywhere.
   const runSilentPromptTurn = async (options: {
     sessionId: string;
-    hasPromptOutputForTurn: boolean;
+    visibleOutput: boolean;
     promptActivity?: PromptActivityObservation;
   }) => {
     let history: Array<Record<string, unknown>> = [
@@ -1199,7 +1200,7 @@ describe('SessionExecutionService', () => {
         ...createBaseDeps({}).turnFinalization,
         notifySessionCompleted,
       },
-      observePromptOutputForTurn: vi.fn(() => options.hasPromptOutputForTurn),
+      observePromptOutputForTurn: vi.fn(() => options.visibleOutput),
       ...(options.promptActivity
         ? { observePromptActivityForTurn: vi.fn(() => options.promptActivity!) }
         : {}),
@@ -1233,7 +1234,7 @@ describe('SessionExecutionService', () => {
     const { deps, sessionDoc, notifySessionCompleted, upsertDocMeta, agentClient, getHistory } =
       await runSilentPromptTurn({
         sessionId: 'session-silent-turn',
-        hasPromptOutputForTurn: false,
+        visibleOutput: false,
       });
 
     expect(agentClient.prompt).toHaveBeenCalled();
@@ -1362,7 +1363,7 @@ describe('SessionExecutionService', () => {
     // is local, and retrying can repeat work the agent already did.
     const { deps, sessionDoc } = await runSilentPromptTurn({
       sessionId: 'session-silent-acted',
-      hasPromptOutputForTurn: false,
+      visibleOutput: false,
       promptActivity: 'dropped_prompt_activity',
     });
 
@@ -1381,7 +1382,7 @@ describe('SessionExecutionService', () => {
     // actionable guess rather than a blanket "state is uncertain".
     const { deps } = await runSilentPromptTurn({
       sessionId: 'session-silent-quiet',
-      hasPromptOutputForTurn: false,
+      visibleOutput: false,
       promptActivity: 'none',
     });
 
@@ -1393,7 +1394,7 @@ describe('SessionExecutionService', () => {
   it('leaves a turn that emitted agent output on the normal completion path', async () => {
     const { deps, notifySessionCompleted, getHistory } = await runSilentPromptTurn({
       sessionId: 'session-output-turn',
-      hasPromptOutputForTurn: true,
+      visibleOutput: true,
     });
 
     expect(deps.recordChatFailure).not.toHaveBeenCalled();
@@ -2085,7 +2086,7 @@ describe('SessionExecutionService', () => {
     // Recovery is allowed only on a POSITIVE "this turn emitted nothing" answer.
     // MessageHandler always wires this dep in production; an absent one is
     // fail-closed and is covered by the next test.
-    const deps = createBaseDeps({ hasPromptOutputForTurn: vi.fn(() => false) });
+    const deps = createBaseDeps({});
     const sessionManager = deps.sessionManager as unknown as {
       getSession: ReturnType<typeof vi.fn>;
       terminateSession: ReturnType<typeof vi.fn>;
@@ -2195,7 +2196,7 @@ describe('SessionExecutionService', () => {
         history = updater(history);
       }),
     };
-    const deps = createBaseDeps({ hasPromptOutputForTurn: vi.fn(() => false) });
+    const deps = createBaseDeps({});
     let service!: SessionExecutionService;
     const instanceCloseVerdicts: boolean[] = [];
     const sessionManager = deps.sessionManager as unknown as {
@@ -2301,9 +2302,6 @@ describe('SessionExecutionService', () => {
     const deps = createBaseDeps({
       beginConversationTurn: vi.fn(() => turnRefOf('assistant-replay')),
       observePromptActivityForTurn: vi.fn(() => 'dropped_prompt_activity' as const),
-      // Deliberately says "no output" so the ONLY thing that can refuse the
-      // replay is the recorder observation under test.
-      hasPromptOutputForTurn: vi.fn(() => false),
     });
     const sessionManager = deps.sessionManager as unknown as {
       getSession: ReturnType<typeof vi.fn>;
@@ -2387,9 +2385,6 @@ describe('SessionExecutionService', () => {
     const deps = createBaseDeps({
       beginConversationTurn: vi.fn(() => turnRefOf('assistant-replay')),
       observePromptActivityForTurn: vi.fn(() => 'unknown' as const),
-      // Deliberately says "no output" so the ONLY thing that can refuse the
-      // replay is the recorder observation under test.
-      hasPromptOutputForTurn: vi.fn(() => false),
     });
     const sessionManager = deps.sessionManager as unknown as {
       getSession: ReturnType<typeof vi.fn>;
@@ -2473,9 +2468,6 @@ describe('SessionExecutionService', () => {
     const deps = createBaseDeps({
       beginConversationTurn: vi.fn(() => turnRefOf('assistant-replay')),
       observePromptActivityForTurn: vi.fn(() => 'none' as const),
-      // Deliberately says "no output" so the ONLY thing that can refuse the
-      // replay is the recorder observation under test.
-      hasPromptOutputForTurn: vi.fn(() => false),
     });
     const sessionManager = deps.sessionManager as unknown as {
       getSession: ReturnType<typeof vi.fn>;
@@ -2504,81 +2496,6 @@ describe('SessionExecutionService', () => {
     expect(agentClient.prompt).toHaveBeenCalledTimes(1);
     expect(sessionManager.createSession).toHaveBeenCalled();
     expect(restoredAgentClient.prompt).toHaveBeenCalledTimes(1);
-  });
-
-  it('refuses the stale-ACP prompt replay when prompt output cannot be observed', async () => {
-    // The replay gate must fail CLOSED. An unwired `hasPromptOutputForTurn` used
-    // to read as "no output yet", which authorized re-sending a prompt whose
-    // tools may already have run.
-    const sessionId = 'session-stale-acp-unobservable' as SessionId;
-    const acpSessionId = 'acp-stale-unobservable' as ACPSessionId;
-    let history: Array<Record<string, unknown>> = [
-      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
-    ];
-    const agentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => {
-        throw new Error('ACP connection closed');
-      }),
-      currentModel: undefined,
-    };
-    const activeSession = {
-      sessionId,
-      acpSessionId,
-      agentClient,
-      terminalManager: {} as unknown,
-      getWorkdir: () => '/tmp',
-      getHostWorkdir: () => '/tmp',
-      getParentSessionId: () => undefined,
-      exec: vi.fn(async () => ''),
-      terminate: vi.fn(async () => {}),
-      updateGitIdentity: vi.fn(),
-      createAgent: vi.fn(async () => acpSessionId),
-      applyExecutionPlaneLimits: vi.fn(async () => {}),
-    };
-    const sessionDoc = {
-      getMetaState: vi.fn(async () => ({ isArchived: false })),
-      setStatus: vi.fn(async () => {}),
-      waitUntilSynced: vi.fn(async () => {}),
-      getHistory: vi.fn(async () => history),
-      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
-        history = updater(history);
-      }),
-    };
-    // No `hasPromptOutputForTurn` dep at all.
-    const deps = createBaseDeps({});
-    const sessionManager = deps.sessionManager as unknown as {
-      getSession: ReturnType<typeof vi.fn>;
-      createSession: ReturnType<typeof vi.fn>;
-    };
-    const workspaceDocument = deps.workspaceDocument as unknown as {
-      getOrCreateSessionDoc: ReturnType<typeof vi.fn>;
-    };
-    sessionManager.getSession.mockReturnValue(activeSession);
-    workspaceDocument.getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
-
-    const service = new SessionExecutionService(deps);
-    await service.continueSession({
-      type: 'session/chat',
-      sessionId,
-      machineId: 'machine-1',
-      workspaceId: 'workspace-1' as WorkspaceId,
-      project: undefined,
-      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
-      userTurnId: 'turn-user-1',
-      userId: 'user-1',
-      userName: 'User',
-      userEmail: 'user@example.com',
-    });
-
-    expect(agentClient.prompt).toHaveBeenCalledTimes(1);
-    expect(sessionManager.createSession).not.toHaveBeenCalled();
-    expect(deps.recordChatFailure).toHaveBeenCalledWith(
-      sessionDoc,
-      'agent_disconnected',
-      expect.any(String)
-    );
   });
 
   it('fails an in-flight prompt as disconnected when its own Session instance is closed', async () => {

--- a/apps/cli/tests/session-execution-service.test.ts
+++ b/apps/cli/tests/session-execution-service.test.ts
@@ -31,7 +31,11 @@ import {
 } from '../src/agent/agent-client';
 import { AcpAuthenticationManager } from '../src/agent/acp-authentication';
 import { GitExecutableNotFoundError } from '../src/session/worktree/git-process-error';
-import type { PromptActivityObservation } from '../src/session/prompt-activity-recorder';
+import {
+  PromptActivityRecorder,
+  type PromptActivityObservation,
+} from '../src/session/prompt-activity-recorder';
+import { SessionTransientStore } from '../src/lib/session-transient-store';
 
 const capabilityConfigId = 'config-1' as AgentConfigId;
 
@@ -1250,6 +1254,105 @@ describe('SessionExecutionService', () => {
         processingUserMsgId: undefined,
       })
     );
+  });
+
+  it('surfaces the uncertain-state notice for a turn whose only activity was a permission request', async () => {
+    // End to end over a REAL `SessionTransientStore` and a REAL recorder, with the
+    // two accessors wired exactly as MessageHandler wires them. The earlier
+    // version of this test mocked `observePromptActivityForTurn` directly and so
+    // could not see that `observePromptOutputForTurn` was answering the wrong
+    // question — it reported "produced output" for a turn that only requested a
+    // permission, which sent the guard down the success path and showed the user
+    // an empty assistant entry with no notice at all.
+    const sessionId = 'session-permission-only' as SessionId;
+    const turnId = 'assistant-permission-only';
+    const store = new SessionTransientStore();
+    const recorder = new PromptActivityRecorder();
+    let history: Array<Record<string, unknown>> = [
+      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
+    ];
+    const sessionDoc = {
+      getMetaState: vi.fn(async () => ({ isArchived: false })),
+      setStatus: vi.fn(async () => {}),
+      waitUntilSynced: vi.fn(async () => {}),
+      getHistory: vi.fn(async () => history),
+      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
+        history = updater(history);
+      }),
+    };
+    const agentClient = {
+      isCreated: vi.fn(() => true),
+      cancel: vi.fn(async () => {}),
+      prompt: vi.fn(async () => {
+        // The agent asks to run a tool, then ends the turn with no ACP update.
+        store.getBoundPromptActivityRecorder(sessionId)?.recordSideEffect();
+        return { stopReason: 'end_turn' };
+      }),
+      currentModel: undefined,
+    };
+    const session = {
+      sessionId,
+      acpSessionId: 'acp-permission-only' as ACPSessionId,
+      agentClient,
+      terminalManager: {} as unknown,
+      getWorkdir: () => '/tmp',
+      getHostWorkdir: () => '/tmp',
+      getParentSessionId: () => undefined,
+      exec: vi.fn(async () => ''),
+      terminate: vi.fn(async () => {}),
+      updateGitIdentity: vi.fn(),
+      createAgent: vi.fn(async () => 'acp-permission-only'),
+      applyExecutionPlaneLimits: vi.fn(async () => {}),
+    };
+    const deps = createBaseDeps({
+      beginConversationTurn: vi.fn(() => {
+        const turnEpoch = store.beginTurn(sessionId, {
+          turnId,
+          assistantEntryId: turnId,
+          ownsACPUpdates: false,
+        });
+        return { turnId, turnEpoch, assistantEntryId: turnId };
+      }),
+      // Same wiring as MessageHandler.
+      bindConversationTurnForPrompt: vi.fn((sid: SessionId, ref, activityRecorder) =>
+        store.bindTurnForPrompt(sid, ref, activityRecorder ?? recorder)
+      ),
+      observePromptActivityForTurn: vi.fn((sid: SessionId, tid: string) =>
+        store.observePromptActivityForTurn(sid, tid)
+      ),
+      observePromptOutputForTurn: vi.fn((sid: SessionId, tid: string) =>
+        store.has(sid) ? store.hasVisiblePromptOutputForTurn(sid, tid) : undefined
+      ),
+    });
+    (deps.sessionManager as unknown as { getSession: ReturnType<typeof vi.fn> }).getSession = vi.fn(
+      () => session
+    );
+    (
+      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
+    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
+
+    const service = new SessionExecutionService(deps);
+    await service.continueSession({
+      type: 'session/chat',
+      sessionId,
+      machineId: 'machine-1',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      project: undefined,
+      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
+      userTurnId: 'turn-user-1',
+      userId: 'user-1',
+      userName: 'User',
+      userEmail: 'user@example.com',
+    });
+
+    // The turn is recorded as a failure at all — conflating the two questions
+    // skipped this entirely — and with the uncertain-state wording.
+    const [, reason, message] = vi.mocked(deps.recordChatFailure).mock.calls[0] ?? [];
+    expect(reason).toBe('agent_no_output');
+    expect(message).toContain('uncertain');
+    expect(message).toContain('do not simply retry');
+    expect(message).not.toContain('context-length');
+    expect(history[0]?.status).toBe('failed');
   });
 
   it('does not blame context length or suggest a retry when the turn actually acted', async () => {

--- a/apps/cli/tests/session-execution-service.test.ts
+++ b/apps/cli/tests/session-execution-service.test.ts
@@ -31,11 +31,7 @@ import {
 } from '../src/agent/agent-client';
 import { AcpAuthenticationManager } from '../src/agent/acp-authentication';
 import { GitExecutableNotFoundError } from '../src/session/worktree/git-process-error';
-import {
-  PromptActivityRecorder,
-  type PromptActivityObservation,
-} from '../src/session/prompt-activity-recorder';
-import { SessionTransientStore } from '../src/lib/session-transient-store';
+import type { PromptActivityObservation } from '../src/session/prompt-activity-recorder';
 
 const capabilityConfigId = 'config-1' as AgentConfigId;
 
@@ -1243,6 +1239,9 @@ describe('SessionExecutionService', () => {
       'agent_no_output',
       expect.stringContaining('without producing any output')
     );
+    const message = vi.mocked(deps.recordChatFailure).mock.calls[0]?.[2];
+    expect(message).toContain('context-length');
+    expect(message).toContain('Retry your message');
     expect(getHistory()[0]?.status).toBe('failed');
     // Claiming the session finished would contradict the failure shown in chat.
     expect(notifySessionCompleted).not.toHaveBeenCalled();
@@ -1255,105 +1254,6 @@ describe('SessionExecutionService', () => {
         processingUserMsgId: undefined,
       })
     );
-  });
-
-  it('surfaces the uncertain-state notice for a turn whose only activity was a permission request', async () => {
-    // End to end over a REAL `SessionTransientStore` and a REAL recorder, with the
-    // two accessors wired exactly as MessageHandler wires them. The earlier
-    // version of this test mocked `observePromptActivityForTurn` directly and so
-    // could not see that `observePromptOutputForTurn` was answering the wrong
-    // question — it reported "produced output" for a turn that only requested a
-    // permission, which sent the guard down the success path and showed the user
-    // an empty assistant entry with no notice at all.
-    const sessionId = 'session-permission-only' as SessionId;
-    const turnId = 'assistant-permission-only';
-    const store = new SessionTransientStore();
-    const recorder = new PromptActivityRecorder();
-    let history: Array<Record<string, unknown>> = [
-      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
-    ];
-    const sessionDoc = {
-      getMetaState: vi.fn(async () => ({ isArchived: false })),
-      setStatus: vi.fn(async () => {}),
-      waitUntilSynced: vi.fn(async () => {}),
-      getHistory: vi.fn(async () => history),
-      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
-        history = updater(history);
-      }),
-    };
-    const agentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => {
-        // The agent asks to run a tool, then ends the turn with no ACP update.
-        store.getBoundPromptActivityRecorder(sessionId)?.recordSideEffect();
-        return { stopReason: 'end_turn' };
-      }),
-      currentModel: undefined,
-    };
-    const session = {
-      sessionId,
-      acpSessionId: 'acp-permission-only' as ACPSessionId,
-      agentClient,
-      terminalManager: {} as unknown,
-      getWorkdir: () => '/tmp',
-      getHostWorkdir: () => '/tmp',
-      getParentSessionId: () => undefined,
-      exec: vi.fn(async () => ''),
-      terminate: vi.fn(async () => {}),
-      updateGitIdentity: vi.fn(),
-      createAgent: vi.fn(async () => 'acp-permission-only'),
-      applyExecutionPlaneLimits: vi.fn(async () => {}),
-    };
-    const deps = createBaseDeps({
-      beginConversationTurn: vi.fn(() => {
-        const turnEpoch = store.beginTurn(sessionId, {
-          turnId,
-          assistantEntryId: turnId,
-          ownsACPUpdates: false,
-        });
-        return { turnId, turnEpoch, assistantEntryId: turnId };
-      }),
-      // Same wiring as MessageHandler.
-      bindConversationTurnForPrompt: vi.fn((sid: SessionId, ref, activityRecorder) =>
-        store.bindTurnForPrompt(sid, ref, activityRecorder ?? recorder)
-      ),
-      observePromptActivityForTurn: vi.fn((sid: SessionId, tid: string) =>
-        store.observePromptActivityForTurn(sid, tid)
-      ),
-      observePromptOutputForTurn: vi.fn((sid: SessionId, tid: string) =>
-        store.has(sid) ? store.hasVisiblePromptOutputForTurn(sid, tid) : undefined
-      ),
-    });
-    (deps.sessionManager as unknown as { getSession: ReturnType<typeof vi.fn> }).getSession = vi.fn(
-      () => session
-    );
-    (
-      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
-    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
-
-    const service = new SessionExecutionService(deps);
-    await service.continueSession({
-      type: 'session/chat',
-      sessionId,
-      machineId: 'machine-1',
-      workspaceId: 'workspace-1' as WorkspaceId,
-      project: undefined,
-      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
-      userTurnId: 'turn-user-1',
-      userId: 'user-1',
-      userName: 'User',
-      userEmail: 'user@example.com',
-    });
-
-    // The turn is recorded as a failure at all — conflating the two questions
-    // skipped this entirely — and with the uncertain-state wording.
-    const [, reason, message] = vi.mocked(deps.recordChatFailure).mock.calls[0] ?? [];
-    expect(reason).toBe('agent_no_output');
-    expect(message).toContain('uncertain');
-    expect(message).toContain('do not simply retry');
-    expect(message).not.toContain('context-length');
-    expect(history[0]?.status).toBe('failed');
   });
 
   it('does not blame context length or suggest a retry when the turn actually acted', async () => {
@@ -1375,20 +1275,6 @@ describe('SessionExecutionService', () => {
     expect(message).not.toContain('rate-limit');
     expect(message).not.toContain('Retry your message');
     void sessionDoc;
-  });
-
-  it('keeps the upstream-cause explanation for a turn that truly did nothing', async () => {
-    // The reverse case: an actual upstream silence should still get the specific,
-    // actionable guess rather than a blanket "state is uncertain".
-    const { deps } = await runSilentPromptTurn({
-      sessionId: 'session-silent-quiet',
-      visibleOutput: false,
-      promptActivity: 'none',
-    });
-
-    const [, , message] = vi.mocked(deps.recordChatFailure).mock.calls[0] ?? [];
-    expect(message).toContain('context-length');
-    expect(message).toContain('Retry your message');
   });
 
   it('leaves a turn that emitted agent output on the normal completion path', async () => {
@@ -2022,481 +1908,114 @@ describe('SessionExecutionService', () => {
     expect(history[0]?.status).toBe('failed');
   });
 
-  it('restores and retries a stale in-memory ACP session when the connection is closed', async () => {
-    const sessionId = 'session-stale-acp' as SessionId;
-    const acpSessionId = 'acp-stale' as ACPSessionId;
-    const restoredAcpSessionId = 'acp-restored' as ACPSessionId;
-    let history: Array<Record<string, unknown>> = [
-      {
-        id: 'turn-user-1',
-        role: 'user',
-        status: 'pending',
-        read: false,
-      },
-    ];
-    const agentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => {
-        throw new Error('ACP connection closed');
-      }),
-      currentModel: undefined,
-    };
-    const restoredAgentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => ({})),
-      currentModel: undefined,
-    };
-    const exec = vi.fn(async (command: string, args: string[]) => {
-      const key = `${command} ${args.join(' ')}`;
-      if (key === 'git rev-parse --is-inside-work-tree') return 'true\n';
-      if (key === 'git rev-parse HEAD') return 'abc123\n';
-      return '';
-    });
-    const activeSession = {
-      sessionId,
-      acpSessionId,
-      agentClient,
-      terminalManager: {} as unknown,
-      getWorkdir: () => '/tmp',
-      getHostWorkdir: () => '/tmp',
-      getParentSessionId: () => undefined,
-      exec,
-      terminate: vi.fn(async () => {}),
-      updateGitIdentity: vi.fn(),
-      createAgent: vi.fn(async () => acpSessionId),
-      applyExecutionPlaneLimits: vi.fn(async () => {}),
-    };
-    const restoredSession = {
-      ...activeSession,
-      acpSessionId: restoredAcpSessionId,
-      agentClient: restoredAgentClient,
-      createAgent: vi.fn(async () => restoredAcpSessionId),
-    };
-    const sessionDoc = {
-      getMetaState: vi.fn(async () => ({ isArchived: false })),
-      setStatus: vi.fn(async () => {}),
-      waitUntilSynced: vi.fn(async () => {}),
-      getHistory: vi.fn(async () => history),
-      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
-        history = updater(history);
-      }),
-    };
-    // Recovery is allowed only on a POSITIVE "this turn emitted nothing" answer.
-    // MessageHandler always wires this dep in production; an absent one is
-    // fail-closed and is covered by the next test.
-    const deps = createBaseDeps({});
-    const sessionManager = deps.sessionManager as unknown as {
-      getSession: ReturnType<typeof vi.fn>;
-      terminateSession: ReturnType<typeof vi.fn>;
-      createSession: ReturnType<typeof vi.fn>;
-    };
-    const workspaceDocument = deps.workspaceDocument as unknown as {
-      getOrCreateSessionDoc: ReturnType<typeof vi.fn>;
-    };
-    sessionManager.getSession.mockReturnValue(activeSession);
-    sessionManager.createSession.mockResolvedValue(restoredSession);
-    workspaceDocument.getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
+  it.each([
+    ['none', true],
+    ['dropped_prompt_activity', false],
+    ['unknown', false],
+  ] as const)(
+    'retries a stale ACP prompt only for activity=%s',
+    async (promptActivity, shouldReplay) => {
+      const sessionId = 'session-stale-acp' as SessionId;
+      const acpSessionId = 'acp-stale' as ACPSessionId;
+      const restoredAcpSessionId = 'acp-restored' as ACPSessionId;
+      let history: Array<Record<string, unknown>> = [
+        {
+          id: 'turn-user-1',
+          role: 'user',
+          status: 'pending',
+          read: false,
+        },
+      ];
+      const agentClient = {
+        isCreated: vi.fn(() => true),
+        cancel: vi.fn(async () => {}),
+        prompt: vi.fn(async () => {
+          throw new Error('ACP connection closed');
+        }),
+        currentModel: undefined,
+      };
+      const restoredAgentClient = {
+        isCreated: vi.fn(() => true),
+        cancel: vi.fn(async () => {}),
+        prompt: vi.fn(async () => ({})),
+        currentModel: undefined,
+      };
+      const exec = vi.fn(async (command: string, args: string[]) => {
+        const key = `${command} ${args.join(' ')}`;
+        if (key === 'git rev-parse --is-inside-work-tree') return 'true\n';
+        if (key === 'git rev-parse HEAD') return 'abc123\n';
+        return '';
+      });
+      const activeSession = {
+        sessionId,
+        acpSessionId,
+        agentClient,
+        terminalManager: {} as unknown,
+        getWorkdir: () => '/tmp',
+        getHostWorkdir: () => '/tmp',
+        getParentSessionId: () => undefined,
+        exec,
+        terminate: vi.fn(async () => {}),
+        updateGitIdentity: vi.fn(),
+        createAgent: vi.fn(async () => acpSessionId),
+        applyExecutionPlaneLimits: vi.fn(async () => {}),
+      };
+      const restoredSession = {
+        ...activeSession,
+        acpSessionId: restoredAcpSessionId,
+        agentClient: restoredAgentClient,
+        createAgent: vi.fn(async () => restoredAcpSessionId),
+      };
+      const sessionDoc = {
+        getMetaState: vi.fn(async () => ({ isArchived: false })),
+        setStatus: vi.fn(async () => {}),
+        waitUntilSynced: vi.fn(async () => {}),
+        getHistory: vi.fn(async () => history),
+        updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
+          history = updater(history);
+        }),
+      };
+      const deps = createBaseDeps({
+        observePromptActivityForTurn: vi.fn(() => promptActivity),
+      });
+      const sessionManager = deps.sessionManager as unknown as {
+        getSession: ReturnType<typeof vi.fn>;
+        terminateSession: ReturnType<typeof vi.fn>;
+        createSession: ReturnType<typeof vi.fn>;
+      };
+      const workspaceDocument = deps.workspaceDocument as unknown as {
+        getOrCreateSessionDoc: ReturnType<typeof vi.fn>;
+      };
+      sessionManager.getSession.mockReturnValue(activeSession);
+      sessionManager.createSession.mockResolvedValue(restoredSession);
+      workspaceDocument.getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
 
-    const service = new SessionExecutionService(deps);
-    await service.continueSession({
-      type: 'session/chat',
-      sessionId,
-      machineId: 'machine-1',
-      workspaceId: 'workspace-1' as WorkspaceId,
-      project: undefined,
-      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
-      userTurnId: 'turn-user-1',
-      userId: 'user-1',
-      userName: 'User',
-      userEmail: 'user@example.com',
-    });
+      const service = new SessionExecutionService(deps);
+      await service.continueSession({
+        type: 'session/chat',
+        sessionId,
+        machineId: 'machine-1',
+        workspaceId: 'workspace-1' as WorkspaceId,
+        project: undefined,
+        acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
+        userTurnId: 'turn-user-1',
+        userId: 'user-1',
+        userName: 'User',
+        userEmail: 'user@example.com',
+      });
 
-    expect(agentClient.prompt).toHaveBeenCalledWith(
-      'acp-stale',
-      [{ type: 'text', text: 'hello' }],
-      {
-        signal: expect.any(AbortSignal),
-      }
-    );
-    expect(sessionManager.terminateSession).toHaveBeenCalledWith(sessionId, true);
-    expect(sessionManager.createSession).toHaveBeenCalled();
-    expect(restoredAgentClient.prompt).toHaveBeenCalledWith(
-      'acp-restored',
-      [{ type: 'text', text: 'hello' }],
-      {
-        signal: expect.any(AbortSignal),
-      }
-    );
-    expect(deps.recordChatFailure).not.toHaveBeenCalled();
-    expect(history[0]?.status).toBe('handled');
-  });
-
-  it('lets the stale-ACP retry proceed when terminating the old instance emits `terminated`', async () => {
-    // The stale-ACP recovery terminates its own Session instance, and in
-    // production that emits a real `terminated` lifecycle event naming the
-    // instance the turn is still bound to. `onSessionInstanceClosed` must NOT
-    // treat that as a disconnect: the terminate runs AFTER `prompt()` already
-    // rejected, so `promptInFlight` is back to false and the close guard is
-    // uninstalled. The sibling test above mocks `terminateSession` into a no-op,
-    // so it never fires the event and cannot catch a regression here.
-    const sessionId = 'session-stale-acp-lifecycle' as SessionId;
-    const acpSessionId = 'acp-stale-lifecycle' as ACPSessionId;
-    const restoredAcpSessionId = 'acp-restored-lifecycle' as ACPSessionId;
-    let history: Array<Record<string, unknown>> = [
-      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
-    ];
-    const agentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => {
-        throw new Error('ACP connection closed');
-      }),
-      currentModel: undefined,
-    };
-    const restoredAgentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => ({})),
-      currentModel: undefined,
-    };
-    const exec = vi.fn(async (command: string, args: string[]) => {
-      const key = `${command} ${args.join(' ')}`;
-      if (key === 'git rev-parse --is-inside-work-tree') return 'true\n';
-      if (key === 'git rev-parse HEAD') return 'abc123\n';
-      return '';
-    });
-    const activeSession = {
-      sessionId,
-      acpSessionId,
-      agentClient,
-      terminalManager: {} as unknown,
-      getWorkdir: () => '/tmp',
-      getHostWorkdir: () => '/tmp',
-      getParentSessionId: () => undefined,
-      exec,
-      terminate: vi.fn(async () => {}),
-      updateGitIdentity: vi.fn(),
-      createAgent: vi.fn(async () => acpSessionId),
-      applyExecutionPlaneLimits: vi.fn(async () => {}),
-    };
-    const restoredSession = {
-      ...activeSession,
-      acpSessionId: restoredAcpSessionId,
-      agentClient: restoredAgentClient,
-      createAgent: vi.fn(async () => restoredAcpSessionId),
-    };
-    const sessionDoc = {
-      getMetaState: vi.fn(async () => ({ isArchived: false })),
-      setStatus: vi.fn(async () => {}),
-      waitUntilSynced: vi.fn(async () => {}),
-      getHistory: vi.fn(async () => history),
-      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
-        history = updater(history);
-      }),
-    };
-    const deps = createBaseDeps({});
-    let service!: SessionExecutionService;
-    const instanceCloseVerdicts: boolean[] = [];
-    const sessionManager = deps.sessionManager as unknown as {
-      getSession: ReturnType<typeof vi.fn>;
-      terminateSession: ReturnType<typeof vi.fn>;
-      createSession: ReturnType<typeof vi.fn>;
-    };
-    sessionManager.getSession.mockReturnValue(activeSession);
-    sessionManager.createSession.mockResolvedValue(restoredSession);
-    // Stand in for SessionManager's own listener: terminating the instance the
-    // turn is bound to reports the close, exactly as production does.
-    sessionManager.terminateSession.mockImplementation(async () => {
-      instanceCloseVerdicts.push(
-        service.onSessionInstanceClosed(
-          sessionId,
-          activeSession as unknown as ISession,
-          'terminated'
-        )
+      expect(agentClient.prompt).toHaveBeenCalledWith(
+        'acp-stale',
+        [{ type: 'text', text: 'hello' }],
+        {
+          signal: expect.any(AbortSignal),
+        }
       );
-    });
-    (
-      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
-    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
-
-    service = new SessionExecutionService(deps);
-    await service.continueSession({
-      type: 'session/chat',
-      sessionId,
-      machineId: 'machine-1',
-      workspaceId: 'workspace-1' as WorkspaceId,
-      project: undefined,
-      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
-      userTurnId: 'turn-user-1',
-      userId: 'user-1',
-      userName: 'User',
-      userEmail: 'user@example.com',
-    });
-
-    // The lifecycle report was seen and declined — the prompt was no longer in
-    // flight, so the turn owner keeps its own recovery.
-    expect(instanceCloseVerdicts).toEqual([false]);
-    expect(restoredAgentClient.prompt).toHaveBeenCalledWith(
-      restoredAcpSessionId,
-      [{ type: 'text', text: 'hello' }],
-      { signal: expect.any(AbortSignal) }
-    );
-    expect(deps.recordChatFailure).not.toHaveBeenCalled();
-    expect(history[0]?.status).toBe('handled');
-  });
-
-  it('refuses a stale-ACP replay after the turn requested a permission or wrote a file', async () => {
-    // Permission requests and `fs/write_text_file` are independent JSON-RPC
-    // requests that never reach `enqueueACPUpdate`. Before the recorder the
-    // gate could not see them, so a turn that had already approved and run a
-    // tool read as 'produced nothing' and its prompt was replayed.
-    const sessionId = 'session-replay-dropped_prompt_activity' as SessionId;
-    let history: Array<Record<string, unknown>> = [
-      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
-    ];
-    const sessionDoc = {
-      getMetaState: vi.fn(async () => ({ isArchived: false })),
-      setStatus: vi.fn(async () => {}),
-      waitUntilSynced: vi.fn(async () => {}),
-      getHistory: vi.fn(async () => history),
-      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
-        history = updater(history);
-      }),
-    };
-    const agentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => {
-        throw new Error('ACP connection closed');
-      }),
-      currentModel: undefined,
-    };
-    const restoredAgentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => ({})),
-      currentModel: undefined,
-    };
-    const activeSession = {
-      sessionId,
-      acpSessionId: 'acp-replay' as ACPSessionId,
-      agentClient,
-      terminalManager: {} as unknown,
-      getWorkdir: () => '/tmp',
-      getHostWorkdir: () => '/tmp',
-      getParentSessionId: () => undefined,
-      exec: vi.fn(async () => ''),
-      terminate: vi.fn(async () => {}),
-      updateGitIdentity: vi.fn(),
-      createAgent: vi.fn(async () => 'acp-replay'),
-      applyExecutionPlaneLimits: vi.fn(async () => {}),
-    };
-    const restoredSession = {
-      ...activeSession,
-      acpSessionId: 'acp-replay-restored' as ACPSessionId,
-      agentClient: restoredAgentClient,
-      createAgent: vi.fn(async () => 'acp-replay-restored'),
-    };
-    const deps = createBaseDeps({
-      beginConversationTurn: vi.fn(() => turnRefOf('assistant-replay')),
-      observePromptActivityForTurn: vi.fn(() => 'dropped_prompt_activity' as const),
-    });
-    const sessionManager = deps.sessionManager as unknown as {
-      getSession: ReturnType<typeof vi.fn>;
-      createSession: ReturnType<typeof vi.fn>;
-    };
-    sessionManager.getSession.mockReturnValue(activeSession);
-    sessionManager.createSession.mockResolvedValue(restoredSession);
-    (
-      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
-    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
-
-    const service = new SessionExecutionService(deps);
-    await service.continueSession({
-      type: 'session/chat',
-      sessionId,
-      machineId: 'machine-1',
-      workspaceId: 'workspace-1' as WorkspaceId,
-      project: undefined,
-      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
-      userTurnId: 'turn-user-1',
-      userId: 'user-1',
-      userName: 'User',
-      userEmail: 'user@example.com',
-    });
-
-    expect(agentClient.prompt).toHaveBeenCalledTimes(1);
-    expect(sessionManager.createSession).not.toHaveBeenCalled();
-    expect(restoredAgentClient.prompt).not.toHaveBeenCalled();
-  });
-
-  it('refuses a stale-ACP replay when the turn is unobservable', async () => {
-    // No recorder (process restart, or a recorder belonging to another turn).
-    // Unobservable is not 'nothing happened'.
-    const sessionId = 'session-replay-unknown' as SessionId;
-    let history: Array<Record<string, unknown>> = [
-      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
-    ];
-    const sessionDoc = {
-      getMetaState: vi.fn(async () => ({ isArchived: false })),
-      setStatus: vi.fn(async () => {}),
-      waitUntilSynced: vi.fn(async () => {}),
-      getHistory: vi.fn(async () => history),
-      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
-        history = updater(history);
-      }),
-    };
-    const agentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => {
-        throw new Error('ACP connection closed');
-      }),
-      currentModel: undefined,
-    };
-    const restoredAgentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => ({})),
-      currentModel: undefined,
-    };
-    const activeSession = {
-      sessionId,
-      acpSessionId: 'acp-replay' as ACPSessionId,
-      agentClient,
-      terminalManager: {} as unknown,
-      getWorkdir: () => '/tmp',
-      getHostWorkdir: () => '/tmp',
-      getParentSessionId: () => undefined,
-      exec: vi.fn(async () => ''),
-      terminate: vi.fn(async () => {}),
-      updateGitIdentity: vi.fn(),
-      createAgent: vi.fn(async () => 'acp-replay'),
-      applyExecutionPlaneLimits: vi.fn(async () => {}),
-    };
-    const restoredSession = {
-      ...activeSession,
-      acpSessionId: 'acp-replay-restored' as ACPSessionId,
-      agentClient: restoredAgentClient,
-      createAgent: vi.fn(async () => 'acp-replay-restored'),
-    };
-    const deps = createBaseDeps({
-      beginConversationTurn: vi.fn(() => turnRefOf('assistant-replay')),
-      observePromptActivityForTurn: vi.fn(() => 'unknown' as const),
-    });
-    const sessionManager = deps.sessionManager as unknown as {
-      getSession: ReturnType<typeof vi.fn>;
-      createSession: ReturnType<typeof vi.fn>;
-    };
-    sessionManager.getSession.mockReturnValue(activeSession);
-    sessionManager.createSession.mockResolvedValue(restoredSession);
-    (
-      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
-    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
-
-    const service = new SessionExecutionService(deps);
-    await service.continueSession({
-      type: 'session/chat',
-      sessionId,
-      machineId: 'machine-1',
-      workspaceId: 'workspace-1' as WorkspaceId,
-      project: undefined,
-      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
-      userTurnId: 'turn-user-1',
-      userId: 'user-1',
-      userName: 'User',
-      userEmail: 'user@example.com',
-    });
-
-    expect(agentClient.prompt).toHaveBeenCalledTimes(1);
-    expect(sessionManager.createSession).not.toHaveBeenCalled();
-    expect(restoredAgentClient.prompt).not.toHaveBeenCalled();
-  });
-
-  it('still replays a stale-ACP prompt when the turn provably did nothing', async () => {
-    // The reverse case, so the gate cannot be 'fixed' by refusing everything:
-    // a positive `none` is what recovery exists for.
-    const sessionId = 'session-replay-none' as SessionId;
-    let history: Array<Record<string, unknown>> = [
-      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
-    ];
-    const sessionDoc = {
-      getMetaState: vi.fn(async () => ({ isArchived: false })),
-      setStatus: vi.fn(async () => {}),
-      waitUntilSynced: vi.fn(async () => {}),
-      getHistory: vi.fn(async () => history),
-      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
-        history = updater(history);
-      }),
-    };
-    const agentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => {
-        throw new Error('ACP connection closed');
-      }),
-      currentModel: undefined,
-    };
-    const restoredAgentClient = {
-      isCreated: vi.fn(() => true),
-      cancel: vi.fn(async () => {}),
-      prompt: vi.fn(async () => ({})),
-      currentModel: undefined,
-    };
-    const activeSession = {
-      sessionId,
-      acpSessionId: 'acp-replay' as ACPSessionId,
-      agentClient,
-      terminalManager: {} as unknown,
-      getWorkdir: () => '/tmp',
-      getHostWorkdir: () => '/tmp',
-      getParentSessionId: () => undefined,
-      exec: vi.fn(async () => ''),
-      terminate: vi.fn(async () => {}),
-      updateGitIdentity: vi.fn(),
-      createAgent: vi.fn(async () => 'acp-replay'),
-      applyExecutionPlaneLimits: vi.fn(async () => {}),
-    };
-    const restoredSession = {
-      ...activeSession,
-      acpSessionId: 'acp-replay-restored' as ACPSessionId,
-      agentClient: restoredAgentClient,
-      createAgent: vi.fn(async () => 'acp-replay-restored'),
-    };
-    const deps = createBaseDeps({
-      beginConversationTurn: vi.fn(() => turnRefOf('assistant-replay')),
-      observePromptActivityForTurn: vi.fn(() => 'none' as const),
-    });
-    const sessionManager = deps.sessionManager as unknown as {
-      getSession: ReturnType<typeof vi.fn>;
-      createSession: ReturnType<typeof vi.fn>;
-    };
-    sessionManager.getSession.mockReturnValue(activeSession);
-    sessionManager.createSession.mockResolvedValue(restoredSession);
-    (
-      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
-    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
-
-    const service = new SessionExecutionService(deps);
-    await service.continueSession({
-      type: 'session/chat',
-      sessionId,
-      machineId: 'machine-1',
-      workspaceId: 'workspace-1' as WorkspaceId,
-      project: undefined,
-      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
-      userTurnId: 'turn-user-1',
-      userId: 'user-1',
-      userName: 'User',
-      userEmail: 'user@example.com',
-    });
-
-    expect(agentClient.prompt).toHaveBeenCalledTimes(1);
-    expect(sessionManager.createSession).toHaveBeenCalled();
-    expect(restoredAgentClient.prompt).toHaveBeenCalledTimes(1);
-  });
+      expect(sessionManager.createSession).toHaveBeenCalledTimes(shouldReplay ? 1 : 0);
+      expect(restoredAgentClient.prompt).toHaveBeenCalledTimes(shouldReplay ? 1 : 0);
+      expect(history[0]?.status).toBe(shouldReplay ? 'handled' : 'failed');
+    }
+  );
 
   it('fails an in-flight prompt as disconnected when its own Session instance is closed', async () => {
     // Nothing in `Session` reports a dead ACP child process, so a prompt whose
@@ -5437,7 +4956,10 @@ describe('SessionExecutionService', () => {
     });
 
     expect(agentClient.cancel).toHaveBeenCalledWith('acp-prompt-cancel');
-    expect(deps.turnFinalization.finalizeACPState).toHaveBeenCalledTimes(1);
+    expect(deps.turnFinalization.finalizeACPState).toHaveBeenCalledWith(
+      'session-prompt-cancel',
+      'assistant-prompt-cancel'
+    );
     expect(deps.processMessageQueue).not.toHaveBeenCalled();
     expect(sessionDoc.setStatus).toHaveBeenCalledWith(SessionStatusFactory.idle());
     expect(history[0]).toMatchObject({ id: 'turn-prompt-cancel', status: 'canceled' });
@@ -5525,200 +5047,6 @@ describe('SessionExecutionService', () => {
     await turn;
 
     expect(releaseWorkspaceWatch).toHaveBeenCalledWith(sessionId);
-  });
-
-  it('keeps the workspace watch when a closed instance was already replaced', async () => {
-    const sessionId = 'session-watch-keep' as SessionId;
-    let history: Array<Record<string, unknown>> = [
-      { id: 'turn-user-1', role: 'user', status: 'pending', read: false },
-    ];
-    const sessionDoc = {
-      getMetaState: vi.fn(async () => ({ isArchived: false })),
-      setStatus: vi.fn(async () => {}),
-      waitUntilSynced: vi.fn(async () => {}),
-      getHistory: vi.fn(async () => history),
-      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
-        history = updater(history);
-      }),
-    };
-    const session = {
-      sessionId,
-      acpSessionId: 'acp-watch-keep' as ACPSessionId,
-      agentClient: {
-        isCreated: vi.fn(() => true),
-        cancel: vi.fn(async () => {}),
-        prompt: vi.fn(async () => {
-          throw new Error('boom');
-        }),
-        currentModel: undefined,
-      },
-      terminalManager: {} as unknown,
-      getWorkdir: () => '/tmp',
-      getHostWorkdir: () => '/tmp',
-      getParentSessionId: () => undefined,
-      exec: vi.fn(async () => ''),
-      terminate: vi.fn(async () => {}),
-      updateGitIdentity: vi.fn(),
-      createAgent: vi.fn(async () => 'acp-watch-keep'),
-      applyExecutionPlaneLimits: vi.fn(async () => {}),
-    };
-    const releaseWorkspaceWatch = vi.fn();
-    const deps = createBaseDeps({});
-    // A replacement instance stays registered under the same id.
-    (deps.sessionManager as unknown as { getSession: ReturnType<typeof vi.fn> }).getSession = vi.fn(
-      () => session
-    );
-    (
-      deps.workspaceDocument as unknown as { getOrCreateSessionDoc: ReturnType<typeof vi.fn> }
-    ).getOrCreateSessionDoc.mockResolvedValue(sessionDoc);
-    deps.turnFinalization.releaseWorkspaceWatch = releaseWorkspaceWatch;
-
-    const service = new SessionExecutionService(deps);
-    await service.continueSession({
-      type: 'session/chat',
-      sessionId,
-      machineId: 'machine-1',
-      workspaceId: 'workspace-1' as WorkspaceId,
-      project: undefined,
-      acpSessionConfig: { prompt: 'hi', cliType: 'builtin', agentType: 'codex' },
-      userTurnId: 'turn-user-1',
-      userId: 'user-1',
-      userName: 'User',
-      userEmail: 'user@example.com',
-    });
-
-    expect(releaseWorkspaceWatch).not.toHaveBeenCalled();
-  });
-
-  it('keeps cancel write ordering when `terminated` lands during cancellation', async () => {
-    // Cancel must persist "user turn canceled" BEFORE the assistant entry is
-    // finalized: Operation reconciliation reads a terminal assistant as success
-    // unless the user turn already carries the stronger cancelled outcome.
-    // A lifecycle close arriving mid-cancel must not jump that order, and must
-    // not re-report the turn as a disconnect — cancel owns this outcome.
-    const sessionId = 'session-cancel-terminated' as SessionId;
-    const turnId = 'assistant-cancel-terminated';
-    let meta: Record<string, unknown> = {};
-    let history: Array<Record<string, unknown>> = [
-      {
-        id: 'turn-cancel-terminated',
-        role: 'user',
-        items: [{ type: 'text', text: 'hello' }],
-        status: 'pending',
-        read: false,
-      },
-    ];
-    const writeOrder: string[] = [];
-    const upsertDocMeta = vi.fn(async (_roomId: string, patch: Record<string, unknown>) => {
-      meta = { ...meta, ...patch };
-    });
-    const sessionDoc = {
-      getMetaState: vi.fn(async () => ({ isArchived: false })),
-      setStatus: vi.fn(async () => {}),
-      setBaseBranch: vi.fn(async () => {}),
-      waitUntilSynced: vi.fn(async () => {}),
-      getHistory: vi.fn(async () => history),
-      updateHistory: vi.fn(async (updater: (prev: typeof history) => typeof history) => {
-        history = updater(history);
-        if (history[0]?.status === 'canceled') {
-          writeOrder.push('user-canceled');
-        }
-      }),
-    };
-    let activeTurnId: string | undefined;
-    let service!: SessionExecutionService;
-    const instanceCloseVerdicts: boolean[] = [];
-    const session = {
-      sessionId,
-      acpSessionId: 'acp-cancel-terminated' as ACPSessionId,
-      agentClient: {
-        isCreated: vi.fn(() => true),
-        // Fires while cancellation is running, exactly where SessionManager's
-        // listener would report the closed instance.
-        cancel: vi.fn(async () => {
-          instanceCloseVerdicts.push(
-            service.onSessionInstanceClosed(sessionId, session as unknown as ISession, 'terminated')
-          );
-        }),
-        prompt: vi.fn(async () => {
-          const result = await service.cancelSession({
-            type: 'session/cancel',
-            sessionId,
-            machineId: 'machine-1',
-            workspaceId: 'workspace-1' as WorkspaceId,
-            turnId,
-          });
-          expect(result).toEqual({ success: true });
-          throw new Error('agent cancelled prompt');
-        }),
-        currentModel: undefined,
-      },
-      terminalManager: {} as unknown,
-      getWorkdir: () => '/tmp',
-      getHostWorkdir: () => '/tmp',
-      getParentSessionId: () => undefined,
-      exec: vi.fn(async () => ''),
-      terminate: vi.fn(async () => {}),
-      updateGitIdentity: vi.fn(),
-      createAgent: vi.fn(async () => 'acp-cancel-terminated'),
-      applyExecutionPlaneLimits: vi.fn(async () => {}),
-    };
-    const sessionManager = {
-      getSession: vi.fn(() => session),
-      getPendingSession: vi.fn(() => null),
-      createSession: vi.fn(),
-      setSessionError: vi.fn(),
-      terminateSession: vi.fn(),
-      refreshGhTokenForSession: vi.fn(async () => {}),
-    } as unknown as SessionManager;
-    const deps = createBaseDeps({
-      sessionManager,
-      beginConversationTurn: vi.fn(() => {
-        activeTurnId = turnId;
-        return turnRefOf(turnId);
-      }),
-      getActiveTurnId: vi.fn(() => activeTurnId),
-      clearActiveTurnId: vi.fn((_sessionId, id) => {
-        if (activeTurnId === id) {
-          activeTurnId = undefined;
-        }
-      }),
-      workspaceDocument: {
-        repo: {
-          upsertDocMeta,
-          getDocMeta: vi.fn(async () => ({ meta })),
-        },
-        getOrCreateSessionDoc: vi.fn(async () => sessionDoc),
-        updateAcpCapabilities: vi.fn(async () => {}),
-      } as unknown as LoroDocumentManager,
-    });
-    vi.mocked(deps.turnFinalization.finalizeACPState).mockImplementation(async () => {
-      writeOrder.push('assistant-finalized');
-      expect(history[0]).toMatchObject({ status: 'canceled' });
-    });
-
-    service = new SessionExecutionService(deps);
-    await service.continueSession({
-      type: 'session/chat',
-      sessionId,
-      machineId: 'machine-1',
-      workspaceId: 'workspace-1' as WorkspaceId,
-      project: { kind: 'github', repoFullName: 'owner/repo', branch: 'main' },
-      acpSessionConfig: { prompt: 'hello', cliType: 'builtin', agentType: 'codex' },
-      userTurnId: 'turn-cancel-terminated',
-      userId: 'user-1',
-      userName: 'User',
-      userEmail: 'user@example.com',
-    });
-
-    // The close was reported and declined: cancel already owns this turn.
-    expect(instanceCloseVerdicts).toEqual([false]);
-    expect(writeOrder).toEqual(['user-canceled', 'assistant-finalized']);
-    expect(history[0]).toMatchObject({ status: 'canceled' });
-    expect(deps.recordChatFailure).not.toHaveBeenCalled();
-    // Step B: the cancel path names its turn instead of finalizing whatever is last.
-    expect(deps.turnFinalization.finalizeACPState).toHaveBeenCalledTimes(1);
-    expect(deps.turnFinalization.finalizeACPState).toHaveBeenCalledWith(sessionId, turnId);
   });
 
   it('does not wait for ACP cancel before interrupting an in-flight prompt', async () => {


### PR DESCRIPTION
Risk: medium | Confidence: high

Auto-detected: concurrency + cross-module API. No persisted schema, no
migration — `ChatFailedReasonSchema` is deliberately untouched. Stacked on #301;
base is `acp/bind-turn-for-prompt`, so this diff shows only Step D.

## What this actually fixes

Steps A–C removed in-turn output loss *structurally*, so this is not more logic
for that. What remained is the **replay gate's completeness** — it could
authorize re-sending a prompt whose tools had already run:

1. **`session/request_permission` and `fs/write_text_file` are independent
   JSON-RPC requests.** They never pass through `enqueueACPUpdate`, so a turn
   could ask for permission, run a tool, and write files while the gate read
   "produced nothing".
2. **`acpFlushCountInTurn` is zeroed by `clearTurnState`** — that is, when a turn
   *ends*, which is exactly when the gate is consulted. The evidence erased
   itself at the only moment it mattered.
3. **Unobservable must not read as "nothing happened".**

## Design

`PromptActivityRecorder` lives on `PromptHandoffRun`, not in a map. That object
is already per-prompt, fiber-held, carried along the steer successor chain, and
dies with the turn — so boundedness is **constructional**: at most one live
recorder per session, no key design, no eviction policy.

The store holds one reference, handed over at bind
(`bindTurnForPrompt(sessionId, turnRef, recorder)`), **deliberately not cleared
by `clearTurnState`**, replaced by the next bind and dropped with the session.

Four states: `persisted_output | dropped_prompt_activity | none | unknown`. Only
a positive `none` permits a replay, so a missing recorder (process restart) and
any recorded activity both refuse. `dropped` is recorded as diagnostic insurance
— A–C removed those paths, and if one regresses it should surface as a refused
replay rather than a silently repeated tool call.

**Two deliberate scope decisions, both commented in the code so they don't get
"fixed" later:**

- Created at **bind** time, so the `beginTurn → bind` window is excluded. What
  arrives there is a resume fallback's pre-prompt startup output, which belongs
  to session startup, not the user's turn.
- `steerApplicationBarrier` guards **only** `session/update` (one `await`, in
  `agent-client.ts` `sessionUpdate` — verified). `requestPermission` and
  `writeTextFile` are unprotected, so a side effect the predecessor caused can
  arrive after the successor binds. Those are credited to **both** runs until the
  successor sees its own output: over-refusing a replay is safe, losing the
  signal is not.

## Copy (PR2.10)

A turn that produced no transcript but demonstrably acted no longer gets the
`SILENT_TURN_FAILURE_MESSAGE` guess ("a context-length or rate-limit rejection is
the usual cause… Retry your message"). Both halves are wrong there: the cause is
local, and retrying can repeat work. It now says the execution state is uncertain
and to check results before deciding. **Both notices keep the `agent_no_output`
reason code** — a dedicated `agent_output_dropped` code changes the persisted,
client-shared `ChatFailedReasonSchema` and is its own high-risk PR.

## Tests

Every one confirmed red against the code it guards:

| Test | Red without the fix |
| --- | --- |
| permission request → replay refused | `expected false to be true` — replay allowed |
| no recorder → `unknown` → refused | `expected false to be true` |
| recorder survives `clearTurnState` | `expected 'unknown' to be 'dropped_prompt_activity'` |
| steer handover credits the predecessor | `expected 'none' to be 'dropped_prompt_activity'` |
| acted-but-silent turn gets new copy | `expected 'The agent ended the turn without prod…' to contain 'uncertain'` |

Reverse cases so the gate cannot be "fixed" by refusing everything: `none` still
permits the stale-ACP retry, a genuinely quiet turn still gets the upstream-cause
explanation, a routed update reads as `persisted_output`, and a successor drop
does **not** leak to the predecessor.

## Also in here

- The store header comment claimed adding a `SessionState` field "automatically
  includes it in both cleanup paths". That was never true — both are hand-written
  enumerations — and it is exactly the belief that would delete `promptActivity`.
  Corrected, with the fields that survive `clearTurnState` on purpose named.
- `session/AGENTS.md` now records the store-turn ≠ runtime-turn fact found while
  reviewing Step B (the auto-prompt runner opens its own store turn inside the
  visible turn's runtime), per review request on #300.

## Verification

`apps/cli` typecheck clean; full CLI suite **2507 passed / 250 files**;
`oxlint --type-aware` 0 errors; prettier clean. Same `check:affected` caveat as
#297/#300/#301 (private backend pinned to OSS `4e57437`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
