### PR TITLE
fix(components): preserve mention caret during IME composition

### DIFF
--- a/packages/components/src/ui/mention/AGENTS.md
+++ b/packages/components/src/ui/mention/AGENTS.md
@@ -24,6 +24,18 @@ Shared mention primitive used by composer autocomplete surfaces.
   commits a highlighted non-navigation item the same way Enter does.
   Shift+Tab still closes the menu so the composer mode-cycle binding
   is not stolen.
+- A committed mention is an atomic editing range. A collapsed caret placed
+  inside it by pointer/focus/selection changes snaps to the nearest boundary;
+  otherwise the chip mirror hides the native caret and the next edit silently
+  decommits the range. Non-collapsed selections remain native so copy and
+  whole-region edits can span mentions. At a mention boundary, the textarea is
+  raised above the opaque chip and its text fill is made transparent while the
+  background mirror carries the glyphs; this leaves the native caret visible
+  without painting a second caret. Readonly inputs still apply this visual
+  boundary constraint. IME composition is the offset exception: its transient
+  caret must not snap against the still-committed ranges, and both mirrors map
+  those ranges through the transient edit so the chip neither disappears nor
+  exposes a duplicated suffix.
 - The pop-back itself is `context.onNavigateBack()`, owned by the root next to
   `onMentionAdd`: it has to interleave the controlled value commit with caret
   restoration, so a menu's own Back affordance calls it rather than restaging the

--- a/packages/components/src/ui/mention/mention-highlighter.tsx
+++ b/packages/components/src/ui/mention/mention-highlighter.tsx
@@ -15,8 +15,10 @@ type HighlighterElement = HTMLDivElement;
  * glyphs — the plain highlight. `chip` sits *over* it and paints opaque chips
  * that hide the raw characters they replace, which is the only way to show an
  * icon and a chip-specific text colour without giving up the native textarea.
- * Both mirrors render the identical character stream, so they agree on every
- * line break and the caret stays aligned with both.
+ * At a mention boundary MentionInput temporarily raises the textarea above
+ * `chip`, so `background` carries the text while the native caret remains on
+ * top. Both mirrors render the identical character stream, so they agree on
+ * every line break and the caret stays aligned with both.
  */
 type MentionHighlighterLayer = 'background' | 'chip';
 
@@ -38,6 +40,12 @@ const defaultHighlighterStyle: React.CSSProperties = {
 
 interface MentionHighlighterProps extends React.HTMLAttributes<HighlighterElement> {
   layer?: MentionHighlighterLayer;
+  /** Text rendered by this mirror; IME preedit may lead the committed context value. */
+  renderValue?: string;
+  /** Ranges addressing `renderValue`; defaults to the committed context ranges. */
+  renderMentions?: readonly Mention[];
+  /** Make the background mirror carry the textarea's visible text. */
+  showText?: boolean;
 }
 
 type MentionHighlightSegment =
@@ -110,8 +118,7 @@ export function getMentionHighlightSegments(
  * defaults to the input colour; a composer on a different surface must say so,
  * or its mentions will show as faint rectangles.
  */
-const CHIP_CLASS_NAME =
-  'box-decoration-clone bg-[var(--mention-chip-surface,hsl(var(--input)))]';
+const CHIP_CLASS_NAME = 'box-decoration-clone bg-[var(--mention-chip-surface,hsl(var(--input)))]';
 
 /**
  * Selection is the one case that still needs a fill: the surface cover also
@@ -126,7 +133,9 @@ const CHIP_SELECTED_CLASS_NAME =
 /**
  * The textarea's selection range, tracked only while chips are painted.
  * `selectionchange` fires on the document for textarea selections in every
- * engine we ship on; `select` alone misses caret-only moves.
+ * engine we ship on; `select` alone misses caret-only moves. Collapsed ranges
+ * do not need to rerender the chip mirror: the native caret is raised above
+ * the chip at a mention boundary by MentionInput.
  */
 function useInputSelection(
   inputRef: React.RefObject<HTMLTextAreaElement | HTMLInputElement | null>,
@@ -134,7 +143,7 @@ function useInputSelection(
 ) {
   const [selection, setSelection] = React.useState<[number, number] | null>(null);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (!enabled) return undefined;
 
     const read = () => {
@@ -144,7 +153,11 @@ function useInputSelection(
         return;
       }
       const { selectionStart, selectionEnd } = input;
-      if (selectionStart === null || selectionEnd === null || selectionStart === selectionEnd) {
+      if (selectionStart === null || selectionEnd === null) {
+        setSelection(null);
+        return;
+      }
+      if (selectionStart === selectionEnd) {
         setSelection(null);
         return;
       }
@@ -207,7 +220,14 @@ function MentionChipContent({ chip, text }: { chip: MentionChip; text: string })
 
 const MentionHighlighter = React.memo(
   React.forwardRef<HighlighterElement, MentionHighlighterProps>((props, forwardedRef) => {
-    const { style, layer = 'background', ...highlighterProps } = props;
+    const {
+      style,
+      layer = 'background',
+      renderValue,
+      renderMentions,
+      showText = false,
+      ...highlighterProps
+    } = props;
     const context = useMentionContext(HIGHLIGHTER_NAME);
     const highlighterRef = React.useRef<HighlighterElement>(null);
     const composedRef = useComposedRefs(forwardedRef, highlighterRef);
@@ -280,9 +300,12 @@ const MentionHighlighter = React.memo(
 
       return {
         ...defaultHighlighterStyle,
-        // Above the textarea: an opaque chip has to cover the raw characters it
-        // stands in for. `pointer-events: none` keeps the textarea clickable.
+        // Usually above the textarea: an opaque chip has to cover the raw
+        // characters it stands in for. At a caret boundary MentionInput raises
+        // the textarea above this layer. `pointer-events: none` keeps the
+        // textarea clickable in either order.
         zIndex: layer === 'chip' ? 20 : defaultHighlighterStyle.zIndex,
+        color: layer === 'background' && showText ? inputStyle.color : 'transparent',
         fontStyle: inputStyle.fontStyle,
         fontVariant: inputStyle.fontVariant,
         fontWeight: inputStyle.fontWeight,
@@ -303,13 +326,15 @@ const MentionHighlighter = React.memo(
         direction: context.dir,
         ...style,
       };
-    }, [inputStyle, style, context.dir, layer]);
+    }, [inputStyle, style, context.dir, layer, showText]);
 
     const getMentionChip = context.getMentionChip;
+    const mirroredValue = renderValue ?? context.inputValue;
+    const mirroredMentions = renderMentions ?? context.mentions;
     const selection = useInputSelection(context.inputRef, layer === 'chip' && !!getMentionChip);
     const onSegmentsRender = React.useCallback(
       () =>
-        getMentionHighlightSegments(context.inputValue, context.mentions).map((segment) => {
+        getMentionHighlightSegments(mirroredValue, mirroredMentions).map((segment) => {
           if (segment.type !== 'mention') {
             return <span key={segment.key}>{segment.text}</span>;
           }
@@ -332,13 +357,16 @@ const MentionHighlighter = React.memo(
               !!selection &&
               selection[0] < segment.mention.end &&
               selection[1] > segment.mention.start;
-
             return layer === 'chip' ? (
               <span
                 key={segment.key}
                 {...rangeProps}
                 data-selected={selected ? '' : undefined}
-                className={cn(CHIP_CLASS_NAME, chip.className, selected && CHIP_SELECTED_CLASS_NAME)}
+                className={cn(
+                  CHIP_CLASS_NAME,
+                  chip.className,
+                  selected && CHIP_SELECTED_CLASS_NAME
+                )}
               >
                 <MentionChipContent chip={chip} text={segment.text} />
               </span>
@@ -369,7 +397,7 @@ const MentionHighlighter = React.memo(
             </span>
           );
         }),
-      [context.inputValue, context.mentions, getMentionChip, layer, selection]
+      [getMentionChip, layer, mirroredMentions, mirroredValue, selection]
     );
 
     if (!inputStyle) return null;

--- a/packages/components/src/ui/mention/mention-input.tsx
+++ b/packages/components/src/ui/mention/mention-input.tsx
@@ -81,6 +81,28 @@ function isPointInsideMentionHighlight(
   return false;
 }
 
+/**
+ * Mention ranges are atomic editing units. Keep a collapsed caret out of the
+ * range so the chip mirror cannot cover the native caret and a following edit
+ * cannot accidentally split the range. Text selections that span a mention are
+ * left alone so the browser can still select/copy ordinary text naturally.
+ */
+function constrainCaretToMentionBoundary(input: InputElement, mentions: readonly Mention[]) {
+  const selectionStart = input.selectionStart ?? 0;
+  const selectionEnd = input.selectionEnd ?? selectionStart;
+  if (selectionStart !== selectionEnd) return;
+
+  const mention = mentions.find(
+    (candidate) => selectionStart > candidate.start && selectionStart < candidate.end
+  );
+  if (!mention) return;
+
+  const distanceFromStart = selectionStart - mention.start;
+  const distanceToEnd = mention.end - selectionStart;
+  const nextPosition = distanceFromStart <= distanceToEnd ? mention.start : mention.end;
+  input.setSelectionRange(nextPosition, nextPosition);
+}
+
 interface MentionInputProps extends React.ComponentPropsWithoutRef<typeof Primitive.textarea> {
   containerClassName?: string;
   highlighterClassName?: string;
@@ -101,6 +123,7 @@ const MentionInput = React.forwardRef<InputElement, MentionInputProps>((props, f
   // during composition, and sync the final value after composition ends.
   const isComposingRef = React.useRef(false);
   const [compositionRenderValue, setCompositionRenderValue] = React.useState<string | null>(null);
+  const [caretAtMentionBoundary, setCaretAtMentionBoundary] = React.useState(false);
 
   const normalizedPropValue = React.useMemo(
     () => normalizeTextareaValue(inputProps.value),
@@ -116,6 +139,52 @@ const MentionInput = React.forwardRef<InputElement, MentionInputProps>((props, f
   }, [compositionRenderValue, normalizedPropValue]);
 
   const renderedInputValue = compositionRenderValue ?? normalizedPropValue;
+  const mentionRenderValue = compositionRenderValue ?? context.inputValue;
+  // IME preedit changes the textarea before the owner commits its controlled
+  // value. Move the mirror ranges through that transient edit so the chip stays
+  // aligned instead of exposing either the raw token or an offset duplicate.
+  const mentionRenderMentions = React.useMemo(() => {
+    if (compositionRenderValue === null) return context.mentions;
+    const diff = getTextDiff(context.inputValue, compositionRenderValue);
+    if (!diff) return context.mentions;
+    return applyTextEditToMentions(context.mentions, diff.start, diff.prevEnd, diff.delta);
+  }, [compositionRenderValue, context.inputValue, context.mentions]);
+
+  const updateCaretLayer = React.useCallback(
+    (input: InputElement | null = inputRef.current) => {
+      if (!input || document.activeElement !== input) {
+        setCaretAtMentionBoundary(false);
+        return;
+      }
+
+      const selectionStart = input.selectionStart;
+      const selectionEnd = input.selectionEnd;
+      const atMentionBoundary =
+        selectionStart !== null &&
+        selectionStart === selectionEnd &&
+        mentionRenderMentions.some(
+          (mention) => selectionStart === mention.start || selectionStart === mention.end
+        );
+      setCaretAtMentionBoundary((previous) =>
+        previous === atMentionBoundary ? previous : atMentionBoundary
+      );
+    },
+    [inputRef, mentionRenderMentions]
+  );
+
+  // A chip must cover the textarea glyphs to recolour them, but that same
+  // cover would hide the native caret at a mention edge. Raise the textarea
+  // only at that edge and let the background mirror carry its text while the
+  // caret remains native. This avoids painting a second, synthetic caret.
+  React.useLayoutEffect(() => {
+    const read = () => updateCaretLayer();
+    read();
+    document.addEventListener('selectionchange', read);
+    return () => document.removeEventListener('selectionchange', read);
+  }, [updateCaretLayer]);
+
+  const showNativeCaretAboveChip =
+    !!context.getMentionChip && mentionRenderMentions.length > 0 && caretAtMentionBoundary;
 
   const queueSelectionRestore = React.useCallback(
     (start: number, end: number = start, expectedValue?: string) => {
@@ -449,40 +518,50 @@ const MentionInput = React.forwardRef<InputElement, MentionInputProps>((props, f
       // The value at compositionEnd should be the final committed text.
       syncInputValue(input);
       onMentionUpdate(input);
+      updateCaretLayer(input);
     },
-    [context, onMentionUpdate, syncInputValue]
+    [context, onMentionUpdate, syncInputValue, updateCaretLayer]
   );
 
   const onClick = React.useCallback(
     (event: React.MouseEvent<InputElement>) => {
       const input = event.currentTarget;
+      if (isComposingRef.current) return;
+      const selectionStart = input.selectionStart ?? 0;
+      const selectionEnd = input.selectionEnd ?? selectionStart;
+      const mentionAtClick =
+        selectionStart === selectionEnd
+          ? context.mentions.find(
+              (mention) => selectionStart >= mention.start && selectionStart <= mention.end
+            )
+          : undefined;
+
+      constrainCaretToMentionBoundary(input, context.mentions);
+      updateCaretLayer(input);
       onMentionUpdate(input);
 
       if (!context.onMentionClick) return;
-
-      const selectionStart = input.selectionStart ?? 0;
-      const selectionEnd = input.selectionEnd ?? selectionStart;
       if (selectionStart !== selectionEnd) return;
 
-      const mentionAtCursor = context.mentions.find(
-        (mention) => selectionStart >= mention.start && selectionStart <= mention.end
-      );
-
       if (
-        mentionAtCursor &&
-        isPointInsideMentionHighlight(input, mentionAtCursor, event.clientX, event.clientY)
+        mentionAtClick &&
+        isPointInsideMentionHighlight(input, mentionAtClick, event.clientX, event.clientY)
       ) {
-        context.onMentionClick(mentionAtCursor);
+        context.onMentionClick(mentionAtClick);
       }
     },
-    [context, onMentionUpdate]
+    [context, onMentionUpdate, updateCaretLayer]
   );
 
   const onFocus = React.useCallback(
     (event: React.FocusEvent<InputElement>) => {
+      if (!isComposingRef.current) {
+        constrainCaretToMentionBoundary(event.currentTarget, context.mentions);
+      }
+      updateCaretLayer(event.currentTarget);
       onMentionUpdate(event.currentTarget);
     },
-    [onMentionUpdate]
+    [context, onMentionUpdate, updateCaretLayer]
   );
 
   const onKeyDown = React.useCallback(
@@ -762,15 +841,27 @@ const MentionInput = React.forwardRef<InputElement, MentionInputProps>((props, f
   );
 
   const onSelect = React.useCallback(() => {
-    if (context.disabled || context.readonly) return;
+    if (context.disabled) return;
+    // IMEs own the transient selection while composing. The committed mention
+    // ranges still use the pre-composition offsets, so snapping against them
+    // moves the IME caret into the wrong text.
+    if (isComposingRef.current) return;
     const inputElement = context.inputRef.current;
     if (!inputElement) return;
+    constrainCaretToMentionBoundary(inputElement, context.mentions);
+    updateCaretLayer(inputElement);
+    if (context.readonly) return;
     onMentionUpdate(inputElement);
-  }, [context, onMentionUpdate]);
+  }, [context, onMentionUpdate, updateCaretLayer]);
 
   return (
     <div className={cn('relative', containerClassName)}>
-      <MentionHighlighter className={highlighterClassName} />
+      <MentionHighlighter
+        className={highlighterClassName}
+        renderValue={mentionRenderValue}
+        renderMentions={mentionRenderMentions}
+        showText={showNativeCaretAboveChip}
+      />
       <Primitive.textarea
         role="combobox"
         id={context.inputId}
@@ -788,7 +879,17 @@ const MentionInput = React.forwardRef<InputElement, MentionInputProps>((props, f
         {...inputProps}
         ref={composedRef}
         value={renderedInputValue}
-        className={cn('relative z-10', inputProps.className, 'bg-transparent')}
+        className={cn(
+          'relative',
+          showNativeCaretAboveChip ? 'z-30' : 'z-10',
+          inputProps.className,
+          'bg-transparent'
+        )}
+        style={
+          showNativeCaretAboveChip
+            ? { ...inputProps.style, WebkitTextFillColor: 'transparent' }
+            : inputProps.style
+        }
         onBeforeInput={composeEventHandlers(inputProps.onBeforeInput, onBeforeInput)}
         onChange={composeEventHandlers(inputProps.onChange, onChange)}
         onClick={composeEventHandlers(inputProps.onClick, onClick)}
@@ -801,12 +902,17 @@ const MentionInput = React.forwardRef<InputElement, MentionInputProps>((props, f
       {/*
         The chip mirror is a second full copy of the draft, re-split into
         segments on every keystroke and measuring the textarea's computed style
-        of its own. With no committed range it paints nothing — its text is
-        `transparent` and only a chip is ever opaque — so it is worth exactly
-        nothing until there is one, which is most of a composer's life.
+        of its own. Its text is `transparent` while the textarea is the visible
+        source; only at a mention boundary does the background mirror carry the
+        text so the raised textarea can expose its native caret.
       */}
-      {context.getMentionChip && context.mentions.length > 0 ? (
-        <MentionHighlighter layer="chip" className={highlighterClassName} />
+      {context.getMentionChip && mentionRenderMentions.length > 0 ? (
+        <MentionHighlighter
+          layer="chip"
+          className={highlighterClassName}
+          renderValue={mentionRenderValue}
+          renderMentions={mentionRenderMentions}
+        />
       ) : null}
     </div>
   );

--- a/packages/components/tests/mention-navigation.test.tsx
+++ b/packages/components/tests/mention-navigation.test.tsx
@@ -40,7 +40,17 @@ function Probe() {
   return null;
 }
 
-function Harness({ items, initialValue }: { items: ItemSpec[]; initialValue: string }) {
+function Harness({
+  items,
+  initialValue,
+  withChips = false,
+  isReadonly = false,
+}: {
+  items: ItemSpec[];
+  initialValue: string;
+  withChips?: boolean;
+  isReadonly?: boolean;
+}) {
   const [value, setValue] = React.useState(initialValue);
   const [mentions, setMentions] = React.useState<MentionRange[]>([]);
   const [selected, setSelected] = React.useState<string[]>([]);
@@ -54,8 +64,10 @@ function Harness({ items, initialValue }: { items: ItemSpec[]; initialValue: str
       onMentionsChange={setMentions}
       value={selected}
       onValueChange={setSelected}
+      getMentionChip={withChips ? () => ({}) : undefined}
       onFilter={(options) => options}
       autoCloseOnEmpty={false}
+      readonly={isReadonly}
     >
       <Probe />
       <MentionInput value={value} onChange={() => {}} />
@@ -113,9 +125,22 @@ describe('Mention navigation and insertion', () => {
     originalRequestAnimationFrame = undefined;
   });
 
-  function render(items: ItemSpec[], initialValue: string, caret = initialValue.length) {
+  function render(
+    items: ItemSpec[],
+    initialValue: string,
+    caret = initialValue.length,
+    withChips = false,
+    isReadonly = false
+  ) {
     act(() => {
-      root?.render(<Harness items={items} initialValue={initialValue} />);
+      root?.render(
+        <Harness
+          items={items}
+          initialValue={initialValue}
+          withChips={withChips}
+          isReadonly={isReadonly}
+        />
+      );
     });
     const input = container?.querySelector('textarea');
     if (!input) throw new Error('Expected mention textarea to render');
@@ -138,6 +163,11 @@ describe('Mention navigation and insertion', () => {
       input.dispatchEvent(event);
     });
     return event;
+  }
+
+  function setNativeValue(input: HTMLTextAreaElement, value: string) {
+    const setValue = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+    setValue?.call(input, value);
   }
 
   it('writes the item insertText instead of composing trigger and label', () => {
@@ -281,5 +311,112 @@ describe('Mention navigation and insertion', () => {
     expect(event.defaultPrevented).toBe(false);
     expect(latest.inputValue).toBe('@');
     expect(latest.mentions).toEqual([]);
+  });
+
+  it('snaps a caret inside a session mention to a boundary before editing', () => {
+    const input = render([{ value: 'sess_1', insertText: '@fix-ci', kind: 'session' }], '@');
+    commit('sess_1', 0);
+
+    act(() => {
+      input.setSelectionRange(3, 3);
+      input.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(input.selectionStart).toBe(0);
+
+    act(() => {
+      setNativeValue(input, `X${input.value}`);
+      input.setSelectionRange(1, 1);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    expect(latest.inputValue).toBe('X@fix-ci ');
+    expect(latest.mentions).toEqual([{ value: 'sess_1', start: 1, end: 8, kind: 'session' }]);
+  });
+
+  it('keeps mention mirrors aligned while an IME composes before a session mention', () => {
+    const input = render(
+      [{ value: 'sess_1', insertText: '@fix-ci', kind: 'session' }],
+      '@',
+      1,
+      true
+    );
+    commit('sess_1', 0);
+
+    act(() => {
+      input.setSelectionRange(0, 0);
+      input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+      setNativeValue(input, 'zhong@fix-ci ');
+      input.setSelectionRange(5, 5);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    expect(input.selectionStart).toBe(5);
+    expect(container?.querySelector('[data-mention-layer="background"]')?.textContent).toContain(
+      'zhong@fix-ci'
+    );
+    expect(container?.querySelector('[data-mention-layer="chip"]')).not.toBeNull();
+    expect(
+      container
+        ?.querySelector('[data-mention-layer="chip"] [data-mention-kind="session"]')
+        ?.getAttribute('data-mention-start')
+    ).toBe('5');
+
+    act(() => {
+      input.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(input.selectionStart).toBe(5);
+
+    act(() => {
+      setNativeValue(input, '中@fix-ci ');
+      input.setSelectionRange(1, 1);
+      input.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '中' }));
+    });
+
+    expect(latest.inputValue).toBe('中@fix-ci ');
+    expect(latest.mentions).toEqual([{ value: 'sess_1', start: 1, end: 8, kind: 'session' }]);
+    expect(container?.querySelector('[data-mention-layer="chip"]')).not.toBeNull();
+  });
+
+  it('keeps the native caret above a chip at both edges', () => {
+    const input = render([{ value: 'plan', insertText: '/plan', kind: 'command' }], '/', 1, true);
+    commit('plan', 0);
+
+    act(() => {
+      input.setSelectionRange(5, 5);
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    expect(container?.querySelector('[data-mention-caret]')).toBeNull();
+    expect(input.className).toContain('z-30');
+    expect(input.style.getPropertyValue('-webkit-text-fill-color')).toBe('transparent');
+
+    act(() => {
+      input.setSelectionRange(0, 0);
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    expect(container?.querySelector('[data-mention-caret]')).toBeNull();
+    expect(input.className).toContain('z-30');
+    expect(input.style.getPropertyValue('-webkit-text-fill-color')).toBe('transparent');
+
+    act(() => {
+      input.setSelectionRange(6, 6);
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    expect(input.className).toContain('z-10');
+    expect(input.className).not.toContain('z-30');
+    expect(input.style.getPropertyValue('-webkit-text-fill-color')).toBe('');
+  });
+
+  it('keeps a readonly caret out of the opaque chip interior', () => {
+    const items = [{ value: 'plan', insertText: '/plan', kind: 'command' }];
+    const input = render(items, '/', 1, true, true);
+    commit('plan', 0);
+
+    act(() => {
+      input.setSelectionRange(2, 2);
+      input.dispatchEvent(new KeyboardEvent('keyup', { key: 'Home', bubbles: true }));
+    });
+
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(0);
   });
 });


### PR DESCRIPTION
## Related issue

Closes #307

## Problem / pressure

The Chat composer uses a native textarea plus an opaque mirror for mention chips. A collapsed caret moved into or beside a chip can be covered or disappear, and a CJK IME's transient preedit text can become offset from the committed mention range. The failure is most visible when a mention starts the draft or when a long mention wraps.

## Summary

- Treat collapsed carets inside committed mentions as atomic and snap them to the nearest boundary, while leaving non-collapsed selections native.
- During IME composition, render the transient textarea value and move mention ranges through the transient edit so both mirrors stay aligned.
- At a mention boundary, raise the textarea above the chip and make its text fill transparent while the background mirror carries the glyphs; this keeps the native caret visible without painting a second caret.
- Keep readonly boundary handling visual-only, ignore mention clicks during composition, and add regression coverage for navigation, wrapping, readonly inputs, and CJK preedit alignment.

## Before / after

| Before | After |
| ------ | ----- |
| Chip mirror could cover the native caret at a mention edge or at offset 0. | The native caret remains visible at both boundaries without a synthetic caret overlay. |
| CJK IME preedit text could shift or duplicate around an opaque chip. | Transient preedit text and mention ranges share the same mirror coordinate space. |
| Moving through a chip could split or silently decommit the mention range. | Collapsed carets stay outside committed ranges; ordinary selections still work. |

## Test plan

- `pnpm --filter @lody/components exec vitest run tests/mention-navigation.test.tsx` — 16/16 passed.
- `pnpm --filter @lody/components exec vitest run` — 420 test files and 3022 tests passed.
- `pnpm --filter @lody/components typecheck` — passed.
- Prettier check on all four changed files — passed.
- `git diff --check` — passed.
- Chromium manual layout check covered a wrapped mention at 220px; boundary carets measured as one line high on their respective fragments.
- Full workspace `pnpm check` was not rerun; this PR is limited to the components package and its focused/full package suites.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Inspect `mention-input.tsx` and `mention-highlighter.tsx` together; the fix depends on their shared caret-layer and transient-range coordinate contract.
- **Decisions to challenge:** Verify snapping only collapsed carets, raising the textarea only at boundaries, and using the background mirror for text are correct across wrapped chips and readonly inputs.
- **Plausible failures / evidence gaps:** Browser coverage is Chromium-based; WebKit/Firefox IME behavior and unusual grapheme edits remain the main residual compatibility risks.

### Authoring context

- **User goal / directives:** Keep the Chat composer caret visible around `@` session chips and prevent CJK IME text from becoming visually misaligned.
- **Constraints / non-goals:** Preserve the native textarea, mention payload/range semantics, chip styling, autocomplete behavior, and ordinary text selections; no protocol or persistence changes.
- **Risk-bearing decisions:** Mention ranges are treated as atomic only for collapsed caret placement; transient IME edits are mapped to the same ranges instead of hiding chips or committing partial text.
- **Destructive or irreversible behavior:** None. The change is presentation and selection handling only; it performs no migration, deletion, overwrite, or external data write.
- **Deliberately not done or tested:** Full workspace `pnpm check` and native WebKit/Firefox IME runs were not performed; package-wide tests, typecheck, formatting, and Chromium layout checks cover the touched surface.
- **Unknowns / confidence:** High confidence for the tested Chromium/Electron path and jsdom regressions; moderate confidence for other browser IME implementations until they are exercised.

<!-- context-handoff:end -->
