### PR TITLE
feat(components): cap mobile session-group previews at 5 rows

### DIFF
--- a/packages/components/src/components/mobile/AGENTS.md
+++ b/packages/components/src/components/mobile/AGENTS.md
@@ -167,6 +167,33 @@ embedded` lazy-imported from `../tasks/tasks-workspace.tsx` (`embedded`
 - Lists: `mobile-chat-list.tsx`, `mobile-swipeable-row.tsx` (iOS-Mail-style
   row actions; also `touch-action: pan-y`), `mobile-filter-pill-bar.tsx`,
   `mobile-filter-drawer.tsx`, `mobile-inline-picker.tsx`.
+- Group preview cap: under `MobileChatList capGroupPreviews` every bucket
+  previews at most `MOBILE_CHAT_PREVIEW_MAX_ROOTS` (5 — the desktop
+  `MAX_VISIBLE_SESSIONS`, copied rather than imported so the mobile bundle skips
+  `session-list.tsx`) and ends in a `sessions.showAll` / `sessions.showLess`
+  toggle. Workspace home passes it, because its buckets compete for the screen;
+  the in-project list does NOT — the user drilled in to read exactly that list
+  and there is nothing else there for a cap to make room for. It counts
+  TOP-LEVEL rows via `countOpenedByTreeRoots`, and `maxRoots` applies AFTER
+  `rootRank`, so a preview truncates the pinned-first / latest-activity order
+  rather than reshuffling it and never splits an opener from the Sessions it
+  opened. The expanded set is per
+  bucket id in `MobileChatList`, NEVER the shared
+  `sidebarCollapsedOpenedBySessionsAtom` — that atom is opener fold state the
+  drawer sidebar must agree on. The cap is SUSPENDED while archived multi-select
+  is active: "select all" takes every id in the list, so a capped surface would
+  confirm a permanent delete of rows it never showed. The preview state joins the
+  `AnimatePresence` key so "Show less" remounts instead of running a 0.4s height
+  exit per hidden row, and collapsing `scrollIntoView({ block: 'nearest' })`s the
+  toggle from a LAYOUT effect — the rows that vanish are above it. The toggle's
+  leading 16px slot stays EMPTY (it only aligns the label to the row-title x):
+  that column carries a row's status indicator and an opener's fold chevron, so a
+  chevron there would read as one of those.
+  The list is deliberately NOT virtualized. `VList` must own the scroll element,
+  but the home screen owns it — pull-to-refresh translates that subtree, the
+  dock-collapse listener reads it, hidden home tabs stay mounted for scroll
+  position — and `contain: strict` would strip the `liftAboveEdgeSwipeZone`
+  escape the opener chevron needs. The cap bounds the row count instead.
 - Opened-by tree: `MobileChatListCard` runs the shared
   `lib/session-opened-by-tree.ts` model over EACH bucket, so a Session created
   by the `lody_session_create` MCP tool indents under its opener the same way

--- a/packages/components/src/components/mobile/mobile-chat-list.tsx
+++ b/packages/components/src/components/mobile/mobile-chat-list.tsx
@@ -475,7 +475,8 @@ export function MobileChatListCard({
      pinned-first / latest-activity order the bucket already promises — it
      truncates that order rather than reshuffling it. */
   const showAll = preview?.showAll ?? false;
-  const capped = preview != null && !showAll;
+  const previewEnabled = preview != null;
+  const capped = previewEnabled && !showAll;
   const treeNodes = useMemo(
     () =>
       buildOpenedBySessionTree(chats, {
@@ -491,14 +492,20 @@ export function MobileChatListCard({
   );
   /* Gate the toggle on TOP-LEVEL rows, matching what the cap actually limits:
      five openers plus the Sessions they opened is not an overflowing bucket,
-     so it must not sprout a "Show all" the tap would not change. */
-  const overflowsPreview = useMemo(
-    () =>
-      preview != null &&
-      countOpenedByTreeRoots(chats, CHAT_OPENED_BY_TREE_ACCESSORS) >
-        MOBILE_CHAT_PREVIEW_MAX_ROOTS,
-    [chats, preview]
-  );
+     so it must not sprout a "Show all" the tap would not change.
+
+     Deliberately NOT wrapped in `useMemo`. `MobileChatList` calls `groupChats`
+     in its render body, so every bucket receives a freshly built `chats` array
+     on every render — measured: a state-only re-render (tapping one bucket's
+     toggle) hands all buckets a new array. A memo keyed on `chats` therefore
+     cannot ever hit, and one that looks like a cache while caching nothing is
+     worse than the O(rows) scan it fails to avoid. `previewEnabled` exists for
+     the same reason: `preview` is a new object literal each render, so only the
+     one bit of it that matters may be read. */
+  const overflowsPreview =
+    previewEnabled &&
+    countOpenedByTreeRoots(chats, CHAT_OPENED_BY_TREE_ACCESSORS) >
+      MOBILE_CHAT_PREVIEW_MAX_ROOTS;
   return (
     /* Flat list — no rounded card shell or inter-row dividers. Rows
        sit directly on the page canvas; `ConversationRow` supplies its

--- a/packages/components/src/components/mobile/mobile-chat-list.tsx
+++ b/packages/components/src/components/mobile/mobile-chat-list.tsx
@@ -1,4 +1,11 @@
-import { Fragment, useMemo, useState, type ReactNode } from 'react';
+import {
+  Fragment,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
   ChevronRight,
@@ -11,7 +18,11 @@ import {
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
 import { getServerNow } from '@lody/shared';
-import { buildOpenedBySessionTree, pinnedFirstRootRank } from '@/lib/session-opened-by-tree';
+import {
+  buildOpenedBySessionTree,
+  countOpenedByTreeRoots,
+  pinnedFirstRootRank,
+} from '@/lib/session-opened-by-tree';
 import {
   sidebarCollapsedOpenedBySessionsAtom,
   toggleSidebarCollapsedOpenedBySessionAtom,
@@ -85,6 +96,41 @@ export const PINNED_BUCKET_ID = '__pinned__';
 /* Flat unpinned tail when groupBy is `none` and there is a Pinned
    section above — no heading; just the remaining rows. */
 const FLAT_UNPINNED_BUCKET_ID = '__flat-unpinned__';
+
+/* Rows a bucket shows before it collapses behind "Show all (N)".
+   Same value as the desktop sidebar's `MAX_VISIBLE_SESSIONS`
+   (`../session-list.tsx`) — deliberately duplicated rather than imported so
+   the mobile bundle does not pull in the desktop session-list module.
+
+   Why 5 and not 3: a phone screen already fits ~8 rows, so 3 turns every
+   project into a two-tap read and puts the toggle back in the user's way on
+   every bucket. 5 is the point where a project's recent work still reads as a
+   list while an idle project costs one line more than its heading — and it
+   keeps the two platforms saying the same thing about the same workspace.
+
+   The cap counts TOP-LEVEL rows only (`maxRoots`), so a preview never splits
+   an opener from the Sessions it opened. */
+export const MOBILE_CHAT_PREVIEW_MAX_ROOTS = 5;
+
+/* Tree accessors shared by the render pass and the overflow count, so the
+   "does this bucket overflow" question is answered by the same nesting model
+   that decides what renders. */
+const CHAT_OPENED_BY_TREE_ACCESSORS = {
+  getId: (chat: MobileConversationItem) => chat.id,
+  getOpenedBySessionId: (chat: MobileConversationItem) =>
+    chat.openedByRowSessionId ?? chat.openedBySessionId,
+} as const;
+
+/* Per-bucket preview state. Owned by `MobileChatList` (one flag per bucket id)
+   rather than by the shared `sidebarCollapsedOpenedBySessionsAtom`: that atom
+   is the opener FOLD state, which the drawer sidebar and this list must agree
+   on. How many rows a mobile bucket previews is a property of this surface
+   alone and must not leak into the sidebar. */
+export type MobileChatPreviewState = {
+  /** True once the user expanded this bucket past the preview cap. */
+  showAll: boolean;
+  onToggle: () => void;
+};
 
 /* Fixed date-bucket ids (ordered newest → oldest). Month buckets use
    `date:month:YYYY-MM` and sort after these named ones. */
@@ -371,6 +417,7 @@ export function MobileChatListCard({
   archived = false,
   onRequestDelete,
   selection,
+  preview,
   secondaryField = 'branch',
 }: {
   chats: MobileConversationItem[];
@@ -392,6 +439,10 @@ export function MobileChatListCard({
      toolbar's "select all" + count stay in sync across grouped
      sections. */
   selection?: ChatSelectionState;
+  /** Caps the bucket at {@link MOBILE_CHAT_PREVIEW_MAX_ROOTS} top-level rows
+     and appends a "Show all (N)" toggle. Omit to render every row (what a
+     standalone card without a `MobileChatList` around it does). */
+  preview?: MobileChatPreviewState;
   /** @deprecated Conversation rows are single-line; branch/project meta
      is no longer shown. Kept for call-site compatibility. */
   secondaryField?: 'branch' | 'project';
@@ -419,18 +470,34 @@ export function MobileChatListCard({
      opener in the drawer and in the mobile list can never disagree. */
   const collapsedOpeners = useAtomValue(sidebarCollapsedOpenedBySessionsAtom);
   const toggleCollapsedOpener = useSetAtom(toggleSidebarCollapsedOpenedBySessionAtom);
+  /* A capped bucket renders at most `MOBILE_CHAT_PREVIEW_MAX_ROOTS` top-level
+     rows. `maxRoots` is applied AFTER `rootRank`, so the preview keeps the
+     pinned-first / latest-activity order the bucket already promises — it
+     truncates that order rather than reshuffling it. */
+  const showAll = preview?.showAll ?? false;
+  const capped = preview != null && !showAll;
   const treeNodes = useMemo(
     () =>
       buildOpenedBySessionTree(chats, {
-        getId: (chat) => chat.id,
-        getOpenedBySessionId: (chat) => chat.openedByRowSessionId ?? chat.openedBySessionId,
+        ...CHAT_OPENED_BY_TREE_ACCESSORS,
         isCollapsed: (openerId) => collapsedOpeners[openerId] === true,
         /* Bucket order is pinned-first then latest activity; rank an opener by
            its freshest opened Session so nesting cannot bury a just-updated
            row under a stale opener. */
         rootRank: (chat) => pinnedFirstRootRank(chat.latestMessageAt ?? 0, chat.isPinned),
+        ...(capped ? { maxRoots: MOBILE_CHAT_PREVIEW_MAX_ROOTS } : {}),
       }),
-    [chats, collapsedOpeners]
+    [capped, chats, collapsedOpeners]
+  );
+  /* Gate the toggle on TOP-LEVEL rows, matching what the cap actually limits:
+     five openers plus the Sessions they opened is not an overflowing bucket,
+     so it must not sprout a "Show all" the tap would not change. */
+  const overflowsPreview = useMemo(
+    () =>
+      preview != null &&
+      countOpenedByTreeRoots(chats, CHAT_OPENED_BY_TREE_ACCESSORS) >
+        MOBILE_CHAT_PREVIEW_MAX_ROOTS,
+    [chats, preview]
   );
   return (
     /* Flat list — no rounded card shell or inter-row dividers. Rows
@@ -449,8 +516,17 @@ export function MobileChatListCard({
          per-row exit animations don't fire for every row at once
          (which felt like a freeze on lists with > 5–10 rows). The
          intentional single-row archive case still works because that
-         path only removes one item from the same key bucket. */}
-      <AnimatePresence initial={false} key={archived ? 'archived' : 'active'}>
+         path only removes one item from the same key bucket.
+
+         "Show less" is the same shape of bulk removal: collapsing a 40-row
+         project back to five would otherwise run 35 simultaneous 0.4s height
+         exits. The preview state joins the key so that transition remounts
+         instead — and `initial={false}` means expanding adds its rows with no
+         enter animation either. */}
+      <AnimatePresence
+        initial={false}
+        key={`${archived ? 'archived' : 'active'}:${capped ? 'preview' : 'full'}`}
+      >
         {treeNodes.map((node) => {
           const conversation = node.item;
           /* Same builder the sidebar rows use, so the disclosure's aria-label
@@ -552,7 +628,71 @@ export function MobileChatListCard({
           );
         })}
       </AnimatePresence>
+      {overflowsPreview && preview ? (
+        <MobileChatPreviewToggle
+          showAll={showAll}
+          totalCount={chats.length}
+          onToggle={preview.onToggle}
+        />
+      ) : null}
     </>
+  );
+}
+
+/* Tail affordance of a capped bucket. Sits inside the bucket body, directly
+   under the last row and above the next group heading, so it reads as the end
+   of THIS list rather than as chrome between sections.
+
+   Geometry: the label starts on the row-title x (px-4 + the 16px leading slot
+   + gap-2.5 = 42px) via an empty spacer, exactly as the desktop sidebar's
+   "Show all" does. The slot stays EMPTY on purpose — it is the column that
+   carries a row's status indicator and an opener's fold chevron, so a chevron
+   here would read as one of those. The label alone says which way it goes.
+
+   The type is quieter than a session title (15px medium foreground) and than a
+   group heading (14px semibold muted), which is the hierarchy: rows, then
+   sections, then this. Full-width `min-h-11` keeps a thumb target the size of
+   a row. */
+function MobileChatPreviewToggle({
+  showAll,
+  totalCount,
+  onToggle,
+}: {
+  showAll: boolean;
+  totalCount: number;
+  onToggle: () => void;
+}) {
+  const { t } = useTranslation();
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const wasShowingAll = useRef(showAll);
+  /* Collapsing removes rows ABOVE this button, so on a long bucket the tap
+     target — and everything the user was reading — jumps off the top of the
+     viewport. Pull it back into view minimally (`nearest` is a no-op when it
+     is already visible). A layout effect runs after the rows are removed and
+     before paint, so the correction never renders as a visible scroll jump.
+     Chrome's native scroll anchoring would cover this on its own; WebKit has
+     never shipped `overflow-anchor`, and iOS is the surface this list is for. */
+  useLayoutEffect(() => {
+    if (wasShowingAll.current && !showAll) {
+      buttonRef.current?.scrollIntoView?.({ block: 'nearest' });
+    }
+    wasShowingAll.current = showAll;
+  }, [showAll]);
+  const label = showAll
+    ? t('sessions.showLess', 'Show less')
+    : t('sessions.showAll', 'Show all ({{count}})', { count: totalCount });
+  return (
+    <button
+      ref={buttonRef}
+      type="button"
+      data-chat-list-preview-toggle=""
+      aria-expanded={showAll}
+      onClick={onToggle}
+      className="flex min-h-11 w-full items-center gap-2.5 bg-background px-4 py-2 text-left text-[13px] font-medium text-muted-foreground transition-colors active:bg-muted/40"
+    >
+      <span className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span className="min-w-0 truncate">{label}</span>
+    </button>
   );
 }
 
@@ -803,6 +943,7 @@ export function MobileChatList({
   onPermanentDelete,
   selectionLabels,
   rowSecondaryField,
+  capGroupPreviews = false,
   privateLabel,
   privateHelpAriaLabel,
   onPrivateHelp,
@@ -837,6 +978,13 @@ export function MobileChatList({
      multi-select flow. The promise lets the list wait before
      clearing its selection state. */
   onPermanentDelete?: (chatIds: string[]) => void | Promise<void>;
+  /** Caps every bucket at {@link MOBILE_CHAT_PREVIEW_MAX_ROOTS} top-level rows
+     behind a "Show all (N)" toggle. On for the workspace home list, where
+     buckets compete for the screen and one busy project would otherwise push
+     every other project and worktree below the fold. Off inside a single
+     project's page: the user drilled in to read exactly that list, and there
+     is nothing else there for a cap to make room for. */
+  capGroupPreviews?: boolean;
   /** Copy for the multi-select toolbar + confirmation alert-dialog.
      All keys are optional with reasonable Chinese defaults; callers
      can override to localize. */
@@ -861,6 +1009,22 @@ export function MobileChatList({
   );
   const toggleBucket = (bucketId: string) => {
     setCollapsedBucketIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(bucketId)) next.delete(bucketId);
+      else next.add(bucketId);
+      return next;
+    });
+  };
+  /* Buckets the user expanded past the preview cap. Every bucket starts capped
+     at `MOBILE_CHAT_PREVIEW_MAX_ROOTS`, which is the whole point: without it a
+     project with forty Sessions pushes every other project and worktree off
+     the screen. This is deliberately NOT the shared opener-fold atom — see
+     `MobileChatPreviewState`. */
+  const [expandedBucketIds, setExpandedBucketIds] = useState<Set<string>>(
+    () => new Set()
+  );
+  const toggleBucketPreview = (bucketId: string) => {
+    setExpandedBucketIds((prev) => {
       const next = new Set(prev);
       if (next.has(bucketId)) next.delete(bucketId);
       else next.add(bucketId);
@@ -1019,6 +1183,17 @@ export function MobileChatList({
         const expanded = !collapsedBucketIds.has(id);
         const onToggle = () => toggleBucket(id);
         const compactTop = index === 0;
+        /* Multi-select drives a permanent delete, and "select all" operates on
+           every id in the list. Capping the rows while it is active would let
+           the user confirm a delete of Sessions the surface never showed them,
+           so selection mode renders the buckets in full. */
+        const bucketPreview: MobileChatPreviewState | undefined =
+          !capGroupPreviews || selectionToolbarActive
+            ? undefined
+            : {
+                showAll: expandedBucketIds.has(id),
+                onToggle: () => toggleBucketPreview(id),
+              };
         const trailing =
           showFirstGroupTrailing && !trailingConsumedByFlatHeading && index === 0
             ? firstGroupTrailing
@@ -1051,6 +1226,7 @@ export function MobileChatList({
                 archived={archived}
                 onRequestDelete={selectionEnabled ? requestSwipeDelete : undefined}
                 selection={selectionState}
+                preview={bucketPreview}
                 secondaryField={resolvedSecondaryField}
               />
             </Fragment>
@@ -1139,6 +1315,7 @@ export function MobileChatList({
                 archived={archived}
                 onRequestDelete={selectionEnabled ? requestSwipeDelete : undefined}
                 selection={selectionState}
+                preview={bucketPreview}
                 secondaryField={resolvedSecondaryField}
               />
             ) : null}

--- a/packages/components/src/components/mobile/mobile-chat-list.tsx
+++ b/packages/components/src/components/mobile/mobile-chat-list.tsx
@@ -518,11 +518,12 @@ export function MobileChatListCard({
          intentional single-row archive case still works because that
          path only removes one item from the same key bucket.
 
-         "Show less" is the same shape of bulk removal: collapsing a 40-row
-         project back to five would otherwise run 35 simultaneous 0.4s height
-         exits. The preview state joins the key so that transition remounts
-         instead — and `initial={false}` means expanding adds its rows with no
-         enter animation either. */}
+         "Show less" is the same shape of bulk removal. Measured with the key
+         carrying only `archived`: collapsing a 14-row bucket leaves all 14 rows
+         in the DOM a frame later, animating out together for 400ms. Adding the
+         preview state to the key makes that transition a remount instead — the
+         same frame reports the 5 rows that remain — and `initial={false}` means
+         expanding adds its rows with no enter animation either. */}
       <AnimatePresence
         initial={false}
         key={`${archived ? 'archived' : 'active'}:${capped ? 'preview' : 'full'}`}
@@ -983,7 +984,18 @@ export function MobileChatList({
      buckets compete for the screen and one busy project would otherwise push
      every other project and worktree below the fold. Off inside a single
      project's page: the user drilled in to read exactly that list, and there
-     is nothing else there for a cap to make room for. */
+     is nothing else there for a cap to make room for.
+
+     This stays an explicit flag rather than being derived from
+     `groupBy !== 'none'`, which is equivalent TODAY and shorter. The project
+     page is `none` only because `chat-landing.tsx` pins it there so a
+     single-bucket list does not render a redundant heading — a presentation
+     decision that has nothing to do with capping. Deriving from it would couple
+     the two through a shared variable and fail silently in both directions: give
+     the project page a date mode and the cap switches on and starts hiding
+     worktree rows, which is the opposite of what it is for; give home a flat
+     mode and the cap disappears. `groupBy` also defaults to `none`, so a new
+     caller would silently opt out. */
   capGroupPreviews?: boolean;
   /** Copy for the multi-select toolbar + confirmation alert-dialog.
      All keys are optional with reasonable Chinese defaults; callers

--- a/packages/components/src/components/mobile/mobile-home-screen.tsx
+++ b/packages/components/src/components/mobile/mobile-home-screen.tsx
@@ -2289,6 +2289,11 @@ function ChatsFlatView({
         chats={visible}
         groupBy={groupBy}
         groupLabels={labels.chatGroupLabels}
+        /* Home aggregates every project and worktree into one scroll, so each
+           bucket previews its latest rows and offers the rest. Without it a
+           single busy project owns the screen — the whole reason the cap
+           exists. The in-project list deliberately does not pass this. */
+        capGroupPreviews
         /* Active list is flat — no "全部对话" section label. Only the
            archived surface keeps a heading so the mode is obvious. */
         flatHeading={archived ? (labels.archivedChatsHeading ?? '归档对话') : undefined}

--- a/packages/components/src/stories/MobileChatList.stories.tsx
+++ b/packages/components/src/stories/MobileChatList.stories.tsx
@@ -445,7 +445,7 @@ export const GroupPreviewExpanded: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const [toggle] = await canvas.findAllByRole('button', { name: /Show all/i });
-    if (toggle) await userEvent.click(toggle);
+    await userEvent.click(toggle!);
   },
 };
 

--- a/packages/components/src/stories/MobileChatList.stories.tsx
+++ b/packages/components/src/stories/MobileChatList.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import { fn } from 'storybook/test';
+import { fn, userEvent, within } from 'storybook/test';
 
 import {
   MobileChatList,
@@ -231,17 +231,86 @@ const openedByChats: MobileConversationItem[] = [
   ...baseChats,
 ];
 
+/* The clutter the preview cap exists for: one busy worktree with twelve
+   Sessions, then two other worktrees that a flat list would push below the
+   fold. `busy-9` is an opener with two opened Sessions — expand the bucket and
+   its group arrives intact, because the cap counts TOP-LEVEL rows rather than
+   rendered ones. */
+const overflowingChats: MobileConversationItem[] = [
+  ...Array.from({ length: 12 }, (_, index): MobileConversationItem => ({
+    id: `busy-${index}`,
+    title: `修复 presence 分片 #${index + 1}`,
+    kind: 'local',
+    branchName: `fix/presence-shard-${index + 1}`,
+    latestMessageAt: now - (index + 1) * 0.4 * hour,
+    ageLabel: `${(index + 1) * 24}m`,
+    machineId: 'zx-macbook',
+    projectKey: 'zx-macbook:lody-main',
+    projectLabel: 'lody (main)',
+    ...(index === 0 ? { isWorking: true } : {}),
+  })),
+  {
+    id: 'busy-9-opened-a',
+    title: '子会话:分片回归测试',
+    kind: 'local',
+    latestMessageAt: now - 4.2 * hour,
+    ageLabel: '4h',
+    machineId: 'zx-macbook',
+    projectKey: 'zx-macbook:lody-main',
+    projectLabel: 'lody (main)',
+    openedBySessionId: 'busy-9',
+    openedByRowSessionId: 'busy-9',
+  },
+  {
+    id: 'busy-9-opened-b',
+    title: '子会话:补 changelog',
+    kind: 'local',
+    latestMessageAt: now - 4.4 * hour,
+    ageLabel: '4h',
+    machineId: 'zx-macbook',
+    projectKey: 'zx-macbook:lody-main',
+    projectLabel: 'lody (main)',
+    openedBySessionId: 'busy-9',
+    openedByRowSessionId: 'busy-9',
+  },
+  ...Array.from({ length: 3 }, (_, index): MobileConversationItem => ({
+    id: `wt-review-${index}`,
+    title: `评审 worktree 里的改动 #${index + 1}`,
+    kind: 'local',
+    branchName: `review/${index + 1}`,
+    latestMessageAt: now - (6 + index) * hour,
+    ageLabel: `${6 + index}h`,
+    machineId: 'zx-macbook',
+    projectKey: 'zx-macbook:lody-review',
+    projectLabel: 'lody (review worktree)',
+  })),
+  {
+    id: 'wt-docs-0',
+    title: '文档站改版',
+    kind: 'local',
+    branchName: 'docs/site-refresh',
+    latestMessageAt: now - 20 * hour,
+    ageLabel: '20h',
+    machineId: 'zx-macbook',
+    projectKey: 'zx-macbook:lody-docs',
+    projectLabel: 'lody (docs worktree)',
+  },
+];
+
 function StoryShell({
   groupBy,
   rowActions,
   flatHeading,
   archived = false,
+  capGroupPreviews = false,
   chats: chatsOverride,
 }: {
   groupBy: MobileChatGroupBy;
   rowActions?: MobileChatListRowActions;
   flatHeading?: string;
   archived?: boolean;
+  /** Mirrors the workspace home list, which caps each bucket's preview. */
+  capGroupPreviews?: boolean;
   /** Story-only dataset override; defaults to the shared mixed list. */
   chats?: MobileConversationItem[];
 }) {
@@ -274,6 +343,7 @@ function StoryShell({
           groupBy={groupBy}
           flatHeading={flatHeading}
           archived={archived}
+          capGroupPreviews={capGroupPreviews}
           groupLabels={{
             chat: 'Chat',
             local: 'Local',
@@ -356,6 +426,27 @@ export const OpenedBySessionsGroupedByDate: Story = {
 
 export const GroupByDate: Story = {
   args: { groupBy: 'date' },
+};
+
+/* Group preview cap — the state this exists for. Three worktrees on the same
+   project plus a long-running one: without the cap the first bucket's twelve
+   rows push every other worktree off the screen. Each bucket previews five
+   top-level rows and ends in "Show all (N)". */
+export const GroupPreviewOverflow: Story = {
+  args: { groupBy: 'project', chats: overflowingChats, capGroupPreviews: true },
+};
+
+/* One bucket expanded past the cap: the toggle reads "Show less" and stays
+   pinned to the tail of the bucket it belongs to. Collapsing it scrolls the
+   toggle back into view rather than dropping the user somewhere else in the
+   list. */
+export const GroupPreviewExpanded: Story = {
+  args: { groupBy: 'project', chats: overflowingChats, capGroupPreviews: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const [toggle] = await canvas.findAllByRole('button', { name: /Show all/i });
+    if (toggle) await userEvent.click(toggle);
+  },
 };
 
 export const WithSwipeActions: Story = {

--- a/packages/components/tests/mobile-chat-list-preview-cap.test.tsx
+++ b/packages/components/tests/mobile-chat-list-preview-cap.test.tsx
@@ -1,0 +1,306 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { createStore, Provider } from 'jotai';
+import {
+  MOBILE_CHAT_PREVIEW_MAX_ROOTS,
+  MobileChatList,
+} from '../src/components/mobile/mobile-chat-list';
+import type { MobileConversationItem } from '../src/components/mobile/mobile-project-screen';
+import { sidebarCollapsedOpenedBySessionsAtom } from '../src/atoms/focus-layer';
+import { initI18n } from '../src/i18n';
+
+/**
+ * Every bucket of the mobile chat list previews at most
+ * `MOBILE_CHAT_PREVIEW_MAX_ROOTS` TOP-LEVEL rows and ends in a "Show all (N)"
+ * toggle — the same model the desktop sidebar's `MAX_VISIBLE_SESSIONS` applies
+ * per group. Without it, one busy project buries every other project and
+ * worktree below the fold.
+ */
+
+const HOUR = 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 3, 22, 10, 0, 0);
+
+function makeItem(overrides: Partial<MobileConversationItem> & { id: string }) {
+  return {
+    kind: 'chat',
+    title: `Session ${overrides.id}`,
+    latestMessageAt: NOW - HOUR,
+    ...overrides,
+  } satisfies MobileConversationItem;
+}
+
+/** `count` unpinned rows in one project bucket, newest first. */
+function makeProjectItems(
+  count: number,
+  projectKey = 'p1',
+  startIndex = 0
+): MobileConversationItem[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeItem({
+      id: `${projectKey}-${startIndex + index}`,
+      projectKey,
+      projectLabel: projectKey,
+      latestMessageAt: NOW - (startIndex + index) * HOUR,
+    })
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let store: ReturnType<typeof createStore>;
+
+beforeEach(async () => {
+  await initI18n();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  store = createStore();
+});
+
+afterEach(() => {
+  flushSync(() => root.unmount());
+  container.remove();
+});
+
+function render(
+  chats: MobileConversationItem[],
+  props: Partial<React.ComponentProps<typeof MobileChatList>> = {}
+) {
+  flushSync(() => {
+    root.render(
+      <Provider store={store}>
+        <MobileChatList chats={chats} groupBy="project" capGroupPreviews {...props} />
+      </Provider>
+    );
+  });
+}
+
+function rows(): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('.mobile-project-conversation-row'));
+}
+
+function titles(): string[] {
+  return rows().map((row) => row.textContent?.trim() ?? '');
+}
+
+function toggles(): HTMLButtonElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>('[data-chat-list-preview-toggle]')
+  );
+}
+
+function toggleLabels(): string[] {
+  return toggles().map((button) => button.textContent?.trim() ?? '');
+}
+
+describe('mobile chat list group preview cap', () => {
+  it('renders every row when the caller does not opt in', () => {
+    // The in-project list drills into one project deliberately: there is
+    // nothing else on that page for a cap to make room for.
+    render(makeProjectItems(9, 'p1'), { capGroupPreviews: false });
+    expect(rows()).toHaveLength(9);
+    expect(toggles()).toHaveLength(0);
+  });
+
+
+  it('previews five top-level rows per bucket and offers the rest', () => {
+    render([...makeProjectItems(9, 'p1'), ...makeProjectItems(2, 'p2')]);
+    // p1 is capped; p2 is under the cap and gets no toggle at all.
+    expect(titles()).toEqual([
+      'Session p1-0',
+      'Session p1-1',
+      'Session p1-2',
+      'Session p1-3',
+      'Session p1-4',
+      'Session p2-0',
+      'Session p2-1',
+    ]);
+    expect(toggleLabels()).toEqual(['Show all (9)']);
+  });
+
+  it('leaves a bucket exactly at the cap untouched', () => {
+    // A toggle whose tap would change nothing must not appear.
+    render(makeProjectItems(MOBILE_CHAT_PREVIEW_MAX_ROOTS, 'p1'));
+    expect(rows()).toHaveLength(MOBILE_CHAT_PREVIEW_MAX_ROOTS);
+    expect(toggles()).toHaveLength(0);
+  });
+
+  it('expands and re-collapses only the bucket that was tapped', () => {
+    render([...makeProjectItems(9, 'p1'), ...makeProjectItems(8, 'p2')]);
+    expect(toggleLabels()).toEqual(['Show all (9)', 'Show all (8)']);
+
+    act(() => {
+      toggles()[0]!.click();
+    });
+    expect(titles().filter((title) => title.includes('p1-'))).toHaveLength(9);
+    // The untapped bucket keeps its preview.
+    expect(titles().filter((title) => title.includes('p2-'))).toHaveLength(5);
+    expect(toggleLabels()).toEqual(['Show less', 'Show all (8)']);
+    expect(toggles()[0]!.getAttribute('aria-expanded')).toBe('true');
+
+    act(() => {
+      toggles()[0]!.click();
+    });
+    expect(titles().filter((title) => title.includes('p1-'))).toHaveLength(5);
+    expect(toggleLabels()).toEqual(['Show all (9)', 'Show all (8)']);
+    expect(toggles()[0]!.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('counts top-level rows, so a preview never splits an opener', () => {
+    // Four standalone rows plus an opener with three opened Sessions is five
+    // TOP-LEVEL rows: nothing overflows, and all eight rows render. Counting
+    // raw rows instead would cut inside the opener's group.
+    const chats = [
+      ...makeProjectItems(4, 'p1'),
+      makeItem({
+        id: 'opener',
+        projectKey: 'p1',
+        projectLabel: 'p1',
+        latestMessageAt: NOW - 10 * HOUR,
+      }),
+      ...['a', 'b', 'c'].map((suffix, index) =>
+        makeItem({
+          id: `opened-${suffix}`,
+          projectKey: 'p1',
+          projectLabel: 'p1',
+          openedBySessionId: 'opener',
+          openedByRowSessionId: 'opener',
+          latestMessageAt: NOW - (11 + index) * HOUR,
+        })
+      ),
+    ];
+    render(chats);
+    expect(rows()).toHaveLength(8);
+    expect(toggles()).toHaveLength(0);
+  });
+
+  it('keeps a kept root together with the Sessions it opened', () => {
+    // Six top-level rows, the last of which opened two Sessions. The cap drops
+    // the sixth root entirely rather than showing it without its children.
+    const chats = [
+      ...makeProjectItems(5, 'p1'),
+      makeItem({
+        id: 'opener',
+        projectKey: 'p1',
+        projectLabel: 'p1',
+        latestMessageAt: NOW - 20 * HOUR,
+      }),
+      ...['a', 'b'].map((suffix, index) =>
+        makeItem({
+          id: `opened-${suffix}`,
+          projectKey: 'p1',
+          projectLabel: 'p1',
+          openedBySessionId: 'opener',
+          openedByRowSessionId: 'opener',
+          latestMessageAt: NOW - (21 + index) * HOUR,
+        })
+      ),
+    ];
+    render(chats);
+    expect(titles()).not.toContain('Session opener');
+    expect(titles()).not.toContain('Session opened-a');
+    expect(toggleLabels()).toEqual(['Show all (8)']);
+
+    act(() => {
+      toggles()[0]!.click();
+    });
+    expect(titles().slice(5)).toEqual([
+      'Session opener',
+      'Session opened-a',
+      'Session opened-b',
+    ]);
+  });
+
+  it('truncates the pinned-first order rather than reshuffling it', () => {
+    // A pinned row outranks fresher unpinned ones, so it must survive the cap
+    // even though it is the stalest row in the bucket.
+    render([
+      ...makeProjectItems(6, 'p1'),
+      makeItem({
+        id: 'stale-pin',
+        isPinned: true,
+        projectKey: 'p1',
+        projectLabel: 'p1',
+        latestMessageAt: NOW - 99 * HOUR,
+      }),
+    ]);
+    // Pinned rows lift into their own bucket, which is itself capped.
+    expect(titles()).toEqual([
+      'Session stale-pin',
+      'Session p1-0',
+      'Session p1-1',
+      'Session p1-2',
+      'Session p1-3',
+      'Session p1-4',
+    ]);
+    expect(toggleLabels()).toEqual(['Show all (6)']);
+  });
+
+  it('pulls the toggle back into view when a bucket collapses', () => {
+    // Collapsing removes rows ABOVE the toggle, so on a long bucket the tap
+    // target and everything around it jumps off the top of the viewport.
+    // jsdom has no layout, so the browser API is the only observable here.
+    const calls: Array<ScrollIntoViewOptions | boolean | undefined> = [];
+    const original = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = function scrollIntoView(arg) {
+      calls.push(arg);
+    };
+    try {
+      render(makeProjectItems(9, 'p1'));
+      act(() => {
+        toggles()[0]!.click();
+      });
+      // Expanding only appends rows below the toggle: nothing to correct.
+      expect(calls).toEqual([]);
+
+      act(() => {
+        toggles()[0]!.click();
+      });
+      expect(calls).toEqual([{ block: 'nearest' }]);
+    } finally {
+      Element.prototype.scrollIntoView = original;
+    }
+  });
+
+  it('does not write the preview state into the shared opener-fold atom', () => {
+    // The fold atom is shared with the drawer sidebar; how many rows a mobile
+    // bucket previews is this surface's business alone.
+    render(makeProjectItems(9, 'p1'));
+    act(() => {
+      toggles()[0]!.click();
+    });
+    expect(store.get(sidebarCollapsedOpenedBySessionsAtom)).toEqual({});
+  });
+
+  it('shows every row while multi-select is active', () => {
+    // "Select all" operates on every id in the list, so a capped surface would
+    // let the user confirm a permanent delete of rows it never showed.
+    vi.useFakeTimers();
+    try {
+      const chats = makeProjectItems(9, 'p1');
+      render(chats, { archived: true, onPermanentDelete: () => {} });
+      expect(rows()).toHaveLength(MOBILE_CHAT_PREVIEW_MAX_ROOTS);
+
+      // Long-press the first row: pointerdown, then let the injected clock run
+      // past the 500ms hold. No wall-clock sleep is involved.
+      act(() => {
+        rows()[0]!.dispatchEvent(
+          new MouseEvent('pointerdown', { bubbles: true, clientX: 8, clientY: 8 })
+        );
+      });
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+
+      expect(rows()).toHaveLength(chats.length);
+      expect(toggles()).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/components/tests/mobile-chat-list-preview-cap.test.tsx
+++ b/packages/components/tests/mobile-chat-list-preview-cap.test.tsx
@@ -99,18 +99,33 @@ function toggleLabels(): string[] {
 }
 
 describe('mobile chat list group preview cap', () => {
-  it('renders every row when the caller does not opt in', () => {
-    // The in-project list drills into one project deliberately: there is
-    // nothing else on that page for a cap to make room for.
+  it('caps only when the caller opts in, independently of grouping', () => {
+    // Both directions matter, and neither follows from the other. The
+    // in-project list drills into one project deliberately, so it opts out and
+    // must render everything. And the cap must NOT be inferred from `groupBy`:
+    // the project page is only `none` because `chat-landing.tsx` pins it for
+    // heading reasons, so deriving the cap from grouping would silently switch
+    // it on there the day that page grows a date mode — hiding the very
+    // worktree rows the cap exists to expose.
     render(makeProjectItems(9, 'p1'), { capGroupPreviews: false });
     expect(rows()).toHaveLength(9);
     expect(toggles()).toHaveLength(0);
+
+    render(makeProjectItems(9, 'p1'), { groupBy: 'none' });
+    expect(rows()).toHaveLength(MOBILE_CHAT_PREVIEW_MAX_ROOTS);
+    expect(toggleLabels()).toEqual(['Show all (9)']);
   });
 
 
-  it('previews five top-level rows per bucket and offers the rest', () => {
-    render([...makeProjectItems(9, 'p1'), ...makeProjectItems(2, 'p2')]);
-    // p1 is capped; p2 is under the cap and gets no toggle at all.
+  it('previews five rows per overflowing bucket and leaves the rest alone', () => {
+    // Three boundary points in one list: over the cap (trimmed, toggle),
+    // exactly at it (untouched, no toggle — an off-by-one in the `>` would
+    // surface here and nowhere else), and under it (untouched, no toggle).
+    render([
+      ...makeProjectItems(9, 'p1'),
+      ...makeProjectItems(MOBILE_CHAT_PREVIEW_MAX_ROOTS, 'p2'),
+      ...makeProjectItems(2, 'p3'),
+    ]);
     expect(titles()).toEqual([
       'Session p1-0',
       'Session p1-1',
@@ -119,15 +134,13 @@ describe('mobile chat list group preview cap', () => {
       'Session p1-4',
       'Session p2-0',
       'Session p2-1',
+      'Session p2-2',
+      'Session p2-3',
+      'Session p2-4',
+      'Session p3-0',
+      'Session p3-1',
     ]);
     expect(toggleLabels()).toEqual(['Show all (9)']);
-  });
-
-  it('leaves a bucket exactly at the cap untouched', () => {
-    // A toggle whose tap would change nothing must not appear.
-    render(makeProjectItems(MOBILE_CHAT_PREVIEW_MAX_ROOTS, 'p1'));
-    expect(rows()).toHaveLength(MOBILE_CHAT_PREVIEW_MAX_ROOTS);
-    expect(toggles()).toHaveLength(0);
   });
 
   it('expands and re-collapses only the bucket that was tapped', () => {
@@ -242,26 +255,31 @@ describe('mobile chat list group preview cap', () => {
   });
 
   it('pulls the toggle back into view when a bucket collapses', () => {
-    // Collapsing removes rows ABOVE the toggle, so on a long bucket the tap
-    // target and everything around it jumps off the top of the viewport.
-    // jsdom has no layout, so the browser API is the only observable here.
-    const calls: Array<ScrollIntoViewOptions | boolean | undefined> = [];
+    // Measured in Chromium with `overflow-anchor: none` (Safari/iOS ships no
+    // scroll anchoring): collapsing a 14-row bucket drops the toggle from
+    // y=328 to y=-68, off the top of the viewport. With this correction it
+    // lands at y=0. jsdom has no layout, so what is observable here is WHICH
+    // element the list asks the browser to keep on screen.
+    let scrolled: { target: Element; options: unknown } | null = null;
     const original = Element.prototype.scrollIntoView;
-    Element.prototype.scrollIntoView = function scrollIntoView(arg) {
-      calls.push(arg);
+    Element.prototype.scrollIntoView = function scrollIntoView(options) {
+      scrolled = { target: this, options };
     };
     try {
       render(makeProjectItems(9, 'p1'));
       act(() => {
         toggles()[0]!.click();
       });
-      // Expanding only appends rows below the toggle: nothing to correct.
-      expect(calls).toEqual([]);
+      // Expanding only appends rows BELOW the toggle. Moving the viewport
+      // there would yank the list out from under the reader.
+      expect(scrolled).toBeNull();
 
       act(() => {
         toggles()[0]!.click();
       });
-      expect(calls).toEqual([{ block: 'nearest' }]);
+      expect(scrolled).not.toBeNull();
+      expect(scrolled!.target).toBe(toggles()[0]);
+      expect(scrolled!.options).toEqual({ block: 'nearest' });
     } finally {
       Element.prototype.scrollIntoView = original;
     }


### PR DESCRIPTION
The mobile home list rendered every Session in every bucket, so one project
with forty Sessions pushed every other project and worktree below the fold.
The desktop sidebar has capped its groups at `MAX_VISIBLE_SESSIONS` for exactly
this reason; mobile never got it.

Each bucket now previews `MOBILE_CHAT_PREVIEW_MAX_ROOTS` (5) top-level rows
behind a **Show all (N)** / **Show less** toggle, reusing the existing
`sessions.showAll` / `sessions.showLess` keys. It counts TOP-LEVEL rows through
`countOpenedByTreeRoots` and applies `maxRoots` **after** `rootRank`, so the
preview truncates the pinned-first / latest-activity order rather than
reshuffling it, and never splits an opener from the Sessions it opened.

## 1. Why 5, not the 3 that was originally suggested

A phone already fits roughly eight rows. At 3, every project becomes a two-tap
read and the toggle is back in your way on every single bucket — the cap starts
costing more attention than the clutter it removes. 5 is the point where a
project's recent work still reads as a list, while an idle project costs one
line more than its heading.

It also keeps the two platforms saying the same thing about the same workspace:
5 is the desktop `MAX_VISIBLE_SESSIONS`. The value is a single exported constant
(`MOBILE_CHAT_PREVIEW_MAX_ROOTS`) if we want to tune it later.

## 2. Why home only

Scoped by an explicit `capGroupPreviews` prop. Workspace home passes it; the
in-project list does not.

The structural reason is that the project page has almost no grouping to cap.
`chat-landing.tsx:6153` force-pins `chatGroupBy="none"` there regardless of the
home tab's view-mode atom, so that surface has at most **two** buckets: Pinned,
and one unlabeled flat tail. A cap would therefore not be trimming one project
among many — it would be hiding the tail of the single list the page exists to
show.

That matters specifically for the worktree-visibility ask this change came from.
Each `ConversationRow` carries a per-row `WorktreeIcon` driven by `isWorktree`
(`mobile-project-screen.tsx:602`), so inside one project the rows are exactly
where worktree identity is visible. Capping the flat tail at 5 would hide rows
6..N and their worktree markers — the opposite of the request. On home, the same
cap does the reverse: it stops one project from burying the *other* projects and
worktrees.

> One correction for anyone tracing this: the project page also passes
> `rowSecondaryField="branch"`, but that prop renders nothing today.
> `ConversationRow` is single-line and explicitly discards it
> (`mobile-project-screen.tsx:448` / `:482`, `void _secondaryField`), with
> age/branch/project meta omitted. It is retained for call-site compatibility
> only, so it is not evidence for anything here — the `WorktreeIcon` is.

## 3. Why no virtualization

Two structural blockers, both already documented in `mobile/AGENTS.md`:

- **`VList` must own the scroll element**, but the home screen owns it.
  Pull-to-refresh translates that whole subtree, the dock-collapse listener
  reads it, and hidden home tabs stay mounted so their scroll position survives
  a tab round-trip.
- **`contain: strict`** on `VList` makes the list its own stacking context,
  which would strip the `liftAboveEdgeSwipeZone` escape the opener fold chevron
  depends on to clear the 48px edge-back swipe strip.

So the cap bounds the row count instead. Measured in Chromium at 393x852 with
200 Sessions across 12 projects, capped vs uncapped:

| | capped | uncapped |
| --- | --- | --- |
| rendered rows | **60** | 200 |
| DOM nodes in the list | **555** | 1219 |
| median mount-to-stable | **142ms** | 201ms |

(Median of 7 runs. The mount figure includes a fixed ~80ms frame-settling
window in the harness, so the actual work is closer to 62ms vs 121ms.) This is
the cost that mattered: `atoms/doc-meta.ts` flushes metadata in batches of 50
per `setTimeout(0)`, and every batch re-renders the whole list, so first paint
was O(rows) x O(N/50). Each row is a framer-motion `motion.div` with `layout`,
so the row count is the multiplier.

Happy to revisit virtualization if the cap proves insufficient, but it would
need the scroll-ownership and stacking-context problems solved first, and this
change makes it much less urgent.

## 4. Out of delegated scope, kept deliberately: data-loss guard

The cap is **suspended while archived multi-select is active**. This was not
part of the request, and I would normally leave it out — but "select all"
operates on every id in the list, not on the rendered rows. A capped surface
would let the user confirm a permanent delete of Sessions it never showed them.
Group collapse already had this shape; adding a cap on by default would have
made it the common case. Flagging it explicitly so it gets reviewed on its own
merits rather than riding along as layout polish.

## Design notes

Verified in a real browser at 393x852:

- The label sits on the row-title x (42px) via an **empty** 16px leading slot.
  That column carries a row's status indicator and an opener's fold chevron, so
  a chevron there would read as one of those. Same construction as the desktop
  sidebar's "Show all".
- 13px medium muted, `min-h-11` full-width: below rows (15px foreground) and
  headings (14px semibold) in the hierarchy, while keeping a row-sized thumb
  target.
- `active:bg-muted/40` press wash, matching `ConversationRow`. No `scale(0.96)`
  — scaling a full-bleed row reads wrong.
- The preview state joins the `AnimatePresence` key, so "Show less" remounts
  instead of running 35 simultaneous 0.4s height exits.
- Collapsing calls `scrollIntoView({ block: 'nearest' })` from a **layout**
  effect. Chrome's native scroll anchoring would cover this, but WebKit has
  never shipped `overflow-anchor` and iOS is the target. Verified: the toggle
  stays in view (347px -> 310px) after collapsing a 14-row bucket.
- Confirmed by touch-tap probe that `:focus-visible` does not match on tap
  (`boxShadow: none`), so the global inset focus ring is keyboard-only. Kept.

## Testing

- `pnpm check` passes end to end: typecheck, lint, tests, i18n, and all three
  boundary guards.
- 10 new tests in `packages/components/tests/mobile-chat-list-preview-cap.test.tsx`
  covering the cap, opt-out, root counting vs raw-row counting, opener groups
  surviving the cut, pinned-first truncation, the shared-atom isolation, the
  multi-select suspension, and the scroll anchoring. No real sleeps — the
  long-press test drives `vi.useFakeTimers()`.
- Storybook: `GroupPreviewOverflow` and `GroupPreviewExpanded`.

## Related

Same batch, all independently reviewable and mergeable — no overlapping files
with this PR: #317 (mobile eager-sync staging), #319 (Live Activity throttling),
#320 (login white flash).

Model: claude-opus-5[1m]
