### PR TITLE
feat(cli): warn when the agent's run config differs from the request

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -274,12 +274,19 @@ Two things the dev build does deliberately, both load-bearing:
   through `resolvePerModelConfigOptionSelection` for the same exemption, because a
   per-model option's ABSENCE from the snapshot is exactly what the probed model's
   lack of the control looks like and can never be the reason to reject another
-  model's turn. Runtime rejections remain in debug diagnostics; Codex/Claude mismatches
-  for model, reasoning effort, Fast, or Plan are not promoted to visible
-  `agent_warning` notices, while other rejected selections still are. Compatibility exception: Claude
-  Fable models omit the Fast mode option, so an explicit `fast=false` is skipped as
-  an already-effective no-op; `fast=true` must still be dispatched and retained in debug
-  diagnostics if rejected.
+  model's turn. Runtime rejections remain in debug diagnostics; what becomes a visible
+  `agent_warning` is DIVERGENCE — the state the agent publishes after applying the
+  turn's config contradicts what was requested. A rejection is not that signal in
+  either direction: Codex accepts `fast-mode` on a model with no fast speed tier and
+  then omits the option from its published state, so the state is the only evidence
+  Fast is off, while a rejected value that was already effective changed nothing and
+  must stay silent. Only where the agent published no config options at all (or for a
+  sensitive id, which the runtime state deliberately omits) does the failed call
+  remain the sole signal. Do not restore a per-agent suppression list: it silenced
+  exactly the per-model controls users most need told about. Compatibility exception:
+  Claude Fable models omit the Fast mode option, so an explicit `fast=false` is
+  skipped as an already-effective no-op and is judged for neither; `fast=true` must
+  still be dispatched and retained in debug diagnostics if rejected.
 - MCP `session_list` defaults to 20 (maximum 100), and `session_history` defaults to 10
   (maximum 50 and 128 KiB). Keep the MCP surface bounded even though the human CLI retains
   `session history --all`. `session_list` and `session_status_many` derive busy/idle from

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -1744,9 +1744,9 @@ export class MessageHandler {
       // Not awaited: this is reporting, and the prompt hot path must not block
       // on a history write.
       void this.recordAgentWarning(session.sessionId, {
-        message: `The agent rejected part of the requested run configuration (${warningSelections.join(
+        message: `The agent did not apply part of the requested run configuration (${warningSelections.join(
           ', '
-        )}) and is using its own values instead. Reasoning effort and fast mode depend on the selected model.`,
+        )}) and is running with its own values instead. Reasoning effort and fast mode depend on the selected model.`,
         source: 'configWarning',
       });
     }

--- a/apps/cli/src/session/acp-session-config-applier.test.ts
+++ b/apps/cli/src/session/acp-session-config-applier.test.ts
@@ -109,60 +109,121 @@ describe('applyAcpSessionRunConfig', () => {
     expect(vi.mocked(logger.debug).mock.calls.flat().join('\n')).not.toContain('private-value');
   });
 
-  it.each(['codex', 'claude'])(
-    'suppresses known %s run-config mismatch warnings while retaining rejection diagnostics',
-    async (agentType) => {
-      const reject = vi.fn(async () => {
-        throw new Error('rejected');
-      });
-      const agentClient = {
-        isCreated: () => true,
-        getConfigOptions: () => [
-          { id: 'effort', category: 'thought_level' },
-          { id: 'fast', category: 'fast-mode' },
-          { id: 'collaboration_mode', category: 'collaboration_mode' },
-          { id: 'custom-option', category: 'custom' },
-        ],
-        setSessionMode: reject,
-        unstable_setSessionModel: reject,
-        setSessionConfigOption: reject,
-      } as unknown as AgentClient;
+  it('reports a selection the agent accepted but dropped from its own state', async () => {
+    // The codex shape: `fast-mode` is accepted without error on a model with no
+    // fast speed tier, and simply does not come back in the published state, so
+    // the turn runs at normal speed with nothing thrown.
+    const agentClient = {
+      isCreated: () => true,
+      getConfigOptions: () => [
+        { id: 'model', category: 'model', type: 'select', currentValue: 'gpt-5.2' },
+        {
+          id: 'reasoning_effort',
+          category: 'thought_level',
+          type: 'select',
+          currentValue: 'high',
+        },
+      ],
+      unstable_setSessionModel: vi.fn(async () => undefined),
+      setSessionConfigOption: vi.fn(async () => undefined),
+    } as unknown as AgentClient;
 
-      await expect(
-        applyAcpSessionRunConfig({
-          session: {
-            sessionId: 'session-3' as SessionId,
-            acpSessionId: 'acp-3' as ACPSessionId,
-            agentClient,
-          },
-          config: {
-            cliType: 'builtin',
-            agentType,
-            modeId: 'plan',
-            modelId: 'model-a',
-            configOptionValues: {
-              effort: 'high',
-              fast: false,
-              collaboration_mode: 'plan',
-              'custom-option': 'enabled',
-            },
-          },
-          logger: createLogger(),
-        })
-      ).resolves.toEqual({
-        rejectedSelections: [
-          'mode="plan"',
-          'model="model-a"',
-          'effort="high"',
-          'fast=false',
-          'collaboration_mode="plan"',
-          'custom-option="enabled"',
-        ],
-        warningSelections: ['custom-option="enabled"'],
-        runtimeConfigPatch: { acpSessionId: 'acp-3', configOptionValues: {} },
-      });
-    }
-  );
+    await expect(
+      applyAcpSessionRunConfig({
+        session: {
+          sessionId: 'session-3' as SessionId,
+          acpSessionId: 'acp-3' as ACPSessionId,
+          agentClient,
+        },
+        config: {
+          cliType: 'builtin',
+          agentType: 'codex',
+          modelId: 'gpt-5.2',
+          configOptionValues: { reasoning_effort: 'high', 'fast-mode': true },
+        },
+        logger: createLogger(),
+      })
+    ).resolves.toEqual({
+      // Nothing was rejected, so diagnostics stay empty: the published state is
+      // the only evidence Fast is not running.
+      rejectedSelections: [],
+      warningSelections: ['fast-mode=true'],
+      runtimeConfigPatch: {
+        acpSessionId: 'acp-3',
+        modelId: 'gpt-5.2',
+        configOptionValues: { model: 'gpt-5.2', reasoning_effort: 'high' },
+      },
+    });
+  });
+
+  it('stays quiet when a rejected selection was already effective', async () => {
+    const agentClient = {
+      isCreated: () => true,
+      getConfigOptions: () => [
+        { id: 'fast', category: 'model_config', type: 'boolean', currentValue: false },
+        {
+          id: 'effort',
+          category: 'thought_level',
+          type: 'select',
+          currentValue: 'high',
+        },
+      ],
+      setSessionConfigOption: vi.fn(async () => {
+        throw new Error('rejected');
+      }),
+    } as unknown as AgentClient;
+
+    await expect(
+      applyAcpSessionRunConfig({
+        session: {
+          sessionId: 'session-6' as SessionId,
+          acpSessionId: 'acp-6' as ACPSessionId,
+          agentClient,
+        },
+        config: {
+          cliType: 'builtin',
+          agentType: 'claude',
+          configOptionValues: { fast: false, effort: 'low' },
+        },
+        logger: createLogger(),
+      })
+    ).resolves.toEqual({
+      rejectedSelections: ['fast=false', 'effort="low"'],
+      // `fast` already held the requested value, so the rejection changed
+      // nothing; `effort` did not, so it is worth saying.
+      warningSelections: ['effort="low"'],
+      runtimeConfigPatch: {
+        acpSessionId: 'acp-6',
+        configOptionValues: { fast: false, effort: 'high' },
+      },
+    });
+  });
+
+  it('treats an on/off select and a boolean toggle as the same choice', async () => {
+    const agentClient = {
+      isCreated: () => true,
+      getConfigOptions: () => [
+        { id: 'fast', category: 'model_config', type: 'select', currentValue: 'on' },
+      ],
+      setSessionConfigOption: vi.fn(async () => undefined),
+    } as unknown as AgentClient;
+
+    await expect(
+      applyAcpSessionRunConfig({
+        session: {
+          sessionId: 'session-7' as SessionId,
+          acpSessionId: 'acp-7' as ACPSessionId,
+          agentClient,
+        },
+        config: { cliType: 'builtin', agentType: 'claude', configOptionValues: { fast: true } },
+        logger: createLogger(),
+      })
+    ).resolves.toEqual({
+      rejectedSelections: [],
+      warningSelections: [],
+      runtimeConfigPatch: { acpSessionId: 'acp-7', configOptionValues: { fast: 'on' } },
+    });
+  });
 
   it('keeps known run-config rejection warnings for other agents', async () => {
     const agentClient = {

--- a/apps/cli/src/session/acp-session-config-applier.ts
+++ b/apps/cli/src/session/acp-session-config-applier.ts
@@ -1,9 +1,7 @@
 import {
-  ACP_PLAN_PERMISSION_MODE_ID,
-  ACP_REASONING_EFFORT_CONFIG_ID,
+  ACP_CONFIG_OPTION_OFF_VALUE,
+  ACP_CONFIG_OPTION_ON_VALUE,
   isAcpFastModeConfigId,
-  isAcpPlanModeConfigOption,
-  isAcpThoughtLevelConfigOption,
   isSensitiveAcpConfigOptionId,
   type ACPSessionId,
   type AcpConfigOptionValue,
@@ -67,25 +65,54 @@ type AcpSessionRunConfigApplyResult = {
   runtimeConfigPatch: SessionAcpRuntimeConfigPatch | null;
 };
 
-function isCodexOrClaudeRunConfig(config: AcpSessionRunConfig): boolean {
-  return config.agentType === 'codex' || config.agentType === 'claude';
-}
-
-function isKnownRunConfigOption(
-  configId: string,
-  agentConfigOptions: ReadonlyArray<{ id: string; category?: string | null }>
+/** A boolean toggle and an `on`/`off` select express the same choice. */
+function configValuesMatch(
+  requested: AcpConfigOptionValue,
+  effective: AcpConfigOptionValue | undefined
 ): boolean {
-  if (
-    configId === ACP_REASONING_EFFORT_CONFIG_ID ||
-    isAcpFastModeConfigId(configId) ||
-    isAcpPlanModeConfigOption({ id: configId })
-  ) {
+  if (requested === effective) {
     return true;
   }
-  const option = agentConfigOptions.find((candidate) => candidate.id === configId);
-  return option
-    ? isAcpThoughtLevelConfigOption({ id: option.id, category: option.category ?? undefined })
-    : false;
+  const toggle = (value: boolean): string =>
+    value ? ACP_CONFIG_OPTION_ON_VALUE : ACP_CONFIG_OPTION_OFF_VALUE;
+  if (typeof requested === 'boolean' && typeof effective === 'string') {
+    return effective === toggle(requested);
+  }
+  if (typeof requested === 'string' && typeof effective === 'boolean') {
+    return requested === toggle(effective);
+  }
+  return false;
+}
+
+/** One requested selection, judged against the agent's own answer for it. */
+type AppliedSelection = {
+  /** Diagnostic label, already redacted for sensitive ids. */
+  label: string;
+  requested: AcpConfigOptionValue;
+  /** How to read the agent's state for this selection once everything is applied. */
+  source: { kind: 'mode' } | { kind: 'model' } | { kind: 'configOption'; configId: string };
+  /** The agent threw while applying it. */
+  rejected: boolean;
+};
+
+/**
+ * Whether the agent's post-apply state contradicts what the turn asked for.
+ *
+ * A rejection alone does not answer this, in either direction. Codex ACCEPTS
+ * `fast-mode` on a model without a fast speed tier and then simply omits the
+ * option from the state it publishes — the turn runs at normal speed and
+ * nothing threw — so the published state is the only evidence Fast is not on.
+ * Conversely a rejected selection that is already effective changed nothing and
+ * is not worth a notice. Only where the agent published nothing to compare
+ * against does the failed call remain the sole signal.
+ */
+function divergesFromAgentState(args: {
+  requested: AcpConfigOptionValue;
+  effective: AcpConfigOptionValue | undefined;
+  known: boolean;
+  rejected: boolean;
+}): boolean {
+  return args.known ? !configValuesMatch(args.requested, args.effective) : args.rejected;
 }
 
 export async function applyAcpSessionRunConfig(args: {
@@ -116,17 +143,10 @@ export async function applyAcpSessionRunConfig(args: {
   }
 
   const rejectedSelections: string[] = [];
-  const warningSelections: string[] = [];
+  const appliedSelections: AppliedSelection[] = [];
   let confirmedLegacyModeId: string | undefined;
   let confirmedLegacyModelId: string | undefined;
   const agentConfigOptions = agentClient.getConfigOptions?.() ?? [];
-  const suppressKnownRunConfigWarnings = isCodexOrClaudeRunConfig(config);
-  const recordRejection = (selection: string, suppressWarning: boolean): void => {
-    rejectedSelections.push(selection);
-    if (!suppressWarning) {
-      warningSelections.push(selection);
-    }
-  };
   const modeConfigId =
     agentConfigOptions.find((option) => option.category === 'mode')?.id ?? 'mode';
   const modelConfigId =
@@ -136,38 +156,57 @@ export async function applyAcpSessionRunConfig(args: {
     config.modelId ?? (typeof configOptionModelId === 'string' ? configOptionModelId : undefined);
 
   if (config.modeId) {
+    const label = `mode=${JSON.stringify(config.modeId)}`;
+    let rejected = false;
     try {
       await agentClient.setSessionMode?.(acpSessionId, config.modeId);
       confirmedLegacyModeId = config.modeId;
     } catch (error) {
-      recordRejection(
-        `mode=${JSON.stringify(config.modeId)}`,
-        suppressKnownRunConfigWarnings && config.modeId === ACP_PLAN_PERMISSION_MODE_ID
-      );
+      rejected = true;
+      rejectedSelections.push(label);
       logger.debug(
         `[${sessionId}] Failed to set ACP mode ${JSON.stringify(config.modeId)}: ${String(error)}`
       );
     }
+    appliedSelections.push({
+      label,
+      requested: config.modeId,
+      source: { kind: 'mode' },
+      rejected,
+    });
   }
   if (config.modelId) {
+    const label = `model=${JSON.stringify(config.modelId)}`;
+    let rejected = false;
     try {
       await agentClient.unstable_setSessionModel?.(acpSessionId, config.modelId);
       confirmedLegacyModelId = config.modelId;
     } catch (error) {
-      recordRejection(`model=${JSON.stringify(config.modelId)}`, suppressKnownRunConfigWarnings);
+      rejected = true;
+      rejectedSelections.push(label);
       logger.debug(
         `[${sessionId}] Failed to set ACP model ${JSON.stringify(config.modelId)}: ${String(error)}`
       );
     }
+    appliedSelections.push({
+      label,
+      requested: config.modelId,
+      source: { kind: 'model' },
+      rejected,
+    });
   }
 
   for (const [configId, value] of configOptionEntries) {
     if (configId === modeConfigId) {
+      // An explicit `config.modeId` outranks this duplicate, and is judged in
+      // its place: losing a precedence contest is not the agent disagreeing.
       if (!config.modeId && typeof value === 'string') {
+        let rejected = false;
         try {
           await agentClient.setSessionMode?.(acpSessionId, value);
           confirmedLegacyModeId = value;
         } catch (error) {
+          rejected = true;
           logger.debug(
             `[${sessionId}] Failed to set ACP mode option ${configId}=${formatAcpConfigValueForLog(
               configId,
@@ -175,15 +214,23 @@ export async function applyAcpSessionRunConfig(args: {
             )}: ${String(error)}`
           );
         }
+        appliedSelections.push({
+          label: `${configId}=${formatAcpConfigValueForLog(configId, value)}`,
+          requested: value,
+          source: { kind: 'mode' },
+          rejected,
+        });
       }
       continue;
     }
     if (configId === modelConfigId) {
       if (!config.modelId && typeof value === 'string') {
+        let rejected = false;
         try {
           await agentClient.unstable_setSessionModel?.(acpSessionId, value);
           confirmedLegacyModelId = value;
         } catch (error) {
+          rejected = true;
           logger.debug(
             `[${sessionId}] Failed to set ACP model option ${configId}=${formatAcpConfigValueForLog(
               configId,
@@ -191,21 +238,33 @@ export async function applyAcpSessionRunConfig(args: {
             )}: ${String(error)}`
           );
         }
+        appliedSelections.push({
+          label: `${configId}=${formatAcpConfigValueForLog(configId, value)}`,
+          requested: value,
+          source: { kind: 'model' },
+          rejected,
+        });
       }
       continue;
     }
     if (shouldSkipFableFastModeDisable({ modelId: targetModelId, configId, value })) {
       continue;
     }
+    const label = `${configId}=${formatAcpConfigValueForLog(configId, value)}`;
+    let rejected = false;
     try {
       await agentClient.setSessionConfigOption(acpSessionId, configId, value);
     } catch (error) {
-      recordRejection(
-        `${configId}=${formatAcpConfigValueForLog(configId, value)}`,
-        suppressKnownRunConfigWarnings && isKnownRunConfigOption(configId, agentConfigOptions)
-      );
+      rejected = true;
+      rejectedSelections.push(label);
       logger.debug(`[${sessionId}] Failed to set ACP config option ${configId}: ${String(error)}`);
     }
+    appliedSelections.push({
+      label,
+      requested: value,
+      source: { kind: 'configOption', configId },
+      rejected,
+    });
   }
 
   logger.debug(`[${sessionId}] applyAcpSessionRunConfig completed`);
@@ -228,6 +287,33 @@ export async function applyAcpSessionRunConfig(args: {
   if (confirmedLegacyModelId && !runtimeConfigPatch.modelId) {
     runtimeConfigPatch.modelId = confirmedLegacyModelId;
   }
+
+  // An agent that publishes no config options at all answered nothing here, and
+  // the effective table deliberately omits sensitive ids, so neither can be read
+  // as "the agent dropped it".
+  const publishesConfigOptions = agentConfigOptions.length > 0;
+  const effectiveConfigOptionValues = runtimeConfigPatch.configOptionValues ?? {};
+  const warningSelections = appliedSelections
+    .filter((selection) => {
+      const effective =
+        selection.source.kind === 'mode'
+          ? runtimeConfigPatch.modeId
+          : selection.source.kind === 'model'
+            ? runtimeConfigPatch.modelId
+            : effectiveConfigOptionValues[selection.source.configId];
+      const known =
+        selection.source.kind === 'configOption'
+          ? publishesConfigOptions && !isSensitiveAcpConfigOptionId(selection.source.configId)
+          : effective !== undefined;
+      return divergesFromAgentState({
+        requested: selection.requested,
+        effective,
+        known,
+        rejected: selection.rejected,
+      });
+    })
+    .map((selection) => selection.label);
+
   return {
     rejectedSelections,
     warningSelections,


### PR DESCRIPTION
Stacked on #316 — review that one first; the base flips to `main` once it merges.

## Problem

`applyAcpSessionRunConfig` decided a user-visible `agent_warning` from a REJECTION, then suppressed it for exactly the four controls users most need told about — model, reasoning effort, Fast, Plan — on Codex and Claude (`suppressKnownRunConfigWarnings && isKnownRunConfigOption(...)`). The suppression existed because those calls fail routinely when the turn config is re-sent every turn.

A rejection is the wrong signal, in both directions:

- **False negative.** Codex `applyFastModeChange` sets `fastModeEnabled` unconditionally — it ACCEPTS `fast-mode` on a model with no fast speed tier. Nothing throws; `createSessionConfigOptions` then omits the option and `resolveFastServiceTier` returns `null`, so the turn runs at normal speed and the user is told nothing. Even without the suppression, no rejection ever existed to report.
- **False positive.** A rejected value that was already effective changed nothing, and was reported.

## Fix

Key the notice off **divergence**: after applying the turn's config, compare each requested selection against the state the agent itself publishes (`runtimeConfigPatch`, already computed from `agentClient.getConfigOptions()`), and warn only where they disagree.

- An `on`/`off` select and a boolean toggle express the same choice, so neither shape alone counts as a divergence.
- An explicit `config.modeId`/`modelId` outranks a duplicate config-option entry; losing that precedence contest is not the agent disagreeing, so only the winner is judged.
- Where the agent published no config options at all — or for a sensitive id, which the runtime state deliberately omits — the failed call stays the only signal and is still used.
- `rejectedSelections` (debug diagnostics) is unchanged.

The notice text now says the agent *did not apply* part of the config rather than *rejected* it, which is what the new signal actually means.

Noise is bounded: the composer re-sends the state the agent reported, so an ordinary turn diverges nowhere, and `recordAgentWarning` already deduplicates by message per session — a stuck divergence costs one notice, not one per turn.

## Invariant change

`apps/cli/AGENTS.md` documented the old behavior ("Codex/Claude mismatches for model, reasoning effort, Fast, or Plan are not promoted to visible `agent_warning` notices"). That paragraph is rewritten to state the divergence rule, why a rejection is not it, and to say plainly that a per-agent suppression list must not come back. The Claude Fable `fast=false` no-op exception is preserved — it is skipped before dispatch, so it is judged for neither.

## Tests

`apps/cli/src/session/acp-session-config-applier.test.ts` — the two tests that encoded the suppression are replaced by ones for the new rule: a selection accepted but dropped from the agent's state (the Codex Fast shape, with empty `rejectedSelections`), a rejected selection that was already effective (silent), and the select/boolean equivalence. The four tests covering redaction, non-publishing agents, and other agent types are unchanged and still pass.

`pnpm --filter lody test` (2467), `typecheck`, `lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)