### PR TITLE
fix(sessions): stabilize child tab ordering

### DIFF
--- a/packages/components/src/atoms/doc-meta.ts
+++ b/packages/components/src/atoms/doc-meta.ts
@@ -354,7 +354,8 @@ const byCreatedAtAscending = (left: SessionMeta, right: SessionMeta): number =>
 
 // Child sessions for a given parent session — used by the multi-tab UI
 export const childSessionsAtomFamily = createChildSessionsAtomFamily(
-  (session, parentId) => isTopTabChild(session, parentId) && !session.isArchived
+  (session, parentId) => isTopTabChild(session, parentId) && !session.isArchived,
+  byCreatedAtAscending
 );
 
 // Archived child sessions for a given parent — used by the tab archive popover

--- a/packages/components/src/components/sessions/session-detail.tsx
+++ b/packages/components/src/components/sessions/session-detail.tsx
@@ -1894,6 +1894,7 @@ const SessionDetail = ({
       modelId: null,
     });
     setDraftTabs((prev) => [...prev, draft]);
+    setTabOrderState((prev) => (prev.includes(draft.id) ? prev : [...prev, draft.id]));
     if (isMobile) {
       setActiveViewerTabId(null);
     }

--- a/packages/components/src/components/sessions/session-detail.tsx
+++ b/packages/components/src/components/sessions/session-detail.tsx
@@ -186,6 +186,7 @@ import {
 import { useSessionDiffSummary } from './use-session-diff-summary';
 import { userAtom } from '@/atoms';
 import {
+  appendTabOrderId,
   createDraftSessionTab,
   filterPendingPromotedChildSessions,
   getDraftTabLabel,
@@ -1267,7 +1268,7 @@ const SessionDetail = ({
       });
       if (placement === 'tab') {
         setTabOrderState((current) =>
-          current.includes(targetSessionId) ? current : [...current, targetSessionId]
+          appendTabOrderId(current, sessionGroupIds, targetSessionId)
         );
       }
       if (response.partial && response.warnings.length > 0) {
@@ -1276,7 +1277,7 @@ const SessionDetail = ({
         );
       }
     },
-    [canForkSession, currentWorkspaceId, pendingForks, postHog, runtime, t, user?.id]
+    [canForkSession, currentWorkspaceId, pendingForks, postHog, runtime, sessionGroupIds, t, user?.id]
   );
   const pendingForkSourceByTargetSessionId = useMemo(() => {
     const sourceByTarget = new Map<SessionId, string>();
@@ -1894,7 +1895,7 @@ const SessionDetail = ({
       modelId: null,
     });
     setDraftTabs((prev) => [...prev, draft]);
-    setTabOrderState((prev) => (prev.includes(draft.id) ? prev : [...prev, draft.id]));
+    setTabOrderState((prev) => appendTabOrderId(prev, sessionGroupIds, draft.id));
     if (isMobile) {
       setActiveViewerTabId(null);
     }
@@ -1903,7 +1904,14 @@ const SessionDetail = ({
       draft_tab_id: draft.id,
       source_session_id: activeSession.id,
     });
-  }, [activeSession, captureSessionDetailEvent, isMobile, navigateToSessionTab, setDraftTabs]);
+  }, [
+    activeSession,
+    captureSessionDetailEvent,
+    isMobile,
+    navigateToSessionTab,
+    sessionGroupIds,
+    setDraftTabs,
+  ]);
 
   const handleDraftChange = useCallback(
     (draftId: DraftSessionTab['id'], patch: Partial<DraftSessionTab>) => {
@@ -2046,7 +2054,13 @@ const SessionDetail = ({
           setSessionChatInputTextDraft(childSessionId, payload.preservedInputText);
         }
         setDraftTabs((prev) => prev.filter((draft) => draft.id !== payload.draftId));
-        setTabOrderState((prev) => replaceTabOrderId(prev, payload.draftId, childSessionId));
+        setTabOrderState((prev) =>
+          replaceTabOrderId(
+            appendTabOrderId(prev, sessionGroupIds, payload.draftId),
+            payload.draftId,
+            childSessionId
+          )
+        );
         if (isMobile) {
           setActiveViewerTabId(null);
         }
@@ -2157,6 +2171,7 @@ const SessionDetail = ({
       navigateToSessionTab,
       openSettings,
       requestSessionDispatch,
+      sessionGroupIds,
       setDraftTabs,
       startSession,
       t,

--- a/packages/components/src/lib/session-draft-tabs.ts
+++ b/packages/components/src/lib/session-draft-tabs.ts
@@ -307,6 +307,28 @@ export const replaceTabOrderId = (
   return nextOrder.includes(nextId) ? nextOrder : [...nextOrder, nextId];
 };
 
+/** Adds a tab after the currently displayed fallback tabs without disturbing saved order. */
+export const appendTabOrderId = (
+  tabOrder: string[],
+  displayedTabIds: Iterable<string>,
+  nextId: string
+): string[] => {
+  const nextOrder = [...tabOrder];
+  const seen = new Set(nextOrder);
+
+  for (const id of displayedTabIds) {
+    if (!seen.has(id)) {
+      nextOrder.push(id);
+      seen.add(id);
+    }
+  }
+  if (!seen.has(nextId)) {
+    nextOrder.push(nextId);
+  }
+
+  return nextOrder;
+};
+
 export const removeTabOrderId = (tabOrder: string[], targetId: string): string[] =>
   tabOrder.filter((id) => id !== targetId);
 

--- a/packages/components/tests/doc-meta-session-list.test.ts
+++ b/packages/components/tests/doc-meta-session-list.test.ts
@@ -65,4 +65,32 @@ describe('sessionListAtom', () => {
     expect(store.get(sideSessionsAtomFamily(parentId)).map((item) => item.id)).toEqual([sideId]);
     expect(store.get(sessionListAtom).map((item) => item.id)).toEqual([parentId]);
   });
+
+  it('orders child tabs by creation time when no local tab order exists', () => {
+    const store = createStore();
+    const parentId = 'parent-session' as SessionId;
+    const olderChildId = 'older-child' as SessionId;
+    const newerChildId = 'newer-child' as SessionId;
+
+    store.set(sessionMetaCacheAtom, {
+      [getSessionRoomId(parentId)]: { ...session, id: parentId },
+      [getSessionRoomId(newerChildId)]: {
+        ...session,
+        id: newerChildId,
+        parentSessionId: parentId,
+        createdAt: '2026-07-19T00:02:00.000Z',
+      },
+      [getSessionRoomId(olderChildId)]: {
+        ...session,
+        id: olderChildId,
+        parentSessionId: parentId,
+        createdAt: '2026-07-19T00:01:00.000Z',
+      },
+    });
+
+    expect(store.get(childSessionsAtomFamily(parentId)).map((item) => item.id)).toEqual([
+      olderChildId,
+      newerChildId,
+    ]);
+  });
 });

--- a/packages/components/tests/session-draft-tabs.test.ts
+++ b/packages/components/tests/session-draft-tabs.test.ts
@@ -9,6 +9,7 @@ import type {
 } from '@lody/shared';
 
 import {
+  appendTabOrderId,
   buildDraftSessionAgentRolePatch,
   createDraftSessionTab,
   filterPendingPromotedChildSessions,
@@ -310,6 +311,17 @@ describe('session draft tabs', () => {
       'a',
       'session-2',
       'c',
+    ]);
+  });
+
+  it('seeds a missing order with displayed tabs before appending a new tab', () => {
+    const initialOrder = appendTabOrderId([], ['child-1', 'child-2'], 'draft:3');
+
+    expect(initialOrder).toEqual(['child-1', 'child-2', 'draft:3']);
+    expect(replaceTabOrderId(initialOrder, 'draft:3', 'child-3')).toEqual([
+      'child-1',
+      'child-2',
+      'child-3',
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Register newly created draft tabs in the local tab order immediately.
- Use creation time as the stable fallback order for child session tabs.
- Cover child-tab ordering when metadata reaches the cache out of order.

## Verification

- `git diff --check`
- Not run: targeted Vitest and component typecheck; workspace dependencies are not installed (`vitest` and `tsgo` unavailable).