### PR TITLE
fix(components): hide onboarding product preview on compact stages

### DIFF
--- a/packages/components/src/components/onboarding/onboarding-shell.tsx
+++ b/packages/components/src/components/onboarding/onboarding-shell.tsx
@@ -227,7 +227,11 @@ const STEP_COMPOSITION: Partial<Record<OnboardingStepKey, StageComposition>> = {
 
 const COMPACT_FORM =
   'max-[1080px]:left-[calc(50%_-_min(310px,43%))]! max-[1080px]:top-[9%]! max-[1080px]:bottom-[7%]! max-[1080px]:w-[min(620px,86%)]!';
-const COMPACT_CAMERA = 'max-[1080px]:opacity-20';
+// Below the two-column breakpoint the centred form overlaps the product and
+// the close-up frames an empty patch of the window, so the preview steps out
+// entirely. Opacity (not unmount) is what flips, keeping the camera mounted
+// and letting the existing 700ms fade carry the transition both ways.
+const COMPACT_CAMERA = 'max-[1080px]:opacity-0';
 
 const STEP_CONFIGURATION_STATE: Partial<Record<OnboardingStepKey, TourConfigurationState>> = {
   login: {

--- a/packages/components/src/stories/OnboardingProvidersStage.stories.tsx
+++ b/packages/components/src/stories/OnboardingProvidersStage.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { OnboardingShell, OnboardingShellHost } from '@/components/onboarding/onboarding-shell';
+import { TestCloudPlatformProvider } from '../../tests/test-platform';
+
+/**
+ * Renders the full onboarding stage for the providers step: the real
+ * `TourStill` product preview behind a mock of the "Connect a coding agent"
+ * form. Exists to eyeball the camera blur / veil treatment.
+ */
+const meta = {
+  title: 'Onboarding/ProvidersStage',
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const PROVIDER_ROWS = [
+  { name: 'Claude Code', subtitle: 'Claude', badge: 'Verified' },
+  { name: 'Codex', subtitle: 'Codex', badge: 'Checking' },
+  { name: 'Grok', subtitle: 'grok', badge: 'Untested' },
+];
+
+function MockProvidersForm() {
+  return (
+    <div className="flex flex-col gap-3">
+      {PROVIDER_ROWS.map((row) => (
+        <div
+          key={row.name}
+          className="group flex flex-wrap items-center gap-3 rounded-lg border border-border/60 bg-card/40 p-4 transition-colors"
+        >
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted/40">
+            <div className="h-5 w-5 rounded-full bg-foreground/70" />
+          </div>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-sm font-medium">{row.name}</span>
+            <span className="text-xs text-muted-foreground">{row.subtitle}</span>
+          </div>
+          <span className="inline-flex items-center gap-1 rounded-full border border-primary/35 bg-primary/8 px-2 py-0.5 text-[10px] text-primary">
+            {row.badge}
+          </span>
+          <span className="text-sm text-muted-foreground">Edit</span>
+          <span className="rounded-md border border-border/60 px-3 py-1 text-sm">Test</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export const ProvidersStep: Story = {
+  render: () => (
+    <TestCloudPlatformProvider>
+      <div className="relative h-screen w-full overflow-hidden bg-[#f7f5f2]">
+        <OnboardingShellHost>
+          <OnboardingShell
+            stepKey="providers"
+            eyebrow="Step 3 of 6"
+            title="Connect a coding agent"
+            description="Add an Agent now. Lody will continue setup and let you know if anything needs your attention."
+          >
+            <MockProvidersForm />
+          </OnboardingShell>
+        </OnboardingShellHost>
+      </div>
+    </TestCloudPlatformProvider>
+  ),
+};


### PR DESCRIPTION
## Summary

Onboarding's compact stage (≤1080px) hid the product preview at `opacity-20` but kept it crisp, so preview text read through the translucent form cards. The compact camera now fades out entirely (`opacity-0`): the centred form stands on the stage grid alone, and because opacity—not unmount—is what flips at the breakpoint, resizing across 1080px fades the preview back in smoothly with the camera still mounted and re-solving live.

Wide windows (>1080px) are byte-identical to before: the two-column shot, veil, and backdrop blur are untouched.

Also adds a Storybook story (`Onboarding/ProvidersStage`) that renders the real `TourStill` stage behind a mock providers form, so this treatment can be eyeballed and screenshotted without booting Electron.

## Test plan

- `pnpm check`
- Storybook `Onboarding/ProvidersStage` at 1440px (crisp preview, unchanged) and 1000px (preview faded out, no text bleed); resized across the breakpoint to confirm the fade
