### PR TITLE
fix(cli): support custom ACP history synchronization

### DIFF
--- a/apps/cli/src/lib/history-session-catalog-client.ts
+++ b/apps/cli/src/lib/history-session-catalog-client.ts
@@ -24,6 +24,7 @@ import {
   type ACPSessionId,
   getLocalProjectHistoryProviderKey,
   type LocalProjectHistoryProvider,
+  type CustomAcpLaunchSpec,
 } from '@lody/shared';
 import { LODY_EXTENSION_METHODS } from 'acp-extension-core';
 
@@ -126,11 +127,19 @@ type ResolvedHistoryACPProcessLaunch = Omit<ResolvedACPProcessLaunch, 'env'> & {
   env: NodeJS.ProcessEnv;
 };
 
+export type HistoryLaunchProvider = LocalProjectHistoryProvider & {
+  customAcp?: CustomAcpLaunchSpec;
+};
+
 export async function resolveHistoryACPProcessLaunch(args: {
-  provider: LocalProjectHistoryProvider;
+  provider: HistoryLaunchProvider;
   env?: NodeJS.ProcessEnv;
 }): Promise<ResolvedHistoryACPProcessLaunch> {
-  const launch = await resolveACPProcessLaunchAsync(args.provider);
+  const launch = await resolveACPProcessLaunchAsync({
+    cliType: args.provider.cliType,
+    agentType: args.provider.agentType,
+    customAcp: args.provider.customAcp,
+  });
   return {
     ...launch,
     env: mergeACPProcessEnv(launch, args.env ?? process.env),
@@ -138,7 +147,7 @@ export async function resolveHistoryACPProcessLaunch(args: {
 }
 
 async function createHistoryAcpConnection(args: {
-  provider: LocalProjectHistoryProvider;
+  provider: HistoryLaunchProvider;
   workdir: string;
   logger: Logger;
 }): Promise<HistoryAcpConnection> {
@@ -327,7 +336,7 @@ export function dedupeHistorySessionsById(sessions: SessionInfo[]): SessionInfo[
 }
 
 export async function listHistorySessionsForLocalProject(args: {
-  provider: LocalProjectHistoryProvider;
+  provider: HistoryLaunchProvider;
   rootPath: string;
   logger: Logger;
   requiredSessionIds?: readonly string[];
@@ -376,7 +385,7 @@ export async function listHistorySessionsForLocalProject(args: {
 }
 
 export async function loadHistorySessionReplay(args: {
-  provider: LocalProjectHistoryProvider;
+  provider: HistoryLaunchProvider;
   rootPath: string;
   acpSessionId: ACPSessionId;
   logger: Logger;

--- a/apps/cli/src/lib/history-session-catalog-client.ts
+++ b/apps/cli/src/lib/history-session-catalog-client.ts
@@ -25,6 +25,7 @@ import {
   getLocalProjectHistoryProviderKey,
   type LocalProjectHistoryProvider,
   type CustomAcpLaunchSpec,
+  type BuiltinRuntimeOverrides,
 } from '@lody/shared';
 import { LODY_EXTENSION_METHODS } from 'acp-extension-core';
 
@@ -129,6 +130,8 @@ type ResolvedHistoryACPProcessLaunch = Omit<ResolvedACPProcessLaunch, 'env'> & {
 
 export type HistoryLaunchProvider = LocalProjectHistoryProvider & {
   customAcp?: CustomAcpLaunchSpec;
+  runtimeOverrides?: BuiltinRuntimeOverrides;
+  env?: NodeJS.ProcessEnv;
 };
 
 export async function resolveHistoryACPProcessLaunch(args: {
@@ -139,10 +142,14 @@ export async function resolveHistoryACPProcessLaunch(args: {
     cliType: args.provider.cliType,
     agentType: args.provider.agentType,
     customAcp: args.provider.customAcp,
+    runtimeOverrides: args.provider.runtimeOverrides,
   });
   return {
     ...launch,
-    env: mergeACPProcessEnv(launch, args.env ?? process.env),
+    env: mergeACPProcessEnv(launch, {
+      ...(args.env ?? process.env),
+      ...(args.provider.env ?? {}),
+    }),
   };
 }
 

--- a/apps/cli/src/lib/local-project-history-sync-service.ts
+++ b/apps/cli/src/lib/local-project-history-sync-service.ts
@@ -578,7 +578,11 @@ export class LocalProjectHistorySyncService {
         candidate.cliType === this.provider.cliType &&
         candidate.agentType === this.provider.agentType
     );
-    const resolved = { ...this.provider, customAcp: config?.customAcp };
+    const resolved = {
+      ...this.provider,
+      customAcp: config?.customAcp,
+      env: config?.env,
+    };
     this.launchProvider = resolved;
     return resolved;
   }

--- a/apps/cli/src/lib/local-project-history-sync-service.ts
+++ b/apps/cli/src/lib/local-project-history-sync-service.ts
@@ -35,8 +35,10 @@ import {
 
 import type { LoroDocumentManager, SessionDocument } from '@/lib/loro/doc';
 import { readMachineLocalProjects, upsertMachineLocalProject } from '@/lib/local-project-meta';
+import { listMergedAgentConfigs } from '@/lib/agent-config-machine-flock';
 import {
   listHistorySessionsForLocalProject,
+  type HistoryLaunchProvider,
   loadHistorySessionReplay,
   MAX_LOCAL_PROJECT_HISTORY_CATALOG_SESSIONS,
 } from './history-session-catalog-client';
@@ -546,6 +548,7 @@ function buildExternalHistoryMeta(args: {
 export class LocalProjectHistorySyncService {
   private readonly provider: LocalProjectHistoryProvider;
   private readonly providerKey: string;
+  private launchProvider: HistoryLaunchProvider;
 
   constructor(
     private readonly manager: LoroDocumentManager,
@@ -559,6 +562,25 @@ export class LocalProjectHistorySyncService {
   ) {
     this.provider = provider;
     this.providerKey = getLocalProjectHistoryProviderKey(provider);
+    this.launchProvider = provider;
+  }
+
+  private async resolveLaunchProvider(): Promise<HistoryLaunchProvider> {
+    if (this.provider.cliType !== 'custom') {
+      return this.provider;
+    }
+    const configs = await listMergedAgentConfigs(this.manager.repo, this.context.workspaceId, [
+      this.context.machineId,
+    ]);
+    const config = configs.find(
+      (candidate) =>
+        candidate.machineId === this.context.machineId &&
+        candidate.cliType === this.provider.cliType &&
+        candidate.agentType === this.provider.agentType
+    );
+    const resolved = { ...this.provider, customAcp: config?.customAcp };
+    this.launchProvider = resolved;
+    return resolved;
   }
 
   async syncLocalProject(args: {
@@ -585,7 +607,8 @@ export class LocalProjectHistorySyncService {
     localProjectId: LocalProjectId;
     rootPath: string;
   }): Promise<LocalProjectHistoryCatalogResult> {
-    const snapshot = await this.listCatalogSnapshot(args);
+    this.launchProvider = await this.resolveLaunchProvider();
+    const snapshot = await this.listCatalogSnapshot(args, this.launchProvider);
     return await this.writeCatalogResult({
       localProjectId: args.localProjectId,
       sessions: snapshot.sessions,
@@ -644,6 +667,7 @@ export class LocalProjectHistorySyncService {
     const summary = emptySummary();
     const selectedIds = [...new Set(args.acpSessionIds)];
     summary.listed = selectedIds.length;
+    this.launchProvider = await this.resolveLaunchProvider();
     const snapshot = await this.listCatalogSnapshot({
       ...args,
       requiredSessionIds: selectedIds,
@@ -672,7 +696,7 @@ export class LocalProjectHistorySyncService {
           snapshot.existingByImportKey.get(importKey);
         if (!existing) {
           const replayNotifications = await loadHistorySessionReplay({
-            provider: this.provider,
+            provider: this.launchProvider,
             rootPath: args.rootPath,
             acpSessionId,
             logger: this.logger,
@@ -730,6 +754,7 @@ export class LocalProjectHistorySyncService {
     sessionId: SessionId;
     acpSessionId: string;
   }): Promise<LocalProjectHistoryConflictResolveResult> {
+    this.launchProvider = await this.resolveLaunchProvider();
     const snapshot = await this.listCatalogSnapshot({
       ...args,
       requiredSessionIds: [args.acpSessionId],
@@ -812,7 +837,7 @@ export class LocalProjectHistorySyncService {
 
     const acpSessionId = args.acpSessionId as unknown as ACPSessionId;
     const replayNotifications = await loadHistorySessionReplay({
-      provider: this.provider,
+      provider: this.launchProvider,
       rootPath: args.rootPath,
       acpSessionId,
       logger: this.logger,
@@ -906,13 +931,16 @@ export class LocalProjectHistorySyncService {
     });
   }
 
-  private async listCatalogSnapshot(args: {
-    localProjectId: LocalProjectId;
-    rootPath: string;
-    requiredSessionIds?: readonly string[];
-  }): Promise<HistoryCatalogSnapshot> {
+  private async listCatalogSnapshot(
+    args: {
+      localProjectId: LocalProjectId;
+      rootPath: string;
+      requiredSessionIds?: readonly string[];
+    },
+    provider: HistoryLaunchProvider = this.launchProvider
+  ): Promise<HistoryCatalogSnapshot> {
     const catalog = await listHistorySessionsForLocalProject({
-      provider: this.provider,
+      provider,
       rootPath: args.rootPath,
       logger: this.logger,
       requiredSessionIds: args.requiredSessionIds,
@@ -1124,7 +1152,7 @@ export class LocalProjectHistorySyncService {
     }
 
     const replayNotifications = await loadHistorySessionReplay({
-      provider: this.provider,
+      provider: this.launchProvider,
       rootPath: args.rootPath,
       acpSessionId: args.acpSessionId,
       logger: this.logger,

--- a/apps/cli/tests/history-session-catalog-client.test.ts
+++ b/apps/cli/tests/history-session-catalog-client.test.ts
@@ -234,6 +234,30 @@ describe('resolveHistoryACPProcessLaunch', () => {
     expect(historyLaunch.args).toEqual(['custom-acp-server.mjs', '--stdio']);
     expect(historyLaunch.env.PATH).toBe('/usr/bin');
   });
+
+  it('merges the authoritative custom ACP environment before spawning history', async () => {
+    const historyLaunch = await resolveHistoryACPProcessLaunch({
+      provider: {
+        cliType: 'custom',
+        agentType: 'my-agent',
+        customAcp: { command: process.execPath },
+        env: {
+          ACP_API_KEY: 'config-secret',
+          ACP_BASE_URL: 'https://config.example.test',
+          PATH: '/config/bin',
+        },
+      },
+      env: {
+        ACP_API_KEY: 'caller-secret',
+        PATH: '/caller/bin',
+      },
+    });
+
+    expect(historyLaunch.env.ACP_API_KEY).toBe('config-secret');
+    expect(historyLaunch.env.ACP_BASE_URL).toBe('https://config.example.test');
+    expect(historyLaunch.env.PATH).toBe('/config/bin');
+  });
+
   it('uses the same registry Interactive Claude npx launch as normal sessions', async () => {
     const provider = { cliType: 'registry', agentType: 'claude-p' } as const;
     const sessionLaunch = resolveACPProcessLaunch(provider);

--- a/apps/cli/tests/history-session-catalog-client.test.ts
+++ b/apps/cli/tests/history-session-catalog-client.test.ts
@@ -217,6 +217,23 @@ describe('resolveHistoryACPProcessLaunch', () => {
     expect(historyLaunch.env.PATH).toBe('/usr/bin');
   });
 
+  it('resolves a custom ACP launch from the provider launch spec', async () => {
+    const historyLaunch = await resolveHistoryACPProcessLaunch({
+      provider: {
+        cliType: 'custom',
+        agentType: 'my-agent',
+        customAcp: {
+          command: process.execPath,
+          args: ['custom-acp-server.mjs', '--stdio'],
+        },
+      },
+      env: { PATH: '/usr/bin' },
+    });
+
+    expect(historyLaunch.command).toBe(process.execPath);
+    expect(historyLaunch.args).toEqual(['custom-acp-server.mjs', '--stdio']);
+    expect(historyLaunch.env.PATH).toBe('/usr/bin');
+  });
   it('uses the same registry Interactive Claude npx launch as normal sessions', async () => {
     const provider = { cliType: 'registry', agentType: 'claude-p' } as const;
     const sessionLaunch = resolveACPProcessLaunch(provider);

--- a/packages/shared/src/node/local-project-control.ts
+++ b/packages/shared/src/node/local-project-control.ts
@@ -39,7 +39,7 @@ function isStringArray(value: unknown): value is string[] {
 function isLocalProjectHistoryProvider(value: unknown): boolean {
   return (
     isObjectRecord(value) &&
-    (value.cliType === 'builtin' || value.cliType === 'registry') &&
+    (value.cliType === 'builtin' || value.cliType === 'registry' || value.cliType === 'custom') &&
     typeof value.agentType === 'string' &&
     value.agentType.trim().length > 0
   );

--- a/packages/shared/tests/local-project-control.test.ts
+++ b/packages/shared/tests/local-project-control.test.ts
@@ -10,6 +10,10 @@ import {
 
 const codexProvider = { cliType: 'builtin', agentType: 'codex' } as const;
 const claudeProvider = { cliType: 'builtin', agentType: 'claude' } as const;
+const customProvider = {
+  cliType: 'custom',
+  agentType: 'custom-agent',
+} as const;
 
 describe('local project control request schema', () => {
   it('parses add request', () => {
@@ -196,6 +200,28 @@ describe('local project control request schema', () => {
       localProjectId: 'project-1',
       provider: codexProvider,
     });
+  });
+
+  it('parses custom provider history sync requests', () => {
+    const parsed = safeParseLocalProjectControlRequest(
+      JSON.stringify({
+        type: 'local-project/sync-history',
+        machineId: 'machine-1',
+        workspaceId: 'workspace-1',
+        localProjectId: 'project-1',
+        provider: customProvider,
+      })
+    );
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) {
+      return;
+    }
+    if (parsed.data.type !== 'local-project/sync-history') {
+      throw new Error(`Unexpected request type: ${parsed.data.type}`);
+    }
+
+    expect(parsed.data.provider).toEqual(customProvider);
   });
 
   it('parses Codex provider history import request with selected sessions', () => {


### PR DESCRIPTION
## Related issue

Closes #187

## Problem / pressure

The local-project history UI lists every agent configuration, including custom ACP agents, but the history sync launch path only received `cliType` and `agentType`. Builtin and registry agents can resolve their executables from static definitions; a custom agent's executable is stored in its machine-scoped `customAcp` configuration. As a result, every custom history sync failed before spawning the ACP process with `Custom ACP <agentType> has no launch command configured`.

## Summary

- Allow the local-project control guard to accept custom ACP history providers.
- Resolve the daemon-authoritative custom agent configuration for the requested machine and provider before history work starts.
- Thread the resolved `customAcp` launch spec through the shared history catalog client so session listing and replay use the same command and arguments as normal custom ACP sessions.
- Apply the resolved launch to sync, selected-session import, and conflict-resolution replay paths without widening the control-plane provider wire contract.
- Add regression coverage for custom launch resolution and custom history control requests.

## Before / after

| Before | After |
| ------ | ----- |
| Custom ACP providers appeared in local-project history settings but were rejected by the remote control guard or reached launch resolution without a command. | Custom providers pass the control boundary, and the owning daemon resolves their current machine-scoped `customAcp` command before spawning history ACP processes. |
| History listing/import/conflict resolution could never start a custom ACP process. | All history entry points share the resolved custom launch while builtin and registry behavior remains unchanged. |

## Test plan

- `corepack pnpm --filter acp-extension-core build` — passed, required local ACP package entry was built.
- `corepack pnpm --filter acp-extension-claude build` — passed, required local workspace entry was built.
- `corepack pnpm --filter lody typecheck` — passed.
- `corepack pnpm --filter @lody/shared typecheck` — passed.
- `corepack pnpm --filter lody exec vitest run tests/history-session-catalog-client.test.ts -t 'custom ACP'` — passed, 1 test.
- `corepack pnpm --filter @lody/shared exec vitest run tests/local-project-control.test.ts` — passed, 29 tests.
- `corepack pnpm --filter lody exec vitest run tests/local-project-history-sync-service.test.ts` — passed, 30 tests.
- Focused type-aware oxlint on changed CLI/shared files — 0 errors.
- Prettier checks on all changed files and `git diff --check` — passed.
- Full `@lody/shared` suite — 1,012 passed, 3 unrelated baseline failures (one local CLI host-lease assertion and two source-guard tests timed out); no changed history-control test failed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check `LocalProjectHistorySyncService.resolveLaunchProvider`, the three history operation paths, and `history-session-catalog-client.ts` to ensure only daemon-authoritative machine config supplies the custom command.
- **Decisions to challenge:** Confirm that resolving by machine plus `cliType:agentType` is the right identity boundary and that keeping `customAcp` out of the control-plane wire schema avoids trusting caller-supplied executable paths.
- **Plausible failures / evidence gaps:** The full shared suite retains three unrelated baseline failures; live spawning of a user-provided ACP server was not run, while the launch resolver regression verifies exact command and argv propagation.

### Authoring context

- **User goal / directives:** Make local-project history synchronization work for custom ACP agents using the command already stored in their agent configuration.
- **Constraints / non-goals:** Keep builtin and registry launches unchanged, do not accept executable paths from the RPC caller, do not duplicate the custom command in session metadata, and do not broaden the change beyond local-project history operations.
- **Risk-bearing decisions:** The daemon reads the merged config for the target machine and provider, then passes that trusted launch spec through list/replay; a missing config or command retains the existing clear failure instead of falling back.
- **Destructive or irreversible behavior:** None; this changes process-launch selection and adds tests only, with no persistence migration or user-data rewrite.
- **Deliberately not done or tested:** No live custom ACP server was launched and no full desktop build was run; focused type, lint, history-service, control-schema, and launch-resolution checks cover the changed paths.
- **Unknowns / confidence:** High confidence in the control and launch plumbing; the remaining uncertainty is compatibility with varied third-party custom ACP servers, which CI and maintainer review can exercise.

<!-- context-handoff:end -->