### PR TITLE
fix(electron): authenticate temporary signing keychain [risk:high]

### DIFF
--- a/patches/app-builder-lib@26.15.3.patch
+++ b/patches/app-builder-lib@26.15.3.patch
@@ -1,0 +1,27 @@
+diff --git a/out/codeSign/macCodeSign.js b/out/codeSign/macCodeSign.js
+index 922c5bc..3b3f7b4 100644
+--- a/out/codeSign/macCodeSign.js
++++ b/out/codeSign/macCodeSign.js
+@@ -156,9 +156,9 @@ async function createKeychain({ tmpDir, cscLink, cscKeyPassword, cscILink, cscI
+     if (cscIKeyPassword != null) {
+         cscPasswords.push(cscIKeyPassword);
+     }
+-    return await importCerts(keychainFile, certPaths, cscPasswords);
++    return await importCerts(keychainFile, certPaths, cscPasswords, keychainPassword);
+ }
+-async function importCerts(keychainFile, paths, keyPasswords) {
++async function importCerts(keychainFile, paths, keyPasswords, keychainPassword) {
+     var _a;
+     for (let i = 0; i < paths.length; i++) {
+         const password = (_a = keyPasswords[i]) !== null && _a !== void 0 ? _a : "";
+@@ -165,7 +165,9 @@ async function importCerts(keychainFile, paths, keyPasswords) {
+         await (0, builder_util_1.exec)("/usr/bin/security", ["import", paths[i], "-k", keychainFile, "-T", "/usr/bin/codesign", "-T", "/usr/bin/productbuild", "-P", password]);
+         // https://stackoverflow.com/questions/39868578/security-codesign-in-sierra-keychain-ignores-access-control-settings-and-ui-p
+         // https://github.com/electron-userland/electron-packager/issues/701#issuecomment-322315996
+-        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]);
++        // `-k` expects the keychain's own unlock password (as used by create-keychain/unlock-keychain above),
++        // not the imported item's password used by `security import -P`.
++        await (0, builder_util_1.exec)("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]);
+     }
+     return {
+         keychainFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ patchedDependencies:
   '@tanstack/router-generator@1.159.4':
     hash: 14fe630c2d7f306f8e60169e6a0116cf02de74368af213699cb449aeeecc663a
     path: patches/@tanstack__router-generator@1.159.4.patch
+  app-builder-lib@26.15.3:
+    hash: 80637977dda4ea924da866a67751774a621195429af5af0f103e9129b3bec57f
+    path: patches/app-builder-lib@26.15.3.patch
   loro-repo@0.20.0:
     hash: 74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357
     path: patches/loro-repo.patch
@@ -18393,7 +18396,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  app-builder-lib@26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
+  app-builder-lib@26.15.3(patch_hash=80637977dda4ea924da866a67751774a621195429af5af0f103e9129b3bec57f)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3):
     dependencies:
       '@electron/asar': 3.4.1
       '@electron/fuses': 1.8.0
@@ -19576,7 +19579,7 @@ snapshots:
 
   dmg-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=80637977dda4ea924da866a67751774a621195429af5af0f103e9129b3bec57f)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       fs-extra: 10.1.0
       js-yaml: 4.1.1
@@ -19695,7 +19698,7 @@ snapshots:
 
   electron-builder-squirrel-windows@26.15.3(dmg-builder@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=80637977dda4ea924da866a67751774a621195429af5af0f103e9129b3bec57f)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       electron-winstaller: 5.4.0
     transitivePeerDependencies:
@@ -19704,7 +19707,7 @@ snapshots:
 
   electron-builder@26.15.3(electron-builder-squirrel-windows@26.15.3):
     dependencies:
-      app-builder-lib: 26.15.3(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
+      app-builder-lib: 26.15.3(patch_hash=80637977dda4ea924da866a67751774a621195429af5af0f103e9129b3bec57f)(dmg-builder@26.15.3)(electron-builder-squirrel-windows@26.15.3)
       builder-util: 26.15.3
       builder-util-runtime: 9.7.0
       chalk: 4.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,6 +93,7 @@ packageExtensions:
 packageManagerStrictVersion: true
 
 patchedDependencies:
+  app-builder-lib@26.15.3: patches/app-builder-lib@26.15.3.patch
   '@better-auth/api-key@1.5.5': patches/@better-auth__api-key@1.5.5.patch
   '@better-auth/electron@1.5.5': patches/@better-auth__electron@1.5.5.patch
   '@pierre/diffs@1.0.10': patches/@pierre__diffs@1.0.10.patch


### PR DESCRIPTION
Risk: 🔴 high | Confidence: high — changes the macOS release-signing dependency path; verified with frozen installs in both public and cloud workspaces plus a direct createKeychain command-wiring assertion

## Summary

- backport electron-builder PR #10101 to app-builder-lib 26.15.3
- keep each certificate password scoped to security import -P
- pass the generated temporary-keychain password to security set-key-partition-list -k
- register the pnpm patch in the public workspace and lockfile

## Verification

- pnpm install --frozen-lockfile in a standalone public checkout
- direct createKeychain assertion confirms import uses the certificate password and partition-list uses the generated keychain password
- typecheck, lint, all non-Electron tests, Electron tests, i18n and repository-boundary checks passed

## Review focus

Confirm the compiled app-builder-lib backport matches upstream electron-builder/electron-builder#10101 and that no certificate password is exposed or reused as a keychain password.

Upstream: https://github.com/electron-userland/electron-builder/pull/10101