### PR TITLE
feat(components): add Zen layout mode

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -3304,6 +3304,7 @@
   "agents.acpBinary.installError": "Download failed",
   "commands.workspace.openSettings": "Open Settings",
   "commands.workspace.openAboutSettings": "About Lody",
+  "commands.layout.toggleZenMode": "Toggle Zen Layout",
   "commands.session.new": "New Chat",
   "commands.project.importLocal": "Import Local Project",
   "sessions.currentBranchUnavailable": "No current branch to copy",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -3304,6 +3304,7 @@
   "agents.acpBinary.installError": "下载失败",
   "commands.workspace.openSettings": "打开设置",
   "commands.workspace.openAboutSettings": "关于 Lody",
+  "commands.layout.toggleZenMode": "切换 Zen 布局",
   "commands.session.new": "新建对话",
   "commands.project.importLocal": "导入本地项目",
   "sessions.currentBranchUnavailable": "没有可复制的当前分支",

--- a/packages/components/src/AGENTS.md
+++ b/packages/components/src/AGENTS.md
@@ -20,6 +20,18 @@ Parent `AGENTS.md` files also apply.
   intercepted. Nested parent scopes yield to their visible child scopes, and an
   open dialog's scopes never switch focus into the background workspace.
 
+## Zen layout
+
+- `zenLayoutModeAtom` is a transient visibility override, never a persisted sidebar
+  preference. Entering or leaving Zen must not write `sidebarCollapsedAtom` or a
+  Session's persisted right-panel `open` state, so the exact pre-Zen layout restores.
+- An explicit request to show either sidebar exits Zen and reveals that sidebar. Use
+  the shared layout-state actions for the navigation sidebar; every Session action
+  that opens a viewer, Files, Changes, PR, Browser, or Side Chat must clear Zen.
+- Drive hidden-panel work from effective visibility (`open && !zen`), not the stored
+  open bit. A Zen-hidden PR, Browser, viewer, or Side Chat must pause exactly like an
+  ordinarily collapsed right panel.
+
 ## Workspace transitions
 
 - Authenticated workspace switches keep `MainLayout` mounted: the sidebar and

--- a/packages/components/src/atoms/index.ts
+++ b/packages/components/src/atoms/index.ts
@@ -14,6 +14,7 @@ export * from './machine-flock';
 export * from './control-connection';
 export * from './local-storage-cache';
 export * from './sidebar-state';
+export * from './layout-state';
 export * from './settings-machine-tab';
 export * from './focus-layer';
 export * from './onboarding';

--- a/packages/components/src/atoms/layout-state.ts
+++ b/packages/components/src/atoms/layout-state.ts
@@ -1,0 +1,47 @@
+import { atom } from 'jotai';
+import { sidebarCollapsedAtom } from './sidebar-state';
+
+/**
+ * Zen is a transient visibility override for the current app window. The
+ * persisted sidebar preferences remain untouched so leaving Zen restores the
+ * exact layout each surface already owns.
+ */
+export const zenLayoutModeAtom = atom(false);
+
+export const navigationSidebarHiddenAtom = atom(
+  (get) => get(zenLayoutModeAtom) || get(sidebarCollapsedAtom)
+);
+
+export type ZenAwarePanelState = {
+  zenMode: boolean;
+  panelOpen: boolean;
+};
+
+/** A panel toggle made during Zen means "leave Zen and reveal this panel". */
+export function getZenAwarePanelToggleState({
+  zenMode,
+  panelOpen,
+}: ZenAwarePanelState): ZenAwarePanelState {
+  return {
+    zenMode: false,
+    panelOpen: zenMode ? true : !panelOpen,
+  };
+}
+
+export const toggleZenLayoutModeAtom = atom(null, (get, set) => {
+  set(zenLayoutModeAtom, !get(zenLayoutModeAtom));
+});
+
+export const showNavigationSidebarAtom = atom(null, (_get, set) => {
+  set(zenLayoutModeAtom, false);
+  set(sidebarCollapsedAtom, false);
+});
+
+export const toggleNavigationSidebarAtom = atom(null, (get, set) => {
+  const next = getZenAwarePanelToggleState({
+    zenMode: get(zenLayoutModeAtom),
+    panelOpen: !get(sidebarCollapsedAtom),
+  });
+  set(zenLayoutModeAtom, next.zenMode);
+  set(sidebarCollapsedAtom, !next.panelOpen);
+});

--- a/packages/components/src/atoms/sidebar-state.ts
+++ b/packages/components/src/atoms/sidebar-state.ts
@@ -213,13 +213,6 @@ export const sidebarCollapsedAtom = atomWithStorage<boolean>('lody-sidebar-colla
  */
 export const sidebarLastWidthAtom = atomWithStorage<number>('lody-sidebar-last-width', 0);
 
-/**
- * Toggle the collapsed state.
- */
-export const toggleSidebarCollapsedAtom = atom(null, (get, set) => {
-  set(sidebarCollapsedAtom, !get(sidebarCollapsedAtom));
-});
-
 // ============================================================================
 // Sidebar Organize Mode (Workspace vs Updated)
 // ============================================================================

--- a/packages/components/src/components/app-commands.tsx
+++ b/packages/components/src/components/app-commands.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from '@tanstack/react-router';
 import { useAtomValue, useSetAtom } from 'jotai';
 import { useTranslation } from 'react-i18next';
-import { currentWorkspaceSlugAtom, settingsDialogOpenAtom } from '@/atoms';
+import { currentWorkspaceSlugAtom, settingsDialogOpenAtom, toggleZenLayoutModeAtom } from '@/atoms';
 import { taskQuickAddOpenAtom } from '@/atoms/tasks';
 import { tasksFeatureEnabledAtom } from '@/atoms/settings';
 import { getCommandKeybindings, useCommand } from '@/lib/commands';
@@ -26,6 +26,7 @@ export function AppCommands() {
   const settingsModalOpen = useAtomValue(settingsDialogOpenAtom);
   const { openSettings, closeSettings } = useOpenSettings();
   const { theme, setTheme } = useTheme();
+  const toggleZenLayoutMode = useSetAtom(toggleZenLayoutModeAtom);
 
   // window.history.back()/forward() (not router.history — TanStack doesn't expose it);
   // both are safe no-ops at the history boundaries, so no `when` gating is needed.
@@ -53,6 +54,15 @@ export function AppCommands() {
     run: () => {
       setTheme(nextCycledTheme(theme));
     },
+  });
+
+  useCommand({
+    id: 'layout.toggleZenMode',
+    title: t('commands.layout.toggleZenMode', 'Toggle Zen Layout'),
+    category: 'View',
+    keybindings: getCommandKeybindings('layout.toggleZenMode'),
+    when: () => !isMobile,
+    run: () => toggleZenLayoutMode(),
   });
 
   // ⌘, toggles settings: open from anywhere (remembering where we came from so the

--- a/packages/components/src/components/archive/web-archive-screen.tsx
+++ b/packages/components/src/components/archive/web-archive-screen.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from 'react';
-import { useAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { Archive, ChevronDown, PanelLeft, Trash2, Undo2, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
-import { sidebarCollapsedAtom } from '@/atoms/sidebar-state';
+import { navigationSidebarHiddenAtom, showNavigationSidebarAtom } from '@/atoms/layout-state';
 import { isMacOSElectronRenderer, useElectronFullscreen } from '@/lib/electron';
 import { useWindowDragRegionClass, useWindowsCaptionPadClass } from '@/ui/window-drag-region';
 import { isNativeAppShell } from '@/lib/native-platform';
@@ -49,7 +49,8 @@ export function WebArchiveScreen({
   children,
 }: WebArchiveScreenProps) {
   const { t } = useTranslation();
-  const [isLeftSidebarCollapsed, setLeftSidebarCollapsed] = useAtom(sidebarCollapsedAtom);
+  const isLeftSidebarHidden = useAtomValue(navigationSidebarHiddenAtom);
+  const showNavigationSidebar = useSetAtom(showNavigationSidebarAtom);
   const isElectronFullscreen = useElectronFullscreen();
   const windowDragClass = useWindowDragRegionClass();
   const windowsCaptionPadClass = useWindowsCaptionPadClass();
@@ -66,17 +67,17 @@ export function WebArchiveScreen({
         <header
           className={cn(
             'flex h-[calc(2.75rem+var(--safe-area-top))] w-full shrink-0 items-center gap-3 border-b border-border bg-background pl-[calc(16px+var(--safe-area-left))] pr-[calc(16px+var(--safe-area-right))] pt-[var(--safe-area-top)]',
-            isLeftSidebarCollapsed && hasMacOSTitlebarInset && 'pl-[4.5rem]',
+            isLeftSidebarHidden && hasMacOSTitlebarInset && 'pl-[4.5rem]',
             windowDragClass,
             windowsCaptionPadClass
           )}
         >
-          {isLeftSidebarCollapsed ? (
+          {isLeftSidebarHidden ? (
             <Button
               type="button"
               variant="ghost"
               size="icon"
-              onClick={() => setLeftSidebarCollapsed(false)}
+              onClick={() => showNavigationSidebar()}
               aria-label={t('sessions.leftSidebar.show', 'Show navigation sidebar')}
               className="-ml-1 h-7 w-7 shrink-0 text-muted-foreground"
             >

--- a/packages/components/src/components/chat/chat-landing.tsx
+++ b/packages/components/src/components/chat/chat-landing.tsx
@@ -71,7 +71,8 @@ import {
   mobileKeyboardActionAtom,
   runtimeInitializingAtom,
   setMobileDrawerOpenAtom,
-  sidebarCollapsedAtom,
+  navigationSidebarHiddenAtom,
+  showNavigationSidebarAtom,
   tasksFeatureEnabledAtom,
   userAtom,
   workspaceReposCacheAtomFamily,
@@ -921,8 +922,8 @@ function WorkspaceChatLanding({
   } = useSessionActions();
   const openMobileDrawer = useSetAtom(setMobileDrawerOpenAtom);
   const setBugReportDialogOpen = useSetAtom(bugReportDialogOpenAtom);
-  const isLeftSidebarCollapsed = useAtomValue(sidebarCollapsedAtom);
-  const setLeftSidebarCollapsed = useSetAtom(sidebarCollapsedAtom);
+  const isLeftSidebarHidden = useAtomValue(navigationSidebarHiddenAtom);
+  const showNavigationSidebar = useSetAtom(showNavigationSidebarAtom);
   const visibleLocalMachineId = useMemo(() => {
     const machineId = localProbeResult?.machineId as MachineId | undefined;
     return machineId && machines.has(machineId) ? machineId : null;
@@ -6559,12 +6560,12 @@ function WorkspaceChatLanding({
         onGoToAgentSettings={handleGoToAgentSettings}
         onOpenMobileDrawer={() => openMobileDrawer(true)}
         leftSidebarExpandSlot={
-          !isMobile && isLeftSidebarCollapsed ? (
+          !isMobile && isLeftSidebarHidden ? (
             <Button
               type="button"
               variant="ghost"
               size="icon"
-              onClick={() => setLeftSidebarCollapsed(false)}
+              onClick={() => showNavigationSidebar()}
               aria-label={t('chat.leftSidebar.show', 'Show navigation sidebar')}
               className="h-7 w-7 shrink-0 text-muted-foreground"
             >

--- a/packages/components/src/components/sessions/session-detail.tsx
+++ b/packages/components/src/components/sessions/session-detail.tsx
@@ -88,7 +88,12 @@ import {
 } from '@/components/terminal/terminal-controller';
 import { isElectronRenderer, isMacOSElectronRenderer, useElectronFullscreen } from '@/lib/electron';
 import { useWindowsCaptionPadClass } from '@/ui/window-drag-region';
-import { sidebarCollapsedAtom } from '@/atoms/sidebar-state';
+import {
+  getZenAwarePanelToggleState,
+  navigationSidebarHiddenAtom,
+  showNavigationSidebarAtom,
+  zenLayoutModeAtom,
+} from '@/atoms/layout-state';
 import { memo, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { useDocumentTitle } from '@/hooks/use-document-title';
 import { useTabStatus, type TabStatus } from '@/hooks/use-tab-status';
@@ -686,6 +691,8 @@ const SessionDetail = ({
   const router = useRouter();
   const postHog = usePostHog();
   const isMobile = useIsMobile();
+  const isZenLayoutMode = useAtomValue(zenLayoutModeAtom);
+  const setZenLayoutMode = useSetAtom(zenLayoutModeAtom);
   const hidesBillingUi = isMobile || isNativeAppShell();
   const { openSettings } = useOpenSettings();
   const isElectronFullscreen = useElectronFullscreen();
@@ -708,6 +715,11 @@ const SessionDetail = ({
     oneActiveSurface: isMobile,
   });
   const [isSidebarOpen, setIsSidebarOpen] = useState(() => initialTabState.sidePanel.open);
+  const isSidebarVisible = isSidebarOpen && !isZenLayoutMode;
+  const revealRightSidebar = useCallback(() => {
+    setZenLayoutMode(false);
+    setIsSidebarOpen(true);
+  }, [setZenLayoutMode]);
   /* Bumped whenever `isSidebarOpen` changes because side-panel state was
      RESTORED (session switch, `?pr=` deep link) rather than toggled by the
      user, so the desktop layout snaps the panel to its target width instead of
@@ -795,8 +807,8 @@ const SessionDetail = ({
   const atomWorkspaceSlug = useAtomValue(currentWorkspaceSlugAtom);
   const workspaceSlug = routeTargetWorkspaceSlug ?? atomWorkspaceSlug;
   const currentWorkspaceId = useAtomValue(currentWorkspaceIdAtom) as WorkspaceId | null;
-  const isLeftSidebarCollapsed = useAtomValue(sidebarCollapsedAtom);
-  const setLeftSidebarCollapsed = useSetAtom(sidebarCollapsedAtom);
+  const isLeftSidebarHidden = useAtomValue(navigationSidebarHiddenAtom);
+  const showNavigationSidebar = useSetAtom(showNavigationSidebarAtom);
   const runtime = useAtomValue(activeWorkspaceRuntimeAtom);
   const runtimeInitializing = useAtomValue(runtimeInitializingAtom);
   const localMachineId = useAtomValue(localMachineIdAtom);
@@ -851,7 +863,7 @@ const SessionDetail = ({
     [viewerTabs]
   );
   const isFileProviderSidebarActive =
-    isSidebarOpen && (activeSidebarTab === 'files' || activeSidebarTab === 'changes');
+    isSidebarVisible && (activeSidebarTab === 'files' || activeSidebarTab === 'changes');
   const isSessionStateCurrent = localStateSessionId === sessionId;
   const activeSessionFileProviderRequested = Boolean(
     activeSession &&
@@ -2702,10 +2714,10 @@ const SessionDetail = ({
         setActiveViewerTabId((prevActiveId) => (prevActiveId === tab.id ? prevActiveId : tab.id));
       } else {
         selectSidePanelTab(tab.id);
-        setIsSidebarOpen(true);
+        revealRightSidebar();
       }
     },
-    [isMobile, selectSidePanelTab]
+    [isMobile, revealRightSidebar, selectSidePanelTab]
   );
 
   const nextFocusRequestSeq = useCallback(() => {
@@ -2958,7 +2970,7 @@ const SessionDetail = ({
         surface: 'mobile_sheet',
       });
     } else {
-      setIsSidebarOpen(true);
+      revealRightSidebar();
       activateSidebarTab('changes');
       captureSessionDetailEvent('session/sidebar_tab_selected', {
         source: 'info_bar_diff_stat',
@@ -2972,6 +2984,7 @@ const SessionDetail = ({
     changeFilePaths,
     isMobile,
     nextFocusRequestSeq,
+    revealRightSidebar,
   ]);
 
   const handleOpenPrTab = useCallback(
@@ -2991,7 +3004,7 @@ const SessionDetail = ({
             minWidthPx: PR_SIDEBAR_MIN_WIDTH_PX,
           }));
         }
-        setIsSidebarOpen(true);
+        revealRightSidebar();
         activateSidebarTab('pr');
       }
       captureSessionDetailEvent('session/pr_tab_opened', {
@@ -3008,6 +3021,7 @@ const SessionDetail = ({
       isMobile,
       isSidebarOpen,
       replaceSessionUrlPr,
+      revealRightSidebar,
     ]
   );
 
@@ -3068,7 +3082,7 @@ const SessionDetail = ({
       if (isMobile) {
         replaceSessionUrlBrowser(true, { push: true });
       } else {
-        setIsSidebarOpen(true);
+        revealRightSidebar();
         activateSidebarTab('browser');
       }
       captureSessionDetailEvent('session/browser_tab_opened', {
@@ -3082,6 +3096,7 @@ const SessionDetail = ({
       captureSessionDetailEvent,
       isMobile,
       navigateToSessionTab,
+      revealRightSidebar,
       replaceSessionUrlBrowser,
     ]
   );
@@ -3310,7 +3325,7 @@ const SessionDetail = ({
       if (!taken) return;
       if (taken.placement === 'side-panel') {
         selectSidePanelTab(getSideSessionPanelTabId(targetSessionId));
-        setIsSidebarOpen(true);
+        revealRightSidebar();
         return;
       }
       if (taken.placement === 'worktree') {
@@ -3324,7 +3339,14 @@ const SessionDetail = ({
       }
       handleSessionTabSelect(targetSessionId);
     },
-    [handleSessionTabSelect, router, selectSidePanelTab, takePendingFork, workspaceSlug]
+    [
+      handleSessionTabSelect,
+      revealRightSidebar,
+      router,
+      selectSidePanelTab,
+      takePendingFork,
+      workspaceSlug,
+    ]
   );
   const handleForkedConversationPrepareError = useCallback(
     (sourceSessionId: string, targetSessionId: SessionId) => {
@@ -3360,14 +3382,14 @@ const SessionDetail = ({
         setActiveViewerTabId(tabId);
       } else {
         selectSidePanelTab(tabId);
-        setIsSidebarOpen(true);
+        revealRightSidebar();
       }
       captureSessionDetailEvent('session/viewer_tab_selected', {
         viewer_tab_id: tabId,
         viewer_tab_type: tabId.startsWith('file:') ? 'file' : 'diff',
       });
     },
-    [captureSessionDetailEvent, isMobile, selectSidePanelTab]
+    [captureSessionDetailEvent, isMobile, revealRightSidebar, selectSidePanelTab]
   );
 
   const handleSidebarTabSelect = useCallback(
@@ -3591,13 +3613,27 @@ const SessionDetail = ({
   );
 
   const handleToggleSidebar = useCallback(() => {
-    const nextOpen = !isSidebarOpen;
-    captureSessionDetailEvent(nextOpen ? 'session/sidebar_opened' : 'session/sidebar_closed', {
-      default_tab: activeSidebarTab,
-      change_file_count: changeEntries.length,
+    const next = getZenAwarePanelToggleState({
+      zenMode: isZenLayoutMode,
+      panelOpen: isSidebarOpen,
     });
-    setIsSidebarOpen((prev) => !prev);
-  }, [activeSidebarTab, captureSessionDetailEvent, changeEntries.length, isSidebarOpen]);
+    captureSessionDetailEvent(
+      next.panelOpen ? 'session/sidebar_opened' : 'session/sidebar_closed',
+      {
+        default_tab: activeSidebarTab,
+        change_file_count: changeEntries.length,
+      }
+    );
+    setZenLayoutMode(next.zenMode);
+    setIsSidebarOpen(next.panelOpen);
+  }, [
+    activeSidebarTab,
+    captureSessionDetailEvent,
+    changeEntries.length,
+    isSidebarOpen,
+    isZenLayoutMode,
+    setZenLayoutMode,
+  ]);
 
   const handleCloseViewerTab = useCallback(
     (tabId: string) => {
@@ -4066,7 +4102,7 @@ const SessionDetail = ({
     () =>
       getSessionTabCloseTarget({
         focusRegion: desktopTabFocusRegionRef.current,
-        sidePanelOpen: isSidebarOpen,
+        sidePanelOpen: isSidebarVisible,
         activeSidePanelTabId,
         activeConversationTabId: activeTabSessionId,
         parentConversationTabId: sessionId,
@@ -4075,7 +4111,7 @@ const SessionDetail = ({
     [
       activeSidePanelTabId,
       activeTabSessionId,
-      isSidebarOpen,
+      isSidebarVisible,
       orderedSessionTabIds.length,
       sessionId,
     ]
@@ -5451,7 +5487,7 @@ const SessionDetail = ({
         className="bg-background"
         // The side panel stays mounted while collapsed, so GitHub polling has
         // to be paused explicitly — same signal SessionBrowserPanel takes.
-        visible={isSidebarOpen}
+        visible={isSidebarVisible}
       />
     ) : activeSidebarTab === 'changes' ? (
       <SessionChangesSidebar
@@ -5479,7 +5515,7 @@ const SessionDetail = ({
         >
           <SessionBrowserPanel
             session={activeBrowserSession}
-            active={activeSidebarTab === 'browser' && isSidebarOpen}
+            active={activeSidebarTab === 'browser' && isSidebarVisible}
             candidateNavigationRequestId={
               browserCandidateNavigationRequest?.sessionId === activeBrowserSession.id
                 ? browserCandidateNavigationRequest.id
@@ -5520,22 +5556,22 @@ const SessionDetail = ({
       size="icon"
       onClick={handleToggleSidebar}
       aria-label={
-        isSidebarOpen
+        isSidebarVisible
           ? t('sessions.sidebar.hide', 'Hide sidebar')
           : t('sessions.sidebar.show', 'Show sidebar')
       }
-      className={cn('h-7 w-7 shrink-0 text-muted-foreground', !isSidebarOpen && 'mr-[9px]')}
+      className={cn('h-7 w-7 shrink-0 text-muted-foreground', !isSidebarVisible && 'mr-[9px]')}
     >
       <PanelRight className="h-4 w-4" />
     </Button>
   );
 
-  const leftSidebarExpandButton = isLeftSidebarCollapsed ? (
+  const leftSidebarExpandButton = isLeftSidebarHidden ? (
     <Button
       type="button"
       variant="ghost"
       size="icon"
-      onClick={() => setLeftSidebarCollapsed(false)}
+      onClick={() => showNavigationSidebar()}
       aria-label={t('sessions.leftSidebar.show', 'Show navigation sidebar')}
       className="h-7 w-7 shrink-0 text-muted-foreground"
     >
@@ -5556,7 +5592,7 @@ const SessionDetail = ({
       headerEndSlot={
         <>
           <TerminalDockToggleButton />
-          {!isSidebarOpen ? sidebarToggleButton : null}
+          {!isSidebarVisible ? sidebarToggleButton : null}
         </>
       }
       titleSyncing={activeSessionDocIsSyncing}
@@ -5632,8 +5668,8 @@ const SessionDetail = ({
         // 6px higher for them to land on that same line: 2 + (44 - 32) / 2 = 8.
         // Re-derive this if the row or the pill height changes.
         'mt-0.5 h-11',
-        isLeftSidebarCollapsed && hasMacOSTitlebarInset && 'pl-[4.5rem]',
-        !isSidebarOpen && windowsCaptionPadClass
+        isLeftSidebarHidden && hasMacOSTitlebarInset && 'pl-[4.5rem]',
+        !isSidebarVisible && windowsCaptionPadClass
       )}
     />
   );
@@ -5751,9 +5787,9 @@ const SessionDetail = ({
       <div
         key={tab.id}
         className={isActive ? 'h-full' : 'hidden h-full'}
-        aria-hidden={!isActive || !isSidebarOpen}
+        aria-hidden={!isActive || !isSidebarVisible}
       >
-        {renderViewerTabContent(tab, 'h-full', isActive && isSidebarOpen)}
+        {renderViewerTabContent(tab, 'h-full', isActive && isSidebarVisible)}
       </div>
     );
   });
@@ -5775,7 +5811,7 @@ const SessionDetail = ({
           aria-hidden={!isActive}
         >
           <SessionChatInterface
-            {...getSharedChatSurfaceProps(sideSession, isActive, isActive && isSidebarOpen)}
+            {...getSharedChatSurfaceProps(sideSession, isActive, isActive && isSidebarVisible)}
             isChildTab
           />
         </div>
@@ -5854,7 +5890,7 @@ const SessionDetail = ({
         chatSurfaces={desktopChatSurfaces}
         terminalDock={<TerminalDockHost />}
         secondaryPanel={desktopSecondaryPanel}
-        sidebarOpen={isSidebarOpen}
+        sidebarOpen={isSidebarVisible}
         onSidebarCollapse={handleToggleSidebar}
         deleteConfirmDialog={deleteConfirmDialog}
         sidebarMinWidthRequest={prSidebarWidthRequest}

--- a/packages/components/src/components/sessions/session-detail.tsx
+++ b/packages/components/src/components/sessions/session-detail.tsx
@@ -94,7 +94,16 @@ import {
   showNavigationSidebarAtom,
   zenLayoutModeAtom,
 } from '@/atoms/layout-state';
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
 import { useDocumentTitle } from '@/hooks/use-document-title';
 import { useTabStatus, type TabStatus } from '@/hooks/use-tab-status';
 import {
@@ -2600,6 +2609,12 @@ const SessionDetail = ({
   } else if (restoredPrSidebar !== null) {
     setRestoredPrSidebar(null);
   }
+
+  // The PR restore token is committed with the open panel and restore sequence.
+  // Clear the transient Zen override before paint without writing Jotai during render.
+  useLayoutEffect(() => {
+    if (restoredPrSidebar !== null) setZenLayoutMode(false);
+  }, [restoredPrSidebar, setZenLayoutMode]);
 
   // Once restored, a user switching away from the PR tab (or closing the
   // sidebar) clears `?pr` so the URL stays consistent. The URL write must be

--- a/packages/components/src/components/sessions/session-monaco-text-viewer.tsx
+++ b/packages/components/src/components/sessions/session-monaco-text-viewer.tsx
@@ -22,6 +22,7 @@ import {
   type SessionMonacoSelectionRestore,
 } from '@/lib/session-monaco-editor-controller';
 import type { LodyResolvedVSCodeTheme } from '@/lib/vscode-theme';
+import { useKeyScope } from '@/lib/commands';
 
 configureSessionMonacoWorkers();
 ensureSessionMonacoLanguages();
@@ -111,6 +112,7 @@ export function SessionMonacoTextViewer({
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const controllerRef = useRef<SessionMonacoEditorController | null>(null);
+  useKeyScope('session-monaco-quick-fix', containerRef, { claims: ['$mod+.'] });
 
   // Line wrap is a global, persisted viewer preference (defaults on). Read it
   // here so every SessionMonacoTextViewer mount — session file viewer, mobile

--- a/packages/components/src/components/web-workspace-layout.tsx
+++ b/packages/components/src/components/web-workspace-layout.tsx
@@ -5,7 +5,11 @@ import { useLocation } from '@tanstack/react-router';
 import { LoroAppSidebar } from './loro-app-sidebar';
 import { ErrorBoundary } from './error-boundary';
 import { useKeyboardNavigation } from '../hooks/use-keyboard-navigation';
-import { sidebarCollapsedAtom, sidebarLastWidthAtom, WORKSPACE_FOCUS_SCOPES } from '../atoms';
+import {
+  navigationSidebarHiddenAtom,
+  sidebarLastWidthAtom,
+  WORKSPACE_FOCUS_SCOPES,
+} from '../atoms';
 import { getWebWorkspaceLayoutRootClassName, isSettingsRoute } from './workspace-layout-utils';
 import { FocusScope } from '@/ui/focus-scope';
 import { WindowDragStrip } from '@/ui/window-drag-region';
@@ -22,7 +26,7 @@ export function WebWorkspaceLayout({ children }: { children: ReactNode }) {
   // resets), so search-only navigations (dialogs, panels) don't re-render the
   // whole workspace shell.
   const pathname = useLocation({ select: (l) => l.pathname });
-  const sidebarCollapsed = useAtomValue(sidebarCollapsedAtom);
+  const sidebarHidden = useAtomValue(navigationSidebarHiddenAtom);
   const sidebarLastWidth = useAtomValue(sidebarLastWidthAtom);
   const shouldReduceMotion = useReducedMotion();
 
@@ -53,7 +57,7 @@ export function WebWorkspaceLayout({ children }: { children: ReactNode }) {
   return (
     <div className={getWebWorkspaceLayoutRootClassName()}>
       <AnimatePresence initial={false}>
-        {!sidebarCollapsed && (
+        {!sidebarHidden && (
           <motion.div
             key="app-sidebar"
             className="h-full shrink-0"

--- a/packages/components/src/hooks/use-keyboard-navigation.ts
+++ b/packages/components/src/hooks/use-keyboard-navigation.ts
@@ -6,7 +6,7 @@ import {
   sidebarNavItemsAtom,
   type SidebarNavItem,
 } from '@/atoms/focus-layer';
-import { toggleSidebarCollapsedAtom } from '@/atoms/sidebar-state';
+import { toggleNavigationSidebarAtom } from '@/atoms/layout-state';
 import { getCommandKeybindings, useCommand } from '@/lib/commands';
 import { useFocusScopeSwitcher } from '@/ui/focus-scope';
 import { useIsMobile } from './use-mobile';
@@ -36,7 +36,7 @@ export function useKeyboardNavigation(): void {
   const { t } = useTranslation();
   const flatItems = useAtomValue(sidebarNavItemsAtom);
   const sidebarCallbacks = useAtomValue(sidebarNavCallbacksAtom);
-  const toggleSidebarCollapsed = useSetAtom(toggleSidebarCollapsedAtom);
+  const toggleNavigationSidebar = useSetAtom(toggleNavigationSidebarAtom);
   const isMobile = useIsMobile();
 
   const flatItemsRef = useRef(flatItems);
@@ -152,7 +152,7 @@ export function useKeyboardNavigation(): void {
     category: 'View',
     keybindings: getCommandKeybindings('sidebar.toggle'),
     when: () => !isMobile,
-    run: () => toggleSidebarCollapsed(),
+    run: () => toggleNavigationSidebar(),
   });
 
   useCommand({

--- a/packages/components/src/lib/commands/AGENTS.md
+++ b/packages/components/src/lib/commands/AGENTS.md
@@ -30,6 +30,8 @@ only tells global dispatch to yield for events originating in its subtree.
 - A scope that yields an event must not call `preventDefault`: the editor/local keymap
   still needs to receive it. This applies after a shortcut is rebound as well.
 - `$mod` means Command on macOS and Control elsewhere. Formatting is platform-aware.
+- `layout.toggleZenMode` owns `$mod+.` outside editors. Monaco claims that binding
+  locally for Quick Fix, so the app command must yield while focus is in its subtree.
 - Alt+letter matching and recording must use `event.code`; macOS `event.key` may be a
   generated glyph such as `∫`.
 - Shortcut capture pauses dispatch. It finishes after the last modifier is released and

--- a/packages/components/src/lib/commands/built-ins.ts
+++ b/packages/components/src/lib/commands/built-ins.ts
@@ -51,6 +51,12 @@ const UNAVAILABLE_COMMANDS: BuiltInCommandDefinition[] = [
     category: 'View',
   },
   {
+    id: 'layout.toggleZenMode',
+    titleKey: 'commands.layout.toggleZenMode',
+    title: 'Toggle Zen Layout',
+    category: 'View',
+  },
+  {
     id: 'session.new',
     titleKey: 'commands.session.new',
     title: 'New Chat',

--- a/packages/components/src/lib/commands/shortcuts.ts
+++ b/packages/components/src/lib/commands/shortcuts.ts
@@ -6,6 +6,7 @@ export type ShortcutCommandId =
   | 'nav.back'
   | 'nav.forward'
   | 'app.cycleTheme'
+  | 'layout.toggleZenMode'
   | 'workspace.openSettings'
   | 'session.new'
   | 'session.archiveCurrent'
@@ -51,6 +52,7 @@ export const COMMAND_SHORTCUTS: Record<ShortcutCommandId, CommandKeybindings> = 
   'nav.back': [electron('$mod+[')],
   'nav.forward': [electron('$mod+]')],
   'app.cycleTheme': [],
+  'layout.toggleZenMode': ['$mod+.'],
   // Settings: ⌘, follows OS convention, on web + desktop. On desktop the native app menu
   // still SHOWS ⌘, next to "Settings" but does NOT register the accelerator
   // (`registerAccelerator: false` in apps/electron menu.ts), so the key reaches this

--- a/packages/components/tests/commands-built-ins.test.ts
+++ b/packages/components/tests/commands-built-ins.test.ts
@@ -31,6 +31,7 @@ describe('built-in commands', () => {
     expect(commands.getDefaultKeybindingsFor('nav.back')).toEqual([]);
     expect(commands.getDefaultKeybindingsFor('session.toggleTerminal')).toEqual([]);
     expect(commands.getDefaultKeybindingsFor('workspace.openSettings')).toEqual(['$mod+,']);
+    expect(commands.getDefaultKeybindingsFor('layout.toggleZenMode')).toEqual(['$mod+.']);
     // Cyclers with no default binding stay rebindable from the settings page.
     expect(commands.getDefaultKeybindingsFor('session.cycleProvider')).toEqual([]);
     expect(commands.getDefaultKeybindingsFor('mention.toggleSessionProjectScope')).toEqual([]);
@@ -66,5 +67,6 @@ describe('built-in commands', () => {
     // ⌘, settings is now a cross-platform registry binding (the desktop native menu shows
     // ⌘, but registerAccelerator:false leaves the key to the registry), so it shows here too.
     expect(commands.getDefaultKeybindingsFor('workspace.openSettings')).toEqual(['$mod+,']);
+    expect(commands.getDefaultKeybindingsFor('layout.toggleZenMode')).toEqual(['$mod+.']);
   });
 });

--- a/packages/components/tests/layout-state.test.ts
+++ b/packages/components/tests/layout-state.test.ts
@@ -1,0 +1,80 @@
+import { createStore } from 'jotai';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getZenAwarePanelToggleState,
+  navigationSidebarHiddenAtom,
+  showNavigationSidebarAtom,
+  toggleNavigationSidebarAtom,
+  toggleZenLayoutModeAtom,
+  zenLayoutModeAtom,
+} from '../src/atoms/layout-state';
+import { sidebarCollapsedAtom } from '../src/atoms/sidebar-state';
+
+describe('Zen layout state', () => {
+  it.each([false, true])(
+    'temporarily hides the navigation sidebar without changing collapsed=%s',
+    (collapsed) => {
+      const store = createStore();
+      store.set(sidebarCollapsedAtom, collapsed);
+
+      store.set(toggleZenLayoutModeAtom);
+
+      expect(store.get(zenLayoutModeAtom)).toBe(true);
+      expect(store.get(navigationSidebarHiddenAtom)).toBe(true);
+      expect(store.get(sidebarCollapsedAtom)).toBe(collapsed);
+
+      store.set(toggleZenLayoutModeAtom);
+
+      expect(store.get(zenLayoutModeAtom)).toBe(false);
+      expect(store.get(navigationSidebarHiddenAtom)).toBe(collapsed);
+      expect(store.get(sidebarCollapsedAtom)).toBe(collapsed);
+    }
+  );
+
+  it('leaves Zen and expands the navigation sidebar for an explicit show', () => {
+    const store = createStore();
+    store.set(sidebarCollapsedAtom, true);
+    store.set(zenLayoutModeAtom, true);
+
+    store.set(showNavigationSidebarAtom);
+
+    expect(store.get(zenLayoutModeAtom)).toBe(false);
+    expect(store.get(sidebarCollapsedAtom)).toBe(false);
+    expect(store.get(navigationSidebarHiddenAtom)).toBe(false);
+  });
+
+  it('treats a navigation sidebar toggle during Zen as an explicit reveal', () => {
+    const store = createStore();
+    store.set(sidebarCollapsedAtom, false);
+    store.set(zenLayoutModeAtom, true);
+
+    store.set(toggleNavigationSidebarAtom);
+
+    expect(store.get(zenLayoutModeAtom)).toBe(false);
+    expect(store.get(sidebarCollapsedAtom)).toBe(false);
+  });
+});
+
+describe('getZenAwarePanelToggleState', () => {
+  it.each([
+    [
+      { zenMode: true, panelOpen: true },
+      { zenMode: false, panelOpen: true },
+    ],
+    [
+      { zenMode: true, panelOpen: false },
+      { zenMode: false, panelOpen: true },
+    ],
+    [
+      { zenMode: false, panelOpen: true },
+      { zenMode: false, panelOpen: false },
+    ],
+    [
+      { zenMode: false, panelOpen: false },
+      { zenMode: false, panelOpen: true },
+    ],
+  ])('maps %o to %o', (current, expected) => {
+    expect(getZenAwarePanelToggleState(current)).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- add a transient Zen layout override that hides both sidebars without changing their persisted state
- bind Toggle Zen Layout to Cmd+. on macOS and Ctrl+. elsewhere, while preserving Monaco Quick Fix inside editors
- exit Zen on explicit sidebar, viewer, PR, Browser, and Side Chat opens, and pause hidden right-panel work

## Testing

- `pnpm --filter @lody/components exec vitest run tests/layout-state.test.ts tests/commands-built-ins.test.ts tests/commands-registry.test.ts tests/desktop-session-detail-layout.test.ts tests/session-tab-close-target.test.ts`
- `pnpm --filter @lody/components typecheck`
- `pnpm lint:i18n`
- `pnpm lint:fast`
- `pnpm check:public-boundary`