### PR TITLE
docs: publish 0.90.0 changelog

### DIFF
--- a/site-docs/content/changelog/en/20260903.mdx
+++ b/site-docs/content/changelog/en/20260903.mdx
@@ -1,0 +1,27 @@
+---
+title: '20260903'
+version: 0.90.0
+date: 2026-09-03
+description: Added Zen layout, incremental macOS updates, session renaming, and custom DeepSeek Harness endpoints, with improvements to agent configuration, CLI reliability, and input handling.
+---
+
+Version 0.90.0
+
+### ✨ New
+
+- Added Zen layout mode for a more focused workspace experience ([#341](https://github.com/LodyAI/Lody/pull/341)).
+- Upgraded macOS auto-updates with incremental updates, native progress reporting, and more reliable installation verification ([#173](https://github.com/LodyAI/Lody/pull/173)).
+- Added session renaming tools ([#337](https://github.com/LodyAI/Lody/pull/337)).
+- Added support for custom DeepSeek Harness service endpoints ([#293](https://github.com/LodyAI/Lody/pull/293)).
+- Improved Agent and Provider settings with clearer configuration, status, and unavailability details ([#257](https://github.com/LodyAI/Lody/pull/257)).
+
+### 🐛 Fixes and Improvements
+
+- Improved CLI daemon startup recovery, status diagnostics, and error messages ([#287](https://github.com/LodyAI/Lody/pull/287)).
+- Fixed Agent capability refresh failures and configuration state inconsistencies across multi-turn operations.
+- Improved Markdown links, bold URLs, CJK input methods, and mention input behavior ([#274](https://github.com/LodyAI/Lody/pull/274), [#309](https://github.com/LodyAI/Lody/pull/309), [#294](https://github.com/LodyAI/Lody/pull/294)).
+- Improved session tabs, plan approval, settings navigation, and compact mobile layouts ([#326](https://github.com/LodyAI/Lody/pull/326), [#315](https://github.com/LodyAI/Lody/pull/315), [#334](https://github.com/LodyAI/Lody/pull/334), [#285](https://github.com/LodyAI/Lody/pull/285)).
+- Improved local project folder selection, SVG file attachments, and desktop Cmd+W behavior ([#291](https://github.com/LodyAI/Lody/pull/291), [#173](https://github.com/LodyAI/Lody/pull/173)).
+- Fixed the built-in browser failing to connect in some proxied network environments ([#299](https://github.com/LodyAI/Lody/pull/299)).
+- Improved Codex goal command control and child-session workspace guidance ([#144](https://github.com/LodyAI/Lody/pull/144), [#225](https://github.com/LodyAI/Lody/pull/225)).
+- Thanks to external contributors [@jeffwcx](https://github.com/jeffwcx), [@EYHN](https://github.com/EYHN), [@Innei](https://github.com/Innei), [@MichaelYuhe](https://github.com/MichaelYuhe), [@sinxy-sai](https://github.com/sinxy-sai), [@natsustan](https://github.com/natsustan), [@slashdevcorpse](https://github.com/slashdevcorpse), and [@ImSingee](https://github.com/ImSingee).

--- a/site-docs/content/changelog/zh/20260903.mdx
+++ b/site-docs/content/changelog/zh/20260903.mdx
@@ -1,0 +1,27 @@
+---
+title: '20260903'
+version: 0.90.0
+date: 2026-09-03
+description: 新增 Zen 布局、macOS 增量更新、会话重命名和 DeepSeek Harness 自定义服务地址，并改善 Agent 配置、CLI 稳定性与输入体验。
+---
+
+版本 0.90.0
+
+### ✨ 新功能
+
+- 新增 Zen 布局模式，提供更专注的工作空间体验（[#341](https://github.com/LodyAI/Lody/pull/341)）。
+- 升级 macOS 自动更新体验，支持增量更新、原生进度提示和更可靠的安装验证（[#173](https://github.com/LodyAI/Lody/pull/173)）。
+- 新增会话重命名工具（[#337](https://github.com/LodyAI/Lody/pull/337)）。
+- 支持为 DeepSeek Harness 配置自定义服务地址（[#293](https://github.com/LodyAI/Lody/pull/293)）。
+- 完善 Agent 与 Provider 设置界面，让配置、状态和不可用原因更加清晰（[#257](https://github.com/LodyAI/Lody/pull/257)）。
+
+### 🐛 修复与改进
+
+- 提升 CLI 后台服务的启动恢复、状态诊断和异常提示能力（[#287](https://github.com/LodyAI/Lody/pull/287)）。
+- 修复 Agent 能力刷新失败，以及多轮操作中配置状态可能不一致的问题。
+- 改进 Markdown 链接、粗体网址、中文输入法和提及输入体验（[#274](https://github.com/LodyAI/Lody/pull/274)、[#309](https://github.com/LodyAI/Lody/pull/309)、[#294](https://github.com/LodyAI/Lody/pull/294)）。
+- 优化会话标签、计划审批、设置导航以及移动端紧凑布局（[#326](https://github.com/LodyAI/Lody/pull/326)、[#315](https://github.com/LodyAI/Lody/pull/315)、[#334](https://github.com/LodyAI/Lody/pull/334)、[#285](https://github.com/LodyAI/Lody/pull/285)）。
+- 改进本地项目目录选择、SVG 文件发送和桌面端 Cmd+W 行为（[#291](https://github.com/LodyAI/Lody/pull/291)、[#173](https://github.com/LodyAI/Lody/pull/173)）。
+- 修复部分代理网络环境下内置浏览器无法正常访问的问题（[#299](https://github.com/LodyAI/Lody/pull/299)）。
+- 改进 Codex 目标指令控制和子会话工作区提示（[#144](https://github.com/LodyAI/Lody/pull/144)、[#225](https://github.com/LodyAI/Lody/pull/225)）。
+- 感谢外部贡献者 [@jeffwcx](https://github.com/jeffwcx)、[@EYHN](https://github.com/EYHN)、[@Innei](https://github.com/Innei)、[@MichaelYuhe](https://github.com/MichaelYuhe)、[@sinxy-sai](https://github.com/sinxy-sai)、[@natsustan](https://github.com/natsustan)、[@slashdevcorpse](https://github.com/slashdevcorpse) 和 [@ImSingee](https://github.com/ImSingee)。


### PR DESCRIPTION
## Summary

- publish the English and Chinese changelog for stable version 0.90.0
- include external contributors and links to their pull requests
- document incremental macOS updates, session renaming, and custom DeepSeek Harness endpoints separately

## Validation

- `pnpm exec prettier --check site-docs/content/changelog/en/20260903.mdx site-docs/content/changelog/zh/20260903.mdx`
- `pnpm --filter @lody/site-docs typecheck`
- `git diff --check origin/main...HEAD`

## Environment notes

- `pnpm --filter @lody/site-docs test` is blocked under the current Node 24 runtime because its `node:test` child-process assertions receive empty stdout; the underlying postinstall command succeeds when run directly.
- The full public-workspace check cannot resolve `tsgo` from the nested submodule workspace. Per repository policy, dependencies were not reinstalled inside `lody-oss`.