### PR TITLE
fix(ci): harden Electron signing credentials [risk:high]

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -88,6 +88,10 @@ their failures and perform expiry.
 
 - `workflows/pr-policy.yml` is the only PR policy event entry point.
   `workflows/pr-policy-reconcile.yml` is callable only through `workflow_call`.
+- Workflows that pass signing or update keys to a third-party Action must pin that
+  Action to a reviewed full commit SHA. Scope signing secrets to the exact trusted
+  preparation, packaging, or signing step that consumes them; never place them in a
+  job-level environment inherited by unrelated actions and dependency scripts.
 - `pull_request_target` provides a write-capable token. For PR events, checkout
   policy from trusted `github.sha`; scheduled and manual audits use
   `github.event.repository.default_branch`. Never checkout or execute the PR

--- a/.github/workflows/release-electron.yml
+++ b/.github/workflows/release-electron.yml
@@ -62,16 +62,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     environment: release
     env:
-      CSC_LINK: ${{ matrix.target == 'mac' && secrets.MACOS_CERTIFICATE_P12_BASE64 || '' }}
-      CSC_KEY_PASSWORD: ${{ matrix.target == 'mac' && secrets.MACOS_CERTIFICATE_PASSWORD || '' }}
-      CSC_NAME: ${{ matrix.target == 'mac' && secrets.MACOS_CERTIFICATE_NAME || '' }}
-      APPLE_API_KEY_P8: ${{ matrix.target == 'mac' && secrets.APPLE_API_KEY_P8 || '' }}
-      APPLE_API_KEY_ID: ${{ matrix.target == 'mac' && secrets.APPLE_API_KEY_ID || '' }}
-      APPLE_API_ISSUER: ${{ matrix.target == 'mac' && secrets.APPLE_API_ISSUER || '' }}
-      SPARKLE_ED_PUBLIC_KEY: ${{ matrix.target == 'mac' && secrets.SPARKLE_ED_PUBLIC_KEY || '' }}
-      SPARKLE_ED_PRIVATE_KEY: ${{ matrix.target == 'mac' && secrets.SPARKLE_ED_PRIVATE_KEY || '' }}
-      # Signing identities come from the secrets above only; never from whatever
-      # happens to be in the runner keychain.
+      # Signing identities are injected only into the trusted preparation and
+      # package steps; never discover whatever happens to be in the runner keychain.
       CSC_IDENTITY_AUTO_DISCOVERY: 'false'
       npm_config_msvs_version: ${{ matrix.target == 'win' && '2022' || '' }}
     steps:
@@ -105,9 +97,32 @@ jobs:
           echo "LODY_OSS_RELEASE_VERSION=${version}" >> "$GITHUB_ENV"
           echo "Packaging Lody OSS ${version}"
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build bundled CLI and renderer
+        run: pnpm --dir apps/electron run build
+
       - name: Prepare macOS signing and notarization credentials
         if: matrix.target == 'mac'
         shell: bash
+        env:
+          CSC_LINK: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          SPARKLE_ED_PUBLIC_KEY: ${{ secrets.SPARKLE_ED_PUBLIC_KEY }}
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           required_envs=(
@@ -132,23 +147,23 @@ jobs:
           chmod 600 "${api_key_path}"
           echo "APPLE_API_KEY=${api_key_path}" >> "$GITHUB_ENV"
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build bundled CLI and renderer
-        run: pnpm --dir apps/electron run build
-
       - name: Package (${{ matrix.target }})
+        env:
+          CSC_LINK: ${{ matrix.target == 'mac' && secrets.MACOS_CERTIFICATE_P12_BASE64 || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.target == 'mac' && secrets.MACOS_CERTIFICATE_PASSWORD || '' }}
+          CSC_NAME: ${{ matrix.target == 'mac' && secrets.MACOS_CERTIFICATE_NAME || '' }}
+          APPLE_API_KEY_ID: ${{ matrix.target == 'mac' && secrets.APPLE_API_KEY_ID || '' }}
+          APPLE_API_ISSUER: ${{ matrix.target == 'mac' && secrets.APPLE_API_ISSUER || '' }}
+          SPARKLE_ED_PUBLIC_KEY: ${{ matrix.target == 'mac' && secrets.SPARKLE_ED_PUBLIC_KEY || '' }}
         run: pnpm --dir apps/electron run package -- ${{ matrix.package_args }} --publish never
+
+      - name: Remove macOS notarization key
+        if: ${{ always() && matrix.target == 'mac' }}
+        shell: bash
+        run: |
+          if [[ -n "${APPLE_API_KEY:-}" ]]; then
+            rm -f "${APPLE_API_KEY}"
+          fi
 
       - name: Prepare Sparkle archive dir
         if: matrix.target == 'mac'
@@ -174,7 +189,7 @@ jobs:
       # Lody's ubuntu job publishes mac/win/linux together.
       - name: Sign appcast and generate Sparkle deltas
         if: matrix.target == 'mac'
-        uses: Innei/electron-sparkle-updater/action@v1
+        uses: Innei/electron-sparkle-updater/action@002472bdb78a9608eddc8b39202572af3f7986fb # v1
         with:
           tag: v${{ env.LODY_OSS_RELEASE_VERSION }}
           repo: ${{ github.repository }}

--- a/apps/electron/AGENTS.md
+++ b/apps/electron/AGENTS.md
@@ -141,9 +141,12 @@ Root `AGENTS.md` also applies.
 - macOS uses Sparkle (`electron-sparkle-updater`): `SUFeedURL` + `SUPublicEDKey` in
   Info.plist, `package-electron.mjs` rebuilds the native addon, afterPack injects
   `SPARKLE_ED_PUBLIC_KEY` before signing. The release workflow then runs
-  `Innei/electron-sparkle-updater/action@v1` against this release's zips only
+  `Innei/electron-sparkle-updater/action` pinned to a reviewed full commit SHA against
+  this release's zips only
   (`publish: false`); the Action fetches the two previous `v*` zip releases as
-  delta bases. Previous zips stay out of the published asset list. Sparkle load
+  delta bases. Keep Apple signing credentials scoped to the packaging step and the
+  Sparkle private key scoped to validation plus the pinned signing Action; never expose
+  them as job-level environment variables. Previous zips stay out of the published asset list. Sparkle load
   failure falls back to electron-updater. Sparkle UI stays silent; progress and
   ready-to-install go through `ElectronUpdaterState` for the renderer banner.
 - Artifact names must stay space-free. GitHub Releases rewrites spaces to periods,

--- a/apps/electron/scripts/sparkle-packaging.test.mjs
+++ b/apps/electron/scripts/sparkle-packaging.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import path from 'node:path'
 import {
@@ -11,6 +12,66 @@ import {
   shouldInjectSparklePublicKey,
   sparkleInfoPlistPath
 } from './sparkle-packaging.mjs'
+
+const releaseWorkflow = readFileSync(
+  new URL('../../../.github/workflows/release-electron.yml', import.meta.url),
+  'utf8'
+)
+
+function releaseWorkflowStep(name) {
+  const marker = `      - name: ${name}\n`
+  const start = releaseWorkflow.indexOf(marker)
+  assert.notEqual(start, -1, `missing release workflow step: ${name}`)
+  const next = releaseWorkflow.indexOf('\n      - name:', start + marker.length)
+  return releaseWorkflow.slice(start, next === -1 ? undefined : next)
+}
+
+void test('pins the Sparkle signing Action and scopes release credentials to trusted steps', () => {
+  assert.match(
+    releaseWorkflow,
+    /uses: Innei\/electron-sparkle-updater\/action@002472bdb78a9608eddc8b39202572af3f7986fb # v1/u
+  )
+  assert.doesNotMatch(releaseWorkflow, /electron-sparkle-updater\/action@v1/u)
+
+  const buildJobStart = releaseWorkflow.indexOf('\n  build:\n')
+  const jobEnvStart = releaseWorkflow.indexOf('\n    env:\n', buildJobStart)
+  const stepsStart = releaseWorkflow.indexOf('\n    steps:\n', jobEnvStart)
+  assert.notEqual(buildJobStart, -1)
+  assert.notEqual(jobEnvStart, -1)
+  assert.notEqual(stepsStart, -1)
+  const jobEnv = releaseWorkflow.slice(jobEnvStart, stepsStart)
+  for (const secretName of [
+    'CSC_LINK',
+    'CSC_KEY_PASSWORD',
+    'CSC_NAME',
+    'APPLE_API_KEY_P8',
+    'APPLE_API_KEY_ID',
+    'APPLE_API_ISSUER',
+    'SPARKLE_ED_PUBLIC_KEY',
+    'SPARKLE_ED_PRIVATE_KEY'
+  ]) {
+    assert.doesNotMatch(jobEnv, new RegExp(`^\\s+${secretName}:`, 'mu'))
+  }
+
+  const prepareStep = releaseWorkflowStep('Prepare macOS signing and notarization credentials')
+  assert.match(prepareStep, /SPARKLE_ED_PRIVATE_KEY: \$\{\{ secrets\.SPARKLE_ED_PRIVATE_KEY \}\}/u)
+  const packageStep = releaseWorkflowStep('Package (${{ matrix.target }})')
+  assert.match(packageStep, /CSC_LINK: \$\{\{ matrix\.target == 'mac'/u)
+  assert.match(packageStep, /APPLE_API_KEY_ID: \$\{\{ matrix\.target == 'mac'/u)
+  assert.match(packageStep, /SPARKLE_ED_PUBLIC_KEY: \$\{\{ matrix\.target == 'mac'/u)
+  assert.doesNotMatch(packageStep, /SPARKLE_ED_PRIVATE_KEY/u)
+
+  const buildStep = releaseWorkflowStep('Build bundled CLI and renderer')
+  const cleanupStep = releaseWorkflowStep('Remove macOS notarization key')
+  const signingStep = releaseWorkflowStep('Sign appcast and generate Sparkle deltas')
+  assert.ok(releaseWorkflow.indexOf(buildStep) < releaseWorkflow.indexOf(prepareStep))
+  assert.ok(releaseWorkflow.indexOf(prepareStep) < releaseWorkflow.indexOf(packageStep))
+  assert.ok(releaseWorkflow.indexOf(packageStep) < releaseWorkflow.indexOf(cleanupStep))
+  assert.ok(releaseWorkflow.indexOf(cleanupStep) < releaseWorkflow.indexOf(signingStep))
+  assert.match(cleanupStep, /rm -f "\$\{APPLE_API_KEY\}"/u)
+  assert.match(signingStep, /ed-private-key: \$\{\{ secrets\.SPARKLE_ED_PRIVATE_KEY \}\}/u)
+  assert.doesNotMatch(signingStep, /APPLE_API_KEY|CSC_LINK|CSC_KEY_PASSWORD/u)
+})
 
 void test('treats explicit --mac and host-default darwin packaging as Sparkle package runs', () => {
   assert.equal(isMacPackaging(['--mac', '--arm64', '--x64'], 'linux'), true)


### PR DESCRIPTION
Risk: 🔴 high | Confidence: high — narrows production signing-secret exposure and pins the custom signing Action to an audited immutable commit.

## Summary

- pin Innei/electron-sparkle-updater/action to the reviewed v1 commit SHA
- expose Apple and Sparkle signing credentials only to the trusted steps that consume them
- remove the temporary notarization key before the third-party Sparkle Action runs
- add a regression test and durable workflow-security guidance

## Security finding

The prior workflow used a movable third-party Action ref while passing it the long-lived Sparkle private key. Apple and Sparkle credentials were also inherited by unrelated setup, install, and build steps through the job environment.

## Validation

- @lody/electron tests: 20 passed
- targeted Prettier: clean
- git diff --check: clean
- upstream v1 tag independently verified to peel to 002472bdb78a9608eddc8b39202572af3f7986fb; its composite Action definition was reviewed
- independent security, correctness, and scope-drift reviews: approved
- full outer-workspace pnpm check:affected: running; result will be recorded before merge