### PR TITLE
fix(components): stop sidebar resize chat jitter

### DIFF
--- a/packages/components/src/hooks/AGENTS.md
+++ b/packages/components/src/hooks/AGENTS.md
@@ -21,6 +21,10 @@ this file; edit `AGENTS.md` only.
 - Follow viewport-size changes from the viewport's `ResizeObserver` records.
   Keyboard and terminal transitions resize that same element, so do not restore
   custom resize-event pumps, guessed transition durations, or stop timers.
+  Only height changes re-anchor the viewport: a flex sibling such as the desktop
+  sidebar can animate width every frame, and sending those width-only records to
+  Virtua competes with the content observer's bottom correction and visibly
+  jitters the conversation.
 - A session composer height change sets a one-shot ref immediately before its
   inline height write. Consume that ref only for the next viewport _height_
   resize, without calling `scrollToRealBottom`; it preserves the reader's

--- a/packages/components/src/hooks/use-sticky-scroll.ts
+++ b/packages/components/src/hooks/use-sticky-scroll.ts
@@ -56,9 +56,9 @@ export interface UseStickyScrollResult {
 
 /**
  * `use-stick-to-bottom` observes content growth. Observe the viewport too so a
- * flex sibling or window inset shrinking the available height cannot leave a
+ * docked panel or window inset shrinking the available height cannot leave a
  * followed conversation floating above the real bottom. ResizeObserver is the
- * completion signal for every committed viewport size; no transition-duration
+ * completion signal for every committed viewport height; no transition-duration
  * clock or custom resize-event pump is needed.
  */
 function useStickyViewportResizeObserver(options: {
@@ -81,18 +81,15 @@ function useStickyViewportResizeObserver(options: {
   useEffect(() => {
     if (!scrollElement || typeof ResizeObserver === 'undefined') return undefined;
 
-    let previousWidth = scrollElement.getBoundingClientRect().width;
     let previousHeight = scrollElement.getBoundingClientRect().height;
     let rafId: number | null = null;
 
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
-        const { width, height } = entry.contentRect;
-        if (width === previousWidth && height === previousHeight) continue;
-        const heightChanged = height !== previousHeight;
-        previousWidth = width;
+        const { height } = entry.contentRect;
+        if (height === previousHeight) continue;
         previousHeight = height;
-        if (heightChanged && skipNextViewportResizeAutoScrollRef?.current) {
+        if (skipNextViewportResizeAutoScrollRef?.current) {
           skipNextViewportResizeAutoScrollRef.current = false;
           if (rafId !== null) {
             cancelAnimationFrame(rafId);

--- a/packages/components/tests/use-sticky-scroll.test.ts
+++ b/packages/components/tests/use-sticky-scroll.test.ts
@@ -57,6 +57,7 @@ type ScrollFixture = {
   setScrollTop: (value: number) => void;
   getScrollTop: () => number;
   setContentHeight: (value: number) => void;
+  setClientWidth: (value: number) => void;
   setScrollHeight: (value: number) => void;
   setClientHeight: (value: number) => void;
 };
@@ -105,7 +106,7 @@ function createScrollFixture(): ScrollFixture {
   let scrollTop = 0;
   let scrollHeight = 640;
   let clientHeight = 400;
-  const width = 320;
+  let clientWidth = 320;
   let contentHeight = 616;
 
   Object.defineProperty(scrollElement, 'scrollTop', {
@@ -125,11 +126,11 @@ function createScrollFixture(): ScrollFixture {
   });
   scrollElement.getBoundingClientRect = () =>
     ({
-      width,
+      width: clientWidth,
       height: clientHeight,
       top: 0,
       left: 0,
-      right: width,
+      right: clientWidth,
       bottom: clientHeight,
       x: 0,
       y: 0,
@@ -137,11 +138,11 @@ function createScrollFixture(): ScrollFixture {
     }) as DOMRect;
   contentElement.getBoundingClientRect = () =>
     ({
-      width,
+      width: clientWidth,
       height: contentHeight,
       top: 0,
       left: 0,
-      right: width,
+      right: clientWidth,
       bottom: contentHeight,
       x: 0,
       y: 0,
@@ -157,6 +158,9 @@ function createScrollFixture(): ScrollFixture {
     getScrollTop: () => scrollTop,
     setContentHeight: (value) => {
       contentHeight = value;
+    },
+    setClientWidth: (value) => {
+      clientWidth = value;
     },
     setScrollHeight: (value) => {
       scrollHeight = value;
@@ -422,6 +426,37 @@ describe('useStickyScroll Virtua adapter', () => {
 
     expect(vlist.scrollToIndex).toHaveBeenCalledWith(3, { align: 'end', offset: 24 });
     expect(fixture.getScrollTop()).toBe(320);
+    expect(latestResult?.isSticky).toBe(true);
+  });
+
+  it('does not re-anchor the viewport while a flex sibling changes only its width', async () => {
+    const sessionId = 'session-viewport-width-resize' as SessionId;
+    const fixture = createScrollFixture();
+    const vlist = createMockVirtualizerHandle(fixture.scrollElement);
+
+    await renderHarness({
+      sessionId,
+      vlist,
+      scrollElement: fixture.scrollElement,
+      itemCount: 4,
+    });
+    await act(async () => {
+      await advanceAnimationFrames();
+    });
+
+    vlist.scrollToIndex.mockClear();
+    fixture.setScrollTop(236);
+
+    for (const width of [300, 280, 260, 240]) {
+      fixture.setClientWidth(width);
+      await act(async () => {
+        emitResize(fixture.scrollElement);
+        await advanceAnimationFrames();
+      });
+    }
+
+    expect(vlist.scrollToIndex).not.toHaveBeenCalled();
+    expect(fixture.getScrollTop()).toBe(236);
     expect(latestResult?.isSticky).toBe(true);
   });
 


### PR DESCRIPTION
## Related issue

Same-repository fix; no tracking issue was required for intake.

## Problem / pressure

Opening or closing the desktop navigation sidebar animates the conversation viewport width. The sticky-scroll viewport observer treated every width-only ResizeObserver record as a reason to re-anchor Virtua at the bottom, competing with `use-stick-to-bottom` and making the conversation move vertically by a few pixels.

## Summary

- Ignore viewport ResizeObserver records when the viewport height did not change.
- Preserve height-driven re-anchoring for keyboard, terminal dock, and window layout changes.
- Add a regression test that emits several consecutive width-only resize records while the conversation remains sticky.
- Record the adapter ownership boundary in the scoped hooks contributor guidance.

## Before / after

| Before | After |
| ------ | ----- |
| Every sidebar animation frame could request a Virtua bottom re-anchor. | Width-only sidebar animation frames leave the vertical scroll position untouched. |
| Viewport height changes kept a sticky conversation pinned to the bottom. | Viewport height changes continue to keep a sticky conversation pinned to the bottom. |

## Test plan

- `pnpm exec vitest run tests/use-sticky-scroll.test.ts` from `packages/components`: 7 tests passed.
- `pnpm typecheck` from `packages/components`: passed.
- `pnpm exec prettier --check src/hooks/use-sticky-scroll.ts tests/use-sticky-scroll.test.ts src/hooks/AGENTS.md`: passed.
- `git diff --check`: passed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the height-only filter in `use-sticky-scroll.ts` and the repeated width-resize regression in `use-sticky-scroll.test.ts`.
- **Decisions to challenge:** Confirm that content reflow remains owned by `use-stick-to-bottom` while the app adapter owns only viewport height re-anchoring.
- **Plausible failures / evidence gaps:** A browser-level Electron interaction test was not run; evidence is the focused deterministic ResizeObserver test plus the existing height/content-growth cases.

### Authoring context

- **User goal / directives:** Remove the visible vertical conversation jitter when toggling the desktop sidebar and publish the fix as a PR.
- **Constraints / non-goals:** Preserve sticky streaming, user escape behavior, composer suppression, session restoration, and keyboard or terminal height handling; do not redesign the sidebar animation.
- **Risk-bearing decisions:** Width-only viewport changes are ignored by the Virtua adapter because content-height changes continue through the library's content observer.
- **Destructive or irreversible behavior:** The change performs no data mutation, migration, deletion, or irreversible operation.
- **Deliberately not done or tested:** Full Electron end-to-end interaction was omitted because the deterministic hook suite directly exercises the conflicting observer path.
- **Unknowns / confidence:** Confidence is high for the reported path; platform-specific ResizeObserver scheduling remains covered indirectly rather than by a packaged-app test.

<!-- context-handoff:end -->
