### PR TITLE
fix(site-docs): brand docs, blog, changelog, and pricing titles with | Lody

### DIFF
--- a/site-docs/AGENTS.md
+++ b/site-docs/AGENTS.md
@@ -82,10 +82,13 @@
   values. Marketing pages (landing/pricing/changelog/download) must stay on
   `--landing-*` / `--mkt-*` and reference no `fd-` token, which is what keeps
   this override off them — check that before moving a component between them.
-- SEO lives in `lib/metadata.ts` and TanStack route `head()` functions. Canonical
-  page URLs should match Cloudflare Pages' directory form (`/`, `/zh/`,
-  `/docs/.../`, `/zh/docs/.../`); file URLs keep their extension. `/home` and
-  `/zh/home` are compatibility routes and should stay `noindex,follow`.
+- SEO lives in `lib/metadata.ts` and TanStack route `head()` functions. Docs,
+  blog, changelog, and pricing `head()` titles go through `brandTitle` so they
+  get `| Lody`; landing/download titles already include the brand and must not be
+  double-suffixed. Visible `DocsTitle` stays unbranded. Canonical page URLs
+  should match Cloudflare Pages' directory form (`/`, `/zh/`, `/docs/.../`,
+  `/zh/docs/.../`); file URLs keep their extension. `/home` and `/zh/home` are
+  compatibility routes and should stay `noindex,follow`.
 - `vite.config.ts` is the build integration point. Keep TanStack Start, Fumadocs
   MDX, Tailwind, React, and preview-only aliases there. The deployable static
   build output is `site-docs/out/client`; do not publish the SSR server bundle.

--- a/site-docs/lib/metadata.test.ts
+++ b/site-docs/lib/metadata.test.ts
@@ -2,17 +2,17 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { brandTitle, pageHead } from './metadata.ts';
 
-test('brandTitle appends | Lody when the title is unbranded', () => {
+await test('brandTitle appends | Lody when the title is unbranded', () => {
   assert.equal(brandTitle('Introduction'), 'Introduction | Lody');
   assert.equal(brandTitle('Blog'), 'Blog | Lody');
   assert.equal(brandTitle('价格'), '价格 | Lody');
 });
 
-test('brandTitle returns the brand when the title is empty', () => {
+await test('brandTitle returns the brand when the title is empty', () => {
   assert.equal(brandTitle(''), 'Lody');
 });
 
-test('brandTitle does not double-brand titles that already include Lody', () => {
+await test('brandTitle does not double-brand titles that already include Lody', () => {
   assert.equal(
     brandTitle('Lody - Run your agents in parallel, safely'),
     'Lody - Run your agents in parallel, safely'
@@ -23,7 +23,7 @@ test('brandTitle does not double-brand titles that already include Lody', () => 
   assert.equal(brandTitle('Download Lody'), 'Download Lody');
 });
 
-test('pageHead falls back to the product description', () => {
+await test('pageHead falls back to the product description', () => {
   const head = pageHead({
     title: 'Introduction | Lody',
     path: '/docs',

--- a/site-docs/lib/metadata.test.ts
+++ b/site-docs/lib/metadata.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { brandTitle, pageHead } from './metadata.ts';
+
+test('brandTitle appends | Lody when the title is unbranded', () => {
+  assert.equal(brandTitle('Introduction'), 'Introduction | Lody');
+  assert.equal(brandTitle('Blog'), 'Blog | Lody');
+  assert.equal(brandTitle('价格'), '价格 | Lody');
+});
+
+test('brandTitle returns the brand when the title is empty', () => {
+  assert.equal(brandTitle(''), 'Lody');
+});
+
+test('brandTitle does not double-brand titles that already include Lody', () => {
+  assert.equal(
+    brandTitle('Lody - Run your agents in parallel, safely'),
+    'Lody - Run your agents in parallel, safely'
+  );
+  assert.equal(brandTitle('Introduction | Lody'), 'Introduction | Lody');
+  assert.equal(brandTitle('Changelog – Lody'), 'Changelog – Lody');
+  assert.equal(brandTitle('Pricing - Lody'), 'Pricing - Lody');
+  assert.equal(brandTitle('Download Lody'), 'Download Lody');
+});
+
+test('pageHead falls back to the product description', () => {
+  const head = pageHead({
+    title: 'Introduction | Lody',
+    path: '/docs',
+    locale: 'en-US',
+  });
+  const description = head.meta.find((entry) => entry.name === 'description');
+  assert.equal(
+    description?.content,
+    'Lody is a team workspace for running AI coding agents in parallel with isolated Git worktrees, live diff review, GitHub integration, and mobile access.'
+  );
+});

--- a/site-docs/lib/metadata.ts
+++ b/site-docs/lib/metadata.ts
@@ -1,5 +1,15 @@
 const SITE_URL = 'https://lody.ai';
 const OG_IMAGE_PATH = '/og-image.png';
+const DEFAULT_DESCRIPTION =
+  'Lody is a team workspace for running AI coding agents in parallel with isolated Git worktrees, live diff review, GitHub integration, and mobile access.';
+
+/** Append `| Lody` to a document head title unless it is already branded. */
+export function brandTitle(title: string, brand = 'Lody'): string {
+  if (!title) return brand;
+  if (title.toLowerCase().includes(brand.toLowerCase())) return title;
+  if (/(?:\| Lody|– Lody|- Lody)$/u.test(title)) return title;
+  return `${title} | ${brand}`;
+}
 
 type Alternate = {
   lang: 'en-US' | 'zh-CN';
@@ -49,7 +59,7 @@ export function pageHead(args: {
   /** Serialized JSON-LD object (placed in head as application/ld+json). */
   jsonLd?: Record<string, unknown> | readonly Record<string, unknown>[];
 }): SiteHead {
-  const description = args.description ?? 'Lody AI';
+  const description = args.description ?? DEFAULT_DESCRIPTION;
   const canonical = absoluteUrl(args.path);
   const image = absoluteUrl(args.image ?? OG_IMAGE_PATH);
   const robots = robotsContent(args.robots);

--- a/site-docs/package.json
+++ b/site-docs/package.json
@@ -13,7 +13,7 @@
     "build": "vite build",
     "pretypecheck": "corepack pnpm run generate && corepack pnpm run generate:routes",
     "typecheck": "tsc --noEmit",
-    "test": "node --test scripts/postinstall.test.mjs"
+    "test": "node --test scripts/postinstall.test.mjs && node --experimental-strip-types --test lib/metadata.test.ts"
   },
   "dependencies": {
     "@lody/components": "workspace:*",

--- a/site-docs/src/site-pages/blog.tsx
+++ b/site-docs/src/site-pages/blog.tsx
@@ -1,6 +1,6 @@
 import { BlogIndexPage, BlogPostPage } from '@site/components/blog';
 import type { BlogEntry, BlogLocale } from '@site/lib/blog';
-import { pageHead } from '@site/lib/metadata';
+import { brandTitle, pageHead } from '@site/lib/metadata';
 import type { SiteHead } from '@site/lib/metadata';
 import { localeCode } from './shared';
 
@@ -45,7 +45,7 @@ export function blogIndexHead(locale: BlogLocale, entries: BlogEntry[] = []): Si
   const text = indexCopy[locale];
 
   return pageHead({
-    title: text.title,
+    title: brandTitle(text.title),
     description: text.description,
     path: text.path,
     locale: localeCode(locale),
@@ -84,7 +84,7 @@ export function BlogIndexRoutePage({
 
 export function blogPostHead(locale: BlogLocale, data: BlogEntry): SiteHead {
   return pageHead({
-    title: data.title,
+    title: brandTitle(data.title),
     description: data.description,
     path: data.url,
     locale: localeCode(locale),

--- a/site-docs/src/site-pages/changelog.tsx
+++ b/site-docs/src/site-pages/changelog.tsx
@@ -1,12 +1,12 @@
 import { ChangelogDetailPage, ChangelogIndexPage } from '@site/components/changelog';
 import type { ChangelogEntry, ChangelogLocale } from '@site/lib/changelog';
-import { pageHead } from '@site/lib/metadata';
+import { brandTitle, pageHead } from '@site/lib/metadata';
 import type { SiteHead } from '@site/lib/metadata';
 import { type ChangelogPostRouteData, localeCode } from './shared';
 
 export function changelogIndexHead(locale: ChangelogLocale): SiteHead {
   return pageHead({
-    title: locale === 'zh' ? '更新日志' : 'Changelog',
+    title: brandTitle(locale === 'zh' ? '更新日志' : 'Changelog'),
     description:
       locale === 'zh'
         ? '追踪 Lody 的产品更新、改进和修复。'
@@ -35,7 +35,7 @@ export function changelogPostHead(locale: ChangelogLocale, data: ChangelogPostRo
   const enPath = `/changelog/${entry.slug}`;
 
   return pageHead({
-    title: entry.title,
+    title: brandTitle(entry.title),
     description: entry.description ?? `Lody ${entry.version} release notes.`,
     path: entry.url,
     locale: localeCode(locale),

--- a/site-docs/src/site-pages/docs.tsx
+++ b/site-docs/src/site-pages/docs.tsx
@@ -2,19 +2,14 @@ import { DocsTocLanguageSelect } from '@site/components/docs-toc-language-select
 import { DocsSidebarFooter } from '@site/components/docs-sidebar-footer';
 import { getMDXComponents } from '@site/components/mdx';
 import { baseOptions } from '@site/lib/layout.shared';
-import { pageHead } from '@site/lib/metadata';
+import { brandTitle, pageHead } from '@site/lib/metadata';
 import type { SiteHead } from '@site/lib/metadata';
 import browserCollections from '@site/.source/browser';
 import { deserializePageTree } from 'fumadocs-core/source/client';
 import type { TOCItemType } from 'fumadocs-core/toc';
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layouts/docs/page';
-import {
-  type DocsRouteData,
-  localeCode,
-  type SerializedTocItem,
-  type SiteLocale,
-} from './shared';
+import { type DocsRouteData, localeCode, type SerializedTocItem, type SiteLocale } from './shared';
 
 const docsContentLoaders = {
   en: browserCollections.docsEn.createClientLoader({
@@ -36,7 +31,7 @@ export function docsHead(locale: SiteLocale, data: DocsRouteData): SiteHead {
   const zhPath = enPath === '/docs' ? '/zh/docs' : `/zh${enPath}`;
 
   return pageHead({
-    title: data.title,
+    title: brandTitle(data.title),
     description: data.description,
     path: data.path,
     locale: localeCode(locale),

--- a/site-docs/src/site-pages/pricing.tsx
+++ b/site-docs/src/site-pages/pricing.tsx
@@ -1,11 +1,11 @@
 import { PricingPage } from '@site/components/pricing-page';
-import { pageHead } from '@site/lib/metadata';
+import { brandTitle, pageHead } from '@site/lib/metadata';
 import type { SiteHead } from '@site/lib/metadata';
 import { localeCode, type SiteLocale } from './shared';
 
 export function pricingHead(locale: SiteLocale): SiteHead {
   return pageHead({
-    title: locale === 'zh' ? '价格' : 'Pricing',
+    title: brandTitle(locale === 'zh' ? '价格' : 'Pricing'),
     description:
       locale === 'zh'
         ? 'Lody 免费版、Plus 和企业版价格。'

--- a/site-docs/tsconfig.json
+++ b/site-docs/tsconfig.json
@@ -31,5 +31,5 @@
     "source.config.ts",
     "vite.config.ts"
   ],
-  "exclude": ["node_modules", "app/**/*.ts", "app/**/*.tsx"]
+  "exclude": ["node_modules", "app/**/*.ts", "app/**/*.tsx", "lib/**/*.test.ts"]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem / pressure

Public docs, blog, changelog, and pricing tab titles on lody.ai were bare page names (`Introduction`, `Blog`, `Pricing`). Search results and browser tabs did not identify Lody. The metadata fallback description was the weak string `Lody AI`. Landing titles already include the brand and must not be double-suffixed.

## Summary

- Add `brandTitle()` in `site-docs/lib/metadata.ts`. Empty titles become `Lody`. Titles that already contain the brand, or already end with `| Lody` / `– Lody` / `- Lody`, stay as-is. Everything else becomes `${title} | Lody`.
- Apply `brandTitle` only to docs, blog, changelog, and pricing `head()` titles. Visible `DocsTitle` stays unbranded. Landing and download heads are unchanged.
- Replace the `pageHead` description fallback with the product sentence used on the homepage.
- Record the invariant in `site-docs/AGENTS.md` and cover `brandTitle` plus the description fallback with a Node test. The test `test()` calls are awaited so type-aware oxlint `no-floating-promises` stays clean.

## Before / after

| Before | After |
| ------ | ----- |
| `/docs/` document title `Introduction` | `Introduction \| Lody` |
| Homepage title `Lody - Run your agents in parallel, safely` | unchanged |
| Missing description fallback `Lody AI` | product sentence about parallel agents, worktrees, diff review, GitHub, and mobile |

## Test plan

- `corepack pnpm --filter @lody/site-docs test` — postinstall tests plus `brandTitle` / `pageHead` fallback tests passed (7/7).
- Direct helper check: `brandTitle('Introduction')` is `Introduction | Lody`; `landingPageTitle('en')` stays `Lody - Run your agents in parallel, safely`.
- `corepack pnpm lint` (type-aware oxlint) — 0 errors after awaiting the `node:test` registrations. First CI run failed on those four floating promises.
- Confirmed `DocsTitle` still renders `data.title` without the brand suffix.
- Confirmed `landing.tsx` / `download.tsx` still pass their existing titles through `pageHead` without `brandTitle`.
- `@lody/site-docs` `tsc` failed on missing `acp-extension-core` / `acp-extension-dsh` submodule types in `@lody/shared`. That is an environment checkout gap, not a title-helper error.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `site-docs/lib/metadata.ts` `brandTitle` and the five `head()` call sites in `src/site-pages/{docs,blog,changelog,pricing}.tsx`.
- **Decisions to challenge:** Branding is applied only at those heads, not inside `pageHead`, so landing/download/legal titles stay author-controlled.
- **Plausible failures / evidence gaps:** A blog or changelog title that mentions "Lody" will not get `| Lody` appended; that is intentional. Legal pages were left unbranded because they were out of scope.

### Authoring context

- **User goal / directives:** Make lody.ai docs/blog/changelog/pricing tab titles `Title | Lody` without double-branding the homepage.
- **Constraints / non-goals:** Touch only `site-docs/`. Do not change visible `DocsTitle`. Leave landing and download heads alone.
- **Risk-bearing decisions:** `brandTitle` treats any case-insensitive occurrence of the brand as already branded, so titles like `Download Lody` are not suffixed.
- **Destructive or irreversible behavior:** None. SEO strings only; no data or auth changes.
- **Deliberately not done or tested:** Legal/support heads were not branded. A full site-docs prerender was not required to prove the title helper.
- **Unknowns / confidence:** High confidence in the title helper and call sites. Full package `tsc` was blocked by missing ACP extension submodule types in this environment.

<!-- context-handoff:end -->

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d725a90-9e1b-4a56-abf0-a7cdb37b3a0f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d725a90-9e1b-4a56-abf0-a7cdb37b3a0f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

