### PR TITLE
fix(cli): resolve archive worktrees from machine Flock

### DIFF
--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -3810,7 +3810,12 @@ export class MessageHandler {
       this.getMachineFlockDocIdForMachine()
     );
     return readMachineFlockRowsFromFlock(handle.flock, {
-      families: ['archiveSessionCommand', 'deleteSessionCommand', 'deleteLocalProjectCommand'],
+      families: [
+        'archiveSessionCommand',
+        'deleteSessionCommand',
+        'deleteLocalProjectCommand',
+        'localProject',
+      ],
     });
   }
 
@@ -3968,9 +3973,10 @@ export class MessageHandler {
     this.logger.debug(`[${sessionId}] Preview tunnel closed for archive`);
 
     const sessionRoomId = getSessionRoomId(sessionId);
-    const [sessionMetaDoc, archiveMachineMetaDoc] = await Promise.all([
+    const [sessionMetaDoc, archiveMachineMetaDoc, archiveMachineFlockRows] = await Promise.all([
       this.workspaceDocument.repo.getDocMeta(sessionRoomId),
       this.workspaceDocument.repo.getDocMeta(getMachineRoomId(this.machineId)),
+      this.tryReadMachineFlockCommandRows(),
     ]);
     const sessionMeta = sessionMetaDoc?.meta as SessionMeta | undefined;
     const archiveMachineMeta = archiveMachineMetaDoc?.meta as MachineLegacyMetaFields | undefined;
@@ -3986,6 +3992,7 @@ export class MessageHandler {
       const cleanupTarget = this.resolveWorktreeCleanupTarget({
         sessionMeta,
         machineMeta: archiveMachineMeta,
+        machineFlockRows: archiveMachineFlockRows,
       });
       if (cleanupTarget) {
         const worktreeManager = getWorktreeManager(this.buildWorktreeManagerConfig(cleanupTarget));

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -3925,6 +3925,14 @@ export class MessageHandler {
   }
 
   private async processArchiveRequests(): Promise<void> {
+    // Archive cleanup may need a local-project root that exists only in Machine
+    // Flock. In cloud mode, wait until its command watcher has completed the
+    // initial remote sync; a successful read before then can still be stale.
+    if (this.cloudPort.kind !== 'local' && !this.machineFlockCommandWatcher.isReady) {
+      this.logger.debug('[archive] Waiting for authoritative Machine Flock before processing');
+      return;
+    }
+
     let snapshot: MachineCommandSnapshot;
     try {
       snapshot = await this.readMachineCommandSnapshot({ strictFlock: true });

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -3833,11 +3833,16 @@ export class MessageHandler {
     }
   }
 
-  private async readMachineCommandSnapshot(): Promise<MachineCommandSnapshot> {
+  private async readMachineCommandSnapshot(options?: {
+    strictFlock?: boolean;
+  }): Promise<MachineCommandSnapshot> {
     const machineRoomId = getMachineRoomId(this.machineId);
+    const flockRows = options?.strictFlock
+      ? this.readMachineFlockCommandRows()
+      : this.tryReadMachineFlockCommandRows();
     const [machineMetaDoc, machineFlockRows] = await Promise.all([
       this.workspaceDocument.repo.getDocMeta(machineRoomId),
-      this.tryReadMachineFlockCommandRows(),
+      flockRows,
     ]);
     return buildMachineCommandSnapshot(
       machineMetaDoc?.meta as MachineLegacyMetaFields | undefined,
@@ -3920,7 +3925,15 @@ export class MessageHandler {
   }
 
   private async processArchiveRequests(): Promise<void> {
-    const snapshot = await this.readMachineCommandSnapshot();
+    let snapshot: MachineCommandSnapshot;
+    try {
+      snapshot = await this.readMachineCommandSnapshot({ strictFlock: true });
+    } catch (error) {
+      this.logger.error(
+        `[archive] Failed to read Machine Flock; keeping archive request queued: ${formatErrorMessage(error)}`
+      );
+      return;
+    }
     const sessionIds = snapshot.archiveSessionIds;
     if (sessionIds.length === 0) {
       this.logger.debug('[archive] No pending archive requests');
@@ -3943,7 +3956,9 @@ export class MessageHandler {
       this.archiveInFlight.add(sessionId);
       try {
         this.logger.debug(`[archive] Start archiving session ${sessionId}`);
-        await this.archiveSessionResources(sessionId);
+        await this.archiveSessionResources(sessionId, {
+          machineFlockRows: snapshot.machineFlockRows,
+        });
         await this.removeArchiveRequest(sessionId);
         this.logger.debug(`[archive] Finished archiving session ${sessionId}`);
       } catch (error) {
@@ -3958,7 +3973,10 @@ export class MessageHandler {
 
   private async archiveSessionResources(
     sessionId: SessionId,
-    options?: { preserveWorktree?: boolean }
+    options?: {
+      preserveWorktree?: boolean;
+      machineFlockRows?: MachineFlockRowMap;
+    }
   ): Promise<void> {
     this.logger.debug(`[${sessionId}] Archiving session resources`);
 
@@ -3973,10 +3991,9 @@ export class MessageHandler {
     this.logger.debug(`[${sessionId}] Preview tunnel closed for archive`);
 
     const sessionRoomId = getSessionRoomId(sessionId);
-    const [sessionMetaDoc, archiveMachineMetaDoc, archiveMachineFlockRows] = await Promise.all([
+    const [sessionMetaDoc, archiveMachineMetaDoc] = await Promise.all([
       this.workspaceDocument.repo.getDocMeta(sessionRoomId),
       this.workspaceDocument.repo.getDocMeta(getMachineRoomId(this.machineId)),
-      this.tryReadMachineFlockCommandRows(),
     ]);
     const sessionMeta = sessionMetaDoc?.meta as SessionMeta | undefined;
     const archiveMachineMeta = archiveMachineMetaDoc?.meta as MachineLegacyMetaFields | undefined;
@@ -3992,7 +4009,8 @@ export class MessageHandler {
       const cleanupTarget = this.resolveWorktreeCleanupTarget({
         sessionMeta,
         machineMeta: archiveMachineMeta,
-        machineFlockRows: archiveMachineFlockRows,
+        machineFlockRows:
+          options?.machineFlockRows ?? (await this.tryReadMachineFlockCommandRows()),
       });
       if (cleanupTarget) {
         const worktreeManager = getWorktreeManager(this.buildWorktreeManagerConfig(cleanupTarget));

--- a/apps/cli/tests/message-handler-terminal-cleanup.test.ts
+++ b/apps/cli/tests/message-handler-terminal-cleanup.test.ts
@@ -224,6 +224,63 @@ function createHarness(options?: {
 }
 
 describe('MessageHandler terminal cleanup', () => {
+  it('cleans a local worktree when its project metadata exists only in the machine Flock', async () => {
+    const localProjectId = 'local-project-archive' as LocalProjectId;
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lody-archive-project-'));
+    const originalDataDir = process.env.LODY_DATA_DIR;
+    const originalLocksDir = process.env.LODY_LOCKS_DIR;
+    process.env.LODY_DATA_DIR = path.join(testDir, 'data');
+    process.env.LODY_LOCKS_DIR = path.join(testDir, 'locks');
+    const rootPath = createLocalRepo(testDir);
+    const sessionId = 'session-archive-worktree' as SessionId;
+    const sessionMeta = {
+      id: sessionId,
+      machineId: 'machine-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      userId: 'user-1',
+      cliType: 'codex',
+      agentType: 'codex',
+      status: SessionStatusFactory.idle(),
+      project: { kind: 'local', localProjectId },
+      isWorktree: true,
+    } as SessionMeta;
+    const machineFlockRows = [
+      {
+        key: machineFlockKeys.localProject(localProjectId),
+        value: {
+          id: localProjectId,
+          name: 'Project',
+          rootPath,
+          createdAtMs: 1,
+        },
+      },
+    ];
+    try {
+      const manager = getWorktreeManager({
+        repoId: deriveRepoIdFromLocalProjectPath(rootPath),
+        source: { kind: 'local-shared', originalRootPath: rootPath },
+        logger: createSilentLogger(),
+      });
+      const worktree = await manager.createWorktree(sessionId);
+      const { handler, sessionManager } = createHarness({
+        sessionId,
+        sessionMetas: [sessionMeta],
+        machineFlockRows,
+      });
+
+      await handler.archiveSessionResources(sessionId);
+
+      expect(fs.existsSync(worktree.hostPath)).toBe(false);
+      expect(sessionManager.archiveSession).toHaveBeenCalledWith(sessionId);
+    } finally {
+      if (originalDataDir === undefined) delete process.env.LODY_DATA_DIR;
+      else process.env.LODY_DATA_DIR = originalDataDir;
+      if (originalLocksDir === undefined) delete process.env.LODY_LOCKS_DIR;
+      else process.env.LODY_LOCKS_DIR = originalLocksDir;
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it('closes session terminals when archiving resources even without an active session', async () => {
     const { handler, sessionId, closeSessionTerminals, sessionManager } = createHarness();
 

--- a/apps/cli/tests/message-handler-terminal-cleanup.test.ts
+++ b/apps/cli/tests/message-handler-terminal-cleanup.test.ts
@@ -39,9 +39,10 @@ const createSilentLogger = (): Logger => ({
 });
 
 type MessageHandlerInternals = {
+  processArchiveRequests: () => Promise<void>;
   archiveSessionResources: (
     sessionId: SessionId,
-    options?: { preserveWorktree?: boolean }
+    options?: { preserveWorktree?: boolean; machineFlockRows?: Record<string, MachineFlockScanRow> }
   ) => Promise<void>;
   deleteLocalProjectResources: (
     localProjectId: LocalProjectId,
@@ -75,8 +76,10 @@ function createHarness(options?: {
   machineFlockRows?: MachineFlockScanRow[];
   sessionMetas?: SessionMeta[];
   activeSessionIds?: SessionId[];
+  archiveSessionIds?: SessionId[];
   includeLegacySessionDeleteRequest?: boolean;
   localProjectRootPaths?: Record<LocalProjectId, string>;
+  machineFlockOpenError?: Error;
 }) {
   const sessionId = options?.sessionId ?? ('session-1' as SessionId);
   const childSessionIds = options?.childSessionIds ?? [];
@@ -128,7 +131,9 @@ function createHarness(options?: {
       if (roomId === machineRoomId) {
         return {
           meta: {
-            needToArchiveSessions: {},
+            needToArchiveSessions: Object.fromEntries(
+              (options?.archiveSessionIds ?? []).map((id) => [id, true])
+            ),
             needToDeleteSessions:
               options?.includeLegacySessionDeleteRequest === false ? {} : { [sessionId]: true },
             localProjects: Object.fromEntries(
@@ -149,15 +154,20 @@ function createHarness(options?: {
           : []
       ),
     })),
-    openFlockDoc: vi.fn(async () => ({
-      flock: {
-        scan: () => machineFlockRows,
-        set: flockSet,
-        delete: flockDelete,
-        commit: flockCommit,
-      },
-      syncOnce: vi.fn(async () => {}),
-    })),
+    openFlockDoc: vi.fn(async () => {
+      if (options?.machineFlockOpenError) {
+        throw options.machineFlockOpenError;
+      }
+      return {
+        flock: {
+          scan: () => machineFlockRows,
+          set: flockSet,
+          delete: flockDelete,
+          commit: flockCommit,
+        },
+        syncOnce: vi.fn(async () => {}),
+      };
+    }),
     upsertDocMeta: vi.fn(async (roomId: string, patch: Partial<SessionMeta>) => {
       events.push(`meta:${roomId}:${patch.isArchived === true ? 'archived' : 'other'}`);
       const current = sessionMetas.get(roomId);
@@ -288,6 +298,22 @@ describe('MessageHandler terminal cleanup', () => {
 
     expect(closeSessionTerminals).toHaveBeenCalledWith(sessionId);
     expect(sessionManager.terminateSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps archive requests queued when the Machine Flock read fails', async () => {
+    const sessionId = 'session-archive-flock-read-failure' as SessionId;
+    const { handler, sessionManager, repo } = createHarness({
+      sessionId,
+      archiveSessionIds: [sessionId],
+      machineFlockOpenError: new Error('temporary Machine Flock failure'),
+    });
+
+    await expect(handler.processArchiveRequests()).resolves.toBeUndefined();
+    expect(sessionManager.archiveSession).not.toHaveBeenCalled();
+    expect(repo.upsertDocMeta).not.toHaveBeenCalledWith(
+      getSessionRoomId(sessionId),
+      expect.objectContaining({ isArchived: true })
+    );
   });
 
   it('closes parent and active child terminals before permanent deletion cleanup', async () => {

--- a/apps/cli/tests/message-handler-terminal-cleanup.test.ts
+++ b/apps/cli/tests/message-handler-terminal-cleanup.test.ts
@@ -18,6 +18,7 @@ import {
   type SessionMeta,
   type WorkspaceId,
 } from '@lody/shared';
+import type { CloudPort } from '@lody/platform';
 import { deriveRepoIdFromLocalProjectPath } from '@lody/shared/node/worktree-paths';
 import { MessageHandler } from '../src/lib/message-handler';
 import type { LoroDocumentManager } from '../src/lib/loro/doc';
@@ -67,6 +68,7 @@ type MessageHandlerInternals = {
   previewService: {
     closeSessionPreviewForCleanup: (sessionId: SessionId, reason: string) => Promise<void>;
   };
+  machineFlockCommandWatcher: { isReady: boolean };
 };
 
 function createHarness(options?: {
@@ -80,6 +82,7 @@ function createHarness(options?: {
   includeLegacySessionDeleteRequest?: boolean;
   localProjectRootPaths?: Record<LocalProjectId, string>;
   machineFlockOpenError?: Error;
+  cloudPort?: CloudPort;
 }) {
   const sessionId = options?.sessionId ?? ('session-1' as SessionId);
   const childSessionIds = options?.childSessionIds ?? [];
@@ -209,7 +212,7 @@ function createHarness(options?: {
       machineName: 'machine',
       cliVersion: '0.0.0',
       closeSessionTerminals,
-      cloudPort: createTestCloudPort(),
+      cloudPort: options?.cloudPort ?? createTestCloudPort(),
     }
   );
   const internal = handler as unknown as MessageHandlerInternals;
@@ -298,6 +301,85 @@ describe('MessageHandler terminal cleanup', () => {
 
     expect(closeSessionTerminals).toHaveBeenCalledWith(sessionId);
     expect(sessionManager.terminateSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps a cloud archive request queued until the Machine Flock watcher is authoritative', async () => {
+    const localProjectId = 'local-project-archive-authority' as LocalProjectId;
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lody-archive-authority-'));
+    const originalDataDir = process.env.LODY_DATA_DIR;
+    const originalLocksDir = process.env.LODY_LOCKS_DIR;
+    process.env.LODY_DATA_DIR = path.join(testDir, 'data');
+    process.env.LODY_LOCKS_DIR = path.join(testDir, 'locks');
+    const rootPath = createLocalRepo(testDir);
+    const sessionId = 'session-archive-awaiting-authority' as SessionId;
+    const sessionMeta = {
+      id: sessionId,
+      machineId: 'machine-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      userId: 'user-1',
+      cliType: 'codex',
+      agentType: 'codex',
+      status: SessionStatusFactory.idle(),
+      project: { kind: 'local', localProjectId },
+      isWorktree: true,
+    } as SessionMeta;
+    const machineFlockRows = [
+      {
+        key: machineFlockKeys.localProject(localProjectId),
+        value: { id: localProjectId, name: 'Project', rootPath, createdAtMs: 1 },
+      },
+    ];
+    const cloudPort = { ...createTestCloudPort(), kind: 'cloud' } as CloudPort;
+    try {
+      const manager = getWorktreeManager({
+        repoId: deriveRepoIdFromLocalProjectPath(rootPath),
+        source: { kind: 'local-shared', originalRootPath: rootPath },
+        logger: createSilentLogger(),
+      });
+      const worktree = await manager.createWorktree(sessionId);
+      const { handler, repo, sessionManager } = createHarness({
+        sessionId,
+        sessionMetas: [sessionMeta],
+        archiveSessionIds: [sessionId],
+        includeLegacySessionDeleteRequest: false,
+        machineFlockRows,
+        cloudPort,
+      });
+      handler.machineFlockCommandWatcher = { isReady: false };
+
+      await handler.processArchiveRequests();
+
+      expect(fs.existsSync(worktree.hostPath)).toBe(true);
+      expect(sessionManager.archiveSession).not.toHaveBeenCalled();
+      expect(repo.upsertDocMeta).not.toHaveBeenCalledWith(
+        getSessionRoomId(sessionId),
+        expect.objectContaining({ isArchived: true })
+      );
+      expect(repo.upsertDocMeta).not.toHaveBeenCalledWith(
+        getMachineRoomId('machine-1'),
+        expect.objectContaining({ needToArchiveSessions: {} })
+      );
+
+      handler.machineFlockCommandWatcher.isReady = true;
+      await handler.processArchiveRequests();
+
+      expect(fs.existsSync(worktree.hostPath)).toBe(false);
+      expect(sessionManager.archiveSession).toHaveBeenCalledWith(sessionId);
+      expect(repo.upsertDocMeta).toHaveBeenCalledWith(
+        getSessionRoomId(sessionId),
+        expect.objectContaining({ isArchived: true })
+      );
+      expect(repo.upsertDocMeta).toHaveBeenCalledWith(
+        getMachineRoomId('machine-1'),
+        expect.objectContaining({ needToArchiveSessions: {} })
+      );
+    } finally {
+      if (originalDataDir === undefined) delete process.env.LODY_DATA_DIR;
+      else process.env.LODY_DATA_DIR = originalDataDir;
+      if (originalLocksDir === undefined) delete process.env.LODY_LOCKS_DIR;
+      else process.env.LODY_LOCKS_DIR = originalLocksDir;
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
   });
 
   it('keeps archive requests queued when the Machine Flock read fails', async () => {


### PR DESCRIPTION
## Related issue

Closes #377

## Problem / pressure

Archiving a local-project session did not remove its worktree or run the configured cleanup script when the project metadata was stored only in the machine Flock document. The archive path resolved local projects from legacy machine metadata but did not load the Flock rows that are authoritative for current local projects.

## Summary

Load the machine Flock command snapshot's `localProject` rows while processing archive requests and pass them to worktree cleanup target resolution. Add a regression that creates a real local Git worktree with project metadata available only through the machine Flock and verifies archiving removes that worktree.

## Visual explanation

```mermaid
flowchart TD
  A[Queued archive request] --> B[Wait for initial Machine Flock sync]
  B --> C[Read authoritative Machine Flock snapshot]
  C --> D[Resolve localProject root path]
  D --> E[Run archive cleanup / remove Lody worktree]
  E --> F[Acknowledge archive request]
```

The archive request stays queued until the Machine Flock watcher has completed its initial cloud sync; cleanup and acknowledgement then use the same authoritative snapshot.

## Before / after

| Before | After |
| ------ | ----- |
| Archive cleanup could not resolve a local project's root path when it existed only in Machine Flock, so cleanup and worktree removal were skipped. | Archive cleanup resolves the root path from the same Machine Flock local-project catalog used by deletion, then removes the archived worktree. |

## Test plan

- `corepack pnpm install --frozen-lockfile --ignore-scripts` — passed.
- `corepack pnpm --dir packages/acp-extension-core build`, plus Claude, Codex, Grok, and DSH adapter builds — passed; required for the CLI test imports.
- `corepack pnpm --dir apps/cli exec vitest run tests/message-handler-terminal-cleanup.test.ts` — 13 tests passed, including the new archive regression.
- `corepack pnpm --filter lody typecheck` — passed.
- `corepack pnpm lint:fast` — 0 errors (465 existing warnings).
- `corepack pnpm check:public-boundary` — passed.
- Prettier check on changed files and `git diff --check` — passed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check that archive processing reads `localProject` rows from Machine Flock and passes them to `resolveWorktreeCleanupTarget`, matching the existing permanent-delete path.
- **Decisions to challenge:** Confirm that one shared command-row reader should include the local-project catalog while preserving the existing legacy metadata fallback.
- **Plausible failures / evidence gaps:** The regression exercises native worktree removal; a configured user cleanup script is not needed to prove the previously skipped target-resolution branch.

### Authoring context

- **User goal / directives:** Make archived local-project sessions clean up their worktree instead of leaving the directory and branch registered.
- **Constraints / non-goals:** Keep the change limited to archive target resolution; do not alter dirty-worktree safety, cleanup script semantics, or the deletion path.
- **Risk-bearing decisions:** Read the authoritative local-project catalog from Machine Flock and retain legacy machine metadata as a fallback for older clients.
- **Destructive or irreversible behavior:** Archive now removes the Lody-owned worktree through the existing forced archive path; the preserved branch behavior and configured cleanup hook remain unchanged.
- **Deliberately not done or tested:** No live desktop release was run; the focused MessageHandler suite uses synthetic session metadata and a real temporary Git repository.
- **Unknowns / confidence:** High confidence in the missing-row diagnosis and focused regression; broader Electron UI behavior remains covered by existing integration paths.

<!-- context-handoff:end -->
