### PR TITLE
fix(site-docs): return HTTP 404 for unknown routes (stop soft-404)

### DIFF
--- a/site-docs/AGENTS.md
+++ b/site-docs/AGENTS.md
@@ -91,7 +91,10 @@
   compatibility routes and should stay `noindex,follow`. Unmatched URLs must not
   SPA-fallback to the homepage: prerender `/404` to `out/client/404.html`
   (Cloudflare Pages serves that file with HTTP 404). The 404 document is
-  `noindex,follow` and must not canonicalize to `/`.
+  `noindex,follow` and must not canonicalize to `/`. Do not add a Vite
+  `configurePreviewServer` 404 interceptor — TanStack prerender uses that
+  preview server to fetch pages that do not exist on disk yet. Use
+  `pnpm --filter @lody/site-docs preview:static` to emulate the static host.
 - `vite.config.ts` is the build integration point. Keep TanStack Start, Fumadocs
   MDX, Tailwind, React, and preview-only aliases there. The deployable static
   build output is `site-docs/out/client`; do not publish the SSR server bundle.

--- a/site-docs/AGENTS.md
+++ b/site-docs/AGENTS.md
@@ -95,6 +95,8 @@
   `configurePreviewServer` 404 interceptor — TanStack prerender uses that
   preview server to fetch pages that do not exist on disk yet. Use
   `pnpm --filter @lody/site-docs preview:static` to emulate the static host.
+  After prerender, `scripts/finalize-404-html.mjs` strips app hydration from
+  `404.html` so a junk URL cannot boot the client router and blank the page.
 - `vite.config.ts` is the build integration point. Keep TanStack Start, Fumadocs
   MDX, Tailwind, React, and preview-only aliases there. The deployable static
   build output is `site-docs/out/client`; do not publish the SSR server bundle.

--- a/site-docs/AGENTS.md
+++ b/site-docs/AGENTS.md
@@ -88,7 +88,10 @@
   double-suffixed. Visible `DocsTitle` stays unbranded. Canonical page URLs
   should match Cloudflare Pages' directory form (`/`, `/zh/`, `/docs/.../`,
   `/zh/docs/.../`); file URLs keep their extension. `/home` and `/zh/home` are
-  compatibility routes and should stay `noindex,follow`.
+  compatibility routes and should stay `noindex,follow`. Unmatched URLs must not
+  SPA-fallback to the homepage: prerender `/404` to `out/client/404.html`
+  (Cloudflare Pages serves that file with HTTP 404). The 404 document is
+  `noindex,follow` and must not canonicalize to `/`.
 - `vite.config.ts` is the build integration point. Keep TanStack Start, Fumadocs
   MDX, Tailwind, React, and preview-only aliases there. The deployable static
   build output is `site-docs/out/client`; do not publish the SSR server bundle.

--- a/site-docs/lib/not-found-seo.test.ts
+++ b/site-docs/lib/not-found-seo.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { localeFromPathname, notFoundCopy, notFoundHead } from './not-found-seo.ts';
+
+await test('localeFromPathname treats /zh and /zh/... as Chinese', () => {
+  assert.equal(localeFromPathname('/zh'), 'zh');
+  assert.equal(localeFromPathname('/zh/'), 'zh');
+  assert.equal(localeFromPathname('/zh/docs/nope'), 'zh');
+  assert.equal(localeFromPathname('/docs/nope'), 'en');
+  assert.equal(localeFromPathname('/zha'), 'en');
+});
+
+await test('notFoundHead uses a branded 404 title and noindex', () => {
+  const en = notFoundHead('en');
+  const zh = notFoundHead('zh');
+
+  assert.equal(en.meta.find((entry) => entry.title)?.title, notFoundCopy.en.title);
+  assert.equal(zh.meta.find((entry) => entry.title)?.title, notFoundCopy.zh.title);
+  assert.equal(en.meta.find((entry) => entry.name === 'robots')?.content, 'noindex, follow');
+  assert.equal(zh.meta.find((entry) => entry.name === 'robots')?.content, 'noindex, follow');
+  assert.match(notFoundCopy.en.title, /\| Lody$/u);
+  assert.match(notFoundCopy.zh.title, /\| Lody$/u);
+});
+
+await test('notFoundHead does not canonicalize or og:url to the homepage', () => {
+  const head = notFoundHead('en');
+  assert.equal(
+    head.links.some((link) => link.rel === 'canonical'),
+    false
+  );
+  assert.equal(
+    head.meta.some((entry) => entry.property === 'og:url' && entry.content === 'https://lody.ai/'),
+    false
+  );
+  assert.notEqual(head.meta.find((entry) => entry.title)?.title, 'Lody Docs');
+  assert.doesNotMatch(
+    head.meta.find((entry) => entry.title)?.title ?? '',
+    /Run your agents in parallel/u
+  );
+});

--- a/site-docs/lib/not-found-seo.ts
+++ b/site-docs/lib/not-found-seo.ts
@@ -1,0 +1,58 @@
+import type { SiteHead } from './metadata.ts';
+
+export type NotFoundSeoLocale = 'en' | 'zh';
+
+export const notFoundCopy = {
+  en: {
+    title: 'Page not found | Lody',
+    heading: 'Page not found',
+    description: 'This page does not exist. It may have been moved or the URL is incorrect.',
+    home: 'Back to home',
+    homeHref: '/',
+    docs: 'Browse docs',
+    docsHref: '/docs',
+  },
+  zh: {
+    title: '页面不存在 | Lody',
+    heading: '页面不存在',
+    description: '该页面不存在，可能已被移动或网址不正确。',
+    home: '返回首页',
+    homeHref: '/zh/',
+    docs: '浏览文档',
+    docsHref: '/zh/docs',
+  },
+} as const;
+
+export function localeFromPathname(pathname: string): NotFoundSeoLocale {
+  return pathname === '/zh' || pathname.startsWith('/zh/') ? 'zh' : 'en';
+}
+
+/**
+ * 404 document head. Static hosts serve one `404.html` for every unknown URL,
+ * so this must not canonicalize to the homepage (the current soft-404). A
+ * requested-URL canonical cannot be baked into that file; `noindex` is the
+ * cleaner signal if a host ever serves the document as HTTP 200.
+ */
+export function notFoundHead(locale: NotFoundSeoLocale): SiteHead {
+  const copy = notFoundCopy[locale];
+  const ogLocale = locale === 'zh' ? 'zh_CN' : 'en_US';
+
+  return {
+    meta: [
+      { title: copy.title },
+      { name: 'description', content: copy.description },
+      { name: 'robots', content: 'noindex, follow' },
+      { property: 'og:title', content: copy.title },
+      { property: 'og:description', content: copy.description },
+      { property: 'og:site_name', content: 'Lody' },
+      { property: 'og:locale', content: ogLocale },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:image', content: 'https://lody.ai/og-image.png' },
+      { name: 'twitter:card', content: 'summary_large_image' },
+      { name: 'twitter:title', content: copy.title },
+      { name: 'twitter:description', content: copy.description },
+      { name: 'twitter:image', content: 'https://lody.ai/og-image.png' },
+    ],
+    links: [],
+  };
+}

--- a/site-docs/package.json
+++ b/site-docs/package.json
@@ -11,9 +11,10 @@
     "dev": "vite dev --host 127.0.0.1 --port 3002",
     "prebuild": "corepack pnpm run clean:out && corepack pnpm run generate && corepack pnpm run generate:routes",
     "build": "vite build",
+    "preview:static": "node scripts/serve-static.mjs",
     "pretypecheck": "corepack pnpm run generate && corepack pnpm run generate:routes",
     "typecheck": "tsc --noEmit",
-    "test": "node --test scripts/postinstall.test.mjs scripts/site-paths.test.mjs && node --experimental-strip-types --test lib/metadata.test.ts lib/not-found-seo.test.ts"
+    "test": "node --test scripts/postinstall.test.mjs scripts/site-paths.test.mjs scripts/static-host.test.mjs && node --experimental-strip-types --test lib/metadata.test.ts lib/not-found-seo.test.ts"
   },
   "dependencies": {
     "@lody/components": "workspace:*",

--- a/site-docs/package.json
+++ b/site-docs/package.json
@@ -13,7 +13,7 @@
     "build": "vite build",
     "pretypecheck": "corepack pnpm run generate && corepack pnpm run generate:routes",
     "typecheck": "tsc --noEmit",
-    "test": "node --test scripts/postinstall.test.mjs && node --experimental-strip-types --test lib/metadata.test.ts"
+    "test": "node --test scripts/postinstall.test.mjs scripts/site-paths.test.mjs && node --experimental-strip-types --test lib/metadata.test.ts lib/not-found-seo.test.ts"
   },
   "dependencies": {
     "@lody/components": "workspace:*",

--- a/site-docs/package.json
+++ b/site-docs/package.json
@@ -10,11 +10,11 @@
     "predev": "corepack pnpm run generate",
     "dev": "vite dev --host 127.0.0.1 --port 3002",
     "prebuild": "corepack pnpm run clean:out && corepack pnpm run generate && corepack pnpm run generate:routes",
-    "build": "vite build",
+    "build": "vite build && node scripts/finalize-404-html.mjs",
     "preview:static": "node scripts/serve-static.mjs",
     "pretypecheck": "corepack pnpm run generate && corepack pnpm run generate:routes",
     "typecheck": "tsc --noEmit",
-    "test": "node --test scripts/postinstall.test.mjs scripts/site-paths.test.mjs scripts/static-host.test.mjs && node --experimental-strip-types --test lib/metadata.test.ts lib/not-found-seo.test.ts"
+    "test": "node --test scripts/postinstall.test.mjs scripts/site-paths.test.mjs scripts/static-host.test.mjs scripts/finalize-404-html.test.mjs && node --experimental-strip-types --test lib/metadata.test.ts lib/not-found-seo.test.ts"
   },
   "dependencies": {
     "@lody/components": "workspace:*",

--- a/site-docs/scripts/finalize-404-html.mjs
+++ b/site-docs/scripts/finalize-404-html.mjs
@@ -1,0 +1,41 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Cloudflare serves this one file for every unknown URL. If the prerendered
+ * React app hydrates, the client router boots against the *requested* path
+ * and blanks or errors. Keep the document static: meta + markup, no app JS.
+ */
+export function stripAppHydration(html) {
+  return html
+    .replace(/<link rel="modulepreload"[^>]*>/gu, '')
+    .replace(/<script class="\$tsr"[^>]*>[\s\S]*?<\/script>/gu, '')
+    .replace(/<script\b[^>]*\btype="module"[^>]*>[\s\S]*?<\/script>/gu, '');
+}
+
+export function finalize404Html(html) {
+  const next = stripAppHydration(html);
+  if (!next.includes('Page not found | Lody')) {
+    throw new Error('404.html is missing the dedicated not-found title');
+  }
+  if (!next.includes('noindex, follow')) {
+    throw new Error('404.html is missing noindex');
+  }
+  if (/rel="canonical"/u.test(next)) {
+    throw new Error('404.html must not include a canonical link');
+  }
+  if (/<script\b[^>]*\btype="module"/u.test(next)) {
+    throw new Error('404.html still contains an app module script');
+  }
+  return next;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  const notFoundPath = path.join(packageRoot, 'out', 'client', '404.html');
+  const html = readFileSync(notFoundPath, 'utf8');
+  writeFileSync(notFoundPath, finalize404Html(html));
+  console.log('Finalized static 404.html (no app hydration)');
+}

--- a/site-docs/scripts/finalize-404-html.test.mjs
+++ b/site-docs/scripts/finalize-404-html.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { finalize404Html, stripAppHydration } from './finalize-404-html.mjs';
+
+const sample = `<!DOCTYPE html><html><head>
+<title>Page not found | Lody</title>
+<meta name="robots" content="noindex, follow"/>
+<link rel="modulepreload" href="/assets/index-abc.js"/>
+<link rel="stylesheet" href="/assets/index.css"/>
+</head><body>
+<main>Page not found</main>
+<script class="$tsr" id="$tsr-stream-barrier">self.$_TSR={}</script>
+<script type="module" async="" src="/assets/index-abc.js"></script>
+</body></html>`;
+
+await test('stripAppHydration removes router boot scripts and keeps markup', () => {
+  const next = stripAppHydration(sample);
+  assert.match(next, /Page not found \| Lody/u);
+  assert.match(next, /index\.css/u);
+  assert.doesNotMatch(next, /modulepreload/u);
+  assert.doesNotMatch(next, /type="module"/u);
+  assert.doesNotMatch(next, /\$tsr/u);
+});
+
+await test('finalize404Html rejects a homepage-canonical 404 document', () => {
+  assert.throws(
+    () =>
+      finalize404Html(
+        '<title>Page not found | Lody</title><meta name="robots" content="noindex, follow"/><link rel="canonical" href="https://lody.ai/"/>'
+      ),
+    /canonical/u
+  );
+});

--- a/site-docs/scripts/generate-sitemap.mjs
+++ b/site-docs/scripts/generate-sitemap.mjs
@@ -1,13 +1,13 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { absoluteSiteUrl, collectSitePaths } from './site-paths.mjs';
+import { absoluteSiteUrl, collectSitePaths, isSitemapPath } from './site-paths.mjs';
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const sitemapPath = path.join(packageRoot, 'public', 'sitemap.xml');
 
 const entries = collectSitePaths(packageRoot)
-  .filter((sitePath) => sitePath !== '/home' && sitePath !== '/zh/home')
+  .filter(isSitemapPath)
   .map((sitePath) => `  <url><loc>${absoluteSiteUrl(sitePath)}</loc></url>`)
   .join('\n');
 

--- a/site-docs/scripts/serve-static.mjs
+++ b/site-docs/scripts/serve-static.mjs
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createStaticHost } from './static-host.mjs';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const root = path.join(packageRoot, 'out', 'client');
+const port = Number(process.env.PORT ?? 4173);
+const host = process.env.HOST ?? '127.0.0.1';
+
+const server = createStaticHost({ root, port, host });
+await server.listen();
+console.log(`Static host (Cloudflare Pages equivalent) http://${host}:${port}/`);
+console.log(`Serving ${root}`);

--- a/site-docs/scripts/site-paths.d.mts
+++ b/site-docs/scripts/site-paths.d.mts
@@ -4,4 +4,6 @@ export function slugFromMdxFile(file: string, rootDir: string): string;
 
 export function collectSitePaths(packageRoot: string): string[];
 
+export function isSitemapPath(sitePath: string): boolean;
+
 export function absoluteSiteUrl(sitePath: string): string;

--- a/site-docs/scripts/site-paths.mjs
+++ b/site-docs/scripts/site-paths.mjs
@@ -26,7 +26,15 @@ const STATIC_PATHS = [
   '/zh/support',
   '/account-deletion',
   '/zh/account-deletion',
+  '/404',
+  '/zh/404',
 ];
+
+const SITEMAP_EXCLUDED_PATHS = new Set(['/home', '/zh/home', '/404', '/zh/404']);
+
+export function isSitemapPath(sitePath) {
+  return !SITEMAP_EXCLUDED_PATHS.has(sitePath);
+}
 
 function exists(p) {
   try {

--- a/site-docs/scripts/site-paths.test.mjs
+++ b/site-docs/scripts/site-paths.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { collectSitePaths, isSitemapPath } from './site-paths.mjs';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+await test('prerender paths include the 404 documents', () => {
+  const paths = collectSitePaths(packageRoot);
+  assert.ok(paths.includes('/404'));
+  assert.ok(paths.includes('/zh/404'));
+  assert.ok(paths.includes('/'));
+  assert.ok(paths.includes('/docs'));
+});
+
+await test('sitemap omits compatibility homes and 404 documents', () => {
+  assert.equal(isSitemapPath('/'), true);
+  assert.equal(isSitemapPath('/docs'), true);
+  assert.equal(isSitemapPath('/home'), false);
+  assert.equal(isSitemapPath('/zh/home'), false);
+  assert.equal(isSitemapPath('/404'), false);
+  assert.equal(isSitemapPath('/zh/404'), false);
+});

--- a/site-docs/scripts/static-host.mjs
+++ b/site-docs/scripts/static-host.mjs
@@ -54,8 +54,11 @@ export function resolveStaticFile(root, pathname) {
           path.join(root, `${relative.replace(/\/$/u, '')}.html`),
         ];
 
+  const notFoundFile = path.resolve(root, '404.html');
   for (const candidate of candidates) {
     const file = existingFile(root, candidate);
+    // Root 404.html is the error document, not a pretty-URL success.
+    if (file && path.resolve(file) === notFoundFile) continue;
     if (file) return file;
   }
 

--- a/site-docs/scripts/static-host.mjs
+++ b/site-docs/scripts/static-host.mjs
@@ -1,0 +1,104 @@
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import http from 'node:http';
+import path from 'node:path';
+
+const MIME_TYPES = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain; charset=utf-8',
+  '.xml': 'application/xml; charset=utf-8',
+  '.woff2': 'font/woff2',
+};
+
+function decodePathname(pathname) {
+  try {
+    return decodeURIComponent(pathname);
+  } catch {
+    return pathname;
+  }
+}
+
+function isInsideRoot(root, candidate) {
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(candidate);
+  return resolved === resolvedRoot || resolved.startsWith(resolvedRoot + path.sep);
+}
+
+function existingFile(root, candidate) {
+  if (!isInsideRoot(root, candidate)) return undefined;
+  try {
+    return statSync(candidate).isFile() ? candidate : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Resolve a request path the way Cloudflare Pages pretty URLs do. */
+export function resolveStaticFile(root, pathname) {
+  const decoded = decodePathname(pathname);
+  if (decoded.includes('\0') || decoded.includes('..')) return undefined;
+
+  const relative = decoded.replace(/^\/+/u, '');
+  const candidates =
+    relative === ''
+      ? [path.join(root, 'index.html')]
+      : [
+          path.join(root, relative),
+          path.join(root, relative, 'index.html'),
+          path.join(root, `${relative.replace(/\/$/u, '')}.html`),
+        ];
+
+  for (const candidate of candidates) {
+    const file = existingFile(root, candidate);
+    if (file) return file;
+  }
+
+  return undefined;
+}
+
+export function createStaticHost({ root, port = 4173, host = '127.0.0.1' }) {
+  const notFoundFile = path.join(root, '404.html');
+
+  const server = http.createServer((req, res) => {
+    const pathname = (req.url ?? '/').split('?')[0] ?? '/';
+    const file = resolveStaticFile(root, pathname);
+
+    if (file) {
+      const ext = path.extname(file);
+      res.statusCode = 200;
+      res.setHeader('Content-Type', MIME_TYPES[ext] ?? 'application/octet-stream');
+      createReadStream(file).pipe(res);
+      return;
+    }
+
+    if (existsSync(notFoundFile)) {
+      res.statusCode = 404;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      createReadStream(notFoundFile).pipe(res);
+      return;
+    }
+
+    res.statusCode = 404;
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.end('Not Found');
+  });
+
+  return {
+    host,
+    port,
+    listen: () =>
+      new Promise((resolve) => {
+        server.listen(port, host, () => resolve(server));
+      }),
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}

--- a/site-docs/scripts/static-host.test.mjs
+++ b/site-docs/scripts/static-host.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+import { resolveStaticFile } from './static-host.mjs';
+
+function fixtureRoot() {
+  const root = mkdtempSync(path.join(tmpdir(), 'site-docs-static-'));
+  mkdirSync(path.join(root, 'docs'), { recursive: true });
+  mkdirSync(path.join(root, 'blog', 'introducing-lody'), { recursive: true });
+  writeFileSync(path.join(root, 'index.html'), 'home');
+  writeFileSync(path.join(root, '404.html'), 'not-found');
+  writeFileSync(path.join(root, 'docs', 'index.html'), 'docs');
+  writeFileSync(path.join(root, 'blog', 'introducing-lody', 'index.html'), 'post');
+  writeFileSync(path.join(root, 'price.html'), 'price');
+  return root;
+}
+
+await test('resolveStaticFile maps pretty URLs and file URLs', () => {
+  const root = fixtureRoot();
+  assert.equal(resolveStaticFile(root, '/'), path.join(root, 'index.html'));
+  assert.equal(resolveStaticFile(root, '/docs'), path.join(root, 'docs', 'index.html'));
+  assert.equal(resolveStaticFile(root, '/docs/'), path.join(root, 'docs', 'index.html'));
+  assert.equal(
+    resolveStaticFile(root, '/blog/introducing-lody'),
+    path.join(root, 'blog', 'introducing-lody', 'index.html')
+  );
+  assert.equal(resolveStaticFile(root, '/price'), path.join(root, 'price.html'));
+  assert.equal(resolveStaticFile(root, '/missing'), undefined);
+  assert.equal(resolveStaticFile(root, '/docs/nope'), undefined);
+});
+
+await test('resolveStaticFile rejects path escape', () => {
+  const root = fixtureRoot();
+  assert.equal(resolveStaticFile(root, '/../package.json'), undefined);
+});

--- a/site-docs/scripts/static-host.test.mjs
+++ b/site-docs/scripts/static-host.test.mjs
@@ -29,6 +29,8 @@ await test('resolveStaticFile maps pretty URLs and file URLs', () => {
   assert.equal(resolveStaticFile(root, '/price'), path.join(root, 'price.html'));
   assert.equal(resolveStaticFile(root, '/missing'), undefined);
   assert.equal(resolveStaticFile(root, '/docs/nope'), undefined);
+  assert.equal(resolveStaticFile(root, '/404'), undefined);
+  assert.equal(resolveStaticFile(root, '/404.html'), undefined);
 });
 
 await test('resolveStaticFile rejects path escape', () => {

--- a/site-docs/src/routes/$.tsx
+++ b/site-docs/src/routes/$.tsx
@@ -1,0 +1,9 @@
+import { localeFromPathname, notFoundHead } from '@site/lib/not-found-seo';
+import { createFileRoute, notFound } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/$')({
+  beforeLoad: () => {
+    throw notFound();
+  },
+  head: ({ params }) => notFoundHead(localeFromPathname(`/${params._splat ?? ''}`)),
+});

--- a/site-docs/src/routes/$.tsx
+++ b/site-docs/src/routes/$.tsx
@@ -1,9 +1,0 @@
-import { localeFromPathname, notFoundHead } from '@site/lib/not-found-seo';
-import { createFileRoute, notFound } from '@tanstack/react-router';
-
-export const Route = createFileRoute('/$')({
-  beforeLoad: () => {
-    throw notFound();
-  },
-  head: ({ params }) => notFoundHead(localeFromPathname(`/${params._splat ?? ''}`)),
-});

--- a/site-docs/src/routes/404.tsx
+++ b/site-docs/src/routes/404.tsx
@@ -1,0 +1,8 @@
+import { notFoundHead } from '@site/lib/not-found-seo';
+import { NotFoundPage } from '@site/src/site-pages/not-found';
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/404')({
+  head: () => notFoundHead('en'),
+  component: () => <NotFoundPage locale="en" />,
+});

--- a/site-docs/src/routes/blog/$.tsx
+++ b/site-docs/src/routes/blog/$.tsx
@@ -1,6 +1,7 @@
 import { preloadBlogContent } from '@site/components/blog';
+import { notFoundHead } from '@site/lib/not-found-seo';
 import { loadBlogPostRoute } from '@site/src/blog-loader';
-import { BlogPostRoutePage, blogIndexHead, blogPostHead } from '@site/src/site-pages/blog';
+import { BlogPostRoutePage, blogPostHead } from '@site/src/site-pages/blog';
 import { createFileRoute } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/blog/$')({
@@ -11,7 +12,7 @@ export const Route = createFileRoute('/blog/$')({
     return data;
   },
   head: ({ loaderData }) =>
-    loaderData ? blogPostHead('en', loaderData.entry) : blogIndexHead('en'),
+    loaderData ? blogPostHead('en', loaderData.entry) : notFoundHead('en'),
   component: BlogPost,
 });
 

--- a/site-docs/src/routes/changelog/$slug.tsx
+++ b/site-docs/src/routes/changelog/$slug.tsx
@@ -1,6 +1,7 @@
 import { preloadChangelogContent } from '@site/components/changelog';
+import { notFoundHead } from '@site/lib/not-found-seo';
 import { loadChangelogPostRoute } from '@site/src/changelog-loader';
-import { ChangelogPostRoutePage, changelogIndexHead, changelogPostHead } from '@site/src/site-pages/changelog';
+import { ChangelogPostRoutePage, changelogPostHead } from '@site/src/site-pages/changelog';
 import { createFileRoute } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/changelog/$slug')({
@@ -10,8 +11,7 @@ export const Route = createFileRoute('/changelog/$slug')({
 
     return data;
   },
-  head: ({ loaderData }) =>
-    loaderData ? changelogPostHead('en', loaderData) : changelogIndexHead('en'),
+  head: ({ loaderData }) => (loaderData ? changelogPostHead('en', loaderData) : notFoundHead('en')),
   component: ChangelogPost,
 });
 

--- a/site-docs/src/routes/docs/$.tsx
+++ b/site-docs/src/routes/docs/$.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { notFoundHead } from '@site/lib/not-found-seo';
 import { loadDocsRoute } from '@site/src/docs-loader';
 import { DocsRoutePage, docsHead, preloadDocsContent } from '@site/src/site-pages/docs';
+import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/docs/$')({
   loader: async ({ params }) => {
     const data = await loadDocsRoute({ data: { locale: 'en', splat: params._splat } });
@@ -8,7 +9,7 @@ export const Route = createFileRoute('/docs/$')({
 
     return data;
   },
-  head: ({ loaderData }) => docsHead('en', loaderData!),
+  head: ({ loaderData }) => (loaderData ? docsHead('en', loaderData) : notFoundHead('en')),
   component: Docs,
 });
 

--- a/site-docs/src/routes/zh/404.tsx
+++ b/site-docs/src/routes/zh/404.tsx
@@ -1,0 +1,8 @@
+import { notFoundHead } from '@site/lib/not-found-seo';
+import { NotFoundPage } from '@site/src/site-pages/not-found';
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/zh/404')({
+  head: () => notFoundHead('zh'),
+  component: () => <NotFoundPage locale="zh" />,
+});

--- a/site-docs/src/routes/zh/blog/$.tsx
+++ b/site-docs/src/routes/zh/blog/$.tsx
@@ -1,6 +1,7 @@
 import { preloadBlogContent } from '@site/components/blog';
+import { notFoundHead } from '@site/lib/not-found-seo';
 import { loadBlogPostRoute } from '@site/src/blog-loader';
-import { BlogPostRoutePage, blogIndexHead, blogPostHead } from '@site/src/site-pages/blog';
+import { BlogPostRoutePage, blogPostHead } from '@site/src/site-pages/blog';
 import { createFileRoute } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/zh/blog/$')({
@@ -11,7 +12,7 @@ export const Route = createFileRoute('/zh/blog/$')({
     return data;
   },
   head: ({ loaderData }) =>
-    loaderData ? blogPostHead('zh', loaderData.entry) : blogIndexHead('zh'),
+    loaderData ? blogPostHead('zh', loaderData.entry) : notFoundHead('zh'),
   component: BlogPost,
 });
 

--- a/site-docs/src/routes/zh/changelog/$slug.tsx
+++ b/site-docs/src/routes/zh/changelog/$slug.tsx
@@ -1,6 +1,7 @@
 import { preloadChangelogContent } from '@site/components/changelog';
+import { notFoundHead } from '@site/lib/not-found-seo';
 import { loadChangelogPostRoute } from '@site/src/changelog-loader';
-import { ChangelogPostRoutePage, changelogIndexHead, changelogPostHead } from '@site/src/site-pages/changelog';
+import { ChangelogPostRoutePage, changelogPostHead } from '@site/src/site-pages/changelog';
 import { createFileRoute } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/zh/changelog/$slug')({
@@ -10,8 +11,7 @@ export const Route = createFileRoute('/zh/changelog/$slug')({
 
     return data;
   },
-  head: ({ loaderData }) =>
-    loaderData ? changelogPostHead('zh', loaderData) : changelogIndexHead('zh'),
+  head: ({ loaderData }) => (loaderData ? changelogPostHead('zh', loaderData) : notFoundHead('zh')),
   component: ChangelogPost,
 });
 

--- a/site-docs/src/routes/zh/docs/$.tsx
+++ b/site-docs/src/routes/zh/docs/$.tsx
@@ -1,6 +1,7 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { notFoundHead } from '@site/lib/not-found-seo';
 import { loadDocsRoute } from '@site/src/docs-loader';
 import { DocsRoutePage, docsHead, preloadDocsContent } from '@site/src/site-pages/docs';
+import { createFileRoute } from '@tanstack/react-router';
 export const Route = createFileRoute('/zh/docs/$')({
   loader: async ({ params }) => {
     const data = await loadDocsRoute({ data: { locale: 'zh', splat: params._splat } });
@@ -8,7 +9,7 @@ export const Route = createFileRoute('/zh/docs/$')({
 
     return data;
   },
-  head: ({ loaderData }) => docsHead('zh', loaderData!),
+  head: ({ loaderData }) => (loaderData ? docsHead('zh', loaderData) : notFoundHead('zh')),
   component: Docs,
 });
 

--- a/site-docs/src/site-pages/not-found.tsx
+++ b/site-docs/src/site-pages/not-found.tsx
@@ -1,3 +1,6 @@
+import { localeFromPathname, notFoundCopy, type NotFoundSeoLocale } from '@site/lib/not-found-seo';
+import { useLocation } from '@tanstack/react-router';
+
 /**
  * Lives in its own module because `src/routes/__root.tsx` wires it as the global
  * `notFoundComponent`. The root route is on EVERY page, so anything it imports is
@@ -5,18 +8,29 @@
  * dragged the docs layout, blog, changelog and pricing pages onto the landing.
  */
 export function SiteNotFound() {
+  return <NotFoundPage />;
+}
+
+export function NotFoundPage({ locale }: { locale?: NotFoundSeoLocale }) {
+  const location = useLocation();
+  const resolved = locale ?? localeFromPathname(location.pathname);
+  const copy = notFoundCopy[resolved];
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
       <p className="text-sm font-medium uppercase tracking-[0.22em] text-fd-muted-foreground">
         404
       </p>
-      <h1 className="text-3xl font-semibold">Page not found</h1>
-      <p className="max-w-md text-fd-muted-foreground">
-        The page does not exist in the current documentation build.
+      <h1 className="text-3xl font-semibold">{copy.heading}</h1>
+      <p className="max-w-md text-fd-muted-foreground">{copy.description}</p>
+      <p className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
+        <a className="text-sm font-medium text-fd-primary hover:underline" href={copy.homeHref}>
+          {copy.home}
+        </a>
+        <a className="text-sm font-medium text-fd-primary hover:underline" href={copy.docsHref}>
+          {copy.docs}
+        </a>
       </p>
-      <a className="text-sm font-medium text-fd-primary hover:underline" href="/docs">
-        Back to docs
-      </a>
     </main>
   );
 }

--- a/site-docs/vite.config.ts
+++ b/site-docs/vite.config.ts
@@ -2,7 +2,6 @@ import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import mdx from 'fumadocs-mdx/vite';
-import { existsSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { NodeRequest, sendNodeResponse } from 'srvx/node';
@@ -100,69 +99,6 @@ function installStartDevServerMiddleware(): Plugin {
           })().catch(next);
         });
       };
-    },
-  };
-}
-
-/**
- * Cloudflare Pages serves `404.html` with HTTP 404 for unmatched paths.
- * Vite preview defaults to SPA fallback (`index.html` + 200), which is the
- * production soft-404. Resolve pretty URLs the same way the static host does,
- * then serve the prerendered 404 document.
- */
-function previewHasStaticFile(clientOut: string, pathname: string): boolean {
-  let decoded = pathname;
-  try {
-    decoded = decodeURIComponent(pathname);
-  } catch {
-    // Keep the raw path when it is not valid percent-encoding.
-  }
-  if (decoded.includes('\0') || decoded.includes('..')) return false;
-
-  const root = path.resolve(clientOut);
-  const relative = decoded.replace(/^\/+/u, '');
-  const candidates =
-    relative === ''
-      ? [path.join(root, 'index.html')]
-      : [
-          path.join(root, relative),
-          path.join(root, relative, 'index.html'),
-          path.join(root, `${relative.replace(/\/$/u, '')}.html`),
-        ];
-
-  return candidates.some((candidate) => {
-    const resolved = path.resolve(candidate);
-    if (!resolved.startsWith(root + path.sep) && resolved !== root) return false;
-    try {
-      return statSync(resolved).isFile();
-    } catch {
-      return false;
-    }
-  });
-}
-
-function previewNotFoundPage(): Plugin {
-  const clientOut = path.resolve(dirname, 'out/client');
-  return {
-    name: 'site-docs-preview-404',
-    configurePreviewServer(server) {
-      server.middlewares.use((req, res, next) => {
-        const pathname = (req.url ?? '/').split('?')[0] ?? '/';
-        if (previewHasStaticFile(clientOut, pathname)) {
-          next();
-          return;
-        }
-
-        const notFoundFile = path.join(clientOut, '404.html');
-        if (!existsSync(notFoundFile)) {
-          next();
-          return;
-        }
-
-        res.statusCode = 404;
-        res.setHeader('Content-Type', 'text/html; charset=utf-8');
-        res.end(readFileSync(notFoundFile));
-      });
     },
   };
 }
@@ -277,7 +213,6 @@ export default defineConfig({
             : { enabled: true },
       })),
     }),
-    previewNotFoundPage(),
     installStartDevServerMiddleware(),
     mdx(),
     tailwindcss(),

--- a/site-docs/vite.config.ts
+++ b/site-docs/vite.config.ts
@@ -2,6 +2,7 @@ import { tanstackStart } from '@tanstack/react-start/plugin/vite';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import mdx from 'fumadocs-mdx/vite';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { NodeRequest, sendNodeResponse } from 'srvx/node';
@@ -41,9 +42,7 @@ function forceSingletonDeps(): Plugin {
     name: 'site-docs-force-singleton-deps',
     enforce: 'pre',
     async resolveId(source, _importer, options) {
-      const hit = SINGLETON_DEPS.some(
-        (dep) => source === dep || source.startsWith(`${dep}/`)
-      );
+      const hit = SINGLETON_DEPS.some((dep) => source === dep || source.startsWith(`${dep}/`));
       if (!hit) return null;
       return this.resolve(source, importer, { ...options, skipSelf: true });
     },
@@ -69,8 +68,7 @@ function createBrowserLoroBuildForClientPlugin(): Plugin {
 
 const isStructurallyRunnableEnvironment = (
   environment: DevEnvironment | undefined
-): environment is RunnableDevEnvironment =>
-  environment !== undefined && 'runner' in environment;
+): environment is RunnableDevEnvironment => environment !== undefined && 'runner' in environment;
 
 /**
  * TanStack Start normally adds this handler itself. In this workspace pnpm
@@ -102,6 +100,69 @@ function installStartDevServerMiddleware(): Plugin {
           })().catch(next);
         });
       };
+    },
+  };
+}
+
+/**
+ * Cloudflare Pages serves `404.html` with HTTP 404 for unmatched paths.
+ * Vite preview defaults to SPA fallback (`index.html` + 200), which is the
+ * production soft-404. Resolve pretty URLs the same way the static host does,
+ * then serve the prerendered 404 document.
+ */
+function previewHasStaticFile(clientOut: string, pathname: string): boolean {
+  let decoded = pathname;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    // Keep the raw path when it is not valid percent-encoding.
+  }
+  if (decoded.includes('\0') || decoded.includes('..')) return false;
+
+  const root = path.resolve(clientOut);
+  const relative = decoded.replace(/^\/+/u, '');
+  const candidates =
+    relative === ''
+      ? [path.join(root, 'index.html')]
+      : [
+          path.join(root, relative),
+          path.join(root, relative, 'index.html'),
+          path.join(root, `${relative.replace(/\/$/u, '')}.html`),
+        ];
+
+  return candidates.some((candidate) => {
+    const resolved = path.resolve(candidate);
+    if (!resolved.startsWith(root + path.sep) && resolved !== root) return false;
+    try {
+      return statSync(resolved).isFile();
+    } catch {
+      return false;
+    }
+  });
+}
+
+function previewNotFoundPage(): Plugin {
+  const clientOut = path.resolve(dirname, 'out/client');
+  return {
+    name: 'site-docs-preview-404',
+    configurePreviewServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const pathname = (req.url ?? '/').split('?')[0] ?? '/';
+        if (previewHasStaticFile(clientOut, pathname)) {
+          next();
+          return;
+        }
+
+        const notFoundFile = path.join(clientOut, '404.html');
+        if (!existsSync(notFoundFile)) {
+          next();
+          return;
+        }
+
+        res.statusCode = 404;
+        res.setHeader('Content-Type', 'text/html; charset=utf-8');
+        res.end(readFileSync(notFoundFile));
+      });
     },
   };
 }
@@ -210,9 +271,13 @@ export default defineConfig({
       },
       pages: collectSitePaths(dirname).map((sitePath) => ({
         path: sitePath,
-        prerender: { enabled: true },
+        prerender:
+          sitePath === '/404'
+            ? { enabled: true, outputPath: '/404.html', autoSubfolderIndex: false }
+            : { enabled: true },
       })),
     }),
+    previewNotFoundPage(),
     installStartDevServerMiddleware(),
     mdx(),
     tailwindcss(),
@@ -242,13 +307,7 @@ export default defineConfig({
     // Do not flatten loro-mirror ahead of resolution: its pre-bundle follows
     // its peer dependency directly to Loro's development bundler entry.
     exclude: ['loro-mirror', 'loro-crdt'],
-    include: [
-      'debug',
-      'next-themes',
-      'react-i18next',
-      'i18next',
-      '@number-flow/react',
-    ],
+    include: ['debug', 'next-themes', 'react-i18next', 'i18next', '@number-flow/react'],
   },
   build: {
     outDir: 'out',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Unknown URLs on `https://lody.ai` were **soft-404s**: HTTP **200**, homepage title/description/OG, and `<link rel="canonical" href="https://lody.ai/">`. Crawlers treated junk paths as duplicate homepage.

Production repro (before):

```
curl -sI https://lody.ai/this-path-should-not-exist-seo-test-9f3a
# HTTP/2 200
# <title>Lody — Your Local, Private Coding Agent</title>
# <link rel="canonical" href="https://lody.ai/" />
```

Same for unknown `/docs/...` paths.

## Root cause

`site-docs` is **static** (TanStack Start prerender → `out/client` on Cloudflare Pages). There was **no root `404.html`**. Cloudflare then treats the site as an SPA and serves `index.html` with 200. Dev/SSR already returned 404; production static hosting did not.

`/app` is a **separate** product HTML on the same host (`<title>Lody</title>`). A catch-all `_redirects` `/* /index.html 200` would steal it. This PR does **not** add that.

## Fix

1. **Dedicated 404 UI + head** (`SiteNotFound`, `/404`, `/zh/404`): title `Page not found | Lody` / `页面不存在 | Lody`; **`noindex, follow`**; **no canonical** and no `og:url`.
2. **Prerender `/404` → `404.html`** (`autoSubfolderIndex: false`).
3. **Strip SPA hydration from `404.html`** after prerender (`scripts/finalize-404-html.mjs`). Hydrating the app on a junk URL blanked the page / showed "Something went wrong". Static 404 is now a complete HTML document.
4. **Static host** (`scripts/static-host.mjs` + `preview:static`): missing files → **HTTP 404 + `404.html`**. Pretty `/404` also 404 (error document, not a 200 page).
5. Docs/blog/changelog splat `head()` uses `notFoundHead` instead of index/homepage head.
6. Sitemap excludes `/404`, `/zh/404`, `/home`, `/zh/home`.

**SEO choice:** static `404.html` cannot bake a per-request canonical. `noindex, follow` + no canonical is correct. Homepage canonical was the bug.

## Local commands

```bash
corepack pnpm install
corepack pnpm --filter @lody/site-docs test
corepack pnpm --filter @lody/site-docs typecheck
corepack pnpm --filter @lody/site-docs dev          # :3002
corepack pnpm --filter @lody/site-docs build        # prerender + finalize-404-html
corepack pnpm --filter @lody/site-docs preview:static  # :4173, CF-equivalent
```

Do **not** add Vite `configurePreviewServer` 404 middleware — TanStack prerender uses `vite.preview()` to fetch pages **before they exist on disk**.

## Curl evidence (`preview:static` :4173)

```
/this-path-should-not-exist-seo-test-9f3a  → 404  title=Page not found | Lody  robots=noindex, follow  canonical=NONE
/docs/this-doc-does-not-exist-seo-test     → 404
/docs/core-concepts/nope                   → 404
/%E4%B8%8D%E5%AD%98%E5%9C%A8               → 404
/                                          → 200  title=Lody — Your Local...  robots=index, follow  canonical=https://lody.ai/
/docs/                                     → 200
/blog/introducing-lody                     → 200
/price                                     → 200
/zh/                                       → 200
/zh/docs/                                  → 200
/docs/?utm=seo                             → 200
```

## Adversarial review

| Case | Result |
|---|---|
| Trailing slashes on known routes | 200 via index.html |
| Nested unknown `/docs/.../nope` | 404 |
| Encoded unknown path | 404 |
| Query strings on known routes | 200 |
| i18n `/zh/` + zh docs | 200 |
| Accidental noindex on real pages | Homepage `index, follow` |
| Pretty `/404` | HTTP 404 (error document) |
| Hydration on junk URL | Fixed by stripping app JS from `404.html` |
| `/app` | Not in this tree; local 404. Production is a separate worker — no catch-all `_redirects` |

## Residual risks

- Cloudflare **dashboard** SPA fallback (`/* /index.html 200`) could still win over `404.html`. Confirm Pages settings after deploy.
- One English `404.html` for all unknown URLs (locale-specific first paint is a follow-up).
- `vite dev` 404 title is still root `"Lody Docs"` (HTTP 404, no homepage canonical). Crawlers hit static `404.html`.
- Prerender of `/404` itself is HTTP 200 (`failOnError` requires `res.ok`).

## Walkthrough

[Unknown URL shows dedicated Not Found page](https://cursor.com/agents/bc-befb904f-1a30-45c9-813b-e8f19b80e6ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fnot_found_page.webp)
[Document title is Page not found | Lody](https://cursor.com/agents/bc-befb904f-1a30-45c9-813b-e8f19b80e6ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fnot_found_document_title.webp)
[Homepage still 200 after visiting 404](https://cursor.com/agents/bc-befb904f-1a30-45c9-813b-e8f19b80e6ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhomepage_after_404.webp)
[Unknown docs path is Not Found](https://cursor.com/agents/bc-befb904f-1a30-45c9-813b-e8f19b80e6ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocs_unknown_not_found.webp)
[Real docs introduction still 200](https://cursor.com/agents/bc-befb904f-1a30-45c9-813b-e8f19b80e6ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdocs_introduction_still_200.webp)
[Chinese homepage still 200](https://cursor.com/agents/bc-befb904f-1a30-45c9-813b-e8f19b80e6ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fzh_homepage_still_200.webp)

[soft_404_fixed_unknown_url_and_known_pages.mp4](https://cursor.com/agents/bc-befb904f-1a30-45c9-813b-e8f19b80e6ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsoft_404_fixed_unknown_url_and_known_pages.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-befb904f-1a30-45c9-813b-e8f19b80e6ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-befb904f-1a30-45c9-813b-e8f19b80e6ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

