### PR TITLE
perf(shared): buffer fragmented local data-plane lines

### DIFF
--- a/packages/shared/src/local-loro-data-plane.ts
+++ b/packages/shared/src/local-loro-data-plane.ts
@@ -578,10 +578,16 @@ export function createJsonLineSplitter(options: {
   onOverflow?: () => void;
 }): (chunk: string | Uint8Array) => void {
   const decodeChunk = createUtf8StreamDecoder();
-  let buffer = '';
+  let parts: string[] = [];
+  let bufferedLength = 0;
+  let retryChunk = '';
   let discardingOversizedLine = false;
   return (input: string | Uint8Array) => {
     let chunk = typeof input === 'string' ? input : decodeChunk(input);
+    if (retryChunk) {
+      chunk = retryChunk + chunk;
+      retryChunk = '';
+    }
     if (discardingOversizedLine) {
       const newlineIndex = chunk.indexOf('\n');
       if (newlineIndex < 0) {
@@ -590,22 +596,39 @@ export function createJsonLineSplitter(options: {
       discardingOversizedLine = false;
       chunk = chunk.slice(newlineIndex + 1);
     }
-    buffer += chunk;
-    let newlineIndex = buffer.indexOf('\n');
-    while (newlineIndex >= 0) {
-      const line = buffer.slice(0, newlineIndex).trim();
-      buffer = buffer.slice(newlineIndex + 1);
-      if (line) {
-        if (options.maxBufferBytes !== undefined && line.length > options.maxBufferBytes) {
-          options.onOverflow?.();
-        } else {
-          options.onLine(line);
+    let start = 0;
+    let newlineIndex = chunk.indexOf('\n');
+    try {
+      while (newlineIndex >= 0) {
+        let line = chunk.slice(start, newlineIndex);
+        if (parts.length > 0) {
+          parts.push(line);
+          line = parts.join('');
+          parts = [];
+          bufferedLength = 0;
         }
+        line = line.trim();
+        start = newlineIndex + 1;
+        if (line) {
+          if (options.maxBufferBytes !== undefined && line.length > options.maxBufferBytes) {
+            options.onOverflow?.();
+          } else {
+            options.onLine(line);
+          }
+        }
+        newlineIndex = chunk.indexOf('\n', start);
       }
-      newlineIndex = buffer.indexOf('\n');
+    } catch (error) {
+      retryChunk = chunk.slice(start);
+      throw error;
     }
-    if (options.maxBufferBytes !== undefined && buffer.length > options.maxBufferBytes) {
-      buffer = '';
+    if (start < chunk.length) {
+      parts.push(chunk.slice(start));
+      bufferedLength += chunk.length - start;
+    }
+    if (options.maxBufferBytes !== undefined && bufferedLength > options.maxBufferBytes) {
+      parts = [];
+      bufferedLength = 0;
       discardingOversizedLine = true;
       options.onOverflow?.();
     }

--- a/packages/shared/tests/local-loro-data-plane-splitter.bench.ts
+++ b/packages/shared/tests/local-loro-data-plane-splitter.bench.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from 'node:assert';
+import { bench, describe } from 'vitest';
+import { createJsonLineSplitter } from '../src/local-loro-data-plane';
+
+// Run: pnpm --filter @lody/shared exec vitest bench --run local-loro-data-plane-splitter
+const largeLine = JSON.stringify({ payload: 'x'.repeat(1_100_000) });
+const shortLine = JSON.stringify({ type: 'ping', sequence: 1 });
+const encoder = new TextEncoder();
+const cases = [
+  ...[64, 4096, 65536].map((chunkSize) => ({
+    name: `1.1 MB line / ${chunkSize} byte chunks`,
+    line: largeLine,
+    count: 1,
+    chunkSize,
+  })),
+  { name: '10000 short frames / 64 KiB batches', line: shortLine, count: 10_000, chunkSize: 65536 },
+];
+
+describe('JSON line splitter', () => {
+  for (const { name, line, count, chunkSize } of cases) {
+    const bytes = encoder.encode(`${line}\n`.repeat(count));
+    const chunks: Uint8Array[] = [];
+    for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+      chunks.push(bytes.subarray(offset, offset + chunkSize));
+    }
+
+    const lines: string[] = [];
+    const verify = createJsonLineSplitter({ onLine: (value) => lines.push(value) });
+    for (const chunk of chunks) verify(chunk);
+    assert.equal(lines.length, count);
+    for (const value of lines) assert.equal(value, line);
+
+    let consumed = 0;
+    bench(
+      name,
+      () => {
+        const split = createJsonLineSplitter({ onLine: (value) => (consumed += value.length) });
+        for (const chunk of chunks) split(chunk);
+      },
+      {
+        time: 200,
+        iterations: 3,
+        warmupTime: 100,
+        warmupIterations: 1,
+        teardown: () => assert.ok(consumed > 0),
+      }
+    );
+  }
+});

--- a/packages/shared/tests/local-loro-data-plane-utf8-chunking.test.ts
+++ b/packages/shared/tests/local-loro-data-plane-utf8-chunking.test.ts
@@ -52,4 +52,66 @@ describe('local data-plane UTF-8 chunk decoding', () => {
     splitLines('2}\n');
     expect(lines).toEqual(['{"a":1}', '{"b":2}']);
   });
+
+  it('reassembles a large frame from small byte chunks without emitting a partial line', () => {
+    const frame = JSON.stringify({ data: 'x'.repeat(1_100_000) });
+    const bytes = new TextEncoder().encode(frame);
+    const lines: string[] = [];
+    const splitLines = createJsonLineSplitter({ onLine: (line) => lines.push(line) });
+    for (let offset = 0; offset < bytes.length; offset += 64) {
+      splitLines(bytes.subarray(offset, offset + 64));
+    }
+    expect(lines).toEqual([]);
+    splitLines('\n{"next":true}\n');
+    expect(lines).toEqual([frame, '{"next":true}']);
+  });
+
+  it('trims complete lines before checking the cap but caps untrimmed partial lines', () => {
+    const events: string[] = [];
+    const splitLines = createJsonLineSplitter({
+      maxBufferBytes: 4,
+      onLine: (line) => events.push(line),
+      onOverflow: () => events.push('overflow'),
+    });
+    splitLines(' 12');
+    splitLines('34 \r\n\t \n');
+    splitLines('1234');
+    splitLines('');
+    splitLines('\n');
+    splitLines('     ');
+    splitLines('discarded');
+    splitLines('\n12345\n12\n3');
+    splitLines('4\n');
+    expect(events).toEqual(['1234', '1234', 'overflow', 'overflow', '12', '34']);
+  });
+
+  it('counts decoded characters across multibyte chunk boundaries for the cap', () => {
+    const events: string[] = [];
+    const splitLines = createJsonLineSplitter({
+      maxBufferBytes: 4,
+      onLine: (line) => events.push(line),
+      onOverflow: () => events.push('overflow'),
+    });
+    const bytes = new TextEncoder().encode('软😀件\n软😀件多\n好\n');
+    for (const byte of bytes) {
+      splitLines(Uint8Array.of(byte));
+    }
+    expect(events).toEqual(['软😀件', 'overflow', '好']);
+  });
+
+  it('retains unprocessed lines and a partial tail when a callback throws', () => {
+    const lines: string[] = [];
+    const splitLines = createJsonLineSplitter({
+      onLine: (line) => {
+        lines.push(line);
+        if (line === 'first') {
+          throw new Error('callback failed');
+        }
+      },
+    });
+    splitLines('fir');
+    expect(() => splitLines('st\nsecond\nthi')).toThrow('callback failed');
+    splitLines('rd\n');
+    expect(lines).toEqual(['first', 'second', 'third']);
+  });
 });


### PR DESCRIPTION
## Related issue

Refs #240

## Problem / pressure

The local data-plane JSON line splitter concatenates and searches the entire pending line on every socket chunk. Large fragmented frames repeatedly scan and flatten the same prefix. Both Electron and the CLI use this shared splitter.

## Summary

Keep decoded fragments and their character count until a newline arrives, then join once. Complete lines within one chunk still use direct slices. Preserve the decoder, trimming, overflow recovery, and unread input after a callback exception.

This is the isolated chunk-buffering slice of #240. The current implementation lives in `packages/shared/src/local-loro-data-plane.ts`, consumed by the Electron relay and CLI server. It does not alter RPC transport, renderer rows, usage queries, wire formats, or dependencies. The remaining issue scope stays open.

## Before / after

Synthetic splitter benchmark on Windows, Node 24.15.0, pnpm 10.20.0, Vitest 3.2.4. Values are mean milliseconds per operation, with fixture creation and full-output verification outside timing.

| Input | Before | After |
| --- | ---: | ---: |
| 1.1 MB ASCII payload, 64-byte chunks | 1795.11 | 2.3141 |
| 1.1 MB ASCII payload, 4096-byte chunks | 27.9515 | 0.2593 |
| 1.1 MB ASCII payload, 65536-byte chunks | 2.0961 | 0.2209 |
| 10,000 short frames, 64 KiB batches | 0.2764 | 0.1494 |

The baseline is `d0e5059`. The same benchmark ran before and after the source change. The slowest baseline had three samples; these are microbenchmark means, not application p95 measurements. No renderer heap, FPS, thread-open, or compression improvement is claimed.

## Test plan

- `corepack pnpm --filter @lody/shared exec vitest bench --run local-loro-data-plane-splitter` passed before and after the change. The committed benchmark verifies complete output and can be rerun without timing thresholds.
- Seven splitter tests passed, including fragmented 1.1 MB frames, multibyte boundaries, trimming and cap equality, overflow recovery, and callback-exception continuation.
- `corepack pnpm --filter @lody/shared typecheck` passed.
- `corepack pnpm --filter lody test local-loro-data-plane-bug-repro --maxWorkers=2` passed the real socket overflow/recovery regression.
- `node --test apps/electron/src/main/services/loro-data-plane-relay.test.mjs` passed.
- Changed-file Prettier, `git diff --check`, and `node scripts/check-public-boundary.mjs` passed.
- `corepack pnpm check` did not pass. Lint reported zero errors; the shared suite passed 1,010 tests but failed the daemon shutdown callback assertion in `local-cli-host-lease.test.ts:133`. The root typecheck command also reported no projects matching its recursive filters, so shared typecheck was run directly.
- The separate Electron suite also failed Sparkle packaging/path tests on Windows. Both failures reproduce on unchanged `d0e5059`. The host-lease test and implementation match baseline byte-for-byte, but its baseline run could not resolve Vitest in the dependency-free clone. These areas are outside this PR. Full desktop interaction and application-level profiling were not run.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check splitter fragment lifetime, newline order, and recovery after overflow or callback exceptions in `packages/shared/src/local-loro-data-plane.ts`.
- **Decisions to challenge:** Retain the existing character-count cap and trim-before-cap behavior for complete lines while eliminating repeated prefix scans.
- **Plausible failures / evidence gaps:** Tiny fragments retain array entries until completion; benchmark results isolate framing and do not prove desktop heap or latency targets.

### Authoring context

- **User goal / directives:** Deliver a focused performance contribution related to the long-session issue with reproducible verification.
- **Constraints / non-goals:** No protocol, schema, dependency, UI, settings, or hosted-service changes; keep the broader issue open.
- **Risk-bearing decisions:** Use decoded string fragments so the existing stateful UTF-8 decoder remains authoritative; retain unread suffixes when callbacks throw.
- **Destructive or irreversible behavior:** No storage deletion, migration, persistent-data rewrite, or deployment. Reverting the commit restores the previous splitter.
- **Deliberately not done or tested:** Renderer optimization and application p95, heap, FPS, and transfer-budget work remain outside this slice; no full desktop session benchmark was run.
- **Unknowns / confidence:** Focused framing tests and the socket regression pass; independent source review found no blocking defects, but broader Windows suites are not green.

<!-- context-handoff:end -->
