### PR TITLE
docs: add stable 0.91.0 changelog

### DIFF
--- a/site-docs/content/changelog/en/20260905.mdx
+++ b/site-docs/content/changelog/en/20260905.mdx
@@ -1,0 +1,29 @@
+---
+title: '20260905'
+version: 0.91.0
+date: 2026-09-05
+description: Added session file actions, semantic diffs, unread indicators, and better mention search, with improvements to agent models, Markdown, mobile, and the public site.
+---
+
+Version 0.91.0
+
+### ✨ New
+
+- Added session file actions so files that cannot be previewed directly can be opened in a system app, revealed in the file manager, or downloaded ([#375](https://github.com/LodyAI/Lody/pull/375)).
+- Markdown can now render semantic diff code blocks ([#373](https://github.com/LodyAI/Lody/pull/373)).
+- Session sidebars and desktop child-session tabs now show unread state ([#332](https://github.com/LodyAI/Lody/pull/332), [#384](https://github.com/LodyAI/Lody/pull/384)).
+- File, Issue, and PR mentions now use VS Code-style fuzzy matching, making targets easier to find ([#378](https://github.com/LodyAI/Lody/pull/378)).
+- Added bilingual guides for shared-session handoff, parallel agents, and agent teams ([#387](https://github.com/LodyAI/Lody/pull/387), [#389](https://github.com/LodyAI/Lody/pull/389), [#390](https://github.com/LodyAI/Lody/pull/390), [#393](https://github.com/LodyAI/Lody/pull/393), [#394](https://github.com/LodyAI/Lody/pull/394)).
+
+### 🐛 Fixes and Improvements
+
+- Strengthened team preview and local browser connection checks for safer, more reliable access ([#374](https://github.com/LodyAI/Lody/pull/374)).
+- DeepSeek Harness now discovers models from custom services and exposes model, reasoning, and permission options from the active runtime ([#380](https://github.com/LodyAI/Lody/pull/380), [#395](https://github.com/LodyAI/Lody/pull/395), [DeepSeek ACP #10](https://github.com/LodyAI/acp-extension-dsh/pull/10), [#11](https://github.com/LodyAI/acp-extension-dsh/pull/11)).
+- Kimi model selectors now display and search model providers, making same-named models easier to distinguish ([Kimi ACP #7](https://github.com/LodyAI/acp-extension-kimi/pull/7)).
+- Improved Markdown and streaming message rendering with TeX bracket delimiters, correct autolink boundaries around non-ASCII punctuation, preserved final text output, and a touch-closeable Mermaid full-screen viewer ([#336](https://github.com/LodyAI/Lody/pull/336), [#370](https://github.com/LodyAI/Lody/pull/370), [#388](https://github.com/LodyAI/Lody/pull/388), [#396](https://github.com/LodyAI/Lody/pull/396)).
+- Fixed chat jitter while resizing the sidebar and made billing information load sooner ([#368](https://github.com/LodyAI/Lody/pull/368), [#371](https://github.com/LodyAI/Lody/pull/371)).
+- Reduced Live Activity update overhead and capped mobile session-group previews for smoother long lists ([#319](https://github.com/LodyAI/Lody/pull/319), [#323](https://github.com/LodyAI/Lody/pull/323)).
+- Improved when App Store review prompts appear and how their state is handled ([#310](https://github.com/LodyAI/Lody/pull/310)).
+- Updated ACP provider icons and runtime registry information ([#369](https://github.com/LodyAI/Lody/pull/369)).
+- Improved public-site page titles, search discoverability, and 404 handling for unknown pages ([#379](https://github.com/LodyAI/Lody/pull/379), [#383](https://github.com/LodyAI/Lody/pull/383), [#391](https://github.com/LodyAI/Lody/pull/391)).
+- Thanks to external contributor [@nokizw](https://github.com/nokizw) for improving provider display and search in Kimi model selectors ([Kimi ACP #7](https://github.com/LodyAI/acp-extension-kimi/pull/7)).

--- a/site-docs/content/changelog/zh/20260905.mdx
+++ b/site-docs/content/changelog/zh/20260905.mdx
@@ -1,0 +1,29 @@
+---
+title: '20260905'
+version: 0.91.0
+date: 2026-09-05
+description: 新增会话文件操作、语义化 diff、未读状态和更好用的提及搜索，并改善 Agent 模型、Markdown、移动端与官网体验。
+---
+
+版本 0.91.0
+
+### ✨ 新功能
+
+- 新增会话文件操作：无法直接预览文件时，可使用系统应用打开、在文件管理器中定位或下载文件（[#375](https://github.com/LodyAI/Lody/pull/375)）。
+- Markdown 现可渲染语义化 diff 代码块（[#373](https://github.com/LodyAI/Lody/pull/373)）。
+- 会话侧边栏和桌面子会话标签现在会显示未读状态（[#332](https://github.com/LodyAI/Lody/pull/332)、[#384](https://github.com/LodyAI/Lody/pull/384)）。
+- 文件、Issue 和 PR 提及改用 VS Code 风格的模糊匹配，更容易找到目标（[#378](https://github.com/LodyAI/Lody/pull/378)）。
+- 新增共享会话交接、并行 Agent 与 Agent 团队的中英文使用指南（[#387](https://github.com/LodyAI/Lody/pull/387)、[#389](https://github.com/LodyAI/Lody/pull/389)、[#390](https://github.com/LodyAI/Lody/pull/390)、[#393](https://github.com/LodyAI/Lody/pull/393)、[#394](https://github.com/LodyAI/Lody/pull/394)）。
+
+### 🐛 修复与改进
+
+- 加强团队预览和本地浏览器连接校验，改善相关访问的安全性与可靠性（[#374](https://github.com/LodyAI/Lody/pull/374)）。
+- DeepSeek Harness 现在会从自定义服务自动发现模型，并根据实际运行时提供模型、推理和权限选项（[#380](https://github.com/LodyAI/Lody/pull/380)、[#395](https://github.com/LodyAI/Lody/pull/395)、[DeepSeek ACP #10](https://github.com/LodyAI/acp-extension-dsh/pull/10)、[#11](https://github.com/LodyAI/acp-extension-dsh/pull/11)）。
+- Kimi 模型选择器现在会显示并支持搜索模型提供商，便于区分同名模型（[Kimi ACP #7](https://github.com/LodyAI/acp-extension-kimi/pull/7)）。
+- 改进 Markdown 与流式消息渲染：支持 TeX 方括号分隔符、修复非 ASCII 标点后的自动链接、保留最终文本输出，并让 Mermaid 全屏视图可在触摸设备上关闭（[#336](https://github.com/LodyAI/Lody/pull/336)、[#370](https://github.com/LodyAI/Lody/pull/370)、[#388](https://github.com/LodyAI/Lody/pull/388)、[#396](https://github.com/LodyAI/Lody/pull/396)）。
+- 修复调整侧边栏宽度时聊天内容抖动的问题，并加快计费信息加载（[#368](https://github.com/LodyAI/Lody/pull/368)、[#371](https://github.com/LodyAI/Lody/pull/371)）。
+- 降低 Live Activity 更新开销，并限制移动端会话组预览行数，改善长列表性能（[#319](https://github.com/LodyAI/Lody/pull/319)、[#323](https://github.com/LodyAI/Lody/pull/323)）。
+- 改进 App Store 评分提示的触达条件和状态处理（[#310](https://github.com/LodyAI/Lody/pull/310)）。
+- 更新 ACP Provider 图标与运行时注册信息（[#369](https://github.com/LodyAI/Lody/pull/369)）。
+- 改进官网页面标题、搜索可发现性和未知页面的 404 行为（[#379](https://github.com/LodyAI/Lody/pull/379)、[#383](https://github.com/LodyAI/Lody/pull/383)、[#391](https://github.com/LodyAI/Lody/pull/391)）。
+- 感谢外部贡献者 [@nokizw](https://github.com/nokizw) 对 Kimi 模型提供商显示与搜索体验的贡献（[Kimi ACP #7](https://github.com/LodyAI/acp-extension-kimi/pull/7)）。


### PR DESCRIPTION
## Related issue

Refs #350

## Problem / pressure

The stable 0.91.0 release needs a bilingual public changelog that covers the user-visible OSS changes and credits the external Kimi contribution included through the managed runtime.

## Summary

- Add equivalent English and Chinese changelog entries dated 2026-09-05.
- Link the relevant public Lody and ACP pull requests.
- Credit @nokizw for the Kimi provider display and search contribution.

## Before / after

| Before | After |
| ------ | ----- |
| The public site had no changelog entry for the 0.91.0 stable release. | English and Chinese entries describe the reviewed release scope and contributor credit. |

## Test plan

- `git diff --check` passed.
- Reviewed the committed diff and verified that only the two changelog MDX files changed.
- Product tests and the site build were deliberately skipped because this release step changes content only and the release operator requested no test run.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Compare the English and Chinese MDX entries for equivalent meaning, matching PR links, version, date, and contributor credit.
- **Decisions to challenge:** Confirm that the grouped user-facing summaries accurately represent the linked public changes without exposing internal security details.
- **Plausible failures / evidence gaps:** A link, translation, or grouped summary could misattribute a change; no site build was run for this content-only PR.

### Authoring context

- **User goal / directives:** Prepare the next stable Lody release, mention the included public pull requests, and explicitly credit the external Kimi contributor while omitting the Codex upgrade item.
- **Constraints / non-goals:** Change only the bilingual public changelog; do not alter product code, generated files, versions, or runtime pointers.
- **Risk-bearing decisions:** The candidate version is 0.91.0 based on the stable Release Please rules and remains subject to the generated release PR.
- **Destructive or irreversible behavior:** The change only adds two reviewable MDX files and performs no deletion, migration, publication, or production merge.
- **Deliberately not done or tested:** Product tests and the site build were skipped by request; diff integrity and exact file scope were checked locally.
- **Unknowns / confidence:** Confidence is high in the reviewed content and links; Release Please remains authoritative for the final version.

<!-- context-handoff:end -->
