### PR TITLE
fix(cli): keep a finished turn's endedAt across teardown finalize

### DIFF
--- a/apps/cli/src/lib/assistant-turn-finalize.test.ts
+++ b/apps/cli/src/lib/assistant-turn-finalize.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionHistoryInput } from '@lody/shared';
+
+import { markAssistantTurnFinished } from './assistant-turn-finalize';
+
+const OPENED_AT = Date.parse('2026-01-01T00:00:00.000Z');
+const TURN_ENDED_AT = OPENED_AT + 12_000;
+const APP_CLOSED_AT = OPENED_AT + 3_600_000;
+
+const assistantEntry = (
+  overrides: Partial<SessionHistoryInput> & { id: string }
+): SessionHistoryInput => ({
+  role: 'assistant',
+  timestamp: new Date(OPENED_AT).toISOString(),
+  items: [],
+  fileDiff: [],
+  ...overrides,
+});
+
+describe('markAssistantTurnFinished', () => {
+  it('stamps the open assistant entry when no turn id is given', () => {
+    const history = [assistantEntry({ id: 'assistant:u1' })];
+
+    markAssistantTurnFinished(history, { endedAt: TURN_ENDED_AT });
+
+    expect(history[0]).toMatchObject({ finished: true, endedAt: TURN_ENDED_AT });
+  });
+
+  it('leaves an already finished turn alone when a later teardown finalizes', () => {
+    // Regression for #260: closing the app runs the no-turnId finalize for every
+    // live session, which used to re-stamp `endedAt = now` on a turn that ended
+    // an hour earlier and inflate its rendered "Worked for …".
+    const history = [assistantEntry({ id: 'assistant:u1' })];
+
+    markAssistantTurnFinished(history, { endedAt: TURN_ENDED_AT });
+    markAssistantTurnFinished(history, { endedAt: APP_CLOSED_AT });
+
+    expect(history[0]).toMatchObject({ finished: true, endedAt: TURN_ENDED_AT });
+  });
+
+  it('records no duration for a finished entry that never carried one', () => {
+    // Image-group and file entries publish `finished: true` with no `endedAt`.
+    const history = [assistantEntry({ id: 'assistant-image-1', finished: true })];
+
+    markAssistantTurnFinished(history, { endedAt: APP_CLOSED_AT });
+
+    expect(history[0]?.endedAt).toBeUndefined();
+  });
+
+  it('stamps the addressed turn even when a later assistant entry follows it', () => {
+    const history = [
+      assistantEntry({ id: 'assistant:u1' }),
+      assistantEntry({ id: 'assistant-image-1', finished: true }),
+    ];
+
+    markAssistantTurnFinished(history, { turnId: 'assistant:u1', endedAt: TURN_ENDED_AT });
+
+    expect(history[0]).toMatchObject({ finished: true, endedAt: TURN_ENDED_AT });
+    expect(history[1]?.endedAt).toBeUndefined();
+  });
+
+  it('records the permission wait when the finalizing turn measured one', () => {
+    const history = [assistantEntry({ id: 'assistant:u1' })];
+
+    markAssistantTurnFinished(history, { endedAt: TURN_ENDED_AT, permissionWaitMs: 4_000 });
+
+    expect(history[0]?.permissionWaitMs).toBe(4_000);
+  });
+
+  it('never stamps a user or system entry standing after the turn', () => {
+    const history: SessionHistoryInput[] = [
+      assistantEntry({ id: 'assistant:u1' }),
+      {
+        id: 'system:1',
+        role: 'system',
+        timestamp: new Date(OPENED_AT).toISOString(),
+        items: [],
+        fileDiff: [],
+      },
+    ];
+
+    markAssistantTurnFinished(history, { endedAt: TURN_ENDED_AT });
+
+    expect(history[0]).toMatchObject({ finished: true, endedAt: TURN_ENDED_AT });
+    expect(history[1]?.finished).toBeUndefined();
+  });
+});

--- a/apps/cli/src/lib/assistant-turn-finalize.ts
+++ b/apps/cli/src/lib/assistant-turn-finalize.ts
@@ -1,0 +1,51 @@
+import type { SessionHistoryInput } from '@lody/shared';
+
+/**
+ * Stamp the terminal footprint (`finished`/`endedAt`/`permissionWaitMs`) on the
+ * assistant entry a finalize call owns. Extracted from `finalizeACPState` so the
+ * one rule that matters here is testable: a terminal stamp is written once.
+ *
+ * `finalizeACPState` has a no-turnId overload used by teardown/cancel paths
+ * (session `exit`/`terminated`, error, cleanup). Those callers only check that
+ * transient state exists, so on app close they run for sessions whose turn ended
+ * long ago — and the loop matched the last assistant entry regardless of state,
+ * re-stamping `endedAt = now`. The renderer derives "Worked for …" from
+ * `endedAt - timestamp`, so every close inflated a finished turn's duration by
+ * the wall-clock time the app stayed open.
+ *
+ * Skipping an already-finished entry (rather than filling in a missing
+ * `endedAt`) is deliberate: `createAssistantImageGroupEntry` and
+ * `createAssistantFileEntry` publish assistant entries with `finished: true` and
+ * no `endedAt`, so an `endedAt`-only guard would still stamp `now` on an entry
+ * that finished whenever it finished. No duration is the honest answer there.
+ *
+ * A turn genuinely still running is never finished: the teardown stamp on an
+ * interrupted turn still lands, and resume clears the footprint through
+ * `writeAssistantEntryForTurn`'s reopen branch before streaming into the entry
+ * again. See `apps/cli/src/session/AGENTS.md`.
+ */
+export const markAssistantTurnFinished = (
+  history: SessionHistoryInput[],
+  options: {
+    /** Finalize the entry with this id; absent means "whichever turn is open". */
+    turnId?: string | undefined;
+    endedAt: number;
+    permissionWaitMs?: number | undefined;
+  }
+): SessionHistoryInput[] => {
+  const { turnId, endedAt, permissionWaitMs } = options;
+  for (let i = history.length - 1; i >= 0; i--) {
+    const entry = history[i];
+    if (entry && entry.role === 'assistant' && (!turnId || entry.id === turnId)) {
+      // Already finalized: its terminal timing is the truth, not this call's clock.
+      if (entry.finished === true) break;
+      entry.finished = true;
+      entry.endedAt = endedAt;
+      if (permissionWaitMs !== undefined) {
+        entry.permissionWaitMs = permissionWaitMs;
+      }
+      break;
+    }
+  }
+  return history;
+};

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -262,6 +262,7 @@ import {
   resolveImageGenerationStatusWrite,
   shouldRestoreRunningAfterPermission,
 } from './session-activity-status';
+import { markAssistantTurnFinished } from './assistant-turn-finalize';
 import type { RepoWatchHandle } from 'loro-repo';
 import { resolveGitBranchName } from './git/resolve-git-branch-name';
 import {
@@ -5807,20 +5808,9 @@ export class MessageHandler {
 
       // Mark the owning assistant entry as finished and record timing.
       const sessionDoc = await this.workspaceDocument.getOrCreateSessionDoc(sessionId);
-      await sessionDoc.updateHistory((history) => {
-        for (let i = history.length - 1; i >= 0; i--) {
-          const entry = history[i];
-          if (entry && entry.role === 'assistant' && (!turnId || entry.id === turnId)) {
-            entry.finished = true;
-            entry.endedAt = endedAt;
-            if (permissionWaitMs !== undefined) {
-              entry.permissionWaitMs = permissionWaitMs;
-            }
-            break;
-          }
-        }
-        return history;
-      });
+      await sessionDoc.updateHistory((history) =>
+        markAssistantTurnFinished(history, { turnId, endedAt, permissionWaitMs })
+      );
       await sessionDoc.waitUntilSynced();
     } catch (error) {
       this.logger.error(`[${sessionId}] Failed to flush ACP updates during finalization:`, error);

--- a/apps/cli/src/session/AGENTS.md
+++ b/apps/cli/src/session/AGENTS.md
@@ -157,7 +157,11 @@ delegation proofs or a shared-machine gate without a new product and security de
   history mutation, leaving B pending and permanently unwatched.
   Because teardown/cancel finalize (`message-handler.ts`
   `finalizeACPState`, no-turnId overload) stamps `finished=true`/`endedAt` on the
-  in-progress entry, resume must **reopen** it: `writeAssistantEntryForTurn`'s
+  in-progress entry — and only that entry: `assistant-turn-finalize.ts`
+  `markAssistantTurnFinished` is a no-op on an already-finished one, because those
+  callers fire per live session at app close and a second stamp would rewrite a
+  long-finished turn's `endedAt` to now — resume must **reopen** it:
+  `writeAssistantEntryForTurn`'s
   existing-entry branch clears `finished`/`endedAt`/`permissionWaitMs` when re-adopting
   the entry for a live turn. Without that reset a machine-death-then-resume turn streams
   new output into a `finished=true` entry — the web renderer folds the still-streaming

--- a/apps/cli/tests/message-handler-turn-duration.test.ts
+++ b/apps/cli/tests/message-handler-turn-duration.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LoroRepo } from 'loro-repo';
+
+import type { SessionHistoryInput, SessionId, WorkspaceId } from '@lody/shared';
+
+import { MessageHandler } from '../src/lib/message-handler';
+import { SessionDocument } from '../src/lib/loro/doc';
+import type { LoroDocumentManager } from '../src/lib/loro/doc';
+import type { SessionManager } from '../src/session/session-manager';
+import type { Logger } from '../src/utils/logger';
+import { loadEnv } from '../src/utils/const';
+import { createTestCloudPort } from './test-cloud-port';
+
+const createSilentLogger = (): Logger => ({
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  success: () => {},
+  debug: () => {},
+  setLevel: () => {},
+  child: () => createSilentLogger(),
+  close: async () => {},
+});
+
+const originalLodyServerUrl = process.env.LODY_SERVER_URL;
+
+type MessageHandlerHost = {
+  finalizeACPState(sessionId: SessionId, turnId?: string): Promise<void>;
+};
+
+const createHandlerHarness = async (sessionId: SessionId) => {
+  const logger = createSilentLogger();
+  const repo = await LoroRepo.create({});
+  const doc = new SessionDocument(repo, sessionId);
+  await doc.initOffline();
+
+  const workspaceDocument = {
+    isTransportConnected: vi.fn(() => true),
+    markMachineFlockDocDirty: vi.fn(),
+    registerMachine: vi.fn(),
+    repo: {
+      watch: vi.fn(() => ({ unsubscribe: vi.fn() })),
+      getDocMeta: vi.fn(async () => ({
+        meta: { needToArchiveSessions: {}, needToDeleteSessions: {} },
+      })),
+    },
+    getOrCreateSessionDoc: vi.fn(async () => doc),
+  };
+  const sessionManager = {
+    on: vi.fn(),
+    setRequestPermissionHandler: vi.fn(),
+    getSession: vi.fn(() => null),
+  };
+
+  const handler = new MessageHandler(
+    sessionManager as unknown as SessionManager,
+    workspaceDocument as unknown as LoroDocumentManager,
+    logger,
+    {
+      token: 't',
+      workspaceId: 'ws-1' as WorkspaceId,
+      userId: 'u-1',
+      machineId: 'm-1',
+      machineName: 'machine',
+      cliVersion: '0.0.0',
+      cloudPort: createTestCloudPort(),
+    }
+  );
+
+  return { repo, doc, handler: handler as unknown as MessageHandlerHost };
+};
+
+const TURN_STARTED_AT = Date.parse('2026-01-01T00:00:00.000Z');
+const TURN_ENDED_AT = TURN_STARTED_AT + 12_000;
+const APP_CLOSED_AT = TURN_STARTED_AT + 3_600_000;
+
+const assistantEntry = (): SessionHistoryInput => ({
+  id: 'assistant:user-turn-1',
+  role: 'assistant',
+  timestamp: new Date(TURN_STARTED_AT).toISOString(),
+  fileDiff: [],
+  items: [{ type: 'text', text: 'done' }] as unknown as SessionHistoryInput['items'],
+});
+
+describe('MessageHandler turn duration (finalize stamps)', () => {
+  beforeEach(() => {
+    process.env.LODY_SERVER_URL = 'https://server.example.test';
+    loadEnv();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    if (originalLodyServerUrl === undefined) {
+      delete process.env.LODY_SERVER_URL;
+    } else {
+      process.env.LODY_SERVER_URL = originalLodyServerUrl;
+    }
+    loadEnv();
+  });
+
+  it('keeps a finished turn timing when teardown finalizes again at app close', async () => {
+    // #260: closing the app raises exit/terminated for every live session, and
+    // both handlers run the no-turnId finalize whether or not the turn is over.
+    // The turn's `endedAt` used to be rewritten to the close-time clock, so the
+    // rendered "Worked for …" grew with however long the app had been open.
+    const sessionId = 's-duration-1' as SessionId;
+    const { repo, doc, handler } = await createHandlerHarness(sessionId);
+
+    try {
+      await doc.updateHistory((history) => [...history, assistantEntry()]);
+
+      const now = vi.spyOn(Date, 'now').mockReturnValue(TURN_ENDED_AT);
+      await handler.finalizeACPState(sessionId);
+      expect((await doc.getHistory())[0]).toMatchObject({
+        finished: true,
+        endedAt: TURN_ENDED_AT,
+      });
+
+      now.mockReturnValue(APP_CLOSED_AT);
+      await handler.finalizeACPState(sessionId);
+
+      expect((await doc.getHistory())[0]?.endedAt).toBe(TURN_ENDED_AT);
+    } finally {
+      await repo.destroy();
+    }
+  });
+
+  it('still stamps a turn that was interrupted before it finished', async () => {
+    const sessionId = 's-duration-2' as SessionId;
+    const { repo, doc, handler } = await createHandlerHarness(sessionId);
+
+    try {
+      await doc.updateHistory((history) => [...history, assistantEntry()]);
+
+      vi.spyOn(Date, 'now').mockReturnValue(APP_CLOSED_AT);
+      await handler.finalizeACPState(sessionId);
+
+      expect((await doc.getHistory())[0]).toMatchObject({
+        finished: true,
+        endedAt: APP_CLOSED_AT,
+      });
+    } finally {
+      await repo.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Related issue

Closes #260

## Problem / pressure

A finished assistant turn's "Worked for X" grew by however long the app stayed
open after that turn ended. It does not tick up while the app is running: the
stored `endedAt` is rewritten exactly once, at teardown, so the displayed
number jumps the next time the session is loaded.

The renderer derives the duration from `endedAt - timestamp`
(`packages/components/src/lib/session-history-duration.ts`
`resolveSessionHistoryDurationMs`), so the inflation comes from `endedAt` being
rewritten after the turn is over.

`finalizeACPState` (`apps/cli/src/lib/message-handler.ts`) has a no-turnId
overload. Without a `turnId` its history loop matches the last assistant entry
regardless of whether that entry already finished, and unconditionally writes
`endedAt = Date.now()`. On app close, `sessionManager.cleanUp()` raises
`exit`/`terminated` for every live session, and both handlers call that overload
after checking only `this.store.has(sessionId)` — no pending-work check. A
session whose turn ended an hour earlier is re-stamped with the close-time clock.

(`flushAllACPUpdates()` is guarded by `hasPendingTurnWork` and skips an idle
turn with an empty buffer, so it is not the unconditional trigger; the two
teardown handlers are.)

`apps/cli/src/session/AGENTS.md` already documents the intended contract — the
no-turnId overload "stamps `finished=true`/`endedAt` on the **in-progress**
entry". The implementation did not honour that.

## Summary

- New `apps/cli/src/lib/assistant-turn-finalize.ts` exports
  `markAssistantTurnFinished(history, { turnId, endedAt, permissionWaitMs })`:
  the finalize history loop, verbatim, plus one guard — an entry already marked
  `finished` is left untouched.
- `finalizeACPState` now calls it instead of inlining the loop, so the guard
  covers every no-turnId call site, not just the teardown pair above.
- The guard tests `finished === true` rather than filling in a missing
  `endedAt`: `createAssistantImageGroupEntry` and `createAssistantFileEntry`
  publish assistant entries with `finished: true` and no `endedAt`, so an
  `endedAt ??=` guard would still stamp close time on them. Leaving `endedAt`
  absent makes `resolveSessionHistoryDurationMs` return `null` and the row shows
  no duration, which is the honest answer.
- A turn interrupted mid-flight is not `finished`, so its teardown stamp still
  lands; resume still clears the footprint through `writeAssistantEntryForTurn`'s
  reopen branch. Behaviour there is unchanged.
- `apps/cli/src/session/AGENTS.md` records that the overload is a no-op on an
  already-finished entry.

## Before / after

| Before | After |
| ------ | ----- |
| Every no-turnId finalize rewrote the last assistant entry's `endedAt` to `Date.now()`, so closing the app inflated a finished turn's "Worked for X" by the time the app had been open. | The first terminal stamp is final; a later teardown finalize for an already-finished turn writes nothing and the displayed duration stays put. |
| The finalize history loop was inline in `finalizeACPState`, with nothing asserting that a second finalize is harmless. | The rule is one named function, covered directly and through `finalizeACPState` itself. |

## Test plan

- New `apps/cli/tests/message-handler-turn-duration.test.ts` drives the real
  `finalizeACPState` against a real `SessionDocument`, with `Date.now` stubbed
  rather than any clock being waited on: finalizing a turn, then finalizing the
  same session an hour later (what app close does), leaves the first `endedAt`
  in place; a turn that was never finished still gets stamped at teardown.
- New `apps/cli/src/lib/assistant-turn-finalize.test.ts` covers the rule itself
  (6 cases, two explicit `endedAt` values standing in for "turn ended" and "app
  closed"): open entry is stamped; a second stamp does not move the first; an
  entry with `finished: true` and no `endedAt` gains none; an explicit `turnId`
  is honoured past a trailing image entry; `permissionWaitMs` is recorded; a
  trailing non-assistant entry is never stamped.
- Both suites fail without the guard (3 failures) and pass with it (8 passed).
- `corepack pnpm format` — clean; all three new files pass `prettier --check`.
- `corepack pnpm check` does not complete on this machine: it aborts in its
  first step (`typecheck` -> `lody prepare:acp-adapters`) on a pre-existing
  `acp-extension-dsh` build error, `src/adapter.ts(1649,7) TS2352` on
  `ReadableStream` generics. That submodule is untouched here
  (`git diff --submodule` and `git status` are clean for it) and the local
  toolchain is Node v24.16.0, so this may be a local `@types/node` lib
  mismatch rather than something CI sees.
- Every other `check` stage was run individually: recursive `typecheck` with
  `acp-extension-dsh` excluded (covers `lody`, all packages, and `site-docs`)
  — pass; `corepack pnpm lint` (oxlint type-aware) — 0 errors;
  `corepack pnpm lint:i18n`, `check:code-collab-imports`,
  `check:platform-boundaries`, `check:public-boundary` — all pass.
- Rebased onto current `main` and re-verified there: applies with no conflict,
  `apps/cli` typechecks clean, both new suites pass (8 cases).
- `corepack pnpm test:ci` on the pre-rebase base: `apps/cli` 248 files / 2474
  tests and every package pass. That count predates both new suites; a full
  `apps/cli` run on the rebased branch reports 250 files / 2489 tests, the delta
  being the two new suites plus suites `main` gained during the rebase window.
  One `apps/electron` file, `src/main/services/loro-data-plane-relay.test.mjs`,
  fails on `Error: Electron failed to install correctly` — the Electron binary
  is missing from this machine's install, not a code failure, and nothing here
  touches `apps/electron`.
- That `test:ci` run predates both new suites, so they were also run together
  with the neighbouring `message-handler-*` suites (5 files, 29 tests, all pass).
  `apps/cli` `typecheck` was re-run afterwards; note its tsconfig excludes test
  files, so that step covers `assistant-turn-finalize.ts` but not either new
  test file — those are typechecked only by `vitest`.
- Not done: no end-to-end app-close run. The teardown path itself
  (`exit`/`terminated` -> `finalizeACPState`) is unchanged; only the history
  write it performs is guarded.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `apps/cli/src/lib/assistant-turn-finalize.ts` (one guard, extracted verbatim otherwise) and the `finalizeACPState` call site in `message-handler.ts`.
- **Decisions to challenge:** guarding on `finished === true` instead of a missing `endedAt`, and extracting the loop into its own module rather than leaving it inline.
- **Plausible failures / evidence gaps:** An adjacent bug is untouched: image/file entries are pushed after the turn entry, so a no-turnId finalize on a session ending with one matches that entry and breaks, and the real turn entry is never finalized at all — previously it got the wrong entry stamped, now neither is. Fixing it means scanning past finished entries, which would stamp `now` on genuinely abandoned older turns; that trade-off is yours, not this PR's. Also intended but worth confirming: when a teardown finalize precedes a turnId finalize, the first stamp wins and the later `permissionWaitMs` is dropped.

### Authoring context

- **User goal / directives:** Fix issue #260 ("Worked for" duration grows while the app stays open) at its root cause, with a regression test and no unrelated changes.
- **Constraints / non-goals:** No behaviour change for interrupted turns or resume; no touching the teardown call sites; no fix for the adjacent image/file-entry ordering bug; tests use no real sleeps or wall-clock races per `AGENTS.md`.
- **Risk-bearing decisions:** The guard makes the first terminal stamp final for an assistant entry, so any future producer that pre-marks a live turn `finished: true` would suppress its real timing; all current `finished: true` writers in `apps/cli/src` were checked and write `system`/`user` entries or separate assistant image/file entries.
- **Destructive or irreversible behavior:** None. No migration, deletion, or rewrite of stored history; the change only declines a write that previously overwrote a durable field.
- **Deliberately not done or tested:** The adjacent finalize-target bug described above, and a manual app-close reproduction — `finalizeACPState` is driven directly against a real `SessionDocument` instead, which is the boundary the bug lives at.
- **Unknowns / confidence:** High confidence in the root cause and the guard; the residual unknown is how often sessions end with an image/file entry, which decides how much of #260 the untouched adjacent bug still accounts for.

<!-- context-handoff:end -->
