### PR TITLE
docs: publish stable 0.91.1 changelog

### DIFF
--- a/site-docs/content/changelog/en/20260905-0.91.1.mdx
+++ b/site-docs/content/changelog/en/20260905-0.91.1.mdx
@@ -1,0 +1,16 @@
+---
+title: '20260905-0.91.1'
+version: 0.91.1
+date: 2026-09-05
+description: Added a dedicated Claude Fable weekly quota meter and fixed Max and Ultra reasoning options for Codex models.
+---
+
+Version 0.91.1
+
+### ✨ New
+
+- Claude usage panels now show Fable's dedicated weekly quota separately from the shared weekly and five-hour quotas ([#407](https://github.com/LodyAI/Lody/pull/407), [Claude ACP #25](https://github.com/LodyAI/acp-extension-claude/pull/25), [Core #3](https://github.com/LodyAI/acp-extension-core/pull/3)).
+
+### 🐛 Fixes and improvements
+
+- Fixed missing Max and Ultra reasoning options for GPT-6 Astra. Available reasoning levels now match each model's capabilities, so Luna no longer offers the unsupported Ultra option ([#406](https://github.com/LodyAI/Lody/pull/406)).

--- a/site-docs/content/changelog/zh/20260905-0.91.1.mdx
+++ b/site-docs/content/changelog/zh/20260905-0.91.1.mdx
@@ -1,0 +1,16 @@
+---
+title: '20260905-0.91.1'
+version: 0.91.1
+date: 2026-09-05
+description: 新增 Claude Fable 专属周额度显示，并修复 Codex 模型的 Max、Ultra 推理选项。
+---
+
+版本 0.91.1
+
+### ✨ 新功能
+
+- Claude 用量面板新增 Fable 专属周额度，与共享周额度和 5 小时额度分别显示（[#407](https://github.com/LodyAI/Lody/pull/407)、[Claude ACP #25](https://github.com/LodyAI/acp-extension-claude/pull/25)、[Core #3](https://github.com/LodyAI/acp-extension-core/pull/3)）。
+
+### 🐛 修复与改进
+
+- 修复 GPT-6 Astra 缺少 Max、Ultra 推理选项的问题，并按模型能力显示可用档位，避免为 Luna 提供不支持的 Ultra 选项（[#406](https://github.com/LodyAI/Lody/pull/406)）。


### PR DESCRIPTION
Risk: 🟢 low | Confidence: high — two owner-confirmed changelog entries; localized release metadata validates.

Publish the English and Chinese 0.91.1 release notes for Fable weekly quota display (#407) and model-specific Codex reasoning options (#406), with links to the related public adapter PRs. The release owner confirmed the Chinese wording and requested version 0.91.1.

Keep the existing 0.91.0 entry intact by using the distinct same-day slug `20260905-0.91.1`. No product code or submodule pointers change. The exact new release range contains no additional external-contributor PR; contributions included in 0.91.0 remain credited in its existing entry.

Validation: both MDX files pass Prettier; the production Electron changelog reader resolves exactly one entry per language for version 0.91.1 with matching date 2026-09-05. `pnpm check:affected` passed in the parent workspace, including typechecks, lint, tests, and boundary checks. `pnpm format` completed; unrelated existing formatting differences were excluded.
