### PR TITLE
fix(components): prefer plain text over synthetic clipboard images (#262)

### DIFF
--- a/packages/components/src/components/chat/chat-landing.tsx
+++ b/packages/components/src/components/chat/chat-landing.tsx
@@ -2785,6 +2785,13 @@ function WorkspaceChatLanding({
         }
       }
 
+      // Prefer inserting plain text if available on the clipboard (for example,
+      // when copying text from Microsoft Word or other rich text editors that
+      // also put a rasterized preview image onto the clipboard).
+      if (text.length > 0) {
+        return;
+      }
+
       const pastedFiles = Array.from(event.clipboardData.items)
         .filter((item) => item.kind === 'file')
         .map((item) => item.getAsFile())

--- a/packages/components/src/components/sessions/session-chat-input-area.tsx
+++ b/packages/components/src/components/sessions/session-chat-input-area.tsx
@@ -1618,6 +1618,13 @@ export const SessionChatInputArea = memo(
           }
         }
 
+        // Prefer inserting plain text if available on the clipboard (for example,
+        // when copying text from Microsoft Word or other rich text editors that
+        // also put a rasterized preview image onto the clipboard).
+        if (text.length > 0) {
+          return;
+        }
+
         const pastedFiles = Array.from(event.clipboardData.items)
           .filter((item) => item.kind === 'file')
           .map((item) => item.getAsFile())

--- a/packages/components/src/components/tasks/task-body-editor-fallback.tsx
+++ b/packages/components/src/components/tasks/task-body-editor-fallback.tsx
@@ -217,6 +217,8 @@ export default function TaskBodyEditorFallback({
           rows={14}
           placeholder={t('tasks.body.placeholderShort', 'Add description…')}
           onPaste={(event) => {
+            const text = event.clipboardData.getData('text/plain');
+            if (text.length > 0) return;
             const files = Array.from(event.clipboardData.files).filter((file) =>
               file.type.startsWith('image/')
             );

--- a/packages/components/src/components/tasks/task-thread.tsx
+++ b/packages/components/src/components/tasks/task-thread.tsx
@@ -389,6 +389,8 @@ export function TaskThread({
             )}
             onChange={(event) => setDraft(event.target.value)}
             onPaste={(event) => {
+              const text = event.clipboardData.getData('text/plain');
+              if (text.length > 0) return;
               const files = Array.from(event.clipboardData.files).filter((file) =>
                 file.type.startsWith('image/')
               );

--- a/packages/components/src/hooks/use-chat-landing-image-draft.ts
+++ b/packages/components/src/hooks/use-chat-landing-image-draft.ts
@@ -294,6 +294,10 @@ export function useChatLandingImageDraft(args: {
       if (isMobile) {
         return;
       }
+      const text = event.clipboardData.getData('text/plain');
+      if (text.length > 0) {
+        return;
+      }
       const fileItems = Array.from(event.clipboardData.items)
         .filter((item) => item.type.startsWith('image/'))
         .map((item) => item.getAsFile())

--- a/packages/components/tests/session-chat-input-paste.test.tsx
+++ b/packages/components/tests/session-chat-input-paste.test.tsx
@@ -1,0 +1,315 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionMeta } from '@lody/shared';
+
+const sessionAgentRoleState = vi.hoisted(() => ({
+  control: {
+    items: [],
+    selectedRoleId: null,
+    onSelect: () => undefined,
+  },
+}));
+
+vi.mock('@posthog/react', () => ({ usePostHog: () => null }));
+
+vi.mock('../src/hooks/use-authenticated-convex', () => ({
+  useAuthenticatedConvex: () => ({}),
+}));
+
+vi.mock('../src/hooks/use-visible-machine-metas', () => ({
+  useVisibleMachineMetas: () => ({
+    machines: new Map(),
+    isLoading: false,
+    accessByMachineId: new Map(),
+  }),
+}));
+
+vi.mock('../src/components/mentions/mention-session-source', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useSessionMentionItems: () => [],
+}));
+
+vi.mock('../src/components/mentions/mention-agent-role-source', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  useAgentRoleMentionItems: () => [],
+}));
+
+vi.mock('../src/hooks/use-code-collab-requested-role', () => ({
+  useCodeCollabRequestedRole: () => null,
+}));
+
+vi.mock('../src/hooks/use-code-collab-session-file-provider', () => ({
+  useCodeCollabSessionFileProvider: () => ({
+    status: 'idle',
+    provider: null,
+    message: null,
+  }),
+}));
+
+import { SessionChatInputArea } from '../src/components/sessions/session-chat-input-area';
+import { useChatLandingImageDraft } from '../src/hooks/use-chat-landing-image-draft';
+import { initI18n } from '../src/i18n';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('SessionChatInputArea clipboard paste handling', () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  beforeEach(async () => {
+    sessionAgentRoleState.control = {
+      items: [],
+      selectedRoleId: null,
+      onSelect: () => undefined,
+    };
+    await initI18n('en');
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    if (typeof URL.createObjectURL === 'undefined') {
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: vi.fn().mockReturnValue('blob:mock-image-url'),
+      });
+    }
+    if (typeof URL.revokeObjectURL === 'undefined') {
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: vi.fn(),
+      });
+    }
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+      root = null;
+    }
+    container?.remove();
+    container = null;
+  });
+
+  const renderComposer = async () => {
+    await act(async () => {
+      root?.render(
+        createElement(SessionChatInputArea, {
+          session: {
+            id: 'session-paste-test',
+            userId: 'user-1',
+            machineId: 'machine-1',
+            agentConfigId: 'agent-1',
+            cliType: 'builtin',
+            agentType: 'codex',
+            status: { type: 'idle' },
+            isArchived: false,
+            createdAt: '2026-08-26T00:00:00.000Z',
+          } as SessionMeta,
+          sessionLocalProjectRootPath: null,
+          isMachineRemoved: false,
+          isAgentBusy: false,
+          isDark: false,
+          isEmptyConversation: false,
+          selectedModeId: 'ask',
+          selectedModelId: null,
+          modeOptions: [{ value: 'ask', label: 'Ask' }],
+          modelOptions: [],
+          onModeChange: () => undefined,
+          onModelChange: () => undefined,
+          onSendMessage: async () => true,
+          onStop: () => undefined,
+          onRemoveQueueItem: async () => undefined,
+        })
+      );
+    });
+
+    const textarea = container!.querySelector('textarea');
+    if (!textarea) {
+      throw new Error('Expected textarea in SessionChatInputArea');
+    }
+    return textarea;
+  };
+
+  it('preserves native plain-text paste and avoids image upload when copying from Microsoft Word', async () => {
+    const textarea = await renderComposer();
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true });
+    const imageFile = new File(['fake-png-data'], 'image.png', { type: 'image/png' });
+
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        getData: (format: string) =>
+          format === 'text/plain' ? 'Paragraph copied from Microsoft Word' : '',
+        items: [
+          { kind: 'string', type: 'text/plain' },
+          { kind: 'string', type: 'text/html' },
+          { kind: 'string', type: 'text/rtf' },
+          {
+            kind: 'file',
+            type: 'image/png',
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+
+    await act(async () => {
+      textarea.dispatchEvent(pasteEvent);
+    });
+
+    // Native text paste must not be canceled so the browser can insert text into textarea
+    expect(pasteEvent.defaultPrevented).toBe(false);
+  });
+
+  it('intercepts paste and handles files when clipboard contains no plain text', async () => {
+    const textarea = await renderComposer();
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true });
+    const imageFile = new File(['fake-png-data'], 'screenshot.png', { type: 'image/png' });
+
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        getData: () => '',
+        items: [
+          {
+            kind: 'file',
+            type: 'image/png',
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+
+    await act(async () => {
+      textarea.dispatchEvent(pasteEvent);
+    });
+
+    // Pure image paste should be intercepted
+    expect(pasteEvent.defaultPrevented).toBe(true);
+  });
+
+  it('captures large text as PastedTextDraft even when synthetic image file is present on clipboard', async () => {
+    const textarea = await renderComposer();
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true });
+    const largeText = 'a'.repeat(2000);
+    const imageFile = new File(['fake-png-data'], 'image.png', { type: 'image/png' });
+
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        getData: (format: string) => (format === 'text/plain' ? largeText : ''),
+        items: [
+          { kind: 'string', type: 'text/plain' },
+          {
+            kind: 'file',
+            type: 'image/png',
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+
+    await act(async () => {
+      textarea.dispatchEvent(pasteEvent);
+    });
+
+    expect(pasteEvent.defaultPrevented).toBe(true);
+    // Verified that large text captured PastedTextDraft chip
+    expect(container!.textContent).toContain('Pasted 2,000 chars');
+  });
+});
+
+describe('useChatLandingImageDraft clipboard paste handling', () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  beforeEach(() => {
+    if (typeof URL.createObjectURL === 'undefined') {
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: vi.fn().mockReturnValue('blob:mock-image-url'),
+      });
+    }
+    if (typeof URL.revokeObjectURL === 'undefined') {
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: vi.fn(),
+      });
+    }
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+      root = null;
+    }
+    container?.remove();
+    container = null;
+  });
+
+  it('does not intercept paste when plain text is present on clipboard', async () => {
+    let hookResult!: ReturnType<typeof useChatLandingImageDraft>;
+
+    function Probe() {
+      hookResult = useChatLandingImageDraft({
+        workspaceId: null,
+        authToken: null,
+        isMobile: false,
+        projectKind: null,
+        sessionId: 'test-session',
+        ensureSessionId: async () => 'test-session',
+      });
+      return null;
+    }
+
+    await act(async () => {
+      root?.render(createElement(Probe));
+    });
+
+    const pasteEvent = new Event('paste', { bubbles: true, cancelable: true });
+    const imageFile = new File(['fake-png-data'], 'image.png', { type: 'image/png' });
+
+    Object.defineProperty(pasteEvent, 'clipboardData', {
+      value: {
+        getData: (format: string) => (format === 'text/plain' ? 'Word text content' : ''),
+        items: [
+          {
+            kind: 'file',
+            type: 'image/png',
+            getAsFile: () => imageFile,
+          },
+        ],
+      },
+    });
+
+    await act(async () => {
+      hookResult.handlePromptPaste(
+        pasteEvent as unknown as React.ClipboardEvent<HTMLTextAreaElement>
+      );
+    });
+
+    expect(pasteEvent.defaultPrevented).toBe(false);
+    expect(hookResult.imageItems.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Related issue

Closes #262

## Problem / pressure

When copying text from Microsoft Word (and certain other rich-text editors on macOS/Windows), Word places multiple MIME representations on the clipboard simultaneously: `text/plain`, `text/html`, `text/rtf`, and a rasterized snapshot image (`image/png`).

In Lody's composer inputs (`SessionChatInputArea`, `WorkspaceChatLanding`, `useChatLandingImageDraft`, `TaskBodyEditorFallback`, and `TaskThread`), paste handlers inspected `event.clipboardData.items` for file entries. Because the rasterized PNG file was present in `items`, Lody immediately intercepted the paste via `event.preventDefault()` and treated the clipboard content as an image file upload. This prevented the copied plain text from being inserted as editable text in the textarea.

## Summary

- In `SessionChatInputArea`, `WorkspaceChatLanding`, `useChatLandingImageDraft`, `TaskBodyEditorFallback`, and `TaskThread`, check whether non-empty `text/plain` is present on the clipboard.
- When `text.length > 0`, avoid intercepting the paste as a file attachment, allowing normal text insertion into the textarea (or draft capture for texts > 1024 characters).
- Pure image pastes (e.g. screenshots or copied images without text content) continue to be intercepted and uploaded as image attachments as before.
- Added comprehensive unit tests in `packages/components/tests/session-chat-input-paste.test.tsx`.

## Visual explanation

```mermaid
flowchart TD
    PasteEvent["User pastes clipboard content"]
    HasText{"Clipboard has non-empty text/plain?"}
    TextPaste["Insert plain text into textarea / draft"]
    HasImage{"Clipboard has image file?"}
    ImageUpload["Upload image attachment"]
    NormalPaste["Default browser paste"]

    PasteEvent --> HasText
    HasText -- "Yes (e.g. Word with synthetic PNG)" --> TextPaste
    HasText -- "No" --> HasImage
    HasImage -- "Yes (e.g. pure screenshot)" --> ImageUpload
    HasImage -- "No" --> NormalPaste
```

```diff
 onPaste(event):
+  const text = event.clipboardData.getData('text/plain')
+  if (text.length > 0) {
+    // Let plain text paste proceed; do not intercept synthetic image
+    return
+  }
   const imageFile = findImageItem(event.clipboardData.items)
   if (imageFile) {
     event.preventDefault()
     attachImage(imageFile)
   }
```

## Before / after

| Before | After |
| ------ | ----- |
| Pasting text copied from Microsoft Word into the composer intercepts the paste and uploads it as an image attachment because Word attaches a synthetic PNG preview to the clipboard. | Text copied from Microsoft Word pastes cleanly as editable plain text into the composer, while pure image pastes (screenshots) continue to attach as images. |

## Test plan

- Ran `pnpm --filter @lody/components test tests/session-chat-input-paste.test.tsx` (all 4 tests passed).
- Ran `pnpm --filter @lody/components test paste` (all 23 tests across paste suites passed).
- Ran `pnpm check:quick` (`oxlint`, `lint:i18n`, `check:code-collab-imports`, `check:platform-boundaries`, `check:public-boundary` all passed with 0 errors).
- Ran Prettier check on all modified files (`packages/components/src/...` and `packages/components/tests/...`).

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Verify paste event handling in `session-chat-input-area.tsx`, `chat-landing.tsx`, `use-chat-landing-image-draft.ts`, `task-body-editor-fallback.tsx`, and `task-thread.tsx`.
- **Decisions to challenge:** Ensure checking `text.length > 0` before checking `event.clipboardData.items` for file entries correctly prioritizes user-intended text without regressing pure image/screenshot pastes.
- **Plausible failures / evidence gaps:** Clipboard formats vary across operating systems; tests mock multi-MIME clipboards (`text/plain` + `image/png`) to verify precedence.

### Authoring context

- **User goal / directives:** Fix issue #262 so that copying plain text from Microsoft Word into chat and task composers pastes as text instead of an image attachment.
- **Constraints / non-goals:** Do not break existing large text draft capture (> 1024 characters) or pure image/screenshot attachments.
- **Risk-bearing decisions:** When both text and image MIME types exist, text is prioritized on text inputs.
- **Destructive or irreversible behavior:** None; no schema or persistent data changes.
- **Deliberately not done or tested:** Did not change rich-text HTML rendering in composer; plain text insertion remains standard.
- **Unknowns / confidence:** High confidence; unit tests cover Word-like multi-format clipboard payloads, pure image pastes, and large text drafts.

<!-- context-handoff:end -->
