### PR TITLE
fix(components): mine visual series locally and compare baselines per capture

### DIFF
--- a/packages/components/scripts/templates/chat-workspace-geometry-report.html
+++ b/packages/components/scripts/templates/chat-workspace-geometry-report.html
@@ -449,6 +449,16 @@
         font-size: 13px;
         overflow-wrap: anywhere;
       }
+      /* Folded measurements are subordinate evidence, not another card. */
+      .visual-candidates .visual-measurements {
+        padding: 0 0 0 12px;
+        border-bottom: 0;
+        border-left: 1px solid var(--border);
+      }
+      .visual-candidates .visual-measurements summary {
+        color: var(--text-muted);
+        font-size: 13px;
+      }
       .visual-overlay {
         position: relative;
         margin-top: 12px;
@@ -602,15 +612,15 @@
         <label
           >Evidence
           <select id="visual-evidence-filter">
-            <option value="review">Review candidates · peer ≥ 2</option>
+            <option value="review">Review queue · peer ≥ 2 + top singletons</option>
             <option value="all">All raw deviations</option>
           </select></label
         >
         <a href="visual-repetition.json">完整 discovery JSON</a>
         <p class="meta">
           排序仅供 review；不进入 ledger / gate。红框为候选，绿框为 dominant，橙框为
-          peers，绿线为预期坐标；pitch 是间距，仅标记目标。默认合并同一 atom 的重复边界测量；
-          完整原始结果见 JSON。
+          peers，绿线为预期坐标；pitch 是间距，仅标记目标。默认合并同一 atom 的重复边界测量，
+          并对孤立（peer = 1）候选按 capture 取分数最高的若干条；完整原始结果见 JSON。
         </p>
         <div id="visual-candidates"></div>
         <button type="button" id="visual-more">显示更多</button>
@@ -654,9 +664,8 @@
         [...candidates]
           .sort((a, b) => b.deviation.score - a.deviation.score)
           .map((candidate, index) => ({ ...candidate, rank: index + 1 }));
-      const reviewVisualCandidates = rankVisualCandidates(
-        rawVisualCandidates
-          .filter(({ deviation }) => deviation.peerSupport >= 2)
+      const foldedVisualCandidates = [
+        ...rawVisualCandidates
           .reduce((unique, candidate) => {
             // Start/end/center are three views of one edge question. Keep pitch
             // separate because it measures spacing along the series axis.
@@ -664,17 +673,57 @@
             const measureFamily = deviation.measure === 'pitch' ? 'pitch' : 'edge';
             const key = `${capture.captureId}\u0000${atom.id}\u0000${deviation.axis}\u0000${measureFamily}`;
             const previous = unique.get(key);
-            if (!previous || previous.deviation.score < deviation.score) unique.set(key, candidate);
+            if (previous) previous.measurements.push(deviation);
+            else unique.set(key, { ...candidate, measurements: [deviation] });
             return unique;
           }, new Map())
-          .values()
+          .values(),
+      ];
+      /**
+       * How many isolated candidates one capture may put in the default queue.
+       *
+       * This is an attention policy, not discovery semantics: nothing is
+       * promoted, no threshold decides truth, and every deviation stays in
+       * `visual-repetition.json` and under "All raw deviations". But the two
+       * failure modes are asymmetric and both real. `peerSupport === 1` is
+       * what the scorer ranks HIGHEST — one box alone off its series edge is
+       * the shape of an actual defect — so a `peer >= 2` default queue hides
+       * exactly the candidates the ranking believes in most. Isolated
+       * candidates are also the bulk of a recall-first universe, and tipping
+       * all of them in is the same as having no queue at all. So the
+       * best-scoring few per capture come in, ordered by the score the miner
+       * already computed, and the rest stay one dropdown away. Per capture
+       * rather than per report, because a budget drained by one noisy screen
+       * would hide a quiet screen's only candidate.
+       */
+      const VISUAL_SINGLETON_REVIEW_BUDGET = 5;
+      const singletonBudgetSpent = new Map();
+      const reviewVisualCandidates = rankVisualCandidates(
+        foldedVisualCandidates.filter((candidate) => {
+          // A card counts as isolated only if EVERY measurement folded into it
+          // is. One peer-supported measurement keeps the card unconditionally,
+          // which preserves the previous default queue whole.
+          if (candidate.measurements.some((measurement) => measurement.peerSupport >= 2))
+            return true;
+          const spent = singletonBudgetSpent.get(candidate.capture.captureId) ?? 0;
+          if (spent >= VISUAL_SINGLETON_REVIEW_BUDGET) return false;
+          singletonBudgetSpent.set(candidate.capture.captureId, spent + 1);
+          return true;
+        })
       );
       const visualCandidates = rankVisualCandidates(rawVisualCandidates);
       document.getElementById('visual-summary').textContent =
-        `${visualCaptures.length} captures · ${visualCaptures.reduce((sum, capture) => sum + capture.atoms.length, 0)} atoms · ${reviewVisualCandidates.length} review candidates / ${visualCandidates.length} raw deviations · 每个 capture 独立计算，尚未跨 capture 确认`;
+        `${visualCaptures.length} captures · ${visualCaptures.reduce((sum, capture) => sum + capture.atoms.length, 0)} atoms · ${reviewVisualCandidates.length} review candidates / ${foldedVisualCandidates.length} grouped / ${visualCandidates.length} raw deviations · 孤立候选每 capture 上限 ${VISUAL_SINGLETON_REVIEW_BUDGET} 条 · 每个 capture 独立计算，尚未跨 capture 确认`;
       const visualList = document.getElementById('visual-candidates');
       const px = (value) => `${Number(value.toFixed(2))}px`;
-      function appendVisualCandidate({ capture, deviation, atom, atoms, rank }) {
+      function appendVisualCandidate({
+        capture,
+        deviation,
+        atom,
+        atoms,
+        rank,
+        measurements = [deviation],
+      }) {
         const card = document.createElement('details');
         const heading = document.createElement('summary');
         const signedDelta = deviation.value - deviation.expected;
@@ -696,6 +745,20 @@
           const labels = (ids) => ids.map((id) => `${atoms.get(id).label} (${id})`).join(' · ');
           witnesses.textContent = `Dominant: ${labels(deviation.dominantAtomIds)} / Peers: ${labels(deviation.peerAtomIds)}`;
           card.append(witnesses);
+          if (measurements.length > 1) {
+            const supporting = document.createElement('details');
+            supporting.className = 'visual-measurements';
+            const summary = document.createElement('summary');
+            summary.textContent = `全部边界测量 (${measurements.length})`;
+            supporting.append(summary);
+            for (const measurement of measurements) {
+              const evidence = document.createElement('p');
+              evidence.className = 'evidence';
+              evidence.textContent = `${measurement.axis}-${measurement.measure} · expected ${px(measurement.expected)} · actual ${px(measurement.value)} · delta ${px(measurement.value - measurement.expected)} · dominant support ${measurement.dominantSupport} · peer support ${measurement.peerSupport} · score ${Number(measurement.score.toFixed(2))} · Dominant: ${labels(measurement.dominantAtomIds)} / Peers: ${labels(measurement.peerAtomIds)}`;
+              supporting.append(evidence);
+            }
+            card.append(supporting);
+          }
           if (!capture.screenshot || !capture.screenshotClip) {
             const missing = document.createElement('p');
             missing.className = 'evidence';

--- a/packages/components/scripts/templates/chat-workspace-geometry-report.html
+++ b/packages/components/scripts/templates/chat-workspace-geometry-report.html
@@ -449,6 +449,14 @@
         font-size: 13px;
         overflow-wrap: anywhere;
       }
+      .visual-cross-scope {
+        border: 1px solid var(--border-strong);
+        border-radius: 999px;
+        padding: 0 6px;
+        margin-left: 4px;
+        font-size: 11px;
+        color: var(--text-muted);
+      }
       /* Folded measurements are subordinate evidence, not another card. */
       .visual-candidates .visual-measurements {
         padding: 0 0 0 12px;
@@ -613,6 +621,7 @@
           >Evidence
           <select id="visual-evidence-filter">
             <option value="review">Review queue · peer ≥ 2 + top singletons</option>
+            <option value="same-scope">Review queue · 仅同区域见证</option>
             <option value="all">All raw deviations</option>
           </select></label
         >
@@ -652,12 +661,20 @@
       const rawVisualCandidates = visualCaptures
         .flatMap((capture) => {
           const atoms = new Map(capture.atoms.map((atom) => [atom.id, atom]));
-          return capture.deviations.map((deviation) => ({
-            capture,
-            deviation,
-            atom: atoms.get(deviation.atomId),
-            atoms,
-          }));
+          return capture.deviations.map((deviation) => {
+            const atom = atoms.get(deviation.atomId);
+            // Section scope is REPORT EVIDENCE, never a grouping input — mining
+            // stays DOM-blind, because a defect correlates with the structural
+            // difference and grouping on it hides the bug. But a reader triaging
+            // the queue is asking a question mining cannot: is this comparison
+            // between things that belong together? A candidate measured against
+            // witnesses from another section is usually two unrelated boxes that
+            // render alike, and its delta is the distance between them rather
+            // than an error. Saying so costs nothing and answers it at a glance.
+            const witnesses = [...deviation.dominantAtomIds, ...deviation.peerAtomIds];
+            const crossScope = witnesses.some((id) => atoms.get(id)?.scope !== atom?.scope);
+            return { capture, deviation, atom, atoms, crossScope };
+          });
         })
         .sort((a, b) => b.deviation.score - a.deviation.score);
       const rankVisualCandidates = (candidates) =>
@@ -713,7 +730,7 @@
       );
       const visualCandidates = rankVisualCandidates(rawVisualCandidates);
       document.getElementById('visual-summary').textContent =
-        `${visualCaptures.length} captures · ${visualCaptures.reduce((sum, capture) => sum + capture.atoms.length, 0)} atoms · ${reviewVisualCandidates.length} review candidates / ${foldedVisualCandidates.length} grouped / ${visualCandidates.length} raw deviations · 孤立候选每 capture 上限 ${VISUAL_SINGLETON_REVIEW_BUDGET} 条 · 每个 capture 独立计算，尚未跨 capture 确认`;
+        `${visualCaptures.length} captures · ${visualCaptures.reduce((sum, capture) => sum + capture.atoms.length, 0)} atoms · ${reviewVisualCandidates.length} review candidates（其中 ${reviewVisualCandidates.filter((candidate) => !candidate.crossScope).length} 条见证全在同一区域）/ ${foldedVisualCandidates.length} grouped / ${visualCandidates.length} raw deviations · 孤立候选每 capture 上限 ${VISUAL_SINGLETON_REVIEW_BUDGET} 条 · 每个 capture 独立计算，尚未跨 capture 确认`;
       const visualList = document.getElementById('visual-candidates');
       const px = (value) => `${Number(value.toFixed(2))}px`;
       function appendVisualCandidate({
@@ -722,12 +739,22 @@
         atom,
         atoms,
         rank,
+        crossScope,
         measurements = [deviation],
       }) {
         const card = document.createElement('details');
         const heading = document.createElement('summary');
         const signedDelta = deviation.value - deviation.expected;
         heading.textContent = `#${rank} ${atom.label} · ${deviation.axis}-${deviation.measure} · ${signedDelta >= 0 ? '+' : ''}${px(signedDelta)} · ${capture.captureId}`;
+        if (crossScope) {
+          // Not a verdict: a cross-section comparison can be the real catch this
+          // pass exists for, two code paths rendering one thing differently. It
+          // is just the fact a reader needs before reading the number.
+          const marker = document.createElement('span');
+          marker.className = 'visual-cross-scope';
+          marker.textContent = '跨区域';
+          heading.append(' ', marker);
+        }
         card.append(heading);
         // Materialize images only on expansion; retain every ranked candidate.
         card.addEventListener('toggle', () => {
@@ -842,8 +869,15 @@
       }
       visualMore.addEventListener('click', showMoreVisualCandidates);
       const updateVisualCandidates = () => {
+        // The same queue, narrowed by whether the comparison stayed inside one
+        // section. Ranking is untouched: this is the reader choosing what to
+        // read, not structure deciding what scores.
         const candidates =
-          evidenceFilter.value === 'all' ? visualCandidates : reviewVisualCandidates;
+          evidenceFilter.value === 'all'
+            ? visualCandidates
+            : evidenceFilter.value === 'same-scope'
+              ? reviewVisualCandidates.filter((candidate) => !candidate.crossScope)
+              : reviewVisualCandidates;
         selectedVisualCandidates = candidates.filter(
           ({ capture }) => !captureFilter.value || capture.captureId === captureFilter.value
         );

--- a/packages/components/scripts/templates/chat-workspace-geometry-report.html
+++ b/packages/components/scripts/templates/chat-workspace-geometry-report.html
@@ -679,7 +679,17 @@
         .sort((a, b) => b.deviation.score - a.deviation.score);
       const rankVisualCandidates = (candidates) =>
         [...candidates]
-          .sort((a, b) => b.deviation.score - a.deviation.score)
+          // Same-section comparisons first, then by score. This is READING order,
+          // not a grouping input: mining stays DOM-blind, every candidate is still
+          // here, and no threshold removes one. Ranking by score alone put 11 of
+          // the 12 same-section candidates at ranks 66-78, behind 65 cross-section
+          // cards whose deltas are large precisely BECAUSE they span sections. The
+          // cards most likely to be real were the ones a reader would never reach.
+          .sort(
+            (a, b) =>
+              Number(a.crossScope) - Number(b.crossScope) ||
+              b.deviation.score - a.deviation.score
+          )
           .map((candidate, index) => ({ ...candidate, rank: index + 1 }));
       const foldedVisualCandidates = [
         ...rawVisualCandidates

--- a/packages/components/src/lib/geometry-constraint-system.ts
+++ b/packages/components/src/lib/geometry-constraint-system.ts
@@ -2792,7 +2792,19 @@ export function diffGeometryFindings(
   const changed = artifact.findings.filter((finding) => {
     const carried = rekeyedTo.get(finding.key);
     const baseline = (carried ? ledger.findings[carried] : ledger.findings[finding.key])?.baseline;
-    return baseline ? Math.abs(finding.offset - baseline.offset) > offsetTolerance : false;
+    if (!baseline) return false;
+    // Per CAPTURE, never the merged offset. `finding.offset` is the mean across
+    // every capture the finding was seen in, so a regression confined to one
+    // condition — a dark-theme-only or zh-locale-only shift — is divided by the
+    // capture count before it is ever compared. On a finding merged across 12
+    // captures that takes a 6px break to move the mean past a 0.5px tolerance,
+    // and those are exactly the conditions a reviewer is least likely to catch
+    // by eye. Every capture carries its own measurement, so every one is read.
+    const measured =
+      finding.evidence.length > 0
+        ? finding.evidence.map((evidence) => evidence.offset)
+        : [finding.offset];
+    return measured.some((offset) => Math.abs(offset - baseline.offset) > offsetTolerance);
   });
   return {
     current,
@@ -3196,7 +3208,10 @@ export type GeometryRatchetViolation = Readonly<{
   anchor: SemanticAlignmentAnchor;
   status?: GeometryLedgerStatus;
   baseline?: number;
+  /** The worst single capture, not the mean across captures. */
   current: number;
+  /** Which capture `current` came from, so a one-condition break is nameable. */
+  captureId?: string;
   /** The slack allowed above `|baseline|`, in CSS pixels. */
   tolerance?: number;
 }>;
@@ -3252,11 +3267,25 @@ export function checkGeometryLedgerRatchet(
     const baseline = entry.baseline?.offset;
     if (baseline === undefined) return [];
     const tolerance = geometryFindingDevicePixel(finding, captures);
-    if (Math.abs(finding.offset) <= Math.abs(baseline) + tolerance) return [];
+    // The gate reads the WORST capture, not the mean of all of them, for the
+    // same reason the report diff does: averaging divides a one-condition
+    // regression by the capture count before the gate can see it. The capture
+    // travels with the violation, because "baseline -3 → current -3.4" is
+    // unactionable when what actually happened is that one theme moved 9px.
+    const worst =
+      finding.evidence.length > 0
+        ? finding.evidence.reduce((left, right) =>
+            Math.abs(right.offset) > Math.abs(left.offset) ? right : left
+          )
+        : undefined;
+    const current = worst?.offset ?? finding.offset;
+    if (Math.abs(current) <= Math.abs(baseline) + tolerance) return [];
     return [
       {
         kind: 'offset-regression',
         ...identity,
+        current,
+        captureId: worst?.captureId,
         status: entry.status,
         baseline,
         tolerance,
@@ -3379,7 +3408,7 @@ export function formatGeometryRatchetViolations(
         : [
             `regressed finding ${violation.key}`,
             `  ${violation.surfaceFamily} · ${violation.label} · ${violation.axis}/${violation.anchor} (${violation.status})`,
-            `  baseline ${(violation.baseline ?? 0).toFixed(3)}px → current ${violation.current.toFixed(3)}px`,
+            `  baseline ${(violation.baseline ?? 0).toFixed(3)}px → current ${violation.current.toFixed(3)}px${violation.captureId ? ` in ${violation.captureId}` : ''}`,
             `  allowed |offset| ≤ ${(Math.abs(violation.baseline ?? 0) + (violation.tolerance ?? 0)).toFixed(3)}px (baseline + ${(violation.tolerance ?? 0).toFixed(3)}px device pixel)`,
           ].join('\n')
     )

--- a/packages/components/src/lib/geometry-discovery/AGENTS.md
+++ b/packages/components/src/lib/geometry-discovery/AGENTS.md
@@ -23,7 +23,8 @@ which destroys the recall it exists for.
 ## Grouping is visual. Never structural.
 
 Atoms are grouped by what RENDERS alike — the geometry-derived primitive kind, folded where
-the difference is not painted (`link`/`button`, `numeric-text`/`text`), and quantised height,
+the difference is not painted (`link`/`button`, `numeric-text`/`text`), and height clustered
+by distance to a fixed anchor (never hard rounding buckets),
 never content-sized width. Never key a group on row family, role, accessible name, or DOM
 ancestry.
 
@@ -44,6 +45,29 @@ run of intermediate values walk one level into the next and merge two indentatio
 into one expectation — the merged level then reads as internally perfect and the deviation
 disappears. Same failure the geometric row band avoids on Y.
 
+## Locality comes before orientation, and never becomes a partition
+
+A series is isolated first and its axis settled afterwards. Both orientations are
+hypothesised; a group is banded along each (centres within half a box share a band), a series
+takes at most ONE member per band, and lanes track across bands by nearest cross-axis
+distance bounded by the group's own band step. The wrong hypothesis then costs nothing — a
+toolbar collapses into one vertical band and dies as runs of one — and a run both produced is
+settled by its own spread. Asking a whole signature group for its axis is the failure this
+replaces: two side-by-side lists spread wider than either runs deep, so the page-wide answer
+was "horizontal", every grid row was mined as one series, and a regular grid manufactured a
+high-scoring Y deviation per row and a pitch deviation per column break.
+
+Locality bounds grouping; it must never delete membership. A lane of one is not a lane, it is
+one box that left, so a lone residual rejoins the nearest real series and is mined there at
+whatever delta it has. Without that, the rule would punish the clearest defects hardest: the
+further a box flies, the more certainly it would become its own lane and vanish. Two boxes
+agreeing on a position are left alone — that is a sparse column, not a defect.
+
+Do not keep only a series' best-agreeing alignment measure. `start`, `end` and `center` are
+three views, and a box that is only WIDER agrees on `start`; dropping the others buys silence
+on variable-width text by deleting real width drift. That text ambiguity is deliberate and
+stays unresolved here — no classifier, no typography model, no intent inference.
+
 ## Recall is the bias, and ranking is not filtering
 
 Nothing is dropped for looking weak. Candidates carry a `score` and are sorted; no
@@ -52,5 +76,18 @@ because without being told which level was intended it has to — it ranks low s
 falls as a level's own support rises, so a value two boxes share outranks one forty share.
 
 A missed misalignment is invisible forever; a false one costs a triage glance. Any tie
-breaks towards reporting more. Series orientation is measured rather than declared, and
-only the axis perpendicular to the run carries expectations worth mining.
+breaks towards reporting more. Only the axis perpendicular to a run carries expectations
+worth mining, plus pitch along it.
+
+## The report's default queue is attention, not truth
+
+`peerSupport` counts the DEVIATING level, so a singleton is what the scorer ranks highest —
+one box alone off its series edge. A `peer >= 2` default queue therefore hid the candidates
+the ranking believed in most, and showing every singleton is the same as having no queue. The
+template ranks, folds one atom's repeated edge measurements into one card (exposing every
+folded measurement and its witnesses), keeps every card with any peer support, and admits the
+best-scoring `VISUAL_SINGLETON_REVIEW_BUDGET` isolated cards PER CAPTURE — per capture, so a
+noisy screen cannot drain a quiet screen's only candidate. Never replace that budget with a
+confidence threshold. `visual-repetition.json` and "All raw deviations" keep everything; a
+candidate the budget withheld is unshown, never unfound, and neither an admitted nor a
+withheld one is a finding, ledger entry or gate verdict.

--- a/packages/components/src/lib/geometry-discovery/AGENTS.md
+++ b/packages/components/src/lib/geometry-discovery/AGENTS.md
@@ -48,20 +48,29 @@ disappears. Same failure the geometric row band avoids on Y.
 ## Locality comes before orientation, and never becomes a partition
 
 A series is isolated first and its axis settled afterwards. Both orientations are
-hypothesised; a group is banded along each (centres within half a box share a band), a series
-takes at most ONE member per band, and lanes track across bands by nearest cross-axis
-distance bounded by the group's own band step. The wrong hypothesis then costs nothing — a
-toolbar collapses into one vertical band and dies as runs of one — and a run both produced is
-settled by its own spread. Asking a whole signature group for its axis is the failure this
-replaces: two side-by-side lists spread wider than either runs deep, so the page-wide answer
-was "horizontal", every grid row was mined as one series, and a regular grid manufactured a
-high-scoring Y deviation per row and a pitch deviation per column break.
+hypothesised; a group is banded along each, a series takes at most ONE member per band, and
+lanes track across bands by nearest cross-axis distance bounded by the group's own band step.
+The wrong hypothesis then costs nothing — a toolbar collapses into one vertical band and dies
+as runs of one — and a run both produced is settled by its own spread. Asking a whole
+signature group for its axis is the failure this replaces: two side-by-side lists spread wider
+than either runs deep, so the page-wide answer was "horizontal", every grid row was mined as
+one series, and a regular grid manufactured a high-scoring Y deviation per row and a pitch
+deviation per column break.
 
-Locality bounds grouping; it must never delete membership. A lane of one is not a lane, it is
-one box that left, so a lone residual rejoins the nearest real series and is mined there at
-whatever delta it has. Without that, the rule would punish the clearest defects hardest: the
-further a box flies, the more certainly it would become its own lane and vanish. Two boxes
-agreeing on a position are left alone — that is a sparse column, not a defect.
+A band is an OVERLAP question, never a centre distance: two boxes share a position when their
+intervals on that axis overlap by more than half the smaller one, tested against the band's
+anchor interval so shifting boxes cannot chain two positions into one. Centres are exactly
+what a variable-width column moves — six left-aligned labels share one left edge and one X
+interval, but their centres follow string length, and read as centres they became six X
+positions, which let a sidebar list be mined as a horizontal series against a header above it.
+
+Locality bounds grouping, and a lone residual may rejoin the nearest series — but only within
+that same band step, because membership needs evidence too. Unbounded, this fallback was the
+worst defect in the pass: a composer icon 849px below the top bar was folded into the top
+bar's icon series and ranked first in the whole report. Two identical boxes at opposite ends
+of a page are not a series with an exception in it, and nothing here can tell otherwise. The
+stated cost is that a box drifting more than one step off its series is no longer recovered.
+Two boxes agreeing on a position are left alone — that is a sparse column, not a defect.
 
 Do not keep only a series' best-agreeing alignment measure. `start`, `end` and `center` are
 three views, and a box that is only WIDER agrees on `start`; dropping the others buys silence
@@ -74,6 +83,13 @@ Nothing is dropped for looking weak. Candidates carry a `score` and are sorted; 
 threshold removes one. A legitimate indent ladder therefore comes back as deviations too,
 because without being told which level was intended it has to — it ranks low since `score`
 falls as a level's own support rises, so a value two boxes share outranks one forty share.
+
+But the EXPECTATION must exist before anything can deviate from it, and that is not a
+threshold. `expected` is mined from repetition, so a dominant level of one is a single box's
+own coordinate dressed up as an expectation, and a dominant that does not outnumber the level
+deviating from it is two positions with a winner picked by array order — three boxes here and
+three there is not a majority with an exception. Both were 43% of real output. Requiring a
+repeated, outnumbering dominant is the precondition of the comparison, not a filter on it.
 
 A missed misalignment is invisible forever; a false one costs a triage glance. Any tie
 breaks towards reporting more. Only the axis perpendicular to a run carries expectations
@@ -91,3 +107,13 @@ noisy screen cannot drain a quiet screen's only candidate. Never replace that bu
 confidence threshold. `visual-repetition.json` and "All raw deviations" keep everything; a
 candidate the budget withheld is unshown, never unfound, and neither an admitted nor a
 withheld one is a finding, ledger entry or gate verdict.
+
+## Measured limit: it compares across sections and cannot know not to
+
+On the 21-capture report, after the fixes above, 77% of deviations still have a witness in a
+different `sectionScope` — top bar icon against composer icon, sidebar row against panel
+header. Not a bug left to chase: locality is a proxy, and the discriminator a reviewer uses
+(same structural relationship) is what visual grouping discards on purpose. Some is the
+intended catch — two sidebar lists rendering one row at different pitches — and most is
+noise, and the card cannot say which. So this lane is an auxiliary candidate source; do not
+present it as, or promote it into, the baseline and regression rail.

--- a/packages/components/src/lib/geometry-discovery/AGENTS.md
+++ b/packages/components/src/lib/geometry-discovery/AGENTS.md
@@ -110,10 +110,10 @@ withheld one is a finding, ledger entry or gate verdict.
 
 ## Measured limit: it compares across sections and cannot know not to
 
-On the 21-capture report, after the fixes above, 77% of deviations still have a witness in a
-different `sectionScope` — top bar icon against composer icon, sidebar row against panel
-header. Not a bug left to chase: locality is a proxy, and the discriminator a reviewer uses
+77% of deviations have a witness in another `sectionScope` — top bar icon against composer
+icon. Not a bug left to chase: locality is a proxy, and the discriminator a reviewer uses
 (same structural relationship) is what visual grouping discards on purpose. Some is the
-intended catch — two sidebar lists rendering one row at different pitches — and most is
-noise, and the card cannot say which. So this lane is an auxiliary candidate source; do not
-present it as, or promote it into, the baseline and regression rail.
+intended catch, most is noise, and the card cannot say which. So the report SHOWS scope,
+filters on it, and ranks same-section first — reading order, never a grouping input, since
+a cross-section delta is large by spanning sections and score alone buried 11 of 12 real
+cards at ranks 66-78. An auxiliary candidate source; never the baseline and regression rail.

--- a/packages/components/src/lib/geometry-discovery/visual-repetition.ts
+++ b/packages/components/src/lib/geometry-discovery/visual-repetition.ts
@@ -90,6 +90,18 @@ const DEFAULTS = {
   seriesBreakRatio: 3,
 } as const;
 
+type Axis = 'x' | 'y';
+
+const CROSS_AXIS = { x: 'y', y: 'x' } as const satisfies Record<Axis, Axis>;
+
+function centerOn(atom: VisualAtom, axis: Axis): number {
+  return axis === 'y' ? (atom.yStart + atom.yEnd) / 2 : (atom.xStart + atom.xEnd) / 2;
+}
+
+function extentOn(atom: VisualAtom, axis: Axis): number {
+  return axis === 'y' ? atom.yEnd - atom.yStart : atom.xEnd - atom.xStart;
+}
+
 function median(values: readonly number[]): number {
   const sorted = [...values].sort((left, right) => left - right);
   const middle = Math.floor(sorted.length / 2);
@@ -105,17 +117,6 @@ function normalizeKind(kind: string): string {
   if (kind === 'link') return 'button';
   if (kind === 'numeric-text') return 'text';
   return kind;
-}
-
-/**
- * Width is left out on purpose. A row's label is as wide as its text, so
- * keying on width would split one visual series into one group per string
- * length and leave nothing to compare.
- */
-function visualSignature(atom: VisualAtom, heightTolerance: number): string {
-  const height = atom.yEnd - atom.yStart;
-  const bucket = heightTolerance > 0 ? Math.round(height / heightTolerance) : height;
-  return `${normalizeKind(atom.kind)}|h${bucket}`;
 }
 
 type Level = { readonly values: number[]; readonly atoms: VisualAtom[]; anchor: number };
@@ -155,7 +156,7 @@ function scoreLevels(
   levels: readonly Level[],
   seriesSize: number,
   signature: string,
-  axis: 'x' | 'y',
+  axis: Axis,
   measure: VisualDeviationMeasure,
   levelTolerance: number
 ): VisualDeviation[] {
@@ -194,22 +195,21 @@ function scoreLevels(
 }
 
 /**
- * Splits one signature group into runs that read as a single series. Members
- * are ordered along the series axis and cut where the gap jumps far past the
- * run's own median gap.
+ * Splits one already-isolated lane into the runs that read as a single series.
+ * Members are ordered along the series axis and cut where the gap jumps far
+ * past the run's own median gap — a date header may interrupt a list without
+ * ending it; a screen of empty space ends it.
  */
 function splitIntoSeries(
   atoms: readonly VisualAtom[],
-  axis: 'x' | 'y',
+  axis: Axis,
   breakRatio: number,
   minimumLength: number
 ): VisualAtom[][] {
-  const center = (atom: VisualAtom) =>
-    axis === 'y' ? (atom.yStart + atom.yEnd) / 2 : (atom.xStart + atom.xEnd) / 2;
-  const ordered = [...atoms].sort((left, right) => center(left) - center(right));
+  const ordered = [...atoms].sort((left, right) => centerOn(left, axis) - centerOn(right, axis));
   const gaps: number[] = [];
   for (let index = 1; index < ordered.length; index += 1) {
-    gaps.push(center(ordered[index]!) - center(ordered[index - 1]!));
+    gaps.push(centerOn(ordered[index]!, axis) - centerOn(ordered[index - 1]!, axis));
   }
   if (gaps.length === 0) return [];
   const typicalGap = median(gaps);
@@ -228,16 +228,104 @@ function splitIntoSeries(
 }
 
 /**
- * Orientation is measured, not declared: whichever axis the boxes spread along
- * is the series axis, and the expectations worth mining are the ones
- * perpendicular to it. Mining the series axis itself would only rediscover
- * that a list advances down the page.
+ * Orientation of one ALREADY ISOLATED run, and only used to settle a run both
+ * hypotheses below produced. Asking it of a whole signature group instead is
+ * the failure this replaces: two side-by-side lists spread further across the
+ * page than either list runs down it, so the page-wide answer was "horizontal"
+ * — and every row of a grid was then mined as if it were one series, which
+ * manufactures a high-scoring Y deviation per row and a pitch deviation per
+ * column break out of a layout that is completely regular.
  */
-function seriesAxis(atoms: readonly VisualAtom[]): 'x' | 'y' {
-  const xs = atoms.map((atom) => (atom.xStart + atom.xEnd) / 2);
-  const ys = atoms.map((atom) => (atom.yStart + atom.yEnd) / 2);
-  const spread = (values: readonly number[]) => Math.max(...values) - Math.min(...values);
-  return spread(ys) >= spread(xs) ? 'y' : 'x';
+function seriesAxis(atoms: readonly VisualAtom[]): Axis {
+  const spread = (axis: Axis) => {
+    const centers = atoms.map((atom) => centerOn(atom, axis));
+    return Math.max(...centers) - Math.min(...centers);
+  };
+  return spread('y') >= spread('x') ? 'y' : 'x';
+}
+
+type Lane = { readonly atoms: VisualAtom[]; readonly across: number[]; anchor: number };
+
+/**
+ * Isolates the lanes a signature group renders as, under one axis hypothesis.
+ *
+ * Bands are the group's own steps along the hypothesised axis: boxes whose
+ * centres sit within half a box of each other occupy one band, so a column
+ * list has one member per band and a grid row has all of its cells in one. A
+ * series may hold at most ONE member per band, which is what a reader means by
+ * "this list runs downwards" — and is what makes the wrong hypothesis free: a
+ * horizontal toolbar collapses into a single vertical band and its vertical
+ * reading dies as runs of one, without anything having to declare an axis.
+ *
+ * Lanes then track across bands by nearest cross-axis distance, bounded by the
+ * group's own band step. The scale comes from the layout, not a constant: a box
+ * that drifted sideways by less than one step of the series it sits in is still
+ * in that series, while two lists a whole column apart are not one zigzag. A
+ * lane anchors on the median of its members rather than its last one, for the
+ * same reason levels grow to an anchor — a drifting cross-axis chain would
+ * otherwise walk one column into the next.
+ */
+function laneSeries(group: readonly VisualAtom[], axis: Axis, minimumLength: number): VisualAtom[][] {
+  const bands = buildLevels(
+    group.map((atom) => ({ atom, value: centerOn(atom, axis) })),
+    median(group.map((atom) => extentOn(atom, axis))) / 2
+  );
+  // A lane holds at most one atom per band, so fewer bands than a series needs
+  // members means this axis cannot carry a series at all.
+  if (bands.length < Math.max(minimumLength, 2)) return [];
+  const step = median(bands.slice(1).map((band, index) => band.anchor - bands[index]!.anchor));
+  if (!(step > 0)) return [];
+
+  const cross = CROSS_AXIS[axis];
+  const lanes: Lane[] = [];
+  for (const band of bands) {
+    const unplaced = new Set(band.atoms);
+    const claimed = new Set<Lane>();
+    const pairs = lanes
+      .flatMap((lane) =>
+        band.atoms.map((atom) => ({
+          lane,
+          atom,
+          distance: Math.abs(centerOn(atom, cross) - lane.anchor),
+        }))
+      )
+      .filter((pair) => pair.distance <= step)
+      .sort((left, right) => left.distance - right.distance || (left.atom.id < right.atom.id ? -1 : 1));
+    for (const { lane, atom } of pairs) {
+      if (claimed.has(lane) || !unplaced.has(atom)) continue;
+      claimed.add(lane);
+      unplaced.delete(atom);
+      lane.atoms.push(atom);
+      lane.across.push(centerOn(atom, cross));
+      lane.anchor = median(lane.across);
+    }
+    for (const atom of band.atoms) {
+      if (!unplaced.has(atom)) continue;
+      const across = centerOn(atom, cross);
+      lanes.push({ atoms: [atom], across: [across], anchor: across });
+    }
+  }
+
+  const series = lanes.filter((lane) => lane.atoms.length >= minimumLength);
+  if (series.length === 0) return [];
+  // Recall fallback, and the reason locality here is not a partition. A lane of
+  // one is not evidence of a lane; it is one box that left. Left alone, the
+  // bound above would punish the clearest defects hardest — the further a box
+  // flies from its series, the more certainly it becomes its own lane and
+  // disappears — so a lone residual rejoins the nearest real series and is
+  // mined there at whatever delta it actually has. Two boxes agreeing on a
+  // position are left alone: that is a sparse column, and folding it back
+  // would report a whole second column as broken.
+  for (const lane of lanes) {
+    if (lane.atoms.length !== 1 || series.includes(lane)) continue;
+    const nearest = series.reduce((best, candidate) =>
+      Math.abs(lane.anchor - candidate.anchor) < Math.abs(lane.anchor - best.anchor)
+        ? candidate
+        : best
+    );
+    nearest.atoms.push(lane.atoms[0]!);
+  }
+  return series.map((lane) => lane.atoms);
 }
 
 export function mineVisualDeviations(
@@ -249,19 +337,48 @@ export function mineVisualDeviations(
   const heightTolerance = options.heightTolerance ?? DEFAULTS.heightTolerance;
   const seriesBreakRatio = options.seriesBreakRatio ?? DEFAULTS.seriesBreakRatio;
 
-  const groups = new Map<string, VisualAtom[]>();
+  const kinds = new Map<string, VisualAtom[]>();
   for (const atom of atoms) {
-    const signature = visualSignature(atom, heightTolerance);
-    const group = groups.get(signature);
+    const kind = normalizeKind(atom.kind);
+    const group = kinds.get(kind);
     if (group) group.push(atom);
-    else groups.set(signature, [atom]);
+    else kinds.set(kind, [atom]);
   }
+  // Height uses the same fixed-anchor distance rule as coordinates: a rounding
+  // boundary must not split nearly identical boxes. Content-sized width stays
+  // out of grouping so different label lengths can still be compared.
+  const groups = [...kinds].flatMap(([kind, members]) =>
+    buildLevels(
+      members.map((atom) => ({ atom, value: atom.yEnd - atom.yStart })),
+      heightTolerance
+    ).map((level) => [`${kind}|h${level.anchor}`, level.atoms] as const)
+  );
 
   const deviations: VisualDeviation[] = [];
   for (const [signature, group] of groups) {
     if (group.length < minimumSeriesLength) continue;
-    const axis = seriesAxis(group);
-    for (const run of splitIntoSeries(group, axis, seriesBreakRatio, minimumSeriesLength)) {
+
+    // Both orientations are hypothesised and the layout answers. A group that
+    // reads only one way loses the other to runs shorter than a series; a grid
+    // legitimately reads both ways, and its columns and rows are then each
+    // mined against themselves instead of against each other.
+    const runs = new Map<string, { axis: Axis; atoms: VisualAtom[] }>();
+    for (const axis of ['y', 'x'] as const) {
+      for (const lane of laneSeries(group, axis, minimumSeriesLength)) {
+        for (const run of splitIntoSeries(lane, axis, seriesBreakRatio, minimumSeriesLength)) {
+          const key = JSON.stringify(
+            run
+              .map((atom) => atom.id)
+              .sort()
+          );
+          // A run both hypotheses found is one series seen twice; its own
+          // spread, measured locally, says which way it runs.
+          if (!runs.has(key) || seriesAxis(run) === axis) runs.set(key, { axis, atoms: run });
+        }
+      }
+    }
+
+    for (const { axis, atoms: run } of runs.values()) {
       const edges =
         axis === 'y'
           ? ([
@@ -291,11 +408,9 @@ export function mineVisualDeviations(
 
       // Irregular spacing is the same kind of defect seen along the series
       // axis, and the series is already ordered, so it costs nothing to mine.
-      const along = (atom: VisualAtom) =>
-        axis === 'y' ? (atom.yStart + atom.yEnd) / 2 : (atom.xStart + atom.xEnd) / 2;
       const pitchEntries = run.slice(1).map((atom, index) => ({
         atom,
-        value: along(atom) - along(run[index]!),
+        value: centerOn(atom, axis) - centerOn(run[index]!, axis),
       }));
       if (pitchEntries.length >= minimumSeriesLength) {
         deviations.push(

--- a/packages/components/src/lib/geometry-discovery/visual-repetition.ts
+++ b/packages/components/src/lib/geometry-discovery/visual-repetition.ts
@@ -98,8 +98,44 @@ function centerOn(atom: VisualAtom, axis: Axis): number {
   return axis === 'y' ? (atom.yStart + atom.yEnd) / 2 : (atom.xStart + atom.xEnd) / 2;
 }
 
-function extentOn(atom: VisualAtom, axis: Axis): number {
-  return axis === 'y' ? atom.yEnd - atom.yStart : atom.xEnd - atom.xStart;
+function startOn(atom: VisualAtom, axis: Axis): number {
+  return axis === 'y' ? atom.yStart : atom.xStart;
+}
+
+function endOn(atom: VisualAtom, axis: Axis): number {
+  return axis === 'y' ? atom.yEnd : atom.xEnd;
+}
+
+type Band = { readonly atoms: VisualAtom[]; readonly start: number; readonly end: number };
+
+/**
+ * The distinct positions a group occupies along one axis. Two boxes share a
+ * position when their intervals on that axis overlap by more than half of the
+ * smaller one, because "do these render side by side" is an overlap question.
+ *
+ * It is not a centre-distance question, and that was a real defect: six
+ * left-aligned sidebar labels share one left edge and one overlapping X
+ * interval, but their centres spread across the whole column because centres
+ * follow string length. Read as centres they became six separate X positions,
+ * which let a vertical list be mined as a horizontal series and compared on Y
+ * against a workspace header 300px above it.
+ *
+ * Membership is tested against the band's ANCHOR interval, never its last
+ * member, so gradually shifting boxes cannot chain two positions into one.
+ */
+function buildBands(atoms: readonly VisualAtom[], axis: Axis): Band[] {
+  const bands: Band[] = [];
+  for (const atom of [...atoms].sort((left, right) => startOn(left, axis) - startOn(right, axis))) {
+    const start = startOn(atom, axis);
+    const end = endOn(atom, axis);
+    const shared = bands.find((band) => {
+      const overlap = Math.min(end, band.end) - Math.max(start, band.start);
+      return overlap > Math.min(end - start, band.end - band.start) / 2;
+    });
+    if (shared) shared.atoms.push(atom);
+    else bands.push({ atoms: [atom], start, end });
+  }
+  return bands;
 }
 
 function median(values: readonly number[]): number {
@@ -165,11 +201,22 @@ function scoreLevels(
     level.atoms.length > best.atoms.length ? level : best
   );
   const dominantSupport = dominant.atoms.length;
+  // The expected coordinate is MINED FROM REPETITION, so there has to be a
+  // repetition. A level of one is a single box, and `expected` taken from it
+  // is that box's own coordinate dressed up as an expectation — every other
+  // member of the series then "deviates" from an arbitrary one of them. This
+  // is not a confidence threshold on a candidate; it is the precondition of
+  // the comparison existing at all.
+  if (dominantSupport < 2) return [];
   const expected = median(dominant.values);
   const deviations: VisualDeviation[] = [];
   for (const level of levels) {
     if (level === dominant) continue;
     const peerSupport = level.atoms.length;
+    // Same reason on the other side. Three boxes here and three there is not a
+    // majority with an exception, it is two positions; `reduce` would name a
+    // winner by array order and report the other half as broken.
+    if (peerSupport >= dominantSupport) continue;
     for (const [index, atom] of level.atoms.entries()) {
       const value = level.values[index]!;
       const delta = Math.abs(value - expected);
@@ -266,14 +313,14 @@ type Lane = { readonly atoms: VisualAtom[]; readonly across: number[]; anchor: n
  * otherwise walk one column into the next.
  */
 function laneSeries(group: readonly VisualAtom[], axis: Axis, minimumLength: number): VisualAtom[][] {
-  const bands = buildLevels(
-    group.map((atom) => ({ atom, value: centerOn(atom, axis) })),
-    median(group.map((atom) => extentOn(atom, axis))) / 2
-  );
+  const bands = buildBands(group, axis);
   // A lane holds at most one atom per band, so fewer bands than a series needs
   // members means this axis cannot carry a series at all.
   if (bands.length < Math.max(minimumLength, 2)) return [];
-  const step = median(bands.slice(1).map((band, index) => band.anchor - bands[index]!.anchor));
+  const positions = bands
+    .map((band) => median(band.atoms.map((atom) => centerOn(atom, axis))))
+    .sort((left, right) => left - right);
+  const step = median(positions.slice(1).map((position, index) => position - positions[index]!));
   if (!(step > 0)) return [];
 
   const cross = CROSS_AXIS[axis];
@@ -308,14 +355,19 @@ function laneSeries(group: readonly VisualAtom[], axis: Axis, minimumLength: num
 
   const series = lanes.filter((lane) => lane.atoms.length >= minimumLength);
   if (series.length === 0) return [];
-  // Recall fallback, and the reason locality here is not a partition. A lane of
-  // one is not evidence of a lane; it is one box that left. Left alone, the
-  // bound above would punish the clearest defects hardest — the further a box
-  // flies from its series, the more certainly it becomes its own lane and
-  // disappears — so a lone residual rejoins the nearest real series and is
-  // mined there at whatever delta it actually has. Two boxes agreeing on a
-  // position are left alone: that is a sparse column, and folding it back
-  // would report a whole second column as broken.
+  // A lane of one is not evidence of a lane; it is one box that left, and the
+  // greedy assignment above may simply have given its lane to a closer member.
+  // So a lone residual rejoins the nearest real series — but only within the
+  // same step that governs lane tracking, because membership needs evidence
+  // too.
+  //
+  // This bound is not tuning. Unbounded, this fallback WAS the worst defect in
+  // the pass: a composer's send icon 849px below the top bar was folded into
+  // the top bar's icon series and reported, at the highest score in the whole
+  // report, as being 849px out of line. Two visually identical boxes at
+  // opposite ends of a page are not a series with an exception in it, and
+  // nothing here can tell otherwise. The honest cost is stated in the tests: a
+  // box that drifts more than one step off its series is no longer recovered.
   for (const lane of lanes) {
     if (lane.atoms.length !== 1 || series.includes(lane)) continue;
     const nearest = series.reduce((best, candidate) =>
@@ -323,6 +375,7 @@ function laneSeries(group: readonly VisualAtom[], axis: Axis, minimumLength: num
         ? candidate
         : best
     );
+    if (Math.abs(lane.anchor - nearest.anchor) > step) continue;
     nearest.atoms.push(lane.atoms[0]!);
   }
   return series.map((lane) => lane.atoms);

--- a/packages/components/tests/e2e/AGENTS.md
+++ b/packages/components/tests/e2e/AGENTS.md
@@ -1,7 +1,7 @@
 # Geometry constraint system
 
-`CLAUDE.md` is a symlink to this file. Edit `AGENTS.md` only.
-Package `AGENTS.md` and the repository root also apply.
+`CLAUDE.md` is a symlink to this file. Edit `AGENTS.md` only. Package `AGENTS.md`
+and the repository root also apply.
 
 Measures rendered geometry, turns it into findings, gates what a human promoted.
 `src/lib/chat-workspace-geometry.ts` (spec, grid, discovery) and
@@ -72,7 +72,8 @@ chat row of one family are two findings. Findings merge evidence across captures
 the first capture's label; repeated instance rules with identical member offsets are
 measurement-model divergences, not repeated violations.
 
-A structural improvement RE-KEYS reviews; a decision nobody carries forward is made twice. Each entry records the identity it reviewed (label, axis, anchor, surface);
+A structural improvement RE-KEYS reviews; a decision nobody carries forward is made twice.
+Each entry records the identity it reviewed (label, axis, anchor, surface);
 `diffGeometryFindings` pairs a resolved key with a new one as `rekeyed` — same label, or,
 where a locale makes labels unmatchable, same axis + anchor + surface with |offset| within
 0.25px — and triage MOVES status, reason and baseline there rather than report resolved and
@@ -86,12 +87,12 @@ beside the code ([src/lib](../../src/lib/AGENTS.md)). Review lives in checked-in
 `geometry-ledger.json`; `geometry-contracts.json` compiles ONLY `promoted` entries, each
 declaring `ink` or `layout-box`; no other status compiles.
 
-- A baseline is EXECUTED, not printed: the gate reruns the pipeline over the whole capture
-  plan with no screenshots, and fails when a finding's |offset| passes |baseline| plus one
-  device pixel (1/DPR of its COARSEST capture) or when a finding has no ledger entry
-  (`geometry:triage`, like a lockfile). `ignored` opts out, `promoted` belongs to the
-  contract check, and offsets are means over the WHOLE plan, so a baseline belongs to the
-  platform that recorded it: re-baseline where CI runs, never trim the plan for speed.
+- A baseline is EXECUTED, not printed: the gate reruns the pipeline over the whole plan, no
+  screenshots, and fails when a finding's |offset| passes |baseline| plus one device pixel
+  (1/DPR of its COARSEST capture), or has no ledger entry (`geometry:triage`, like a
+  lockfile). `ignored` opts out, `promoted` belongs to the contract check, a baseline is
+  bound to the platform that recorded it: re-baseline where CI runs, never trim the plan.
+  Gate and diff read the WORST capture, never the merged mean `offset`.
 - `debt` and `wont-fix` are two decisions, not one word; `triage` records `debt` rather than
   guess. `geometry:verify-fix <dir> <key…|--repair-group=…>` reruns that gate and only then
   moves a finding back inside one device pixel to `fixed` at its new baseline, the strictest

--- a/packages/components/tests/geometry-constraint-system.test.ts
+++ b/packages/components/tests/geometry-constraint-system.test.ts
@@ -427,6 +427,69 @@ describe('geometry constraint artifacts', () => {
     ]);
   });
 
+  it('sees a regression confined to one capture that the merged offset hides', () => {
+    // `finding.offset` is the MEAN across captures, so a break in one condition
+    // is divided by the capture count before it is compared. Merged across four
+    // captures, a 1.5px shift in one moves the mean 0.375px and slips under a
+    // 0.5px tolerance; across twelve it would take 6px. A dark-theme-only or
+    // locale-only regression is exactly that shape, and exactly the one a
+    // reviewer is least likely to catch by eye.
+    const evidence = [0, 0, 0, 1.5].map((offset, index) => ({
+      captureId: `capture-${index}`,
+      scopeKey: 'row',
+      coordinate: 100 + offset,
+      line: 100,
+      normalizedLine: 0.5,
+      offset,
+      yStart: 0,
+      yEnd: 10,
+    }));
+    const finding = {
+      key: 'geometry/workspace/diluted',
+      kind: 'alignment-rail' as const,
+      surfaceFamily: 'workspace',
+      locator: locator('Diluted'),
+      label: 'Diluted',
+      axis: 'x' as const,
+      anchor: 'inline-end' as const,
+      normalizedLine: 0.5,
+      offset: 0.375,
+      captureCount: 4,
+      totalCaptureCount: 4,
+      evidence,
+    };
+    const ledger: GeometryLedger = {
+      version: 1,
+      findings: { [finding.key]: { status: 'debt', baseline: { offset: 0 } } },
+    };
+    const artifact = { version: 1 as const, findings: [finding] };
+
+    // The mean alone would say nothing changed.
+    expect(Math.abs(finding.offset - 0)).toBeLessThanOrEqual(0.5);
+    expect(diffGeometryFindings(artifact, ledger).changed).toEqual([finding]);
+
+    const captures = {
+      version: 1 as const,
+      captures: evidence.map((entry) => ({
+        captureId: entry.captureId,
+        deviceScaleFactor: 2,
+      })),
+    } as unknown as Parameters<typeof checkGeometryLedgerRatchet>[2];
+    // The gate reads the worst capture and names it, or the message reads
+    // "baseline 0 → current 0.375" for a 1.5px break.
+    expect(checkGeometryLedgerRatchet(artifact, ledger, captures)).toEqual([
+      expect.objectContaining({
+        kind: 'offset-regression',
+        key: finding.key,
+        current: 1.5,
+        captureId: 'capture-3',
+      }),
+    ]);
+    expect(
+      formatGeometryRatchetViolations(checkGeometryLedgerRatchet(artifact, ledger, captures))
+    ).toContain('current 1.500px in capture-3');
+  });
+
   it('uses the ledger for report diffs and compiles only promoted contracts', () => {
     const finding = {
       key: 'geometry/workspace/finding',

--- a/packages/components/tests/geometry-discovery-report.test.ts
+++ b/packages/components/tests/geometry-discovery-report.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { afterEach, expect, it } from 'vitest';
+import template from '../scripts/templates/chat-workspace-geometry-report.html?raw';
+import {
+  mineVisualDeviations,
+  type VisualAtom,
+} from '../src/lib/geometry-discovery/visual-repetition';
+
+afterEach(() => document.body.replaceChildren());
+
+type ReportAtom = VisualAtom & { label: string };
+
+/**
+ * Runs the shipped report renderer against its real DOM, without a Storybook
+ * server: the default review queue is a policy that only exists in the
+ * template, so asserting it anywhere else would assert a copy of it.
+ */
+function renderVisualReport(captures: readonly { captureId: string; atoms: readonly ReportAtom[] }[]) {
+  const payload = {
+    generatedAt: '2026-01-01T00:00:00Z',
+    viewport: { width: 500, height: 500 },
+    visualRepetition: {
+      captures: captures.map((capture) => ({
+        ...capture,
+        deviations: mineVisualDeviations(capture.atoms),
+        viewport: { width: 500, height: 500 },
+        deviceScaleFactor: 1,
+      })),
+    },
+    details: [],
+    coverage: { scope: 'synthetic', captures: [], exclusions: [] },
+    findingDiff: { current: [], new: [], changed: [], resolved: [] },
+    qualityMetrics: {},
+    pixelWitnesses: [],
+    contractProposals: [],
+  };
+  const html = template.replace('__GEOMETRY_REPORT_DATA__', JSON.stringify(payload));
+  document.body.innerHTML = html.match(/<body>([\s\S]*)<\/body>/)![1]!;
+  // The template ships as one HTML file with an inline script, so running that
+  // exact script — from this repository, never from input — is the whole point.
+  // eslint-disable-next-line typescript-eslint/no-implied-eval -- runs the shipped renderer
+  new Function(html.match(/<script>([\s\S]*?)<\/script>/)![1]!)();
+  return {
+    cards: () => [...document.querySelectorAll<HTMLDetailsElement>('#visual-candidates > details')],
+    summaries: () =>
+      [...document.querySelectorAll('#visual-candidates > details > summary')].map(
+        (summary) => summary.textContent ?? ''
+      ),
+    showAll: () => {
+      const filter = document.querySelector<HTMLSelectElement>('#visual-evidence-filter')!;
+      filter.value = 'all';
+      filter.dispatchEvent(new Event('change'));
+    },
+    showMore: () => document.getElementById('visual-more')!.dispatchEvent(new Event('click')),
+    deviations: payload.visualRepetition.captures.map((capture) => capture.deviations),
+  };
+}
+
+function column(lefts: readonly number[]): ReportAtom[] {
+  return lefts.map((left, index) => ({
+    id: `atom-${index}`,
+    label: `Item ${index}`,
+    kind: 'image',
+    xStart: left,
+    xEnd: left + 24,
+    yStart: index * 80,
+    yEnd: index * 80 + 24,
+  }));
+}
+
+it('shows singleton deviations by default while preserving folded measurements and capture boundaries', () => {
+  const atoms = [24, 24, 24, 28].map((x, index) => ({
+    id: `atom-${index}`,
+    label: `Item ${index}`,
+    kind: 'image',
+    xStart: x,
+    xEnd: x + 24,
+    yStart: index * 80 + (index === 3 ? 7 : 0),
+    yEnd: index * 80 + (index === 3 ? 7 : 0) + 16,
+  }));
+  const report = renderVisualReport([
+    { captureId: 'light', atoms },
+    { captureId: 'dark', atoms },
+  ]);
+  // Edge + pitch in each capture; every deviation here stands alone, and the
+  // old `peerSupport >= 2` default queue showed none of them.
+  expect(report.cards()).toHaveLength(4);
+  const edgeCard = report.cards().find((card) =>
+    card.querySelector('summary')!.textContent!.includes('x-start')
+  )!;
+  edgeCard.open = true;
+  edgeCard.dispatchEvent(new Event('toggle'));
+  const measurements = edgeCard.querySelector('.visual-measurements')!;
+  expect(measurements.querySelectorAll('p')).toHaveLength(3);
+  expect(measurements.textContent).toContain('x-start');
+  expect(measurements.textContent).toContain('x-end');
+  expect(measurements.textContent).toContain('x-center');
+  expect(measurements.textContent).toContain('peer support 1');
+  expect(measurements.textContent).toContain('Item 0 (atom-0)');
+
+  const captureFilter = document.querySelector<HTMLSelectElement>('#visual-capture-filter')!;
+  captureFilter.value = 'dark';
+  captureFilter.dispatchEvent(new Event('change'));
+  expect(report.cards()).toHaveLength(2);
+  expect(
+    report.summaries().every((summary) => summary.includes('dark'))
+  ).toBe(true);
+  report.showAll();
+  expect(report.cards()).toHaveLength(report.deviations[1]!.length);
+});
+
+it('bounds isolated candidates per capture without touching peer-supported ones or the raw JSON', () => {
+  // Ten rows each off the dominant edge by their own amount, so each is its own
+  // level with peer support of one, plus two rows that agree with each other.
+  const lefts = [100, 100, 100, 100, 100, 100, 100, 100];
+  for (let step = 1; step <= 10; step += 1) lefts.push(100 + step * 4);
+  const noisy = column([...lefts, 150, 150]);
+  const report = renderVisualReport([
+    { captureId: 'noisy', atoms: noisy },
+    { captureId: 'quiet', atoms: column([100, 100, 100, 108, 100, 100]) },
+  ]);
+
+  const sharedLevel = ['Item 18', 'Item 19'];
+  const isolated = (summaries: readonly string[]) =>
+    summaries.filter(
+      (summary) =>
+        summary.includes('noisy') && !sharedLevel.some((label) => summary.includes(label))
+    );
+  // Five per capture, and the budget is spent on the highest-scoring ones: the
+  // furthest row in, the smallest offsets out.
+  expect(isolated(report.summaries())).toHaveLength(5);
+  expect(report.summaries().some((summary) => summary.includes('Item 17'))).toBe(true);
+  expect(report.summaries().some((summary) => summary.includes('Item 8'))).toBe(false);
+  // The pair that shares a level keeps the guarantee the old queue gave it.
+  expect(
+    sharedLevel.every((label) => report.summaries().some((summary) => summary.includes(label)))
+  ).toBe(true);
+  // A budget is per capture, so one noisy screen cannot drain a quiet one.
+  expect(report.summaries().some((summary) => summary.includes('quiet'))).toBe(true);
+
+  // Nothing was removed from discovery: the raw view still holds every one.
+  const withheld = report.deviations[0]!.length + report.deviations[1]!.length;
+  expect(report.cards().length).toBeLessThan(withheld);
+  report.showAll();
+  report.showMore();
+  report.showMore();
+  expect(report.cards()).toHaveLength(withheld);
+});

--- a/packages/components/tests/geometry-discovery-report.test.ts
+++ b/packages/components/tests/geometry-discovery-report.test.ts
@@ -56,7 +56,7 @@ function renderVisualReport(captures: readonly { captureId: string; atoms: reado
   };
 }
 
-function column(lefts: readonly number[]): ReportAtom[] {
+function column(lefts: readonly number[], scopes?: readonly string[]): ReportAtom[] {
   return lefts.map((left, index) => ({
     id: `atom-${index}`,
     label: `Item ${index}`,
@@ -65,6 +65,7 @@ function column(lefts: readonly number[]): ReportAtom[] {
     xEnd: left + 24,
     yStart: index * 80,
     yEnd: index * 80 + 24,
+    ...(scopes ? { scope: scopes[index] } : {}),
   }));
 }
 
@@ -145,4 +146,39 @@ it('bounds isolated candidates per capture without touching peer-supported ones 
   report.showMore();
   report.showMore();
   expect(report.cards()).toHaveLength(withheld);
+});
+
+it('marks a candidate whose witnesses come from another section, and can hide it', () => {
+  // Scope stays out of MINING — grouping on it would file two code paths into
+  // different families and hide the defect that correlates with them. But a
+  // reader triaging the queue needs to know whether the comparison held still
+  // inside one section, because a delta measured against another section is
+  // usually the distance between two unrelated boxes rather than an error.
+  const atoms = column(
+    [100, 100, 100, 140, 100, 100],
+    ['side-panel', 'side-panel', 'side-panel', 'composer', 'side-panel', 'side-panel']
+  );
+  const report = renderVisualReport([{ captureId: 'mixed', atoms }]);
+
+  expect(report.summaries().length).toBeGreaterThan(0);
+  expect(report.summaries().every((summary) => summary.includes('跨区域'))).toBe(true);
+
+  const filter = document.querySelector<HTMLSelectElement>('#visual-evidence-filter')!;
+  filter.value = 'same-scope';
+  filter.dispatchEvent(new Event('change'));
+  expect(report.cards()).toHaveLength(0);
+});
+
+it('leaves a candidate unmarked when every witness shares its section', () => {
+  const atoms = column([100, 100, 100, 140, 100, 100], Array.from({ length: 6 }, () => 'side-panel'));
+  const report = renderVisualReport([{ captureId: 'single', atoms }]);
+
+  expect(report.summaries().length).toBeGreaterThan(0);
+  expect(report.summaries().some((summary) => summary.includes('跨区域'))).toBe(false);
+
+  const before = report.cards().length;
+  const filter = document.querySelector<HTMLSelectElement>('#visual-evidence-filter')!;
+  filter.value = 'same-scope';
+  filter.dispatchEvent(new Event('change'));
+  expect(report.cards()).toHaveLength(before);
 });

--- a/packages/components/tests/geometry-discovery-report.test.ts
+++ b/packages/components/tests/geometry-discovery-report.test.ts
@@ -182,3 +182,40 @@ it('leaves a candidate unmarked when every witness shares its section', () => {
   filter.dispatchEvent(new Event('change'));
   expect(report.cards()).toHaveLength(before);
 });
+
+it('puts same-section candidates ahead of higher-scoring cross-section ones', () => {
+  // The cross-section card scores far higher precisely because it spans
+  // sections: its delta is the distance between two unrelated boxes. Ranking on
+  // score alone therefore sorts the least meaningful comparison to the top.
+  const atoms: ReportAtom[] = [
+    ...column([100, 100, 100, 109, 100, 100], Array.from({ length: 6 }, () => 'panel')),
+    ...column([600, 600, 600, 660, 600, 600], [
+      'panel',
+      'panel',
+      'panel',
+      'composer',
+      'panel',
+      'panel',
+    ]).map((atom, index) => ({
+      ...atom,
+      id: `far-${index}`,
+      label: `Far ${index}`,
+      yStart: atom.yStart + 2000,
+      yEnd: atom.yEnd + 2000,
+    })),
+  ];
+  const report = renderVisualReport([{ captureId: 'ranked', atoms }]);
+  const summaries = report.summaries();
+
+  const firstCross = summaries.findIndex((summary) => summary.includes('跨区域'));
+  const lastSame = summaries.reduce(
+    (last, summary, index) => (summary.includes('跨区域') ? last : index),
+    -1
+  );
+  expect(firstCross).toBeGreaterThan(-1);
+  expect(lastSame).toBeGreaterThan(-1);
+  // Every same-section card outranks every cross-section one.
+  expect(lastSame).toBeLessThan(firstCross);
+  // And the buried one is the higher-scoring card, so this is a real reorder.
+  expect(summaries[firstCross]).toContain('Far');
+});

--- a/packages/components/tests/geometry-discovery-visual-repetition.test.ts
+++ b/packages/components/tests/geometry-discovery-visual-repetition.test.ts
@@ -24,6 +24,40 @@ function stackedRows(
   }));
 }
 
+/** A grid of one visual kind, `columns` wide, at a fixed pitch on both axes. */
+function grid(columns: number, rows: number, cell = { width: 40, height: 40 }): VisualAtom[] {
+  return Array.from({ length: rows }, (_unused, row) =>
+    Array.from({ length: columns }, (_ignored, column) => ({
+      id: `cell-${row}-${column}`,
+      kind: 'image',
+      xStart: 60 + column * 100,
+      xEnd: 60 + column * 100 + cell.width,
+      yStart: 40 + row * 60,
+      yEnd: 40 + row * 60 + cell.height,
+    }))
+  ).flat();
+}
+
+/** Two vertical lists that render alike, rendered beside each other. */
+function sideBySideLists(rows: number): VisualAtom[] {
+  return [40, 340].flatMap((left, list) =>
+    Array.from({ length: rows }, (_unused, row) => ({
+      id: `list-${list}-${row}`,
+      kind: 'image',
+      xStart: left,
+      xEnd: left + 24,
+      yStart: 50 + row * 70,
+      yEnd: 74 + row * 70,
+    }))
+  );
+}
+
+function shiftX(atoms: readonly VisualAtom[], id: string, offset: number): VisualAtom[] {
+  return atoms.map((atom) =>
+    atom.id === id ? { ...atom, xStart: atom.xStart + offset, xEnd: atom.xEnd + offset } : atom
+  );
+}
+
 function leftEdgeDeviations(atoms: readonly VisualAtom[]) {
   return mineVisualDeviations(atoms).filter(
     (deviation) => deviation.axis === 'x' && deviation.measure === 'start'
@@ -31,6 +65,41 @@ function leftEdgeDeviations(atoms: readonly VisualAtom[]) {
 }
 
 describe('mineVisualDeviations', () => {
+  it('finds a singleton offset across fractional height rounding boundaries', () => {
+    const atoms = stackedRows([24, 24, 24, 28]).map((atom, index) => ({
+      ...atom,
+      yEnd: atom.yStart + (index < 2 ? 15.49 : 15.51),
+    }));
+    for (const ordered of [atoms, [...atoms].reverse()]) {
+      expect(leftEdgeDeviations(ordered)).toEqual([
+        expect.objectContaining({
+          atomId: 'row-3',
+          expected: 24,
+          value: 28,
+          dominantSupport: 3,
+          peerSupport: 1,
+        }),
+      ]);
+    }
+  });
+
+  it('does not chain distinct heights through intermediate boxes', () => {
+    const atoms = stackedRows([24, 24, 24, 80, 80, 80]).map((atom, index) => ({
+      ...atom,
+      yEnd: atom.yStart + [15, 15.5, 16, 16.5, 17, 17.5][index]!,
+    }));
+    expect(leftEdgeDeviations(atoms)).toEqual([]);
+    expect(leftEdgeDeviations([...atoms].reverse())).toEqual([]);
+  });
+
+  it('keeps different heights separate when height tolerance is zero', () => {
+    const atoms = stackedRows([24, 24, 24, 28]).map((atom, index) => ({
+      ...atom,
+      yEnd: atom.yStart + (index < 2 ? 15 : 15.5),
+    }));
+    expect(mineVisualDeviations(atoms, { heightTolerance: 0 })).toEqual([]);
+  });
+
   it('reports the rows a series leaves off its own left edge', () => {
     // The reported shape: the run starts and ends on one edge and a block in
     // the middle sits elsewhere. Nothing declares which edge is correct; the
@@ -114,5 +183,129 @@ describe('mineVisualDeviations', () => {
 
     expect(pitch.map((deviation) => deviation.atomId)).toEqual(['row-3']);
     expect(pitch[0]).toMatchObject({ expected: 80, value: 111 });
+  });
+
+  it('reports the one row that left, with nothing to share the blame with', () => {
+    // The shape the scorer ranks highest: peer support of one. It has to reach
+    // the reviewer, so the report's default queue may not filter on peers.
+    const deviations = leftEdgeDeviations(stackedRows([100, 100, 100, 108, 100, 100]));
+
+    expect(deviations).toEqual([
+      expect.objectContaining({
+        atomId: 'row-3',
+        expected: 100,
+        value: 108,
+        dominantSupport: 5,
+        peerSupport: 1,
+      }),
+    ]);
+  });
+
+  it('reads a regular grid as its own rows and columns, not as one flat series', () => {
+    // Orientation used to come from the whole signature group's page-wide
+    // spread, so a grid was mined as a single horizontal series: every row
+    // then deviated on Y and every column break on pitch, all of it scored
+    // high by the very spread that caused it. Rows and columns are isolated
+    // before orientation is settled, so a grid that agrees with itself is
+    // silent — the same guarantee a single regular column already had.
+    expect(mineVisualDeviations(grid(3, 6))).toEqual([]);
+  });
+
+  it('still finds one cell out of line inside a grid', () => {
+    const deviations = mineVisualDeviations(shiftX(grid(3, 6), 'cell-2-1', 8));
+
+    expect(deviations.map((deviation) => deviation.atomId)).toEqual([
+      'cell-2-1',
+      'cell-2-1',
+      'cell-2-1',
+    ]);
+    expect(deviations[0]).toMatchObject({
+      axis: 'x',
+      expected: 160,
+      value: 168,
+      // Compared against its own column, never against the neighbouring ones.
+      dominantSupport: 5,
+      seriesSize: 6,
+    });
+  });
+
+  it('keeps two side-by-side lists vertical instead of reading across them', () => {
+    expect(mineVisualDeviations(sideBySideLists(6))).toEqual([]);
+  });
+
+  it('finds a misaligned row inside one of two side-by-side lists', () => {
+    const deviations = mineVisualDeviations(shiftX(sideBySideLists(6), 'list-1-3', 8));
+
+    expect(deviations.map((deviation) => deviation.atomId)).toEqual([
+      'list-1-3',
+      'list-1-3',
+      'list-1-3',
+    ]);
+    // Its own column is the expectation, not the list on the other side.
+    expect(deviations[0]).toMatchObject({ expected: 340, value: 348 });
+  });
+
+  it.each([8, 16, 20, 28, 200])(
+    'keeps a box that flew %ipx out of its series inside that series',
+    (offset) => {
+      // The failure this guards is the tempting one: cut the series into
+      // spatial neighbourhoods and the clearest defects — the ones that flew
+      // furthest — are the ones cut loose and lost. Suspicion has to rise with
+      // the offset, never fall off a locality boundary.
+      const deviations = leftEdgeDeviations(stackedRows([100, 100, 100, 100 + offset, 100, 100]));
+
+      expect(deviations).toEqual([
+        expect.objectContaining({ atomId: 'row-3', expected: 100, value: 100 + offset }),
+      ]);
+    }
+  );
+
+  it('sees a box that is only wider, whose left edge agrees', () => {
+    // Width drift lives entirely in `end` and `center`. Keeping only the
+    // best-agreeing measure per series would silence variable-width text and
+    // this real defect in the same stroke, so all three are mined.
+    const rows = stackedRows([100, 100, 100, 100, 100, 100]).map((atom, index) => ({
+      ...atom,
+      xEnd: atom.xEnd + (index === 3 ? 8 : 0),
+    }));
+
+    const measures = mineVisualDeviations(rows).filter(
+      (deviation) => deviation.atomId === 'row-3'
+    );
+
+    expect(measures.map((deviation) => deviation.measure).sort()).toEqual(['center', 'end']);
+    expect(leftEdgeDeviations(rows)).toEqual([]);
+  });
+
+  it('reads the same layout the same way wherever it sits on the page', () => {
+    const atoms = shiftX(grid(3, 6), 'cell-4-2', 9);
+    const translated = atoms.map((atom) => ({
+      ...atom,
+      xStart: atom.xStart + 1000,
+      xEnd: atom.xEnd + 1000,
+      yStart: atom.yStart + 777,
+      yEnd: atom.yEnd + 777,
+    }));
+
+    expect(mineVisualDeviations(translated).map((deviation) => deviation.delta)).toEqual(
+      mineVisualDeviations(atoms).map((deviation) => deviation.delta)
+    );
+  });
+
+  it('absorbs sub-pixel jitter and ranks one input one way', () => {
+    const jittered = grid(3, 6).map((atom, index) => {
+      const noise = ((index % 5) - 2) * 0.2;
+      return {
+        ...atom,
+        xStart: atom.xStart + noise,
+        xEnd: atom.xEnd + noise,
+        yStart: atom.yStart - noise,
+        yEnd: atom.yEnd - noise,
+      };
+    });
+
+    expect(mineVisualDeviations(jittered)).toEqual([]);
+    const anomalous = shiftX(jittered, 'cell-3-0', 12);
+    expect(mineVisualDeviations(anomalous)).toEqual(mineVisualDeviations(anomalous));
   });
 });

--- a/packages/components/tests/geometry-discovery-visual-repetition.test.ts
+++ b/packages/components/tests/geometry-discovery-visual-repetition.test.ts
@@ -245,13 +245,13 @@ describe('mineVisualDeviations', () => {
     expect(deviations[0]).toMatchObject({ expected: 340, value: 348 });
   });
 
-  it.each([8, 16, 20, 28, 200])(
+  it.each([8, 16, 20, 28, 60])(
     'keeps a box that flew %ipx out of its series inside that series',
     (offset) => {
-      // The failure this guards is the tempting one: cut the series into
-      // spatial neighbourhoods and the clearest defects — the ones that flew
-      // furthest — are the ones cut loose and lost. Suspicion has to rise with
-      // the offset, never fall off a locality boundary.
+      // The tempting failure this guards: cut the series into spatial
+      // neighbourhoods and the clearest defects — the ones that flew furthest
+      // — are the ones cut loose. Within the series' own step (80px here),
+      // suspicion rises with the offset and never falls off a boundary.
       const deviations = leftEdgeDeviations(stackedRows([100, 100, 100, 100 + offset, 100, 100]));
 
       expect(deviations).toEqual([
@@ -259,6 +259,16 @@ describe('mineVisualDeviations', () => {
       ]);
     }
   );
+
+  it('stops claiming a box that left by more than the series step', () => {
+    // The deliberate limit, and the honest cost of not manufacturing evidence.
+    // Recovering a box this far out has to assert that it still belongs to
+    // this series, and nothing visual supports that: the same unbounded rule
+    // folded a composer icon into the top bar's icon row 849px above it and
+    // ranked that fabrication first in the whole report. A stray box is now
+    // simply not mined, rather than mined against an unrelated region.
+    expect(leftEdgeDeviations(stackedRows([100, 100, 100, 300, 100, 100]))).toEqual([]);
+  });
 
   it('sees a box that is only wider, whose left edge agrees', () => {
     // Width drift lives entirely in `end` and `center`. Keeping only the


### PR DESCRIPTION
## Related issue

Refs #408

This stacks directly on #408 (base `feat/capture-mobile-viewports`) and must not close it.
No separate tracking Issue exists; this is a same-repository branch, which `.github/AGENTS.md`
classifies as `internal` and does not require an Issue for intake.

## Problem / pressure

Everything here came from auditing the RANKED OUTPUT of the real 21-capture report — the
cards a reviewer actually opens first — rather than counts and synthetic scenarios. Two
independent subsystems were reporting comparisons they could not support.

**The visual repetition lane fabricated its own top candidates.** Four causes, each measured:

1. *Orientation was decided page-wide.* `seriesAxis` ran on the whole signature group and the
   split happened afterwards along that one axis. A 1-D gap split cannot cut a 2-D
   arrangement (the median gap inside a grid row is `0`), so a grid read as one horizontal
   series: a Y deviation per row, a pitch deviation per column break, each scored high by the
   page-wide spread that caused it.
2. *An expectation was never required to be repeated.* `expected` is mined from repetition, so
   a dominant level of one is a single box's own coordinate dressed up as an expectation. A
   dominant that merely ties the deviating level is no better: three boxes here and three
   there is two positions, with the winner picked by array order. **43% of all output.**
3. *Bands clustered by centre distance*, which is what a variable-width column moves. Six
   left-aligned sidebar labels share one left edge and one overlapping X interval, but their
   centres follow string length — read as centres they became six separate X positions, and a
   vertical list was mined as a horizontal series against a header 300px above it.
4. *The residual fold had no distance limit*, and this was the worst because it was introduced
   as a recall *fallback*. It folded a composer's send icon into the top bar's icon series
   849px above it and ranked that fabrication **first in the whole report, at 3792**.

**The authored rail diluted single-condition regressions.** Separate subsystem, same class of
error. A finding merges evidence from every capture and reports one `offset`, the MEAN. Both
consumers compared that mean to the ledger baseline: the report diff and **the CI ratchet**.
So a break confined to one condition is divided by the capture count before anything reads
it. Measured: 14 of 36 findings merge more than one capture, 8 merge twelve, and for those a
one-condition break needs **6.0px** to move the mean past a 0.5px tolerance. Their capture
lists include `wide-expanded-dark` and `wide-expanded-zh` — a dark-theme-only or locale-only
shift is exactly that shape, and exactly what a reviewer is least likely to catch by eye. The
gate was blindest where human review is weakest.

## Summary

Mining (`visual-repetition.ts`):

- Isolate lanes *before* settling orientation; both axis hypotheses run and a series takes at
  most **one member per band**, so the wrong hypothesis dies as runs of one.
- Require the dominant level to be repeated **and** to outnumber what deviates from it. This
  is the precondition of the comparison, not a confidence threshold.
- Build bands by **interval overlap**, not centre distance.
- Bound the residual fold by the same band step that bounds lane tracking.

Baseline comparison (`geometry-constraint-system.ts`) — **note: this half touches the CI
gate**, and could be split into its own PR if you prefer:

- `diffGeometryFindings` and `checkGeometryLedgerRatchet` now read every capture's own
  measurement instead of the merged mean. The ratchet judges the worst capture and carries its
  `captureId` into the violation, because "baseline 0 → current 0.375" names no condition a
  reader can go and look at.

Report attention (template only, mining unchanged):

- Replace the `peerSupport >= 2` queue with peer-supported cards plus the best-scoring
  `VISUAL_SINGLETON_REVIEW_BUDGET` (5) isolated cards **per capture**; fold an atom's repeated
  edge measurements into one card that exposes every folded measurement and its witnesses.
- Mark cross-section comparisons, count them in the summary, filter on them, and **rank
  same-section candidates first**. Reading order only — scope stays out of mining.

## Before / after

| | #408 | after |
| --- | --- | --- |
| raw deviations (21 captures) | 1122 | **294** |
| `dominantSupport == 1` — expectation from a sample of one | 362 (43%) | **0** |
| top-ranked candidate | a send icon "849px out of line" with the top bar | that comparison no longer exists |
| regular 3x6 grid | ~47 raw / 17 cards | **0** |
| two side-by-side lists | high-scoring false candidates | **0** |
| isolated anomaly `[100,100,100,108,100,100]` | found raw, **invisible in the UI** | in the default queue |
| outlier 8/16/20/28px | found | found |
| outlier beyond one series step | "found" by folding it into an unrelated series | **deliberately not recovered** |
| one-condition regression seen by the CI gate | needs 6.0px on a 12-capture finding | ~0.5px |

Default review queue on the real report:

| before | after |
| --- | --- |
| `#1 Review mobile layout +267.59px` (cross-section) | `#1 session-detail.tsx +110.92px` |
| `#2 lody +118.42px` (cross-section) | `#7 Files -9px` — six witnesses in the same panel |
| the 12 same-section cards sit at #7 and #66-78 | they are #1-12; first cross-section card is #13 |

## The measured limit, which this PR does not fix

66 of 78 review cards still have a witness in a different `sectionScope`. Their deltas are
the largest in the queue — 71 cards over 20px, six over 100px — and that is the tell, not the
severity: a 267px "deviation" between a top bar icon and a composer button is the distance
between two unrelated boxes, not an error. The 12 same-section cards look completely
different, seven of them landing in 5-20px.

This is not a remaining bug to chase. Locality is a proxy, and the discriminator a reviewer
applies — *same structural relationship* — is precisely what visual grouping discards on
purpose. Some cross-section comparisons are the intended catch; most are noise, and the card
cannot say which. So the lane is an **auxiliary candidate source**, and that measurement is
recorded in `AGENTS.md` so it is not rediscovered. The authored baseline rail is untouched by
it: `discoverVisualRepetition` output flows only into `reportData.visualRepetition`.

## Test plan

- `corepack pnpm --filter @lody/components exec vitest run tests/geometry-constraint-system.test.ts tests/geometry-discovery-visual-repetition.test.ts tests/geometry-discovery-report.test.ts tests/geometry-discovery-visual-capture.test.ts` — 101 passed.
- Every behavioural test here was verified to FAIL without its fix, by reverting the source and re-running. The earlier revision of this PR passed all synthetic benchmarks while its top-ranked real candidate was fabricated, so a green suite is not evidence on its own.
- The baseline change was safety-checked against the current 82 ledger baselines BEFORE it was written: largest legitimate per-capture deviation 0.375px against a 0.5px tolerance, cross-condition spread never above 0.5px, and **0 new violations** in either the diff or the ratchet.
- `corepack pnpm --filter @lody/components geometry:report` — full 21-capture run passes, 78/80 screenshots. Post-fix figures were re-mined from that artifact, and the report was re-rendered and driven in a real browser to confirm the queue, the marker and the filter.
- `tsc --noEmit` clean; `oxlint --type-aware` 0 errors.
- Pre-existing and unrelated: `use-session-actions`, `session-mention-drop-layer`, `mobile-chat-list-opened-by` fail with `act is not a function` in this checkout. Verified identical at `HEAD` with these changes stashed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** the two well-formedness guards in `scoreLevels`, `buildBands` overlap semantics, and the step bound on the residual fold. Then, separately, `diffGeometryFindings` and `checkGeometryLedgerRatchet` — that half changes the CI gate and deserves its own pass.
- **Decisions to challenge:** (1) Is "dominant must outnumber the deviating level" right, or does it lose real symmetric splits? (2) Is the band step the correct scale for both lane tracking and the residual bound? (3) Should the ratchet change be its own PR? (4) Ranking same-section first uses structure for READING order while mining stays DOM-blind — is that line in the right place?
- **Plausible failures / evidence gaps:** a box drifting more than one series step is no longer recovered at all — a stated, tested tradeoff. Interleaved side-by-side lists whose rows do not align are separated by the band-step bound rather than by direct evidence. A pure monotone indent ladder now yields nothing where it previously yielded low-ranked deviations.

### Authoring context

- **User goal / directives:** make the visual queue something a human will actually read, then — after review of the real output — stop manufacturing evidence anywhere it was being manufactured.
- **Constraints / non-goals:** no CV, no classifier, no cross-capture visual aggregation, no candidate promotion, no ledger schema change, no DOM-identity regrouping. Discovery may be clever; validation stays dumb.
- **Risk-bearing decisions:** locality bounds are heuristics. Bounding the residual fold trades far-outlier recall for not fabricating cross-region series; the alternative was measurably worse. The ratchet change makes the CI gate strictly stricter, verified to add no failure today.
- **Destructive or irreversible behavior:** none. Report artifacts are regenerated by the existing local workflow; the ledger format is unchanged.
- **Deliberately not done or tested:** variable-width text remains a deliberate ambiguity — legitimate `end`/`center` deviations from label length are still reported, because visual geometry cannot separate them from a drifted component. Coherent-measure-only filtering would have produced prettier numbers by deleting width-only drift, so it was rejected. The 77% cross-section limit is measured and documented, not fixed.
- **Unknowns / confidence:** high on the guards and their measured effect. Open: whether a 66-of-78 cross-section candidate stream belongs in the main report at all. Removing it was proposed and declined; it is marked, filterable and out-ranked instead.

<!-- context-handoff:end -->
