### PR TITLE
fix(cli): discard adapter output emitted before the title prompt

### DIFF
--- a/apps/cli/src/agent/title-generator-out-of-turn-chunks.test.ts
+++ b/apps/cli/src/agent/title-generator-out-of-turn-chunks.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AcpSessionNotification } from '@lody/shared';
+
+import type { Logger } from '@/utils/logger';
+
+const mocks = vi.hoisted(() => ({
+  startLocalAcpAgent: vi.fn(),
+  shutdownLocalAcpAgent: vi.fn(async () => {}),
+}));
+
+vi.mock('./acp-runner', () => ({
+  startLocalAcpAgent: mocks.startLocalAcpAgent,
+  shutdownLocalAcpAgent: mocks.shutdownLocalAcpAgent,
+}));
+
+import { generateTitleIsolated } from './title-generator';
+
+const SESSION_ID = 'acp-session-1';
+/** Shape of pi-acp 0.0.33's prelude: version banner plus the skills listing. */
+const BANNER =
+  'pi v0.84.3\n---\n## Skills\n- /home/example/.pi/agent/skills/demo/SKILL.md\n- /home/example/.agents/skills/other/SKILL.md\n';
+const TITLE = 'Refactor the session title generator';
+
+/**
+ * pi-acp always advertises a `thought_level` select, so the title agent always has a
+ * config option to apply and therefore always makes a `session/set_config_option`
+ * round trip before prompting. That round trip is what puts the adapter's prelude in
+ * the buffer ahead of the prompt, so the fixture carries enough of that option for the
+ * title agent to pick the same value it picks in production ('minimal'). pi-acp offers
+ * six thought levels; three are enough to fix the choice.
+ */
+const PI_CONFIG_OPTIONS = [
+  {
+    id: 'thought_level',
+    name: 'Thought level',
+    type: 'select' as const,
+    category: 'thought_level' as const,
+    currentValue: 'medium',
+    options: [
+      { value: 'off', name: 'Off' },
+      { value: 'minimal', name: 'Minimal' },
+      { value: 'medium', name: 'Medium' },
+    ],
+  },
+];
+
+const createSilentLogger = (): Logger =>
+  ({
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    success: () => {},
+    debug: () => {},
+    setLevel: () => {},
+    child: () => createSilentLogger(),
+    close: async () => {},
+  }) as unknown as Logger;
+
+/** An untyped agent_message_chunk: what an adapter without Lody phase metadata sends. */
+const agentChunk = (text: string): AcpSessionNotification =>
+  ({
+    sessionId: SESSION_ID,
+    update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text } },
+  }) as AcpSessionNotification;
+
+type PreludeDelivery = 'during-config-round-trip' | 'before-startup-resolves' | 'never';
+
+const runTitleGeneration = async (
+  delivery: PreludeDelivery
+): Promise<{ title: string | null; preludeArrivedBeforePrompt: boolean }> => {
+  let preludeArrived = false;
+  let preludeArrivedBeforePrompt = false;
+
+  mocks.startLocalAcpAgent.mockImplementation(async (options: Record<string, never>) => {
+    const onUpdateMessage = options.onUpdateMessage as (msg: AcpSessionNotification) => void;
+    const deliverPrelude = () => {
+      preludeArrived = true;
+      onUpdateMessage(agentChunk(BANNER));
+    };
+
+    if (delivery === 'before-startup-resolves') deliverPrelude();
+
+    return {
+      agentProcess: {} as never,
+      acpSessionId: SESSION_ID,
+      client: {
+        setSessionConfigOption: vi.fn(async () => {
+          // pi-acp schedules the prelude with setTimeout(0) during session/new, so it is
+          // on the wire long before this round trip -- itself several pipe RPCs to the pi
+          // child -- can answer.
+          if (delivery === 'during-config-round-trip') deliverPrelude();
+          return undefined;
+        }),
+        prompt: vi.fn(async () => {
+          preludeArrivedBeforePrompt = preludeArrived;
+          onUpdateMessage(agentChunk(TITLE));
+          return { stopReason: 'end_turn' };
+        }),
+      } as never,
+      sessionResponse: { sessionId: SESSION_ID, configOptions: PI_CONFIG_OPTIONS },
+    };
+  });
+
+  const title = await generateTitleIsolated({
+    cliType: 'registry',
+    agentType: 'pi-acp',
+    taskPrompt: 'clean up how session titles are generated',
+    logger: createSilentLogger(),
+  });
+
+  return { title, preludeArrivedBeforePrompt };
+};
+
+describe('title generation ignores adapter output emitted outside the title turn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('discards a prelude delivered while the title config round trip is in flight', async () => {
+    const result = await runTitleGeneration('during-config-round-trip');
+
+    // Pins the delivery window the reset depends on: the prelude is in the buffer
+    // before the prompt is sent, because applying pi-acp's thought_level option is a
+    // real round trip. Remove that round trip and this flag goes false; move the reset
+    // above it and the title assertion fails instead. Either mutation turns this test
+    // red, and either one is a production regression.
+    expect(result.preludeArrivedBeforePrompt).toBe(true);
+    expect(result.title).toBe(TITLE);
+  });
+
+  it('discards a prelude already buffered when the agent finishes starting up', async () => {
+    const result = await runTitleGeneration('before-startup-resolves');
+
+    expect(result.preludeArrivedBeforePrompt).toBe(true);
+    expect(result.title).toBe(TITLE);
+  });
+
+  it('leaves an adapter that emits nothing outside the turn exactly as it is today', async () => {
+    const result = await runTitleGeneration('never');
+
+    expect(result.preludeArrivedBeforePrompt).toBe(false);
+    expect(result.title).toBe(TITLE);
+  });
+});

--- a/apps/cli/src/agent/title-generator.ts
+++ b/apps/cli/src/agent/title-generator.ts
@@ -356,6 +356,16 @@ export const generateTitleIsolated = async (
         }
       }
 
+      // Title material is only what the agent streams in answer to this prompt;
+      // everything delivered before this line is discarded. pi-acp emits its startup
+      // banner (or, with quietStartup, its update notice) as an untyped
+      // agent_message_chunk right after session/new, outside any turn, and without this
+      // reset it filled sanitizeTitle's 80-character window. What puts that chunk ahead
+      // of the reset is the config round trip above: applying an option is a real
+      // request to the agent. A titleConfig whose every value the agent cannot apply
+      // skips that request, and is not covered.
+      collectedText = '';
+
       options.logger.debug(`[title-generator] Sending title prompt (acpSessionId=${acpSessionId})`);
       const response = await client?.prompt(acpSessionId, prompt);
       options.logger.debug(


### PR DESCRIPTION
## Related issue

Closes #170

The root cause and reproduction are the reporter's (JmPotato); this PR implements
the first of the two host-side directions their issue proposes.

## Problem / pressure

Sessions created with the pi ACP agent get their title from the adapter's startup
output instead of the model, whenever pi has a prelude to send. The stored title is the first 80 characters
of pi's version banner and skills listing, or — with `"quietStartup": true` — of
pi's update notice as soon as a newer pi is published. There is no user-side
configuration that avoids both.

Two things in `apps/cli/src/agent/title-generator.ts` combine with one adapter
behaviour:

- `collectedText` starts accumulating the moment `startLocalAcpAgent` installs
  `onUpdateMessage`, which is before the title prompt is sent.
- `extractTitleChunkFromNotification` accepts a chunk whose Lody `messagePhase`
  is `undefined`, because most third-party adapters send none. That is deliberate
  and pinned by an existing test.
- pi-acp emits its prelude as exactly such a chunk, from a `setTimeout(…, 0)`
  scheduled during `session/new` and outside any turn, so it lands in the buffer
  ahead of the title and `sanitizeTitle`'s `.slice(0, 80)` keeps only the prelude.

It also broke the safety net: the "wait up to 10s for streamed text" loop was
satisfied instantly by prelude text, so it stopped waiting for a title.

## Summary

Reset `collectedText` immediately before `client.prompt(...)` — only what the
agent streams in answer to that prompt is title material. This is the guard the
issue asks for. It discards whatever has already been delivered, so it is not
pi-specific in what it drops; what is pi-specific is the argument below for why
the prelude has already been delivered by then.

The reset relies on the prelude reaching Lody before the prompt is sent. For
pi-acp that ordering is supplied by `applyTitleConfigOptions`:

- it always runs — `computeTitleGenerationDefaults` returns a record (`{}` is
  truthy), so the `if (configOptionValues)` branch is always taken;
- pi-acp always advertises a `thought_level` select, so the record is never empty
  and the option is applied;
- `session/set_config_option` is a real round trip to the pi child, several pipe
  RPCs deep, against pi-acp's `setTimeout(…, 0)`.

The regression test pins that window instead of assuming it: it delivers the
prelude while the config round trip is in flight and asserts, as an observable
flag, that it had arrived before `prompt` was called. Remove that round trip and
the flag goes false; move the reset above it and the title assertion fails
instead. Either mutation turns the test red, and either one is a production
regression. The residual case where no round trip happens is noted at the reset
itself, not only here.

Two alternatives were considered and rejected:

- **Requiring a phase marker** for title collection — `title-generator.test.ts`
  pins that untyped chunks must keep working, so this would regress every adapter
  that sends none.
- **Matching the banner text** the adapter declares in
  `_meta.piAcp.startupInfo` — it would put a provider-private key in a session
  consumer, and once the config round trip runs, an out-of-turn arrival *after the
  reset* is what it would defend against, which that round trip already excludes.

## Before / after

| Before | After |
| ------ | ----- |
| A pi ACP session is titled `pi v0.84.3 --- ## Skills - /Users/…` (80-char cut of the banner) | titled with the model-generated title |
| With `quietStartup`, titled `New version available: v0.84.4 (installed v0.84.3). Run: …` | titled with the model-generated title |
| The 10s "wait for streamed text" loop is satisfied instantly by prelude text | the loop waits for actual title text |
| Adapters that emit nothing before the turn | unchanged |

## Test plan

- `pnpm --filter lody run typecheck` — passed.
- `cd apps/cli && pnpm exec vitest run --no-file-parallelism` — 251 files, 2496
  tests passed, 1 skipped, 0 failed.
- Red without the fix, reproducible on this branch. From the repository root:
  `git show origin/main:apps/cli/src/agent/title-generator.ts > apps/cli/src/agent/title-generator.ts`,
  then re-run the new test file: both delivery cases fail with
  `expected 'pi v0.84.3 --- ## Skills - /home/exam…' to be 'Refactor the session title generator'`
  — the reported symptom, reproduced. The "emits nothing" control passes with and
  without the fix. `git checkout HEAD -- apps/cli/src/agent/title-generator.ts`
  restores it. Verified.
- `pnpm lint` — 0 errors, and the warning count is identical on this branch and on
  its merge base (9822 locally on both); the delta is what this claims, not the
  absolute number, which differs between a local run and CI's clean checkout.
- `pnpm check:public-boundary` — passed (4112 files, 22 manifests on this branch;
  `main` has grown since, so a post-rebase run reports a larger count).
- The adapter behaviour was read from the published tarball (`npm pack pi-acp@0.0.33`),
  not inferred: `preludeText` is built at `dist/index.js:2013` for both the banner
  and the `quietStartup` update-notice branch, and emitted verbatim by
  `sendStartupInfoIfPending` at `:823-828` from the timer scheduled at `:2032`.

Not run: no end-to-end reproduction against a live pi. pi-acp is an npx registry
agent whose `session/new` requires a real pi install plus credentials, so the test
drives the ordering through a mocked `startLocalAcpAgent`.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** the reset's position relative to `applyTitleConfigOptions`, and
  the first test case, which is what pins the delivery window the reset depends on.
  Everything else follows from those two.
- **Decisions to challenge:** relying on ordering rather than on matching the banner
  text the adapter declares in `_meta.piAcp.startupInfo`. The content guard was
  rejected because it puts a provider-private key in a session consumer and defends
  against an arrival that does not occur here — but it is the honest alternative.
- **Plausible failures / evidence gaps:** a `titleConfig` whose every configured
  value pi-acp cannot apply skips the round trip, leaving no ordering guarantee; no
  live pi reproduction; PR #211 rewrites the same region.

### Authoring context

- **User goal / directives:** fix a visible, every-time defect with the smallest
  change that is honestly defensible, and avoid scope needing a design decision.
- **Constraints / non-goals:** no change to `extractTitleChunkFromNotification`'s
  acceptance of untyped chunks (pinned by an existing test); no provider-specific
  reader in this file; no submodule change. No `AGENTS.md` edit — the nearest scoped
  file already documents this paragraph's title-generation contracts and PR #211 is
  rewriting it, so recording the invariant there is left to land with that PR rather
  than conflicting with it. Happy to add it here instead if you would rather.
- **Risk-bearing decisions:** the reset discards everything buffered before the
  prompt. For this function that is by definition not title material, since it runs
  an isolated agent that sends exactly one prompt.
- **Destructive or irreversible behavior:** none. Titles are computed per session at
  creation; nothing persisted is migrated, and existing wrong titles are unaffected
  (renaming already works).
- **Deliberately not done or tested:** the stale-`titleConfig` hole above — PR #211
  merges the automatic `thought_level` default regardless of stale configured keys,
  which closes it, so fixing it here would collide. No live pi run, for the reason in
  the Test plan. The upstream side is also left alone: svkozak/pi-acp#68 reported the
  out-of-turn chunk as a protocol violation and was closed without a fix, so a
  host-side guard is the reliable one.
- **Unknowns / confidence:** high on the mechanism, which was read from the published
  pi-acp tarball and reproduced in the test down to the reported 80-character string.
  The ordering claim is stated as a bound — a multi-RPC round trip against a 0ms
  timer — not as a proof. One overlap to flag: PR #211 (open) edits
  `title-generator.ts` (`+106/-20`) including the config-option block just above this
  reset; this change is one statement and a new test file, so they should not collide,
  but whichever lands second is worth a glance.

<!-- context-handoff:end -->

