### PR TITLE
fix(components): explain the disabled launch-at-startup switch on Linux

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -2653,6 +2653,7 @@
   "settings.general.autoLaunch.hideWindowToggleFailed": "Failed to update hidden auto-launch",
   "settings.general.autoLaunch.title": "Startup",
   "settings.general.autoLaunch.toggleFailed": "Failed to update auto launch",
+  "settings.general.autoLaunch.unsupported": "This platform does not support launching at startup.",
   "settings.general.cliAutoStart.helper": "Lody runs an agent on this computer to work on your local projects. Turn this off to use Lody only as a control panel for agents running on other machines.",
   "settings.general.cliAutoStart.label": "Run local agent",
   "settings.general.cliAutoStart.toggleFailed": "Failed to update local agent setting",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -2653,6 +2653,7 @@
   "settings.general.autoLaunch.hideWindowToggleFailed": "更新自动启动窗口设置失败",
   "settings.general.autoLaunch.title": "启动项",
   "settings.general.autoLaunch.toggleFailed": "更新自动启动设置失败",
+  "settings.general.autoLaunch.unsupported": "当前平台不支持开机自动启动。",
   "settings.general.cliAutoStart.helper": "Lody 会在本机运行 Agent（CLI）来处理你的本地项目。关闭后，可将 Lody 仅作为控制界面，用于操作其他机器上运行的 Agent。",
   "settings.general.cliAutoStart.label": "运行本机 Agent",
   "settings.general.cliAutoStart.toggleFailed": "更新本机 Agent 设置失败",

--- a/packages/components/src/components/mobile/mobile-general-settings.tsx
+++ b/packages/components/src/components/mobile/mobile-general-settings.tsx
@@ -741,7 +741,7 @@ export function MobileGeneralSettings() {
                 <Switch
                   id="auto-launch-toggle"
                   checked={autoLaunch.enabled}
-                  disabled={!autoLaunch.supported || autoLaunch.loading}
+                  disabled={autoLaunch.supported !== true || autoLaunch.loading}
                   onCheckedChange={(checked) => {
                     void autoLaunch.updateEnabled(checked);
                   }}

--- a/packages/components/src/components/mobile/mobile-general-settings.tsx
+++ b/packages/components/src/components/mobile/mobile-general-settings.tsx
@@ -722,7 +722,19 @@ export function MobileGeneralSettings() {
       {isElectron && (
         <MobileSettingsSection title={t('settings.general.autoLaunch.title', 'Startup')}>
           <MobileSettingsRowGroup>
-            <MobileSettingsRow label={t('settings.general.autoLaunch.label', 'Launch at startup')}>
+            <MobileSettingsRow
+              label={t('settings.general.autoLaunch.label', 'Launch at startup')}
+              helper={
+                autoLaunch.unsupported ? (
+                  <span className="text-destructive">
+                    {t(
+                      'settings.general.autoLaunch.unsupported',
+                      'This platform does not support launching at startup.'
+                    )}
+                  </span>
+                ) : undefined
+              }
+            >
               {autoLaunch.enabledLoading ? (
                 <Loading size="sm" className="h-5 w-9" />
               ) : (

--- a/packages/components/src/components/settings/general-setting.tsx
+++ b/packages/components/src/components/settings/general-setting.tsx
@@ -741,7 +741,7 @@ export function GeneralSettingsComponent() {
                 <Switch
                   id="auto-launch-toggle"
                   checked={autoLaunch.enabled}
-                  disabled={!autoLaunch.supported || autoLaunch.loading}
+                  disabled={autoLaunch.supported !== true || autoLaunch.loading}
                   onCheckedChange={(checked) => {
                     void autoLaunch.updateEnabled(checked);
                   }}

--- a/packages/components/src/components/settings/general-setting.tsx
+++ b/packages/components/src/components/settings/general-setting.tsx
@@ -715,10 +715,25 @@ export function GeneralSettingsComponent() {
             <CliDaemonSetting />
             <CompactRow
               label={t('settings.general.autoLaunch.label', 'Launch at startup')}
-              helper={t(
-                'settings.general.autoLaunch.helper',
-                'Automatically run Lody when you sign in'
-              )}
+              helper={
+                <span className="flex flex-col gap-0.5">
+                  <span>
+                    {t(
+                      'settings.general.autoLaunch.helper',
+                      'Automatically run Lody when you sign in'
+                    )}
+                  </span>
+                  {autoLaunch.unsupported ? (
+                    <span className="text-destructive">
+                      {t(
+                        'settings.general.autoLaunch.unsupported',
+                        'This platform does not support launching at startup.'
+                      )}
+                    </span>
+                  ) : null}
+                </span>
+              }
+              alignTop={autoLaunch.unsupported}
             >
               {autoLaunch.enabledLoading ? (
                 <Loading size="sm" className="h-5 w-9" />

--- a/packages/components/src/hooks/use-electron-auto-launch.ts
+++ b/packages/components/src/hooks/use-electron-auto-launch.ts
@@ -8,7 +8,9 @@ type AutoLaunchStatus = Awaited<ReturnType<IpcServices['app']['getAutoLaunchStat
 
 export function useElectronAutoLaunch(isElectron: boolean) {
   const { t } = useTranslation();
-  const [supported, setSupported] = useState(false);
+  // null until the main process answers. "Not answered" and "answered: unsupported"
+  // have to be distinguishable, or a failed read reads as an unsupported platform.
+  const [supported, setSupported] = useState<boolean | null>(null);
   const [enabled, setEnabled] = useState(false);
   const [hideWindowOnAutoLaunch, setHideWindowOnAutoLaunch] = useState(false);
   const [pendingOperation, setPendingOperation] = useState<PendingAutoLaunchOperation>(
@@ -21,7 +23,7 @@ export function useElectronAutoLaunch(isElectron: boolean) {
       ? services.app.getAutoLaunchStatus.bind(services.app)
       : undefined;
     if (!isElectron || typeof window === 'undefined' || !getAutoLaunchStatus) {
-      setSupported(false);
+      setSupported(null);
       setEnabled(false);
       setHideWindowOnAutoLaunch(false);
       setPendingOperation(null);
@@ -39,7 +41,7 @@ export function useElectronAutoLaunch(isElectron: boolean) {
       })
       .catch(() => {
         if (!active) return;
-        setSupported(false);
+        setSupported(null);
         setEnabled(false);
         setHideWindowOnAutoLaunch(false);
       })
@@ -128,6 +130,7 @@ export function useElectronAutoLaunch(isElectron: boolean) {
     loading,
     enabledLoading: pendingOperation === 'read' || pendingOperation === 'enabled',
     hideWindowLoading: pendingOperation === 'read' || pendingOperation === 'hide-window',
+    unsupported: supported === false,
     updateEnabled,
     updateHideWindow,
   };

--- a/packages/components/tests/electron-auto-launch-unsupported-hook.test.tsx
+++ b/packages/components/tests/electron-auto-launch-unsupported-hook.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ getAutoLaunchStatus: vi.fn() }));
+
+vi.mock('../src/lib/electron-ipc-client', () => ({
+  getIpcServices: () => ({ app: { getAutoLaunchStatus: mocks.getAutoLaunchStatus } }),
+}));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, fallback?: string) => fallback ?? _key }),
+}));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { useElectronAutoLaunch } from '../src/hooks/use-electron-auto-launch';
+
+type AutoLaunchStatus = {
+  supported: boolean;
+  enabled: boolean;
+  hideWindowOnAutoLaunch: boolean;
+};
+
+const deferredStatus = () => {
+  let resolve!: (value: AutoLaunchStatus) => void;
+  const promise = new Promise<AutoLaunchStatus>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+};
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+const render = (isElectron: boolean): { readonly current: { unsupported: boolean } } => {
+  const state = { current: { unsupported: false } };
+  function Probe() {
+    state.current = useElectronAutoLaunch(isElectron);
+    return null;
+  }
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(<Probe />);
+  });
+  return state;
+};
+
+describe('useElectronAutoLaunch unsupported flag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container?.remove();
+    root = null;
+    container = null;
+  });
+
+  it('stays quiet while the initial status read is still in flight', async () => {
+    const status = deferredStatus();
+    mocks.getAutoLaunchStatus.mockReturnValue(status.promise);
+
+    const state = render(true);
+
+    // Before the main process answers there is no verdict to report. Treating "not
+    // answered" as "unsupported" would flash the notice on macOS and Windows on every
+    // visit to Settings.
+    expect(state.current.unsupported).toBe(false);
+
+    await act(async () => {
+      status.resolve({ supported: true, enabled: false, hideWindowOnAutoLaunch: false });
+      await status.promise;
+    });
+
+    expect(state.current.unsupported).toBe(false);
+  });
+
+  it('reports unsupported once the platform answers that it cannot auto-launch', async () => {
+    const status = deferredStatus();
+    mocks.getAutoLaunchStatus.mockReturnValue(status.promise);
+
+    const state = render(true);
+
+    await act(async () => {
+      status.resolve({ supported: false, enabled: false, hideWindowOnAutoLaunch: false });
+      await status.promise;
+    });
+
+    expect(state.current.unsupported).toBe(true);
+  });
+
+  it('stays quiet when the status read fails', async () => {
+    // A read that never answered is not a verdict about the platform. Reporting it
+    // would tell the user their platform cannot auto-launch when in fact Lody just
+    // could not ask -- the same confusion as the unexplained disabled switch, inverted.
+    mocks.getAutoLaunchStatus.mockRejectedValue(new Error('ipc unavailable'));
+
+    const state = render(true);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(state.current.unsupported).toBe(false);
+  });
+
+  it('never reports unsupported outside Electron', async () => {
+    mocks.getAutoLaunchStatus.mockResolvedValue({
+      supported: false,
+      enabled: false,
+      hideWindowOnAutoLaunch: false,
+    });
+
+    const state = render(false);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(state.current.unsupported).toBe(false);
+  });
+});


### PR DESCRIPTION
## Related issue

Refs #179

The issue separates two gaps and asks maintainers which is in scope. This PR
takes only the second — the silent dead control — so #179 stays open for the
first, the actual Linux launch-at-startup implementation.

The diagnosis below, and the `app-ipc.ts` reference with it, are @DoyoDia's; this
only implements the interim the issue itself proposes. Gap 1 is deliberately left with
them — it is the half their issue writes most about. If they or a maintainer
would rather own this half too, say so and I will close this.

## Problem / pressure

On Linux, **Settings → General → Startup → "Launch at startup"** is a permanently
greyed-out switch with nothing saying why. It is indistinguishable from a control
that is still loading, or one that failed to read its state.

The platform gate is correct and should stay: Electron declares
`app.setLoginItemSettings` as `darwin`/`win32` only, so
`apps/electron/src/main/ipc/services/app-ipc.ts` returns `{ supported: false }`
on Linux instead of pretending the toggle works. The missing half is in the
renderer, which already receives that flag and then throws it away — the switch
is disabled with no explanation.

## Summary

- `useElectronAutoLaunch` gains a derived `unsupported` flag, and `supported`
  becomes tri-state so that flag can exist.
- Both Startup surfaces render it as a `text-destructive` line under the helper —
  the same shape the notifications row already uses for an unsupported capability a
  little further up the same screen, so this proposes no new pattern.
- One locale key, added to both locale files.

Both surfaces, because `general-setting.tsx` delegates to `MobileGeneralSettings`
in a narrow window and that surface passed no `helper` at all.

`supported` becomes `boolean | null` because a plain boolean cannot express what
this notice needs to know. It starts `false`, and the hook's own `.catch()` and
its no-IPC early return both leave it `false` — so a read that merely *failed*
would have rendered "This platform does not support launching at startup." on
macOS and Windows. That is the same confusion the issue reports, inverted, and it
would have shipped. Deriving the flag as `supported === false` covers the initial
read, both failure paths and a remount at once, without inferring any of them
from the pending-operation state. Call sites read `!autoLaunch.supported`, which
`null` leaves unchanged.

`alignTop` is applied only when the notice renders, and `CompactRow` defaults it to
`false`, so passing `false` is indistinguishable from not passing it — the row's
alignment on supported platforms is unchanged. The helper itself does change shape
everywhere: it was a bare translated string and is now that string inside a
`flex flex-col` wrapper, which renders the same single line.

The flag is derived once in the hook rather than inlined twice, so there is one
place to get it right, and the regression test pins that derivation in four states.
It does not pin the rendering: no test asserts that either surface puts the string
on screen, so together with the absent visual check (below) the user-visible half of
this change has no automated coverage.

## Visual explanation

| Before | After |
| ------ | ----- |
| Linux: a greyed-out switch with no explanation | the same disabled switch, with "This platform does not support launching at startup." under the label |
| Narrow window / mobile surface: no helper text at all | the same explanation |
| macOS / Windows: interactive switch | unchanged — no notice during the initial read, none after a failed read, and the row keeps its current alignment |

## Test plan

- `pnpm --filter @lody/components run typecheck` — passed.
- `cd packages/components && pnpm exec vitest run --no-file-parallelism` — 435
  files, 3191 tests passed, 0 failed.
- New: `packages/components/tests/electron-auto-launch-unsupported-hook.test.tsx`
  — 4 passed.
- The derivation is load-bearing, verified by mutation: relaxing it to
  `supported !== true` (i.e. treating "not answered" as unsupported) turns three
  of the four red — the in-flight read, the failed read, and the non-Electron
  case — while the genuine unsupported case stays green.
- `pnpm lint` — 0 errors, and the warning count is identical on this branch and on
  its merge base (9822 locally on both). The tri-state change initially added two
  `strict-boolean-expressions` warnings by negating a nullable at both call sites;
  the second commit compares against the answered value instead, which restores the
  base count.
- `pnpm lint:i18n` — all translation keys present in all languages.
- `pnpm check:public-boundary` — passed (4112 files, 22 manifests on this branch;
  `main` has grown since, so a post-rebase run reports a larger count).
- `pnpm check:platform-boundaries` — passed (1698 source files).
- `pnpm exec prettier --check` on all six changed files — clean.

**Not verified visually.** The Electron binary is not installed in this checkout
(`require('electron')` reports "Electron failed to install correctly"), so I could
not run the desktop app and cannot offer before/after screenshots — which for a
UI change is the evidence you would most want. What limits the risk: the helper
node is copied verbatim from the notifications `CompactRow` in the same file,
which already renders exactly this shape with `alignTop`, and `helper` is
`ReactNode` on both row components, so no prop contract changes. The logic, which
is the part a screenshot would not have checked anyway, is covered by the test.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** the `unsupported` derivation in `use-electron-auto-launch.ts`
  (`supported === false`) and the three states `supported` can now hold. Getting that
  wrong is the difference between this fix and a new bug on macOS/Windows.
- **Decisions to challenge:** explaining the disabled control rather than hiding the
  row; and deriving the flag in the hook rather than inlining `!supported` at both
  call sites.
- **Plausible failures / evidence gaps:** no visual verification (see Test plan); and
  the copy assumes the row stays disabled — if Linux support later lands, the notice
  must go with it. `supported` changing to `boolean | null` is a public change to the
  hook's return type, though both call sites only read it in a boolean position.

### Authoring context

- **User goal / directives:** ship the half of #179 that needs no platform work,
  without pre-empting the half that does. #179 puts both halves to maintainers; this
  takes the one the issue itself names as an acceptable interim, and leaves the other.
- **Constraints / non-goals:** no change to the `darwin || win32` gate in
  `app-ipc.ts`, and no XDG autostart implementation — that is gap 1. It also shares
  no file with PR #320, which is editing `auto-launch-settings.ts` and `app-ipc.ts`
  among others.
- **Risk-bearing decisions:** a new user-visible string on a screen every user opens.
  It renders only when the main process has answered `supported: false` — which today
  means Linux, and specifically not a read that failed or never happened.
- **Destructive or irreversible behavior:** none. Nothing is persisted, no IPC
  contract changes, and the switch's disabled state is unchanged.
- **Deliberately not done or tested:** gap 1. It needs an XDG autostart entry whose
  `Exec` path differs across the deb, snap and AppImage targets this repo ships —
  under strict snap confinement `~/.config/autostart` remaps into `$SNAP_USER_DATA`
  and the entry silently never fires, which would reintroduce this exact bug in a new
  form. That is the scope question the issue puts to maintainers, so it is left to
  them. No visual verification, for the reason above.
- **Unknowns / confidence:** high on the logic and on the rendering shape, which is
  lifted from a working sibling in the same file. Lower on the copy itself — if you
  would rather word it differently, or hide the row entirely on unsupported
  platforms, say so and I will change it. One overlap to note: PR #305 also edits
  `general-setting.tsx`, but only the `Button` import and the clear-cache button, not
  the Startup section.

<!-- context-handoff:end -->

