### PR TITLE
fix(shared): keep new history metadata primitive without migrating old data

### DIFF
--- a/packages/components/src/components/AGENTS.md
+++ b/packages/components/src/components/AGENTS.md
@@ -1,7 +1,6 @@
 # Product surfaces (`src/components`)
 
-Parent `AGENTS.md` files also apply. `CLAUDE.md` is a symlink; edit `AGENTS.md` only.
-Child directories (`sessions/`, `mobile/`, `chat/`, `settings/`, …) own their own rules.
+Parent and child-directory `AGENTS.md` rules apply. Edit `AGENTS.md`, not `CLAUDE.md`.
 
 ## Sidebar and session rows
 
@@ -26,20 +25,18 @@ Reasoning: [components-sidebar-session-tree.md](../../../../.agents/docs/compone
   groups, the local-project sections, and `sidebar-updated-session-list.tsx` (Updated
   bucket and Pinned section) — plus `sidebar-navigation-model.ts`, so keyboard nav
   matches what is rendered.
-- It is presentation only and is NOT `parentSessionId`: opened Sessions keep their own
-  workspace/lifecycle and stay first-class rows, while `parentSessionId` children never
-  reach the sidebar at all (`sessionListAtom`).
+- This is presentation, not `parentSessionId`: opened Sessions own their workspace and
+  lifecycle; `parentSessionId` children stay out of the sidebar (`sessionListAtom`).
 - TWO fields, never merged: `openedBySessionId` is the PRECISE opener and drives
   navigation; `openedByRowSessionId` is the sidebar ROW to indent under. They differ when
   an agent inside a child Tab creates a Session, so `buildSidebarOpenerRowResolver`
-  (`sessions/session-list-rows.ts`) walks `parentSessionId` up to the root row. Never
-  "simplify" that by rewriting `openedBySessionId` to the root: "Go to Opener Session"
-  and the conversation's "Opened by" entry must land on the exact Tab that created it.
+  (`sessions/session-list-rows.ts`) walks `parentSessionId` to the root row. Never
+  rewrite `openedBySessionId`: "Go to Opener Session" and "Opened by" must reach the
+  exact Tab that created it.
 - The opener and unrelated top-level rows keep the exact flat-list alignment. The shared
   leading slot owns the node-centre affordance: an opener shows its disclosure at rest
   and swaps it for ⋯ on row hover; a child shows ├/└ and swaps those for ⋯ in the SAME
-  7px-centred position. It draws the tree UNCONDITIONALLY — a working / unread / waiting
-  row must never lose its nesting, which is the whole point of moving status out of it.
+  7px-centred position. Working / unread / waiting rows must keep their tree nesting.
   Only a child widens that slot from 14px to 26px, producing the 12px title indent
   without shifting the row background. Keep connector geometry in
   `sidebar-row-shared.tsx`, and keep the context menu's expand/collapse item wired to the
@@ -51,8 +48,7 @@ Reasoning: [components-sidebar-session-tree.md](../../../../.agents/docs/compone
   hover away in the desktop info card. Pass the three flags to the end slot, never to the
   leading slot. The mobile chat rows keep their own leading-node rule
   ([mobile/AGENTS.md](mobile/AGENTS.md)); do not assume the two match.
-- The resolver needs `allActiveSessions`, so any new list must take it from the sidebar
-  rather than re-deriving it from rows.
+- Pass the sidebar's `allActiveSessions` to the resolver; do not derive it from rows.
 - The tree never hides a Session: a missing, cross-section, cross-group, cycling, or
   deeper-than-one-level opener degrades to a top-level row, and the preview cap
   (`MAX_VISIBLE_SESSIONS` / `SHOW_FULL_BUCKET_THRESHOLD`) counts top-level rows.

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -1,0 +1,9 @@
+# Shared history storage
+
+New history metadata strings are primitive Loro values; declared streaming text,
+plan markdown, tool text/output and script output remain LoroText. This insertion
+policy never migrates stored data. Existing inferred/Any and declared Text string
+fields keep their actual Text or primitive shape when edited, including their
+Text container IDs. The pinned Mirror patch and history-string-storage tests
+enforce this compatibility boundary. Keep old-reader, snapshot and concurrent
+update tests when changing the schema or Mirror version.

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -7,3 +7,11 @@ fields keep their actual Text or primitive shape when edited, including their
 Text container IDs. The pinned Mirror patch and history-string-storage tests
 enforce this compatibility boundary. Keep old-reader, snapshot and concurrent
 update tests when changing the schema or Mirror version.
+
+History payload storage hints (`Any.storageSchema` in the pinned Mirror patch)
+select container layouts without tightening the legacy payload validation
+contract. Resolve hints against the actual value on insertion and diff; an
+incompatible legacy Map/Text must keep its container identity when edited.
+This is not a write whitelist: unknown-field filtering, invalid-update
+preservation/diagnostics and inline-image removal remain separate work. Never
+sanitize persisted history on open to satisfy a newer schema.

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/shared/src/history-content-schema.ts
+++ b/packages/shared/src/history-content-schema.ts
@@ -1,0 +1,453 @@
+import { z } from 'zod';
+
+/**
+ * Candidate write contract for history items. Every object is closed: Zod's
+ * default object parsing strips undeclared keys. Unknown list variants are
+ * skipped independently, so they cannot reject neighboring supported items.
+ * This is deliberately separate from the transport schemas and is not yet
+ * wired into production writes: corpus validation must precede that change.
+ */
+const strings = <K extends string>(...keys: K[]) =>
+  Object.fromEntries(keys.map((key) => [key, z.string().nullish()])) as {
+    [P in K]: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+  };
+const numbers = <K extends string>(...keys: K[]) =>
+  Object.fromEntries(keys.map((key) => [key, z.number().nullish()])) as {
+    [P in K]: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+  };
+const flags = <K extends string>(...keys: K[]) =>
+  Object.fromEntries(keys.map((key) => [key, z.boolean().nullish()])) as {
+    [P in K]: z.ZodOptional<z.ZodNullable<z.ZodBoolean>>;
+  };
+const optionalObject = (shape: z.ZodRawShape) => z.object(shape).nullish();
+const supportedArray = <S extends z.ZodType>(item: S) =>
+  z.preprocess(
+    (value) =>
+      Array.isArray(value)
+        ? value.flatMap((entry: unknown) => {
+            const parsed = item.safeParse(entry);
+            return parsed.success ? [parsed.data] : [];
+          })
+        : value,
+    z.array(item)
+  );
+const imageFields = {
+  imageId: z.string(),
+  mimeType: z.string(),
+  sizeBytes: z.number(),
+  ...strings('fileName', 'storageSessionId'),
+  ...numbers('width', 'height'),
+};
+const exitStatus = optionalObject({ ...numbers('exitCode'), ...strings('signal') });
+const rect = z.object({ x: z.number(), y: z.number(), width: z.number(), height: z.number() });
+const actor = optionalObject({ kind: z.string(), ...strings('agentConfigId', 'name') });
+const error = z.object({
+  code: z.string(),
+  message: z.string(),
+  retryable: z.boolean().optional(),
+});
+const target = z.object({ sessionId: z.string(), userTurnId: z.string() });
+const operationResult = z.object({
+  items: z.array(
+    z.object({
+      status: z.string(),
+      ...strings('label', 'assistantTurnId'),
+      target: target.optional(),
+      inputDurable: z.boolean().optional(),
+      error: error.optional(),
+      output: optionalObject({
+        text: z.string(),
+        ...flags('truncated'),
+        ...numbers('omittedBytes'),
+      }),
+    })
+  ),
+});
+const completion = z.object({
+  type: z.string(),
+  value: operationResult.optional(),
+  partial: operationResult.optional(),
+  error: error.optional(),
+  truncation: optionalObject({ truncated: z.boolean(), omittedBytes: z.number() }),
+});
+
+/** JSON tool-image wrappers observed in local history are text, not renderable images. */
+export function removeSerializedToolImages(text: string): string {
+  if (!text.includes('data:image/') || text.length > 10_000_000) return text;
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    return text;
+  }
+  if (!Array.isArray(value)) return text;
+  const result = value.filter((entry: unknown) => {
+    if (!entry || typeof entry !== 'object' || !('imageUrl' in entry)) return true;
+    const image = entry.imageUrl;
+    return !(
+      image &&
+      typeof image === 'object' &&
+      'url' in image &&
+      typeof image.url === 'string' &&
+      image.url.startsWith('data:image/')
+    );
+  });
+  return result.length === value.length ? text : result.length ? JSON.stringify(result) : '';
+}
+
+const standardToolContent = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('text'), text: z.string().transform(removeSerializedToolImages) }),
+  // Structured image/audio blocks do have renderers. Keep them distinct from
+  // imageUrl wrappers hidden inside JSON text; externalizing them is separate.
+  z
+    .object({
+      type: z.literal('image'),
+      mimeType: z.string(),
+      ...strings('uri', 'data'),
+    })
+    .refine((value) => typeof value.uri === 'string' || typeof value.data === 'string'),
+  z.object({ type: z.literal('audio'), mimeType: z.string(), data: z.string() }),
+  z.object({
+    type: z.literal('resource_link'),
+    uri: z.string(),
+    name: z.string(),
+    ...strings('title', 'description', 'mimeType'),
+    ...numbers('size'),
+  }),
+  z.object({
+    type: z.literal('resource'),
+    resource: z.object({ uri: z.string(), ...strings('text', 'mimeType') }),
+  }),
+]);
+export const historyToolContentSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('content'), content: standardToolContent }),
+  z.object({ type: z.literal('terminal'), terminalId: z.string() }),
+  z.object({
+    type: z.literal('terminal_command'),
+    command: z.string(),
+    args: z.array(z.string()).nullish(),
+    ...strings('cwd'),
+  }),
+  // Diff evidence has a separate consumer; this schema does not remove it implicitly.
+  z.object({
+    type: z.literal('diff'),
+    path: z.string(),
+    ...strings('oldText'),
+    newText: z.string(),
+  }),
+]);
+const schedulingInput = optionalObject({
+  ...strings('cron', 'prompt', 'id', 'jobId', 'taskId', 'description', 'message', 'reason'),
+  ...numbers('delaySeconds'),
+  ...flags('recurring'),
+});
+const schedulingOutput = optionalObject({
+  ...strings('id', 'jobId', 'taskId'),
+  jobs: z.array(z.object({ ...strings('id', 'cron', 'prompt'), ...flags('recurring') })).optional(),
+});
+// These are named dictionaries of question answers, not arbitrary provider metadata.
+const answers = z
+  .record(
+    z.string(),
+    z.union([z.string(), z.array(z.string()), z.object({ answers: z.array(z.string()) })])
+  )
+  .optional();
+const question = z.object({
+  ...strings('id'),
+  question: z.string(),
+  header: z.string(),
+  ...flags('multiSelect', 'allowCustomAnswer', 'isSecret', 'is_secret', 'isOther', 'is_other'),
+  options: z
+    .array(z.object({ label: z.string(), ...strings('description', 'preview') }))
+    .optional(),
+});
+const questionMeta = optionalObject({
+  ...numbers('version', 'autoResolveAt', 'autoResolveAtEpochSeconds'),
+  ...flags('allowCustomAnswer'),
+  questions: z.array(question).optional(),
+  answers,
+});
+const permissionMeta = optionalObject({
+  claudeCode: optionalObject({ ...strings('requestType'), askUserQuestion: questionMeta }),
+  codex: optionalObject({
+    ...strings('requestType', 'decision'),
+    execpolicyAmendment: z.array(z.string()).optional(),
+    requestUserInput: questionMeta,
+  }),
+  lody: optionalObject({ elicitation: questionMeta }),
+});
+const variants = {
+  text: z.object({
+    type: z.literal('text'),
+    text: z.string(),
+    spans: z
+      .array(
+        z.object({
+          start: z.number(),
+          end: z.number(),
+          kind: z.string(),
+          label: z.string(),
+          ...strings('target'),
+        })
+      )
+      .optional(),
+  }),
+  thought: z.object({ type: z.literal('thought'), text: z.string() }),
+  image: z.object({ type: z.literal('image'), ...imageFields }),
+  image_group: z.object({ type: z.literal('image_group'), images: z.array(z.object(imageFields)) }),
+  file: z.object({
+    type: z.literal('file'),
+    fileId: z.string(),
+    fileName: z.string(),
+    mimeType: z.string(),
+    sizeBytes: z.number(),
+    sha256: z.string(),
+    textPreview: z.boolean(),
+    transport: z.string(),
+    uploadedAt: z.number(),
+    ...strings('sourcePath', 'machineId', 'storageSessionId'),
+  }),
+  plan: z.object({
+    type: z.literal('plan'),
+    entries: z.array(z.object({ content: z.string(), status: z.string(), ...strings('priority') })),
+  }),
+  proposed_plan: z.object({
+    type: z.literal('proposed_plan'),
+    turnId: z.string(),
+    markdown: z.string(),
+    status: z.string(),
+    isLatest: z.boolean(),
+  }),
+  goal: z.object({
+    type: z.literal('goal'),
+    threadId: z.string(),
+    objective: z.string(),
+    status: z.string(),
+    ...strings('turnId'),
+    ...numbers('tokenBudget', 'tokensUsed', 'timeUsedSeconds', 'createdAt', 'updatedAt'),
+  }),
+  tool_call: z
+    .object({
+      type: z.literal('tool_call'),
+      status: z.string(),
+      ...strings('toolCallId', 'title', 'kind', 'activityKind', 'toolName', 'schedulingTimeZone'),
+      content: supportedArray(historyToolContentSchema).nullish(),
+      locations: z
+        .array(z.object({ path: z.string(), ...numbers('startLine', 'endLine', 'line') }))
+        .nullish(),
+      ref: optionalObject({ machineId: z.string(), turnId: z.string(), index: z.number() }),
+      rawInput: schedulingInput,
+      rawOutput: z.union([z.string(), schedulingOutput]),
+      permissionRequest: optionalObject({
+        requestId: z.string(),
+        options: z.array(
+          z.object({
+            optionId: z.string(),
+            name: z.string(),
+            ...strings('kind', 'description'),
+            _meta: permissionMeta,
+          })
+        ),
+        _meta: permissionMeta,
+        outcome: optionalObject({
+          outcome: z.string(),
+          ...strings('optionId'),
+          _meta: permissionMeta,
+        }),
+      }),
+    })
+    .refine((value) => typeof value.toolCallId === 'string' || value.ref != null),
+  subagent_task: z.object({
+    type: z.literal('subagent_task'),
+    taskId: z.string(),
+    status: z.string(),
+    ...strings(
+      'taskKind',
+      'actor',
+      'parentTaskId',
+      'modelId',
+      'event',
+      'toolUseId',
+      'subagentType',
+      'taskType',
+      'workflowName',
+      'description',
+      'summary',
+      'rawStatus',
+      'lastToolName',
+      'error'
+    ),
+    ...numbers('startedAtEpochSeconds', 'endedAtEpochSeconds'),
+    ...flags('isBackgrounded', 'skipTranscript', 'hasOutputFile'),
+    usage: optionalObject({ ...numbers('totalTokens', 'toolUses', 'durationMs') }),
+  }),
+  available_commands: z.object({
+    type: z.literal('available_commands'),
+    commands: z.array(
+      z.object({
+        name: z.string(),
+        ...strings('description'),
+        input: optionalObject({ ...strings('hint') }),
+      })
+    ),
+  }),
+  system_notice: z.object({
+    type: z.literal('system_notice'),
+    name: z.string(),
+    meta: optionalObject({
+      ...flags('truncated', 'terminalOmitted', 'thinkingOmitted'),
+      ...strings(
+        'reason',
+        'code',
+        'message',
+        'source',
+        'proposalId',
+        'title',
+        'body',
+        'outcome',
+        'taskId',
+        'sourceSessionId',
+        'sourceTurnId',
+        'sourceTitle'
+      ),
+      proposedBy: actor,
+    }),
+  }),
+  operation_completion: z.object({
+    type: z.literal('operation_completion'),
+    deliveryId: z.string(),
+    operationId: z.string(),
+    operationKind: z.string(),
+    completion,
+    continuation: optionalObject({ status: z.string(), reason: error }),
+  }),
+  worktree_script: z.object({
+    type: z.literal('worktree_script'),
+    phase: z.string(),
+    status: z.string(),
+    steps: z.array(
+      z.object({
+        command: z.string(),
+        status: z.string(),
+        output: z.string(),
+        ...flags('truncated'),
+        exitStatus,
+        ...numbers('startedAt', 'endedAt'),
+      })
+    ),
+    ...numbers('startedAt', 'endedAt'),
+  }),
+  comment_reference: z.object({
+    type: z.literal('comment_reference'),
+    source: z.string(),
+    path: z.string(),
+    lineNumber: z.number(),
+    side: z.string(),
+    commentBody: z.string(),
+    authorName: z.string(),
+    ...strings('authorImage', 'turnId', 'mode', 'threadId'),
+    ...numbers('githubThreadId'),
+    replies: z.array(z.object({ authorName: z.string(), body: z.string() })).optional(),
+  }),
+  visual_annotation_reference: z.object({
+    type: z.literal('visual_annotation_reference'),
+    source: z.string(),
+    commentId: z.string(),
+    body: z.string(),
+    ...strings('turnId', 'authorName', 'status'),
+    anchor: z.object({
+      version: z.literal(1),
+      page: z.object({
+        url: z.string(),
+        pathname: z.string(),
+        viewport: z.object({
+          width: z.number(),
+          height: z.number(),
+          ...numbers('devicePixelRatio', 'scrollX', 'scrollY'),
+        }),
+      }),
+      click: z.object({
+        ...numbers(
+          'x',
+          'y',
+          'clientX',
+          'clientY',
+          'pageX',
+          'pageY',
+          'viewportXRatio',
+          'viewportYRatio',
+          'button'
+        ),
+      }),
+      target: z.object({
+        tag: z.string(),
+        ...strings('id', 'role', 'text', 'xpath'),
+        selector: z.string(),
+        rect,
+        rectRatio: rect,
+        attributes: z.record(z.string(), z.string()),
+      }),
+      context: z.object({
+        ancestors: z.array(
+          z.object({ tag: z.string(), ...strings('id', 'role', 'selector', 'text') })
+        ),
+        nearbyText: z.array(z.string()).optional(),
+      }),
+    }),
+  }),
+} satisfies Record<string, z.ZodType>;
+
+export type HistoryContentValidation =
+  | { status: 'accepted'; value: object }
+  | { status: 'unsupported' }
+  | { status: 'invalid'; issues: { path: string; code: string }[] };
+
+/** Never throws for JSON input; diagnostics distinguish unsupported from broken known items. */
+export function validateHistoryContent(value: unknown): HistoryContentValidation {
+  if (!value || typeof value !== 'object' || !('type' in value) || typeof value.type !== 'string') {
+    return { status: 'invalid', issues: [{ path: 'type', code: 'missing_type' }] };
+  }
+  if (!Object.hasOwn(variants, value.type)) return { status: 'unsupported' };
+  let input: object = value;
+  // Legacy CronCreate receipts can live only in terminal_output. The scheduled
+  // task reader uses the receipt's job id to recognize CronDelete; removing it
+  // would resurrect cancelled tasks. Move this specific business result into
+  // the declared rawOutput field before dropping ordinary terminal blocks.
+  if (value.type === 'tool_call') {
+    const tool = value as {
+      toolName?: unknown;
+      title?: unknown;
+      rawOutput?: unknown;
+      content?: unknown;
+    };
+    if (
+      (tool.toolName ?? tool.title) === 'CronCreate' &&
+      tool.rawOutput == null &&
+      Array.isArray(tool.content)
+    ) {
+      const receipts = tool.content.flatMap((block: unknown) => {
+        if (
+          !block ||
+          typeof block !== 'object' ||
+          !('type' in block) ||
+          block.type !== 'terminal_output' ||
+          !('output' in block) ||
+          typeof block.output !== 'string'
+        )
+          return [];
+        return [block.output];
+      });
+      if (receipts.length) input = { ...value, rawOutput: receipts.join('\n') };
+    }
+  }
+  const parsed = variants[value.type as keyof typeof variants].safeParse(input);
+  return parsed.success
+    ? { status: 'accepted', value: parsed.data }
+    : {
+        status: 'invalid',
+        issues: parsed.error.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          code: issue.code,
+        })),
+      };
+}

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -227,9 +227,15 @@ const historyMessageItemSchema = schema
     {
       type: schema.String<MessageContent['type']>(),
       text: schema.LoroText({ required: false }),
-      markdown: schema.LoroText({ required: false }),
-      content: schema.LoroList(historyToolContentSchema, undefined, { required: false }),
-      steps: schema.LoroList(historyScriptStepSchema, undefined, { required: false }),
+      // These are insertion hints, not new validation constraints on old/future
+      // payloads. A malformed legacy field must not reject unrelated writes.
+      markdown: schema.Any({ storageSchema: schema.LoroText({ required: false }) }),
+      content: schema.Any({
+        storageSchema: schema.LoroList(historyToolContentSchema, undefined, { required: false }),
+      }),
+      steps: schema.Any({
+        storageSchema: schema.LoroList(historyScriptStepSchema, undefined, { required: false }),
+      }),
       // `file` item: the mutable lifecycle fields `transport`/`machineId` are
       // carried through the `.catchall(...)` below (like every other variant's
       // payload fields, e.g. image's `imageId`/`sizeBytes`). They are plain

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -187,7 +187,32 @@ export type AgentConfigMeta = {
 export type SessionHistoryItem = MessageContent;
 export type SessionHistoryItems = MessageContent[];
 
-const historyItemAnySchema = schema.Any({ defaultLoroText: true });
+// This is an insertion policy, not a migration. Mirror reads and edits existing
+// containers by their actual kind; legacy Text values retain their container IDs.
+// Only explicitly declared streaming fields create Text for new history items.
+const historyItemAnySchema = schema.Any({ defaultLoroText: false });
+// Retain incremental text storage for payloads that are updated while streaming.
+// Every other field inside these blocks inherits primitive-string insertion.
+const historyToolContentSchema = schema
+  .LoroMap({
+    type: schema.String(),
+    output: schema.LoroText({ required: false }),
+    content: schema
+      .LoroMap(
+        {
+          type: schema.String(),
+          text: schema.LoroText({ required: false }),
+        },
+        { required: false }
+      )
+      .catchall(historyItemAnySchema),
+  })
+  .catchall(historyItemAnySchema);
+const historyScriptStepSchema = schema
+  .LoroMap({
+    output: schema.LoroText({ required: false }),
+  })
+  .catchall(historyItemAnySchema);
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -202,6 +227,9 @@ const historyMessageItemSchema = schema
     {
       type: schema.String<MessageContent['type']>(),
       text: schema.LoroText({ required: false }),
+      markdown: schema.LoroText({ required: false }),
+      content: schema.LoroList(historyToolContentSchema, undefined, { required: false }),
+      steps: schema.LoroList(historyScriptStepSchema, undefined, { required: false }),
       // `file` item: the mutable lifecycle fields `transport`/`machineId` are
       // carried through the `.catchall(...)` below (like every other variant's
       // payload fields, e.g. image's `imageId`/`sizeBytes`). They are plain

--- a/packages/shared/tests/history-content-schema.test.ts
+++ b/packages/shared/tests/history-content-schema.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it } from 'vitest';
+import { validateHistoryContent, removeSerializedToolImages } from '../src/history-content-schema';
+import {
+  parseAskUserQuestionPermissionMeta,
+  extractAskUserQuestionAnswersFromOutcome,
+} from '../src/acp/ask-user-question';
+import { collectPendingScheduledTasksFromHistory } from '../src/scheduled-tasks-from-history';
+
+function accepted(value: unknown) {
+  const result = validateHistoryContent(value);
+  expect(result.status).toBe('accepted');
+  if (result.status !== 'accepted') throw new Error('Expected accepted fixture');
+  return result.value;
+}
+
+describe('closed history write candidate', () => {
+  it('does not resurrect a deleted cron whose receipt lived only in terminal output', () => {
+    const items = [
+      {
+        type: 'tool_call',
+        toolCallId: 'create-1',
+        title: 'CronCreate',
+        status: 'completed',
+        rawInput: { cron: '* * * * *', prompt: 'Report' },
+        content: [{ type: 'terminal_output', output: 'Created job: task-123' }],
+      },
+      {
+        type: 'tool_call',
+        toolCallId: 'delete-1',
+        title: 'CronDelete',
+        status: 'completed',
+        rawInput: { id: 'task-123' },
+      },
+    ];
+    expect(collectPendingScheduledTasksFromHistory([{ items }])).toEqual([]);
+    const projected = items.map(accepted);
+    expect(projected[0]).toMatchObject({ content: [], rawOutput: 'Created job: task-123' });
+    expect(collectPendingScheduledTasksFromHistory([{ items: projected }])).toEqual([]);
+  });
+  it('preserves scheduled-task derivation, including deletion by legacy output text', () => {
+    const items = [
+      {
+        type: 'tool_call',
+        toolCallId: 'cron-1',
+        title: 'CronCreate',
+        status: 'completed',
+        rawInput: { cron: '* * * * *', prompt: 'Report' },
+        rawOutput: 'Created job-1',
+      },
+      {
+        type: 'tool_call',
+        toolCallId: 'delete-1',
+        title: 'CronDelete',
+        status: 'completed',
+        rawInput: { id: 'job-1' },
+      },
+      {
+        type: 'tool_call',
+        toolCallId: 'wake-1',
+        title: 'ScheduleWakeup',
+        status: 'completed',
+        rawInput: { delaySeconds: 30, reason: 'Follow up' },
+      },
+    ];
+    const before = collectPendingScheduledTasksFromHistory([{ endedAt: 1000, items }]);
+    const after = collectPendingScheduledTasksFromHistory([
+      { endedAt: 1000, items: items.map(accepted) },
+    ]);
+    expect(before).toHaveLength(1);
+    expect(before[0]?.summary).toBe('Follow up');
+    expect(after).toEqual(before);
+  });
+
+  it('retains structured media that has an actual renderer', () => {
+    const item = {
+      type: 'tool_call',
+      toolCallId: 'media-1',
+      status: 'completed',
+      content: [
+        { type: 'content', content: { type: 'image', mimeType: 'image/png', data: 'AAAA' } },
+        { type: 'content', content: { type: 'audio', mimeType: 'audio/wav', data: 'AAAA' } },
+      ],
+    };
+    expect(accepted(item)).toEqual(item);
+  });
+  it('preserves the questions and answers consumed by the actual permission reader', () => {
+    const permission = {
+      requestId: 'request-1',
+      options: [{ optionId: 'answer', name: 'Answer' }],
+      _meta: {
+        claudeCode: {
+          askUserQuestion: {
+            questions: [{ question: 'Choose', header: 'Choice', options: [{ label: 'A' }] }],
+          },
+        },
+      },
+      outcome: {
+        outcome: 'selected',
+        optionId: 'answer',
+        _meta: { claudeCode: { askUserQuestion: { answers: { Choose: 'A' } } } },
+      },
+    };
+    const result = accepted({
+      type: 'tool_call',
+      toolCallId: 'tool-1',
+      status: 'completed',
+      permissionRequest: permission,
+    }) as { permissionRequest: typeof permission };
+    const before = parseAskUserQuestionPermissionMeta(permission._meta);
+    const after = parseAskUserQuestionPermissionMeta(result.permissionRequest._meta);
+    expect(before).not.toBeNull();
+    expect(after).toEqual(before);
+    if (!before || !after) throw new Error('Expected a supported question');
+    expect(
+      extractAskUserQuestionAnswersFromOutcome(after, result.permissionRequest.outcome)
+    ).toEqual(extractAskUserQuestionAnswersFromOutcome(before, permission.outcome));
+  });
+  it('drops undeclared fields without changing the input', () => {
+    const input = { type: 'text', text: 'hello', unused: { large: 'discard' } };
+    expect(accepted(input)).toEqual({ type: 'text', text: 'hello' });
+    expect(input.unused).toEqual({ large: 'discard' });
+  });
+
+  it('does not let unknown or malformed messages reject their neighbors', () => {
+    const batch = [
+      { type: 'text', text: 'first' },
+      { type: 'future_variant', large: 'unused' },
+      { type: 'text', text: 123 },
+      { type: '__proto__' },
+      { type: 'thought', text: 'last' },
+    ];
+    const results = batch.map(validateHistoryContent);
+    expect(results.map((r) => r.status)).toEqual([
+      'accepted',
+      'unsupported',
+      'invalid',
+      'unsupported',
+      'accepted',
+    ]);
+  });
+
+  it('keeps permission decisions, locations and old nullable fields', () => {
+    const input = {
+      type: 'tool_call',
+      toolCallId: 'tool-1',
+      status: 'completed',
+      content: null,
+      locations: null,
+      permissionRequest: {
+        requestId: 'request-1',
+        options: [{ optionId: 'allow-1', name: 'Allow', kind: 'allow_once', future: true }],
+        outcome: { outcome: 'selected', optionId: 'allow-1', future: true },
+        future: 'unused',
+      },
+    };
+    expect(accepted(input)).toEqual({
+      type: 'tool_call',
+      toolCallId: 'tool-1',
+      status: 'completed',
+      content: null,
+      locations: null,
+      permissionRequest: {
+        requestId: 'request-1',
+        options: [{ optionId: 'allow-1', name: 'Allow', kind: 'allow_once' }],
+        outcome: { outcome: 'selected', optionId: 'allow-1' },
+      },
+    });
+  });
+
+  it('filters unknown tool blocks and retired terminal output independently', () => {
+    expect(
+      accepted({
+        type: 'tool_call',
+        toolCallId: 'tool-1',
+        status: 'completed',
+        content: [
+          { type: 'future_block', data: 'unused' },
+          { type: 'terminal_output', output: 'not persisted' },
+          { type: 'terminal_command', command: 'echo hello', args: null, future: true },
+          { type: 'content', content: { type: 'text', text: 'kept', future: true } },
+        ],
+      })
+    ).toEqual({
+      type: 'tool_call',
+      toolCallId: 'tool-1',
+      status: 'completed',
+      content: [
+        { type: 'terminal_command', command: 'echo hello', args: null },
+        { type: 'content', content: { type: 'text', text: 'kept' } },
+      ],
+    });
+  });
+
+  it('preserves file, image and mention metadata used by existing consumers', () => {
+    const fixtures = [
+      {
+        type: 'image',
+        imageId: 'image-1',
+        mimeType: 'image/png',
+        sizeBytes: 10,
+        storageSessionId: 'session-1',
+      },
+      {
+        type: 'file',
+        fileId: 'file-1',
+        fileName: 'example.txt',
+        mimeType: 'text/plain',
+        sizeBytes: 10,
+        sha256: 'hash',
+        textPreview: true,
+        transport: 'local',
+        machineId: 'machine-1',
+        uploadedAt: 1,
+      },
+      {
+        type: 'text',
+        text: '@Role',
+        spans: [{ start: 0, end: 5, kind: 'agent_role', label: 'Role', target: 'role-1' }],
+      },
+      {
+        type: 'tool_call',
+        status: 'completed',
+        ref: { machineId: 'machine-1', turnId: 'turn-1', index: 0 },
+      },
+      {
+        type: 'system_notice',
+        name: 'session_fork_origin',
+        meta: { sourceSessionId: 'session-1', sourceTurnId: 'turn-1', sourceTitle: 'Source' },
+      },
+    ];
+    for (const value of fixtures) expect(accepted(value)).toEqual(value);
+  });
+
+  it('also preserves supported variants not represented in every local corpus', () => {
+    const rectangle = { x: 0, y: 0, width: 1, height: 1 };
+    const fixtures = [
+      { type: 'plan', entries: [{ content: 'Step', priority: 'high', status: 'pending' }] },
+      {
+        type: 'proposed_plan',
+        turnId: 'turn-1',
+        markdown: 'Plan',
+        status: 'completed',
+        isLatest: true,
+      },
+      { type: 'goal', threadId: 'thread-1', objective: 'Goal', status: 'active' },
+      { type: 'subagent_task', taskId: 'task-1', status: 'completed', summary: 'Done' },
+      { type: 'available_commands', commands: [{ name: 'help', input: { hint: 'Topic' } }] },
+      {
+        type: 'operation_completion',
+        deliveryId: 'delivery-1',
+        operationId: 'op-1',
+        operationKind: 'session_chat',
+        completion: {
+          type: 'result',
+          value: {
+            items: [
+              {
+                status: 'succeeded',
+                target: { sessionId: 'session-1', userTurnId: 'turn-1' },
+                assistantTurnId: 'reply-1',
+                output: { text: 'Done' },
+              },
+            ],
+          },
+        },
+      },
+      {
+        type: 'worktree_script',
+        phase: 'setup',
+        status: 'completed',
+        steps: [{ command: 'echo ok', status: 'completed', output: 'ok' }],
+      },
+      {
+        type: 'comment_reference',
+        source: 'lody',
+        path: 'file.ts',
+        lineNumber: 1,
+        side: 'additions',
+        commentBody: 'Comment',
+        authorName: 'Reviewer',
+        replies: [{ authorName: 'Author', body: 'Reply' }],
+      },
+      {
+        type: 'visual_annotation_reference',
+        source: 'visual_annotation',
+        commentId: 'comment-1',
+        body: 'Annotation',
+        anchor: {
+          version: 1,
+          page: {
+            url: 'https://example.test',
+            pathname: '/',
+            viewport: { width: 100, height: 100, scrollX: 0, scrollY: 0, devicePixelRatio: 1 },
+          },
+          click: {
+            clientX: 0,
+            clientY: 0,
+            pageX: 0,
+            pageY: 0,
+            viewportXRatio: 0,
+            viewportYRatio: 0,
+          },
+          target: {
+            tag: 'button',
+            selector: '#save',
+            attributes: { 'data-testid': 'save' },
+            rect: rectangle,
+            rectRatio: rectangle,
+          },
+          context: { ancestors: [] },
+        },
+      },
+    ];
+    for (const value of fixtures) expect(accepted(value)).toEqual(value);
+  });
+
+  it('only removes recognized JSON image wrappers from tool text', () => {
+    const text = JSON.stringify([
+      { imageUrl: { url: 'data:image/png;base64,AAAA' } },
+      { type: 'text', text: 'keep' },
+    ]);
+    expect(removeSerializedToolImages(text)).toBe(JSON.stringify([{ type: 'text', text: 'keep' }]));
+    expect(removeSerializedToolImages('Example: data:image/png;base64,AAAA')).toBe(
+      'Example: data:image/png;base64,AAAA'
+    );
+    expect(accepted({ type: 'text', text })).toEqual({ type: 'text', text });
+  });
+});

--- a/packages/shared/tests/history-string-storage.test.ts
+++ b/packages/shared/tests/history-string-storage.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import { LoroDoc, LoroMap, LoroList, LoroText } from 'loro-crdt';
+import { Mirror, schema } from 'loro-mirror';
+import { sessionDocSchema } from '../src/schema';
+
+// Preserve the previous schema's insertion policy for an actual old reader/writer.
+const turn = sessionDocSchema.definition.history.itemSchema;
+const item = turn.definition.items.itemSchema;
+const legacySchema = schema({
+  ...sessionDocSchema.definition,
+  history: schema.LoroList(
+    schema.LoroMap(
+      {
+        ...turn.definition,
+        items: schema.LoroList(
+          schema
+            .LoroMap(item.definition, item.options)
+            .catchall(schema.Any({ defaultLoroText: true })),
+          undefined,
+          { required: false }
+        ),
+      },
+      turn.options
+    ),
+    (value) => value.id
+  ),
+});
+const entry = (id: string) => ({
+  id,
+  role: 'assistant' as const,
+  timestamp: '2026-01-01T00:00:00Z',
+  items: [
+    { type: 'text' as const, text: 'Hello 世界 🦀' },
+    { type: 'thought' as const, text: 'Thinking' },
+    {
+      type: 'tool_call' as const,
+      toolCallId: 'call-1',
+      status: 'in_progress' as const,
+      title: 'command',
+      locations: [{ path: '/workspace/a.ts' }],
+      content: [
+        {
+          type: 'terminal_command' as const,
+          command: 'echo hello',
+          args: ['hello'],
+          cwd: '/workspace',
+        },
+      ],
+    },
+  ],
+});
+const create = (doc: LoroDoc, old = false) =>
+  new Mirror({
+    doc,
+    schema: old ? legacySchema : sessionDocSchema,
+    throwOnValidationError: true,
+  });
+const toolMap = (doc: LoroDoc, index = 0) =>
+  ((doc.getList('history').get(index) as LoroMap).get('items') as LoroList).get(2) as LoroMap;
+const clean = (v: unknown): unknown => {
+  if (Array.isArray(v)) return v.map(clean);
+  if (v && typeof v === 'object')
+    return Object.fromEntries(
+      Object.entries(v)
+        .filter(([k]) => k !== '$cid')
+        .map(([k, x]) => [k, clean(x)])
+    );
+  return v;
+};
+
+describe('history string storage compatibility', () => {
+  it('creates plain metadata, nested strings and list strings while keeping streaming Text', () => {
+    const doc = new LoroDoc();
+    const mirror = create(doc);
+    try {
+      mirror.setState((s) => ({ ...s, history: [entry('new')] }));
+      const items = (doc.getList('history').get(0) as LoroMap).get('items') as LoroList;
+      expect((items.get(0) as LoroMap).get('text')).toBeInstanceOf(LoroText);
+      expect((items.get(1) as LoroMap).get('text')).toBeInstanceOf(LoroText);
+      const tool = toolMap(doc);
+      expect(tool.get('toolCallId')).toBe('call-1');
+      expect(tool.get('status')).toBe('in_progress');
+      const command = (tool.get('content') as LoroList).get(0) as LoroMap;
+      expect(command.get('command')).toBe('echo hello');
+      expect(command.get('cwd')).toBe('/workspace');
+      expect((command.get('args') as LoroList).get(0)).toBe('hello');
+      const old = create(doc, true);
+      expect(clean(old.getState())).toEqual(clean(mirror.getState()));
+      old.dispose();
+    } finally {
+      mirror.dispose();
+      doc.free();
+    }
+  });
+
+  it('opens old snapshots without writes and preserves legacy Text IDs when editing', () => {
+    const seed = new LoroDoc();
+    const old = create(seed, true);
+    old.setState((s) => ({ ...s, history: [entry('old')] }));
+    const snapshot = seed.export({ mode: 'snapshot' });
+    old.dispose();
+    seed.free();
+    const doc = new LoroDoc();
+    doc.import(snapshot);
+    const before = doc.version().encode();
+    const legacyText = toolMap(doc).get('title') as LoroText;
+    const mirror = create(doc);
+    try {
+      expect(doc.version().encode()).toEqual(before);
+      mirror.setState((s) => {
+        s.history[0]!.items[2]!.title = 'renamed';
+      });
+      expect((toolMap(doc).get('title') as LoroText).id).toBe(legacyText.id);
+      expect((toolMap(doc).get('title') as LoroText).toString()).toBe('renamed');
+      mirror.setState((s) => {
+        s.history.push(entry('new'));
+      });
+      expect(toolMap(doc, 1).get('title')).toBe('command');
+      const reader = create(doc, true);
+      expect(clean(reader.getState())).toEqual(clean(mirror.getState()));
+      reader.dispose();
+    } finally {
+      mirror.dispose();
+      doc.free();
+    }
+  });
+
+  it('exchanges updates with an old writer after reopening the mixed snapshot', () => {
+    const a = new LoroDoc();
+    const next = create(a);
+    next.setState((s) => ({ ...s, history: [entry('new')] }));
+    const b = new LoroDoc();
+    b.import(a.export({ mode: 'snapshot' }));
+    const old = create(b, true);
+    try {
+      const v = a.version();
+      old.setState((s) => {
+        s.history[0]!.items[2]!.title = 'old edit';
+      });
+      a.import(b.export({ mode: 'update', from: v }));
+      expect(clean(next.getState())).toEqual(clean(old.getState()));
+      next.setState((s) => {
+        s.history[0]!.items[0]!.text += ' appended';
+      });
+      b.import(a.export({ mode: 'update', from: b.version() }));
+      expect(clean(next.getState())).toEqual(clean(old.getState()));
+      expect(toolMap(a).get('title')).toBe('old edit');
+    } finally {
+      next.dispose();
+      old.dispose();
+      a.free();
+      b.free();
+    }
+  });
+  it('merges concurrent edits into the same legacy Text instead of replacing it', () => {
+    const a = new LoroDoc();
+    const seed = create(a, true);
+    seed.setState((s) => ({ ...s, history: [entry('old')] }));
+    seed.dispose();
+    const b = new LoroDoc();
+    b.import(a.export({ mode: 'snapshot' }));
+    const next = create(a);
+    const oldText = toolMap(b).get('title') as LoroText;
+    try {
+      next.setState((s) => {
+        s.history[0]!.items[2]!.title += ' A';
+      });
+      oldText.insert(oldText.length, ' B');
+      a.import(b.export({ mode: 'update', from: a.version() }));
+      b.import(a.export({ mode: 'update', from: b.version() }));
+      const merged = toolMap(a).get('title') as LoroText;
+      expect(merged.id).toBe(oldText.id);
+      expect(merged.toString()).toContain(' A');
+      expect(merged.toString()).toContain(' B');
+      expect(a.toJSON()).toEqual(b.toJSON());
+    } finally {
+      next.dispose();
+      a.free();
+      b.free();
+    }
+  });
+  it('keeps streamed tool and script outputs as Text but their metadata as primitives', () => {
+    const doc = new LoroDoc();
+    const mirror = create(doc);
+    try {
+      mirror.setState((state) => ({
+        ...state,
+        history: [
+          {
+            id: 'stream',
+            role: 'assistant',
+            timestamp: '2026-01-01T00:00:00Z',
+            items: [
+              {
+                type: 'tool_call',
+                toolCallId: 'call',
+                status: 'in_progress',
+                content: [
+                  { type: 'terminal_output', output: 'first', stream: 'stdout' },
+                  { type: 'content', content: { type: 'text', text: 'first' } },
+                ],
+              },
+              {
+                type: 'worktree_script',
+                phase: 'setup',
+                status: 'in_progress',
+                steps: [{ command: 'setup', status: 'in_progress', output: 'first' }],
+              },
+            ],
+          },
+        ],
+      }));
+      const items = (doc.getList('history').get(0) as LoroMap).get('items') as LoroList;
+      const tool = items.get(0) as LoroMap;
+      const blocks = tool.get('content') as LoroList;
+      const terminal = blocks.get(0) as LoroMap;
+      const text = (blocks.get(1) as LoroMap).get('content') as LoroMap;
+      const step = ((items.get(1) as LoroMap).get('steps') as LoroList).get(0) as LoroMap;
+      const output = terminal.get('output') as LoroText;
+      expect(output).toBeInstanceOf(LoroText);
+      expect(text.get('text')).toBeInstanceOf(LoroText);
+      expect(step.get('output')).toBeInstanceOf(LoroText);
+      expect(terminal.get('stream')).toBe('stdout');
+      expect(step.get('command')).toBe('setup');
+      mirror.setState((s) => {
+        s.history[0]!.items[0]!.content![0]!.output = 'first second';
+      });
+      expect((terminal.get('output') as LoroText).id).toBe(output.id);
+      expect(output.toString()).toBe('first second');
+    } finally {
+      mirror.dispose();
+      doc.free();
+    }
+  });
+  it('does not convert a legacy primitive into Text when the field is now explicitly streaming', () => {
+    const doc = new LoroDoc();
+    const seed = create(doc);
+    seed.setState((s) => ({ ...s, history: [entry('old-plain')] }));
+    seed.dispose();
+    const textItem = ((doc.getList('history').get(0) as LoroMap).get('items') as LoroList).get(
+      0
+    ) as LoroMap;
+    textItem.set('text', 'legacy primitive');
+    doc.commit();
+    const mirror = create(doc);
+    try {
+      mirror.setState((s) => {
+        s.history[0]!.items[0]!.text = 'legacy primitive appended';
+      });
+      expect(textItem.get('text')).toBe('legacy primitive appended');
+    } finally {
+      mirror.dispose();
+      doc.free();
+    }
+  });
+});

--- a/packages/shared/tests/history-string-storage.test.ts
+++ b/packages/shared/tests/history-string-storage.test.ts
@@ -6,6 +6,7 @@ import { sessionDocSchema } from '../src/schema';
 // Preserve the previous schema's insertion policy for an actual old reader/writer.
 const turn = sessionDocSchema.definition.history.itemSchema;
 const item = turn.definition.items.itemSchema;
+const legacyItemDefinition = { type: item.definition.type, text: item.definition.text };
 const legacySchema = schema({
   ...sessionDocSchema.definition,
   history: schema.LoroList(
@@ -14,7 +15,7 @@ const legacySchema = schema({
         ...turn.definition,
         items: schema.LoroList(
           schema
-            .LoroMap(item.definition, item.options)
+            .LoroMap(legacyItemDefinition, item.options)
             .catchall(schema.Any({ defaultLoroText: true })),
           undefined,
           { required: false }
@@ -69,6 +70,149 @@ const clean = (v: unknown): unknown => {
 };
 
 describe('history string storage compatibility', () => {
+  it.each([
+    ['content', 'legacy content'],
+    ['content', { text: 'legacy map' }],
+    ['content', [{ type: 'content', content: 'legacy nested content' }]],
+    ['markdown', { text: 'legacy markdown' }],
+    ['steps', { output: 'legacy steps' }],
+  ] as const)('keeps legacy %s shapes without blocking unrelated writes', (key, value) => {
+    const doc = new LoroDoc();
+    const old = create(doc, true);
+    old.setState((s) => {
+      s.history.push(entry('old'));
+    });
+    old.setState((s) => {
+      Object.assign(s.history[0]!.items[2]!, { [key]: value });
+    });
+    old.dispose();
+    const tool = toolMap(doc);
+    const stored = tool.get(key);
+    const id = stored && typeof stored === 'object' && 'id' in stored ? stored.id : undefined;
+    const before = doc.version().encode();
+    const json = doc.toJSON();
+    const mirror = create(doc);
+    try {
+      expect(doc.version().encode()).toEqual(before);
+      expect(doc.toJSON()).toEqual(json);
+      expect(() =>
+        mirror.setState((s) => {
+          s.history[0]!.items[0]!.text += ' world';
+          s.history.push(entry('next'));
+        })
+      ).not.toThrow();
+      const after = tool.get(key);
+      expect(clean(mirror.getState().history[0]!.items[2]![key])).toEqual(value);
+      if (id) expect(after).toHaveProperty('id', id);
+      expect(mirror.getState().history).toHaveLength(2);
+      const reader = create(doc, true);
+      expect(clean(reader.getState())).toEqual(clean(mirror.getState()));
+      reader.dispose();
+    } finally {
+      mirror.dispose();
+      doc.free();
+    }
+  });
+
+  it('edits a legacy Map behind a List hint without replacing its container', () => {
+    const doc = new LoroDoc();
+    const old = create(doc, true);
+    old.setState((s) => {
+      s.history.push(entry('old'));
+    });
+    old.setState((s) => {
+      Object.assign(s.history[0]!.items[2]!, { content: { output: 'old' } });
+    });
+    old.dispose();
+    const content = toolMap(doc).get('content') as LoroMap;
+    const output = content.get('output') as LoroText;
+    const mirror = create(doc);
+    try {
+      expect(() =>
+        mirror.setState((s) => {
+          Object.assign(s.history[0]!.items[2]!, { content: { output: 'edited' } });
+        })
+      ).not.toThrow();
+      expect((toolMap(doc).get('content') as LoroMap).id).toBe(content.id);
+      expect((content.get('output') as LoroText).id).toBe(output.id);
+      expect(output.toString()).toBe('edited');
+    } finally {
+      mirror.dispose();
+      doc.free();
+    }
+  });
+
+  it('edits a legacy Text behind a List hint without replacing its container', () => {
+    const doc = new LoroDoc();
+    const old = create(doc, true);
+    old.setState((s) => {
+      s.history.push(entry('old'));
+    });
+    old.setState((s) => {
+      Object.assign(s.history[0]!.items[2]!, { content: 'old' });
+    });
+    old.dispose();
+    const content = toolMap(doc).get('content') as LoroText;
+    const mirror = create(doc);
+    try {
+      mirror.setState((s) => {
+        Object.assign(s.history[0]!.items[2]!, { content: 'edited' });
+      });
+      expect((toolMap(doc).get('content') as LoroText).id).toBe(content.id);
+      expect(content.toString()).toBe('edited');
+    } finally {
+      mirror.dispose();
+      doc.free();
+    }
+  });
+
+  it('uses actual value kinds when new payloads do not match storage hints', () => {
+    const doc = new LoroDoc();
+    const mirror = create(doc);
+    try {
+      mirror.setState((s) => {
+        const next = entry('new');
+        Object.assign(next.items[2]!, {
+          content: { output: 'map output' },
+          markdown: ['list markdown'],
+          steps: 'string steps',
+        });
+        s.history.push(next);
+      });
+      const tool = toolMap(doc);
+      expect(tool.get('content')).toBeInstanceOf(LoroMap);
+      expect(tool.get('markdown')).toBeInstanceOf(LoroList);
+      expect(tool.get('steps')).toBe('string steps');
+      mirror.setState((s) => {
+        Object.assign(s.history[0]!.items[2]!, { content: { output: 'edited output' } });
+      });
+      expect((tool.get('content') as LoroMap).get('output')).toBe('edited output');
+      const reader = create(doc);
+      expect(clean(reader.getState())).toEqual(clean(mirror.getState()));
+      reader.dispose();
+    } finally {
+      mirror.dispose();
+      doc.free();
+    }
+  });
+
+  it('still rejects invalid required history fields before writing', () => {
+    const doc = new LoroDoc();
+    const mirror = create(doc);
+    mirror.setState((s) => {
+      s.history.push(entry('new'));
+    });
+    const before = doc.version().encode();
+    expect(() =>
+      mirror.setState((s) => {
+        Object.assign(s.history[0]!.items[0]!, { text: 42 });
+      })
+    ).toThrow('validation');
+    expect(doc.version().encode()).toEqual(before);
+    mirror.dispose();
+    doc.free();
+  });
+
   it('creates plain metadata, nested strings and list strings while keeping streaming Text', () => {
     const doc = new LoroDoc();
     const mirror = create(doc);

--- a/patches/loro-mirror@2.3.1.patch
+++ b/patches/loro-mirror@2.3.1.patch
@@ -1,6 +1,16 @@
 --- a/src/core/diff.ts
 +++ b/src/core/diff.ts
-@@ -1355,4 +1355,24 @@
+@@ -1293,7 +1293,7 @@
+         }
+ 
+         // Figure out if the modified new value is a container
+-        const childSchema = getMapFieldSchema(schema, key);
++        const childSchema = getMapFieldSchema(schema, key, newItem);
+ 
+         // Skip ignored fields defined in schema
+         if (childSchema && childSchema.type === "ignore") {
+@@ -1354,6 +1354,26 @@
+ 
          // Item inside map has changed
          if (oldItem !== newItem) {
 +            // String storage declarations control insertion. A changed string retains the
@@ -25,9 +35,20 @@
 +
              // The key was previously a container and new item is also a container
              if (
+                 containerType &&
 --- a/dist/core/diff.js
 +++ b/dist/core/diff.js
-@@ -967,4 +967,24 @@
+@@ -920,7 +920,7 @@
+             continue;
+         }
+         // Figure out if the modified new value is a container
+-        const childSchema = getMapFieldSchema(schema, key);
++        const childSchema = getMapFieldSchema(schema, key, newItem);
+         // Skip ignored fields defined in schema
+         if (childSchema && childSchema.type === "ignore") {
+             continue;
+@@ -966,6 +966,26 @@
+         }
          // Item inside map has changed
          if (oldItem !== newItem) {
 +            // String storage declarations control insertion. A changed string retains the
@@ -52,3 +73,124 @@
 +
              // The key was previously a container and new item is also a container
              if (containerType &&
+                 isValueOfContainerType(containerType, newItem) &&
+--- a/src/schema/types.ts
++++ b/src/schema/types.ts
+@@ -77,6 +77,8 @@
+     : false;
+ 
+ export type AnySchemaOptions = SchemaOptions & {
++    /** Container layout hint for map fields; validation remains JSON-like. */
++    storageSchema?: ContainerSchemaType;
+     /**
+      * Per-Any inference overrides.
+      *
+--- a/dist/schema/types.d.ts
++++ b/dist/schema/types.d.ts
+@@ -73,6 +73,8 @@
+     };
+ } ? true : false;
+ export type AnySchemaOptions = SchemaOptions & {
++    /** Container layout hint for map fields; validation remains JSON-like. */
++    storageSchema?: ContainerSchemaType;
+     /**
+      * Per-Any inference overrides.
+      *
+--- a/src/schema/resolver.ts
++++ b/src/schema/resolver.ts
+@@ -1,3 +1,4 @@
++import { matchesContainerType } from "../core/container-inference.js";
+ import {
+     ContainerSchemaType,
+     LoroMapSchema,
+@@ -17,11 +18,18 @@
+ export function getMapFieldSchema(
+     schema: MapLikeSchema | undefined,
+     key: string,
++    value?: unknown,
+ ): SchemaType | undefined {
+     if (!schema) return undefined;
+ 
+     if (Object.prototype.hasOwnProperty.call(schema.definition, key)) {
+-        return schema.definition[key];
++        const field = schema.definition[key];
++        const storage = field.type === "any" ? field.options.storageSchema : undefined;
++        const kind = storage?.getContainerType();
++        // A layout hint must never force an incompatible legacy/future value
++        // into that container kind. Diffing supplies the actual new value.
++        return storage && kind && (value === undefined || matchesContainerType(kind, value))
++            ? storage : field;
+     }
+ 
+     if (schema.type === "loro-map" && "catchallType" in schema) {
+--- a/dist/schema/resolver.js
++++ b/dist/schema/resolver.js
+@@ -1,8 +1,15 @@
+-export function getMapFieldSchema(schema, key) {
++import { matchesContainerType } from "../core/container-inference.js";
++export function getMapFieldSchema(schema, key, value) {
+     if (!schema)
+         return undefined;
+     if (Object.prototype.hasOwnProperty.call(schema.definition, key)) {
+-        return schema.definition[key];
++        const field = schema.definition[key];
++        const storage = field.type === "any" ? field.options.storageSchema : undefined;
++        const kind = storage?.getContainerType();
++        // A layout hint must never force an incompatible legacy/future value
++        // into that container kind. Diffing supplies the actual new value.
++        return storage && kind && (value === undefined || matchesContainerType(kind, value))
++            ? storage : field;
+     }
+     if (schema.type === "loro-map" && "catchallType" in schema) {
+         return schema.catchallType;
+--- a/dist/schema/resolver.d.ts
++++ b/dist/schema/resolver.d.ts
+@@ -3,7 +3,7 @@
+ type MapSchemaRecord = LoroMapSchema<Record<string, SchemaType>>;
+ type MapSchemaWithCatchallRecord = LoroMapSchemaWithCatchall<Record<string, SchemaType>, SchemaType>;
+ type MapLikeSchema = RootSchemaRecord | MapSchemaRecord | MapSchemaWithCatchallRecord;
+-export declare function getMapFieldSchema(schema: MapLikeSchema | undefined, key: string): SchemaType | undefined;
++export declare function getMapFieldSchema(schema: MapLikeSchema | undefined, key: string, value?: unknown): SchemaType | undefined;
+ export declare function getChildSchema(schema: SchemaType | undefined, childKey?: string | number): SchemaType | undefined;
+ export declare function getChildContainerSchema(schema: SchemaType | undefined, childKey?: string | number): ContainerSchemaType | undefined;
+ export {};
+--- a/src/core/mirror.ts
++++ b/src/core/mirror.ts
+@@ -2060,7 +2060,7 @@
+                 // Skip undefined values - treat them as non-existent fields
+                 if (val === undefined) continue;
+                 if (mapSchema) {
+-                    const fieldSchema = getMapFieldSchema(mapSchema, key);
++                    const fieldSchema = getMapFieldSchema(mapSchema, key, val);
+ 
+                     if (fieldSchema?.type === "any") {
+                         const infer = this.getInferOptionsForChild(
+@@ -2413,7 +2413,7 @@
+         // Check if this field should be a container according to schema
+         const mapSchema = schema?.type === "loro-map" ? schema : null;
+         if (mapSchema) {
+-            const fieldSchema = getMapFieldSchema(mapSchema, key);
++            const fieldSchema = getMapFieldSchema(mapSchema, key, value);
+             if (fieldSchema && fieldSchema.type === "ignore") {
+                 // Skip ignore fields: they live only in mirrored state
+                 return;
+--- a/dist/core/mirror.js
++++ b/dist/core/mirror.js
+@@ -1258,7 +1258,7 @@
+                 if (val === undefined)
+                     continue;
+                 if (mapSchema) {
+-                    const fieldSchema = getMapFieldSchema(mapSchema, key);
++                    const fieldSchema = getMapFieldSchema(mapSchema, key, val);
+                     if (fieldSchema?.type === "any") {
+                         const infer = this.getInferOptionsForChild(map.id, fieldSchema);
+                         const ct = tryInferContainerType(val, infer);
+@@ -1521,7 +1521,7 @@
+         // Check if this field should be a container according to schema
+         const mapSchema = schema?.type === "loro-map" ? schema : null;
+         if (mapSchema) {
+-            const fieldSchema = getMapFieldSchema(mapSchema, key);
++            const fieldSchema = getMapFieldSchema(mapSchema, key, value);
+             if (fieldSchema && fieldSchema.type === "ignore") {
+                 // Skip ignore fields: they live only in mirrored state
+                 return;

--- a/patches/loro-mirror@2.3.1.patch
+++ b/patches/loro-mirror@2.3.1.patch
@@ -1,0 +1,54 @@
+--- a/src/core/diff.ts
++++ b/src/core/diff.ts
+@@ -1355,4 +1355,24 @@
+         // Item inside map has changed
+         if (oldItem !== newItem) {
++            // String storage declarations control insertion. A changed string retains the
++            // actual representation already stored in this map, including legacy Text.
++            if (containerId !== "" &&
++                (!childSchema || childSchema.type === "any" || childSchema.type === "loro-text") &&
++                !hasTransform(childSchema) &&
++                typeof oldItem === "string" && typeof newItem === "string") {
++                const parent = doc.getContainerById(containerId);
++                if (parent?.kind() === "Map") {
++                    const stored = (parent as LoroMap).get(key);
++                    if (isContainer(stored) && stored.kind() === "Text") {
++                        changes.push(...diffText(oldItem, newItem, stored.id));
++                        continue;
++                    }
++                    if (typeof stored === "string") {
++                        changes.push({ container: containerId, key, value: newItem, kind: "insert" });
++                        continue;
++                    }
++                }
++            }
++
+             // The key was previously a container and new item is also a container
+             if (
+--- a/dist/core/diff.js
++++ b/dist/core/diff.js
+@@ -967,4 +967,24 @@
+         // Item inside map has changed
+         if (oldItem !== newItem) {
++            // String storage declarations control insertion. A changed string retains the
++            // actual representation already stored in this map, including legacy Text.
++            if (containerId !== "" &&
++                (!childSchema || childSchema.type === "any" || childSchema.type === "loro-text") &&
++                !hasTransform(childSchema) &&
++                typeof oldItem === "string" && typeof newItem === "string") {
++                const parent = doc.getContainerById(containerId);
++                if (parent?.kind() === "Map") {
++                    const stored = parent.get(key);
++                    if (isContainer(stored) && stored.kind() === "Text") {
++                        changes.push(...diffText(oldItem, newItem, stored.id));
++                        continue;
++                    }
++                    if (typeof stored === "string") {
++                        changes.push({ container: containerId, key, value: newItem, kind: "insert" });
++                        continue;
++                    }
++                }
++            }
++
+             // The key was previously a container and new item is also a container
+             if (containerType &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ patchedDependencies:
     hash: 80637977dda4ea924da866a67751774a621195429af5af0f103e9129b3bec57f
     path: patches/app-builder-lib@26.15.3.patch
   loro-mirror@2.3.1:
-    hash: c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306
+    hash: ba4635306b23358997952dbc2c3bd3cffb64583abc90d8ea75733e981d64c24f
     path: patches/loro-mirror@2.3.1.patch
   loro-repo@0.20.0:
     hash: 74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357
@@ -355,7 +355,7 @@ importers:
         version: link:../../packages/code-review-viewer
       loro-mirror:
         specifier: 'catalog:'
-        version: 2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)
+        version: 2.3.1(patch_hash=ba4635306b23358997952dbc2c3bd3cffb64583abc90d8ea75733e981d64c24f)(loro-crdt@1.15.1)
       loro-repo:
         specifier: 'catalog:'
         version: 0.20.0(patch_hash=74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357)(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.15.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.3)(loro-crdt@1.15.1)
@@ -1109,13 +1109,13 @@ importers:
         version: 1.15.1
       loro-mirror:
         specifier: 'catalog:'
-        version: 2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)
+        version: 2.3.1(patch_hash=ba4635306b23358997952dbc2c3bd3cffb64583abc90d8ea75733e981d64c24f)(loro-crdt@1.15.1)
       loro-mirror-jotai:
         specifier: 'catalog:'
-        version: 2.3.1(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1))
+        version: 2.3.1(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=ba4635306b23358997952dbc2c3bd3cffb64583abc90d8ea75733e981d64c24f)(loro-crdt@1.15.1))
       loro-mirror-react:
         specifier: 'catalog:'
-        version: 2.3.1(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1))(react@19.2.0)
+        version: 2.3.1(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=ba4635306b23358997952dbc2c3bd3cffb64583abc90d8ea75733e981d64c24f)(loro-crdt@1.15.1))(react@19.2.0)
       loro-repo:
         specifier: 'catalog:'
         version: 0.20.0(patch_hash=74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357)(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.15.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(loro-crdt@1.15.1)
@@ -1425,7 +1425,7 @@ importers:
         version: 1.15.1
       loro-mirror:
         specifier: 'catalog:'
-        version: 2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)
+        version: 2.3.1(patch_hash=ba4635306b23358997952dbc2c3bd3cffb64583abc90d8ea75733e981d64c24f)(loro-crdt@1.15.1)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -22522,19 +22522,19 @@ snapshots:
 
   loro-crdt@1.15.1: {}
 
-  loro-mirror-jotai@2.3.1(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)):
+  loro-mirror-jotai@2.3.1(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=ba4635306b23358997952dbc2c3bd3cffb64583abc90d8ea75733e981d64c24f)(loro-crdt@1.15.1)):
     dependencies:
       jotai: 2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0)
       loro-crdt: 1.15.1
-      loro-mirror: 2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)
+      loro-mirror: 2.3.1(patch_hash=ba4635306b23358997952dbc2c3bd3cffb64583abc90d8ea75733e981d64c24f)(loro-crdt@1.15.1)
 
-  loro-mirror-react@2.3.1(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1))(react@19.2.0):
+  loro-mirror-react@2.3.1(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=ba4635306b23358997952dbc2c3bd3cffb64583abc90d8ea75733e981d64c24f)(loro-crdt@1.15.1))(react@19.2.0):
     dependencies:
       loro-crdt: 1.15.1
-      loro-mirror: 2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)
+      loro-mirror: 2.3.1(patch_hash=ba4635306b23358997952dbc2c3bd3cffb64583abc90d8ea75733e981d64c24f)(loro-crdt@1.15.1)
       react: 19.2.0
 
-  loro-mirror@2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1):
+  loro-mirror@2.3.1(patch_hash=ba4635306b23358997952dbc2c3bd3cffb64583abc90d8ea75733e981d64c24f)(loro-crdt@1.15.1):
     dependencies:
       immer: 10.2.0
       loro-crdt: 1.15.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ patchedDependencies:
   app-builder-lib@26.15.3:
     hash: 80637977dda4ea924da866a67751774a621195429af5af0f103e9129b3bec57f
     path: patches/app-builder-lib@26.15.3.patch
+  loro-mirror@2.3.1:
+    hash: c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306
+    path: patches/loro-mirror@2.3.1.patch
   loro-repo@0.20.0:
     hash: 74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357
     path: patches/loro-repo.patch
@@ -352,7 +355,7 @@ importers:
         version: link:../../packages/code-review-viewer
       loro-mirror:
         specifier: 'catalog:'
-        version: 2.3.1(loro-crdt@1.15.1)
+        version: 2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)
       loro-repo:
         specifier: 'catalog:'
         version: 0.20.0(patch_hash=74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357)(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.15.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@13.0.3)(loro-crdt@1.15.1)
@@ -1106,13 +1109,13 @@ importers:
         version: 1.15.1
       loro-mirror:
         specifier: 'catalog:'
-        version: 2.3.1(loro-crdt@1.15.1)
+        version: 2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)
       loro-mirror-jotai:
         specifier: 'catalog:'
-        version: 2.3.1(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.15.1)(loro-mirror@2.3.1(loro-crdt@1.15.1))
+        version: 2.3.1(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1))
       loro-mirror-react:
         specifier: 'catalog:'
-        version: 2.3.1(loro-crdt@1.15.1)(loro-mirror@2.3.1(loro-crdt@1.15.1))(react@19.2.0)
+        version: 2.3.1(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1))(react@19.2.0)
       loro-repo:
         specifier: 'catalog:'
         version: 0.20.0(patch_hash=74be8ab90bed65c9ce8b0d7cb32f8cafdbd0ecda6d9b7c8048836600d116d357)(@loro-dev/flock-wasm@0.4.3)(@loro-dev/flock@4.4.4)(@loro-dev/streams-crdt@0.15.1(@loro-dev/flock-wasm@0.4.3)(loro-crdt@1.15.1))(@types/better-sqlite3@7.6.13)(better-sqlite3@12.10.0)(loro-crdt@1.15.1)
@@ -1422,7 +1425,7 @@ importers:
         version: 1.15.1
       loro-mirror:
         specifier: 'catalog:'
-        version: 2.3.1(loro-crdt@1.15.1)
+        version: 2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -22519,19 +22522,19 @@ snapshots:
 
   loro-crdt@1.15.1: {}
 
-  loro-mirror-jotai@2.3.1(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.15.1)(loro-mirror@2.3.1(loro-crdt@1.15.1)):
+  loro-mirror-jotai@2.3.1(jotai@2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0))(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)):
     dependencies:
       jotai: 2.17.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@19.2.17)(react@19.2.0)
       loro-crdt: 1.15.1
-      loro-mirror: 2.3.1(loro-crdt@1.15.1)
+      loro-mirror: 2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)
 
-  loro-mirror-react@2.3.1(loro-crdt@1.15.1)(loro-mirror@2.3.1(loro-crdt@1.15.1))(react@19.2.0):
+  loro-mirror-react@2.3.1(loro-crdt@1.15.1)(loro-mirror@2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1))(react@19.2.0):
     dependencies:
       loro-crdt: 1.15.1
-      loro-mirror: 2.3.1(loro-crdt@1.15.1)
+      loro-mirror: 2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1)
       react: 19.2.0
 
-  loro-mirror@2.3.1(loro-crdt@1.15.1):
+  loro-mirror@2.3.1(patch_hash=c8eb6e4bfc44f1089f4a1c57794a098e4dc31210e091e4677cb1831076469306)(loro-crdt@1.15.1):
     dependencies:
       immer: 10.2.0
       loro-crdt: 1.15.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -94,6 +94,7 @@ packageExtensions:
 packageManagerStrictVersion: true
 
 patchedDependencies:
+  loro-mirror@2.3.1: patches/loro-mirror@2.3.1.patch
   app-builder-lib@26.15.3: patches/app-builder-lib@26.15.3.patch
   '@better-auth/api-key@1.5.5': patches/@better-auth__api-key@1.5.5.patch
   '@better-auth/electron@1.5.5': patches/@better-auth__electron@1.5.5.patch

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -58,3 +58,8 @@ maintenance commands here.
 Keep tests deterministic and side-effect-contained. Temporary files must use a
 dedicated temporary directory and cleanup must never target the repository root
 or a user data directory.
+
+- `history-schema-audit/` validates a candidate history-item write projection
+  against local SQLite stores. Keep reads transactionally read-only, temporary
+  frames isolated and deleted, and reports free of transcript content. Accepted
+  projection is not proof of production Mirror or whole-document compatibility.

--- a/scripts/history-schema-audit/README.md
+++ b/scripts/history-schema-audit/README.md
@@ -51,3 +51,38 @@ This is not a general image-size limit or attachment externalization feature.
 after the entire projection, including terminal-output removal. They do not
 isolate image savings or measure SQLite size, CRDT snapshots, or retained history.
 Merging this audit does not reduce production writes or shrink existing documents.
+
+## String storage compatibility
+
+This mode tests the production insertion-policy change independently of the
+candidate filtering schema. It never projects away fields. Pass the package
+directory of an **unpatched** baseline Mirror installation, so old-reader checks
+exercise its actual code, not just the old schema on the new engine:
+
+```sh
+node scripts/history-schema-audit/build-storage.mjs \
+  /private/temporary/storage-modules BASELINE_GIT_REF /absolute/path/to/unpatched/loro-mirror
+python3 scripts/history-schema-audit/audit.py \
+  --storage-compat \
+  --old-storage-module /private/temporary/storage-modules/old.cjs \
+  --new-storage-module /private/temporary/storage-modules/new.cjs \
+  --loro-package /absolute/path/to/installed/loro-crdt \
+  --output /private/temporary/storage-results
+```
+
+Every stored document is read by both schemas without creating operations.
+Every conversation's message items are then rebuilt in a disposable document with
+the production new-write schema (using only turn id/role/timestamp as envelope).
+The audit checks exact item round trips, plain nested metadata strings, explicit
+streaming Text fields, old-reader compatibility after snapshot import, old/new
+update exchange, and preservation of an existing legacy title Text ID when that
+shape is present. Original root/turn metadata is compared on read, not rebuilt.
+No migration, SQLite update, compaction, or real document write is performed.
+The unit tests cover legacy fields and stream updates even when a corpus document
+has no matching tool title. Module hashes identify the exact old and new bundles.
+
+The new runtime includes a narrow Mirror patch: for inferred/Any and declared Text map fields,
+string-to-string edits retain the actual existing Text or primitive representation.
+Explicit transforms and non-Text declared schemas retain their own rules.
+Future upstream Mirror upgrades must retain these regression tests before removing
+the patch. This does not make unpatched old writers use the new insertion policy.

--- a/scripts/history-schema-audit/README.md
+++ b/scripts/history-schema-audit/README.md
@@ -1,0 +1,53 @@
+# Local history schema audit
+
+This is a read-only calibration tool for `history-content-schema.ts`, a candidate
+**write projection** for `history[].items`. It does not replace the production
+Mirror schema, change existing CRDTs, validate every root field, or prove that a
+reader/writer rollout is compatible.
+
+Run from the standalone repository after installing its dependencies:
+
+```sh
+python3 scripts/history-schema-audit/audit.py \
+  --loro-package /absolute/path/to/installed/loro-crdt \
+  --output /private/temporary/output-directory
+```
+
+Without `--limit`, it inspects every stored document replica in the local SQLite stores
+and validates the items of every conversation, including empty histories. `--root` can select a
+different local repository directory. Snapshot and update bytes are captured in
+one read-only transaction per document, then decoded in an isolated Node process.
+Every workspace is reported separately. If a document id occurs in multiple stores, each replica is validated; none is skipped in favor of a larger replica.
+Temporary binary frames are deleted; no transcript text is written to the report.
+
+The result separates:
+
+- accepted known messages (including their projected fields);
+- unsupported top-level variants, skipped independently;
+- malformed known messages, reported as validation failures;
+- field paths removed by projection (including deliberately removed tool blocks);
+- differences in the existing question/answer reader's behavior before and after
+  projection.
+
+The command fails if any document cannot be analyzed, a known message or supported nested tool block fails,
+question/answer behavior or scheduled-task derivation changes, or no conversations are found. Nested unsupported
+or malformed tool blocks are filtered individually; a parent message accepted by
+this write policy does not imply every original nested block was retained.
+
+Arbitrary provider metadata is not accepted. Named dictionaries such as question
+answers have explicit value types; they are not an unrestricted object escape.
+Synthetic unit tests cover variants absent from the current local sample. Do not
+commit local report output or use captured conversations as test fixtures.
+
+## Image filtering and size claims
+
+The candidate removes recognized `imageUrl.url: data:image/...` entries only from
+JSON arrays inside tool text. Ordinary text and supported structured image/audio
+blocks are retained. Invalid JSON, other shapes, and tool strings longer than
+10,000,000 JavaScript string code units are left unchanged to bound parsing work.
+This is not a general image-size limit or attachment externalization feature.
+
+`beforeBytes` and `afterBytes` measure serialized message-item JSON before and
+after the entire projection, including terminal-output removal. They do not
+isolate image savings or measure SQLite size, CRDT snapshots, or retained history.
+Merging this audit does not reduce production writes or shrink existing documents.

--- a/scripts/history-schema-audit/analyze-storage.cjs
+++ b/scripts/history-schema-audit/analyze-storage.cjs
@@ -1,0 +1,181 @@
+// All mutations are on isolated, disposable LoroDoc instances, never SQLite.
+const fs = require('node:fs');
+const assert = require('node:assert/strict');
+const next = require(process.env.LODY_STORAGE_NEW_MODULE);
+const old = require(process.env.LODY_STORAGE_OLD_MODULE);
+const { LoroDoc, isContainer, Mirror, sessionDocSchema } = next;
+const clean = (v) => {
+  if (Array.isArray(v)) return v.map(clean);
+  if (v && typeof v === 'object')
+    return Object.fromEntries(
+      Object.entries(v)
+        .filter(([k]) => k !== '$cid')
+        .map(([k, x]) => [k, clean(x)])
+    );
+  return v;
+};
+const make = (doc, legacy = false) => {
+  const module = legacy ? old : next;
+  return new module.Mirror({ doc, schema: module.sessionDocSchema, throwOnValidationError: true });
+};
+function main() {
+  const doc = new LoroDoc();
+  const bytes = fs.readFileSync(process.argv[2]);
+  let offset = 4;
+  for (let i = 0; i < bytes.readUInt32LE(0); i++) {
+    const n = bytes.readUInt32LE(offset);
+    offset += 4;
+    const result = doc.import(bytes.subarray(offset, offset + n));
+    offset += n;
+    assert(!result.pending || result.pending.size === 0);
+  }
+  const version = doc.version().encode();
+  const legacy = make(doc, true),
+    reader = make(doc);
+  assert.deepEqual(clean(reader.getState()), clean(legacy.getState()));
+  assert.deepEqual(doc.version().encode(), version);
+  legacy.dispose();
+  reader.dispose();
+  if (!doc.getShallowValue().history) {
+    doc.free();
+    return { conversation: false };
+  }
+  const history = doc.getList('history').toJSON();
+  const turns = history.map((t, i) => ({
+    id: String(i),
+    role: t.role,
+    timestamp: typeof t.timestamp === 'string' ? t.timestamp : '2026-01-01T00:00:00Z',
+    items: Array.isArray(t.items)
+      ? t.items
+      : typeof t.contents === 'string'
+        ? JSON.parse(t.contents)
+        : [],
+  }));
+  let legacyEdits = 0;
+  // Exercise existing nested Text edits through the NEW writer, preserving IDs.
+  const edit = make(doc);
+  outer: for (let i = 0; i < history.length; i++) {
+    const entry = doc.getList('history').get(i);
+    const items = entry?.get?.('items');
+    if (!items?.get) continue;
+    for (let j = 0; j < items.length; j++) {
+      const item = items.get(j);
+      if (!item?.get || item.get('type') !== 'tool_call') continue;
+      const text = item.get('title');
+      if (!isContainer(text) || text.kind() !== 'Text') continue;
+      const id = text.id,
+        value = text.toString();
+      edit.setState((s) => {
+        s.history[i].items[j].title = value + ' [storage audit]';
+      });
+      assert.equal(item.get('title').id, id);
+      assert.equal(item.get('title').toString(), value + ' [storage audit]');
+      legacyEdits++;
+      break outer;
+    }
+  }
+  edit.dispose();
+  doc.free();
+  // Reconstruct EVERY message using the production new-write schema.
+  const fresh = new LoroDoc(),
+    writer = make(fresh);
+  writer.setState((s) => ({ ...s, history: turns }));
+  assert.deepEqual(fresh.toJSON().history, turns);
+  let textContainers = 0,
+    plainStrings = 0;
+  function inspect(container, allowText = false, path = '') {
+    if (container.kind() === 'Text') {
+      assert(allowText);
+      textContainers++;
+      return;
+    }
+    const entries =
+      container.kind() === 'Map'
+        ? container.entries()
+        : Array.from({ length: container.length }, (_, i) => [i, container.get(i)]);
+    for (const [k, v] of entries) {
+      if (isContainer(v))
+        inspect(
+          v,
+          /^(content\[\]\.(output|content.text)|steps\[\].output)$/.test(
+            path + (typeof k === 'number' ? '[]' : '.' + k)
+          ),
+          path + (typeof k === 'number' ? '[]' : '.' + k)
+        );
+      else if (typeof v === 'string') plainStrings++;
+    }
+  }
+  const root = fresh.getList('history');
+  for (let i = 0; i < root.length; i++) {
+    const list = root.get(i).get('items');
+    for (let j = 0; j < list.length; j++)
+      for (const [k, v] of list.get(j).entries()) {
+        if (isContainer(v)) inspect(v, k === 'text' || k === 'markdown', k);
+        else if (typeof v === 'string') plainStrings++;
+      }
+  }
+  const snapshot = fresh.export({ mode: 'snapshot' });
+  const reopened = new LoroDoc();
+  reopened.import(snapshot);
+  const oldReader = make(reopened, true);
+  assert.deepEqual(clean(oldReader.getState()), clean(writer.getState()));
+  // An unchanged round trip must not add operations or convert storage.
+  const before = reopened.version().encode();
+  oldReader.setState((s) => s);
+  assert.deepEqual(reopened.version().encode(), before);
+  // Real unpatched old engine consumes and edits a newly inserted tool item.
+  const probe = {
+    id: 'storage-compat-probe',
+    role: 'assistant',
+    timestamp: '2026-01-01T00:00:00Z',
+    items: [
+      {
+        type: 'tool_call',
+        toolCallId: 'storage-compat-probe',
+        status: 'in_progress',
+        title: 'before',
+      },
+    ],
+  };
+  writer.setState((s) => {
+    s.history.push(probe);
+  });
+  reopened.import(fresh.export({ mode: 'update', from: reopened.version() }));
+  const index = turns.length;
+  oldReader.setState((s) => {
+    s.history[index].items[0].title = 'old writer';
+  });
+  fresh.import(reopened.export({ mode: 'update', from: fresh.version() }));
+  assert.deepEqual(clean(writer.getState()), clean(oldReader.getState()));
+  const map = fresh.getList('history').get(index).get('items').get(0);
+  const previous = map.get('title');
+  writer.setState((s) => {
+    s.history[index].items[0].title = 'new writer';
+  });
+  if (isContainer(previous)) assert.equal(map.get('title').id, previous.id);
+  reopened.import(fresh.export({ mode: 'update', from: reopened.version() }));
+  assert.deepEqual(clean(writer.getState()), clean(oldReader.getState()));
+  oldReader.dispose();
+  reopened.free();
+  writer.dispose();
+  fresh.free();
+  return {
+    conversation: true,
+    accepted: turns.reduce((n, t) => n + t.items.length, 0),
+    unsupported: 0,
+    invalid: 0,
+    invalidToolBlocks: 0,
+    questionMetadataMismatches: 0,
+    answerMismatches: 0,
+    schedulingMismatch: false,
+    legacyEdits,
+    textContainers,
+    plainStrings,
+  };
+}
+try {
+  console.log(JSON.stringify(main()));
+} catch (e) {
+  console.log(JSON.stringify({ failed: true, errorClass: e.name }));
+  process.exitCode = 1;
+}

--- a/scripts/history-schema-audit/analyze.cjs
+++ b/scripts/history-schema-audit/analyze.cjs
@@ -1,0 +1,170 @@
+const fs = require('fs');
+const { LoroDoc } = require(process.argv[3]);
+const { validateHistoryContent, historyToolContentSchema } = require(
+  process.env.LODY_HISTORY_SCHEMA_MODULE
+);
+const { parseAskUserQuestionPermissionMeta, extractAskUserQuestionAnswersFromOutcome } = require(
+  process.env.LODY_HISTORY_PERMISSION_MODULE
+);
+const { collectPendingScheduledTasksFromHistory } = require(
+  process.env.LODY_HISTORY_SCHEDULING_MODULE
+);
+function main() {
+  const b = fs.readFileSync(process.argv[2]),
+    d = new LoroDoc();
+  let p = 4;
+  for (let i = 0; i < b.readUInt32LE(0); i++) {
+    const n = b.readUInt32LE(p);
+    p += 4;
+    d.import(b.subarray(p, p + n));
+    p += n;
+  }
+  if (!d.getShallowValue().history) return { conversation: false };
+  const h = d.getList('history').toJSON();
+
+  let accepted = 0,
+    unsupported = 0,
+    invalid = 0,
+    beforeBytes = 0,
+    afterBytes = 0,
+    legacyTurns = 0,
+    invalidToolBlocks = 0,
+    omittedToolBlocks = 0,
+    questionMetadataMismatches = 0,
+    answerMismatches = 0;
+  const types = {},
+    invalidByType = {},
+    issues = {},
+    droppedPaths = {};
+  function count(v, path, out, depth = 0) {
+    if (depth > 40 || !v || typeof v !== 'object') return;
+    if (Array.isArray(v)) {
+      for (const x of v) count(x, path + '[]', out, depth + 1);
+    } else
+      for (const [k, x] of Object.entries(v)) {
+        const key = /^[a-zA-Z_$][a-zA-Z0-9_$-]{0,63}$/.test(k) ? k : '<key>';
+        const q = path + '.' + key;
+        out[q] = (out[q] || 0) + 1;
+        count(x, q, out, depth + 1);
+      }
+  }
+  const projectedHistory = [];
+  for (const turn of h) {
+    const projectedItems = [];
+    projectedHistory.push({ ...turn, items: projectedItems });
+    let items = turn.items;
+    if (!Array.isArray(items) && typeof turn.contents === 'string') {
+      legacyTurns++;
+      try {
+        items = JSON.parse(turn.contents);
+      } catch {
+        invalid++;
+        issues['history.contents:invalid_json'] =
+          (issues['history.contents:invalid_json'] || 0) + 1;
+        items = [];
+      }
+    }
+    if (!Array.isArray(items)) {
+      if (items != null) {
+        invalid++;
+        issues['history.items:invalid_type'] = (issues['history.items:invalid_type'] || 0) + 1;
+      }
+      continue;
+    }
+    for (const item of items) {
+      const type =
+        typeof item?.type === 'string' && /^[a-z_]{1,40}$/.test(item.type) ? item.type : 'unknown';
+      types[type] = (types[type] || 0) + 1;
+      if (item?.type === 'tool_call' && Array.isArray(item.content)) {
+        for (const block of item.content) {
+          const known =
+            ['content', 'terminal', 'terminal_command', 'diff'].includes(block?.type) &&
+            (block.type !== 'content' ||
+              ['text', 'image', 'audio', 'resource', 'resource_link'].includes(
+                block.content?.type
+              ));
+          if (!known) {
+            omittedToolBlocks++;
+            continue;
+          }
+          const check = historyToolContentSchema.safeParse(block);
+          if (!check.success) {
+            invalidToolBlocks++;
+            for (const issue of check.error.issues) {
+              const key = 'tool_block.' + issue.path.join('.') + ':' + issue.code;
+              issues[key] = (issues[key] || 0) + 1;
+            }
+          }
+        }
+      }
+      const r = validateHistoryContent(item);
+      beforeBytes += Buffer.byteLength(JSON.stringify(item));
+      if (r.status === 'accepted') {
+        accepted++;
+        projectedItems.push(r.value);
+        if (item.type === 'tool_call') {
+          const a = item.permissionRequest,
+            b = r.value.permissionRequest;
+          if (
+            JSON.stringify(parseAskUserQuestionPermissionMeta(a?._meta)) !==
+            JSON.stringify(parseAskUserQuestionPermissionMeta(b?._meta))
+          )
+            questionMetadataMismatches++;
+          const meta = parseAskUserQuestionPermissionMeta(a?._meta);
+          if (
+            meta &&
+            JSON.stringify(extractAskUserQuestionAnswersFromOutcome(meta, a?.outcome)) !==
+              JSON.stringify(extractAskUserQuestionAnswersFromOutcome(meta, b?.outcome))
+          )
+            answerMismatches++;
+        }
+        afterBytes += Buffer.byteLength(JSON.stringify(r.value));
+        const a = {},
+          b = {};
+        count(item, type, a);
+        count(r.value, type, b);
+        for (const [k, n] of Object.entries(a)) {
+          const removed = n - (b[k] || 0);
+          if (removed > 0) droppedPaths[k] = (droppedPaths[k] || 0) + removed;
+        }
+      } else if (r.status === 'unsupported') unsupported++;
+      else {
+        invalid++;
+        invalidByType[type] = (invalidByType[type] || 0) + 1;
+        for (const issue of r.issues) {
+          const path = type + '.' + issue.path.replace(/\.\d+(?=\.|$)/g, '.[]') + ':' + issue.code;
+          issues[path] = (issues[path] || 0) + 1;
+        }
+      }
+    }
+  }
+  d.free();
+  return {
+    conversation: true,
+    schedulingMismatch:
+      JSON.stringify(collectPendingScheduledTasksFromHistory(h)) !==
+      JSON.stringify(collectPendingScheduledTasksFromHistory(projectedHistory)),
+    userRounds: h.filter((x) => x.role === 'user').length,
+    entries: h.length,
+    legacyTurns,
+    invalidToolBlocks,
+    omittedToolBlocks,
+    questionMetadataMismatches,
+    answerMismatches,
+    accepted,
+    unsupported,
+    invalid,
+    beforeBytes,
+    afterBytes,
+    types,
+    invalidByType,
+    issues,
+    droppedPaths,
+  };
+}
+try {
+  console.log(JSON.stringify(main()));
+} catch (e) {
+  console.log(JSON.stringify({ failed: true, errorClass: e.name }));
+  process.exitCode = 1;
+}

--- a/scripts/history-schema-audit/audit.py
+++ b/scripts/history-schema-audit/audit.py
@@ -69,13 +69,18 @@ def main():
     parser.add_argument('--limit', type=int, help='Optional smoke-test conversation limit; default: all')
     parser.add_argument('--loro-package', required=True, help='Absolute installed loro-crdt module path')
     parser.add_argument('--output', type=Path, required=True, help='Private output directory')
+    parser.add_argument('--storage-compat', action='store_true', help='Verify storage insertion policy instead of filtering')
+    parser.add_argument('--old-storage-module', type=Path, help='Bundled baseline schema and unpatched Mirror')
+    parser.add_argument('--new-storage-module', type=Path, help='Bundled current schema and patched Mirror')
     args = parser.parse_args()
+    if args.storage_compat and not (args.old_storage_module and args.new_storage_module):
+        parser.error('--storage-compat requires both storage modules')
     if args.limit is not None and args.limit <= 0:
         parser.error('--limit must be positive')
     os.umask(0o077)
     args.output.mkdir(parents=True, exist_ok=True)
     scripts = Path(__file__).resolve().parent
-    source = scripts.parents[1] / 'packages/shared/src/history-content-schema.ts'
+    source = scripts.parents[1] / ('packages/shared/src/schema.ts' if args.storage_compat else 'packages/shared/src/history-content-schema.ts')
     databases, replicas, ranked = inventory(args.root)
     results, failures = [], []
     workspace_aliases = {db: hashlib.sha256(str(db.relative_to(args.root)).encode()).hexdigest()[:12] for db in databases}
@@ -91,6 +96,8 @@ def main():
             'allReplicasScanned': scanned == len(ranked),
             'conversations': len(results), 'limit': args.limit,
             'schemaSha256': schema_hash,
+            'storageCompatibility': args.storage_compat,
+            'storageModuleHashes': ({name: hashlib.sha256(path.read_bytes()).hexdigest() for name, path in [('old', args.old_storage_module), ('new', args.new_storage_module)]} if args.storage_compat else None),
             'elapsedSeconds': round(time.time() - started, 2),
             'failures': failures, 'results': results,
             'workspaces': [{
@@ -115,6 +122,9 @@ def main():
             'LODY_HISTORY_PERMISSION_MODULE': str(temp / 'permission.cjs'),
             'LODY_HISTORY_SCHEDULING_MODULE': str(temp / 'scheduling.cjs'),
         }
+        if args.storage_compat:
+            child_env.update(LODY_STORAGE_OLD_MODULE=str(args.old_storage_module.resolve()),
+                             LODY_STORAGE_NEW_MODULE=str(args.new_storage_module.resolve()))
         for row in ranked:
             if args.limit is not None and len(results) >= args.limit:
                 break
@@ -125,7 +135,7 @@ def main():
             try:
                 snapshot, stored = write_frames(row, frame)
                 child = subprocess.run(
-                    ['node', '--max-old-space-size=1536', str(scripts / 'analyze.cjs'),
+                    ['node', '--max-old-space-size=1536', str(scripts / ('analyze-storage.cjs' if args.storage_compat else 'analyze.cjs')),
                      str(frame), args.loro_package],
                     capture_output=True, text=True, timeout=90, env=child_env)
                 result = json.loads(child.stdout.strip().splitlines()[-1])

--- a/scripts/history-schema-audit/audit.py
+++ b/scripts/history-schema-audit/audit.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Validate local conversation items with the closed candidate write schema.
+
+SQLite is read-only. Each document runs in a fresh Node process. Only anonymous
+counts and field paths are retained; the private binary frames are removed.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import sqlite3
+import struct
+import subprocess
+import tempfile
+import time
+
+
+def connect(db):
+    connection = sqlite3.connect('file:' + str(db) + '?mode=ro', uri=True)
+    connection.execute('pragma query_only=on')
+    connection.execute('begin')
+    return connection
+
+
+def inventory(root):
+    databases = sorted(root.rglob('repo.sqlite3'))
+    replicas = []
+    query = '''
+      with u as (
+        select doc_id, sum(length(update_data)) as b from doc_updates group by doc_id
+      ), ids as (select doc_id from docs union select doc_id from doc_updates)
+      select ids.doc_id, coalesce(length(d.snapshot),0) + coalesce(u.b,0)
+      from ids left join docs d on ids.doc_id=d.doc_id
+      left join u on ids.doc_id=u.doc_id
+    '''
+    for db in databases:
+        connection = connect(db)
+        try:
+            replicas.extend({'db': db, 'id': key, 'bytes': size}
+                            for key, size in connection.execute(query))
+        finally:
+            connection.close()
+    return databases, replicas, sorted(replicas, key=lambda r: r['bytes'], reverse=True)
+
+
+def write_frames(row, frame):
+    connection = connect(row['db'])
+    try:
+        snapshot = connection.execute('select snapshot from docs where doc_id=?',
+                                      (row['id'],)).fetchone()
+        snapshot = snapshot[0] if snapshot and snapshot[0] else b''
+        updates = [v[0] for v in connection.execute(
+            'select update_data from doc_updates where doc_id=? order by id', (row['id'],))]
+        blocks = ([snapshot] if snapshot else []) + updates
+        with frame.open('wb') as output:
+            output.write(struct.pack('<I', len(blocks)))
+            for block in blocks:
+                output.write(struct.pack('<I', len(block)))
+                output.write(block)
+        return len(snapshot), sum(map(len, blocks))
+    finally:
+        connection.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--root', type=Path, default=Path.home() / '.lody/loro-repo')
+    parser.add_argument('--limit', type=int, help='Optional smoke-test conversation limit; default: all')
+    parser.add_argument('--loro-package', required=True, help='Absolute installed loro-crdt module path')
+    parser.add_argument('--output', type=Path, required=True, help='Private output directory')
+    args = parser.parse_args()
+    if args.limit is not None and args.limit <= 0:
+        parser.error('--limit must be positive')
+    os.umask(0o077)
+    args.output.mkdir(parents=True, exist_ok=True)
+    scripts = Path(__file__).resolve().parent
+    source = scripts.parents[1] / 'packages/shared/src/history-content-schema.ts'
+    databases, replicas, ranked = inventory(args.root)
+    results, failures = [], []
+    workspace_aliases = {db: hashlib.sha256(str(db.relative_to(args.root)).encode()).hexdigest()[:12] for db in databases}
+    workspace_scanned = {db: 0 for db in databases}
+    scanned = 0
+    started = time.time()
+    schema_hash = hashlib.sha256(source.read_bytes()).hexdigest()
+
+    def save():
+        manifest = {
+            'databases': len(databases), 'replicas': len(replicas),
+            'uniqueDocuments': len({r['id'] for r in ranked}), 'scanned': scanned,
+            'allReplicasScanned': scanned == len(ranked),
+            'conversations': len(results), 'limit': args.limit,
+            'schemaSha256': schema_hash,
+            'elapsedSeconds': round(time.time() - started, 2),
+            'failures': failures, 'results': results,
+            'workspaces': [{
+                'alias': workspace_aliases[db],
+                'storedDocuments': sum(row['db'] == db for row in ranked),
+                'scannedDocuments': workspace_scanned[db],
+                'conversations': sum(r['workspaceAlias'] == workspace_aliases[db] for r in results),
+                'items': sum(r['accepted'] + r['unsupported'] + r['invalid'] for r in results if r['workspaceAlias'] == workspace_aliases[db]),
+                'invalid': sum(r['invalid'] + r['invalidToolBlocks'] for r in results if r['workspaceAlias'] == workspace_aliases[db]),
+                'behaviorMismatches': sum(r['questionMetadataMismatches'] + r['answerMismatches'] + int(r['schedulingMismatch']) for r in results if r['workspaceAlias'] == workspace_aliases[db]),
+                'readFailures': sum(r['workspaceAlias'] == workspace_aliases[db] for r in failures),
+            } for db in databases],
+        }
+        (args.output / 'results.json').write_text(json.dumps(manifest, indent=2))
+
+    with tempfile.TemporaryDirectory(prefix='private-history-validation-') as temp:
+        temp = Path(temp)
+        subprocess.run(['node', str(scripts / 'build.mjs'), str(temp)], check=True)
+        child_env = {
+            **os.environ,
+            'LODY_HISTORY_SCHEMA_MODULE': str(temp / 'schema.cjs'),
+            'LODY_HISTORY_PERMISSION_MODULE': str(temp / 'permission.cjs'),
+            'LODY_HISTORY_SCHEDULING_MODULE': str(temp / 'scheduling.cjs'),
+        }
+        for row in ranked:
+            if args.limit is not None and len(results) >= args.limit:
+                break
+            scanned += 1
+            workspace_scanned[row['db']] += 1
+            alias = hashlib.sha256(row['id'].encode()).hexdigest()[:12]
+            frame = temp / 'doc.frames'
+            try:
+                snapshot, stored = write_frames(row, frame)
+                child = subprocess.run(
+                    ['node', '--max-old-space-size=1536', str(scripts / 'analyze.cjs'),
+                     str(frame), args.loro_package],
+                    capture_output=True, text=True, timeout=90, env=child_env)
+                result = json.loads(child.stdout.strip().splitlines()[-1])
+                if child.returncode or result.get('failed'):
+                    raise RuntimeError('analyzer failed')
+                if not result['conversation']:
+                    continue
+                result.update(workspaceAlias=workspace_aliases[row['db']], alias=alias, rank=len(results) + 1, storedBytes=stored,
+                              storedSnapshotBytes=snapshot, storedUpdateBytes=stored - snapshot)
+                results.append(result)
+                save()
+                print(json.dumps({'completed': len(results), 'invalid': result['invalid'],
+                                  'unsupported': result['unsupported']}), flush=True)
+            except Exception as error:
+                failures.append({'workspaceAlias': workspace_aliases[row['db']], 'alias': alias, 'errorClass': type(error).__name__})
+            finally:
+                frame.unlink(missing_ok=True)
+    save()
+    failed = bool(failures or any(
+        r['schedulingMismatch'] or r['invalid'] or r['invalidToolBlocks'] or r['questionMetadataMismatches'] or r['answerMismatches']
+        for r in results))
+    print(json.dumps({'done': True, 'conversations': len(results), 'failed': failed}))
+    return int(failed or not results)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/history-schema-audit/build-storage.mjs
+++ b/scripts/history-schema-audit/build-storage.mjs
@@ -1,0 +1,53 @@
+import { createRequire } from 'node:module';
+import { readFileSync, mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { resolve, join } from 'node:path';
+
+const [output, baselineRef, baselineMirror] = process.argv.slice(2);
+if (!output || !baselineRef || !baselineMirror) {
+  throw new Error('Usage: build-storage.mjs OUTPUT BASELINE_GIT_REF UNPATCHED_MIRROR_PACKAGE');
+}
+const root = fileURLToPath(new URL('../../', import.meta.url));
+const cli = createRequire(join(root, 'apps/cli/package.json'));
+const shared = createRequire(join(root, 'packages/shared/package.json'));
+const { build } = cli('esbuild');
+mkdirSync(output, { recursive: true, mode: 0o700 });
+for (const legacy of [true, false]) {
+  const source = legacy
+    ? execFileSync('git', ['show', `${baselineRef}:packages/shared/src/schema.ts`], {
+        cwd: root,
+        encoding: 'utf8',
+      })
+    : readFileSync(join(root, 'packages/shared/src/schema.ts'), 'utf8');
+  await build({
+    stdin: {
+      contents:
+        source +
+        '\nexport { Mirror } from "loro-mirror"; export { LoroDoc, isContainer } from "loro-crdt";',
+      resolveDir: join(root, 'packages/shared/src'),
+      loader: 'ts',
+    },
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    outfile: join(output, legacy ? 'old.cjs' : 'new.cjs'),
+    plugins: [
+      {
+        name: 'storage-versions',
+        setup(builder) {
+          builder.onResolve({ filter: /^loro-mirror$/ }, () => ({
+            path: legacy
+              ? join(resolve(baselineMirror), 'dist/index.js')
+              : shared.resolve('loro-mirror'),
+          }));
+          builder.onResolve({ filter: /^loro-crdt$/ }, () => ({
+            path: shared.resolve('loro-crdt'),
+            external: true,
+          }));
+        },
+      },
+    ],
+    logLevel: 'warning',
+  });
+}

--- a/scripts/history-schema-audit/build.mjs
+++ b/scripts/history-schema-audit/build.mjs
@@ -1,0 +1,20 @@
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+const require = createRequire(new URL('../../apps/cli/package.json', import.meta.url));
+const { buildSync } = require('esbuild');
+const root = fileURLToPath(new URL('../../', import.meta.url));
+for (const [name, source] of [
+  ['schema', 'packages/shared/src/history-content-schema.ts'],
+  ['permission', 'packages/shared/src/acp/ask-user-question.ts'],
+  ['scheduling', 'packages/shared/src/scheduled-tasks-from-history.ts'],
+]) {
+  buildSync({
+    entryPoints: [join(root, source)],
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    outfile: join(process.argv[2], name + '.cjs'),
+    logLevel: 'warning',
+  });
+}


### PR DESCRIPTION
## Related issue

Same-repository follow-up for conversation storage size and compatibility.

## Problem / pressure

History catchall inference creates independent LoroText containers for ordinary metadata strings. Turning it off alone replaces legacy Text containers on edit, so the insertion policy needs a compatibility fix as well as explicit streaming fields.

## Summary

- Store newly inserted metadata (IDs, status, paths, commands and nested metadata) as primitive strings. Explicitly retain Text for message text/thought, plan markdown, tool text/output and script output.
- Pin a narrow Mirror 2.3.1 patch: string edits in inferred/Any or declared Text map fields retain the actual existing Text or primitive representation. Existing Text IDs survive edits and concurrent updates. No data migration runs.
- Add synthetic regression tests plus a read-only all-workspace storage audit using the real unpatched baseline Mirror engine and schema, not only old options on the new engine.
- Retain the candidate closed filtering schema and corpus calibration tool from this PR. Image/unknown-field filtering is still not wired into production writes.

## Before / after

| Case | Before | After |
| --- | --- | --- |
| New nested metadata string | Often a Text container | Primitive string |
| New streaming content | Inferred or declared Text | Explicit Text |
| Existing stored string | Schema change could replace its representation on edit | Existing representation and Text ID retained |
| Opening existing documents | Normal read | Same read; no migration or rewrite |

## Test plan

- Full shared suite: 1,045 tests across 92 files pass; six focused storage cases cover plain metadata, streaming fields, legacy snapshots, legacy primitives, update exchange and concurrent legacy Text edits.
- CLI ACP history: 22 tests pass against the updated shared package.
- Shared typecheck, focused Oxlint, formatting, public-boundary checks, patch applicability and lockfile hash checks pass. Full application build/typecheck and browser/mobile UI tests were not run locally.
- Final read-only corpus: all 7 workspace databases and 1,103 stored documents scanned; 323,883 message items reconstructed through the production new-write schema with exact JSON equality. Zero failures.
- Baseline/new reads match without adding operations; all reconstructed snapshots are readable by the unpatched old Mirror; old/new writer update exchange matches. 954 documents contain a legacy title Text tested for ID preservation on edit.
- SQLite is opened read-only with query_only enabled. All experimental writes are confined to disposable imported/new LoroDoc instances. No original database, snapshot, document or remote room is rewritten.
- Source documents' full root/turn metadata is compared on read. Reconstruction uses every message item in a minimal id/role/timestamp turn envelope; it is not a whole-document migration simulation.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the explicit streaming paths in schema.ts, both runtime/source halves of the Mirror patch, and the existing-Text concurrent-edit regression.
- **Decisions to challenge:** The boundary between primitive metadata and streaming Text, especially future provider fields, needs source-grounded review.
- **Plausible failures / evidence gaps:** The patch affects other inferred/Any and declared Text map string edits too; explicit transforms and non-Text declarations retain their previous behavior. Browser/mobile integration remains CI/manual scope.

### Authoring context

- **User goal / directives:** Reduce unnecessary Text containers only for new writes, preserve existing storage, and validate all locally stored documents plus backward compatibility.
- **Constraints / non-goals:** No migration, compaction, deletion, captured transcript fixtures, or production integration of candidate filtering.
- **Risk-bearing decisions:** New inserts use the new policy; existing string representations remain authoritative. Old unpatched writers can still create Text using their old policy, and new readers tolerate that.
- **Destructive or irreversible behavior:** None on existing user data. Application behavior changes only for new string insertion and compatible edits; audit mutations are disposable.
- **Deliberately not done or tested:** Image filtering rollout, attachment externalization, old-history compaction, future ConversationView integration and 3000-round UI performance remain separate work.
- **Unknowns / confidence:** Corpus and synthetic tests cover the pinned Loro 1.15.1/Mirror 2.3.1 baseline and the patched runtime, not every historical released application or future schema variant.

<!-- context-handoff:end -->
