### PR TITLE
fix(cli): persist task lifecycle progress into session history

### DIFF
--- a/apps/cli/src/lib/acp/AGENTS.md
+++ b/apps/cli/src/lib/acp/AGENTS.md
@@ -74,3 +74,10 @@ first `await awaitTurnHistoryGate(sessionId)` — see
 `../../session/turn-history-gate.ts`. Add the same await to any NEW code path that
 appends or positions history entries during a turn; map-keyed status/meta writes stay
 ungated.
+
+A non-terminal `tool_call_update` reaches history only when it carries a non-empty
+`rawInput`, `_meta.claudeCode.toolResponse`, or a parseable `_meta.lody.task` —
+`filterNotificationsForHistory` in `history.ts`. A new `_meta.lody.*` carrier that needs
+mid-flight persistence must therefore ride a `tool_call` or a terminal update, or add its
+own clause there; otherwise it is dropped before the applier and unit tests that fabricate
+history will not catch it.

--- a/apps/cli/src/lib/acp/history.test.ts
+++ b/apps/cli/src/lib/acp/history.test.ts
@@ -372,6 +372,380 @@ describe('handleACPUpdateMessage', () => {
     });
   });
 
+  // The bundled Claude adapter publishes task lifecycle through `_meta.lody.task` on a
+  // `tool_call` (task_started) and non-terminal `tool_call_update`s (task_progress /
+  // task_updated). The fixtures below transcribe that update shape verbatim: no `rawInput`
+  // and no `_meta.claudeCode`, because that absence is what used to drop them from history.
+  const lodyTaskMeta = (task: Record<string, unknown>) => ({
+    lody: { task: { version: 1, kind: 'subagent', ...task } },
+  });
+
+  it('persists the shipped _meta.lody.task progress snapshot so lastToolName reaches the panel', async () => {
+    const { doc, readHistory } = createDoc();
+
+    await handleACPUpdateMessage(
+      doc,
+      [
+        parseSessionNotification({
+          sessionId: 'acp-session',
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'task:task-1',
+            title: 'Explore: Find CLI startup behavior',
+            kind: 'think',
+            status: 'in_progress',
+            _meta: lodyTaskMeta({
+              taskId: 'task-1',
+              status: 'in_progress',
+              actor: 'Explore',
+              description: 'Find CLI startup behavior',
+            }),
+          },
+        }),
+        parseSessionNotification({
+          sessionId: 'acp-session',
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'task:task-1',
+            title: 'Explore: Find CLI startup behavior',
+            kind: 'think',
+            status: 'in_progress',
+            _meta: lodyTaskMeta({
+              taskId: 'task-1',
+              status: 'in_progress',
+              actor: 'Explore',
+              description: 'Find CLI startup behavior',
+              lastToolName: 'Read',
+              usage: { totalTokens: 100, toolUses: 2, durationMs: 500 },
+            }),
+          },
+        }),
+      ],
+      { getCurrentSessionTurnId: () => 'turn-1' }
+    );
+
+    const items = readHistory()[0]?.items as MessageContent[] | undefined;
+    const task = items?.find(
+      (item): item is Extract<MessageContent, { type: 'subagent_task' }> =>
+        item.type === 'subagent_task'
+    );
+    expect(task).toMatchObject({
+      taskId: 'task-1',
+      status: 'in_progress',
+      actor: 'Explore',
+      description: 'Find CLI startup behavior',
+      lastToolName: 'Read',
+      usage: { totalTokens: 100, toolUses: 2, durationMs: 500 },
+    });
+    // Lifecycle events never leak a raw tool call into history.
+    expect(items?.some((item) => item.type === 'tool_call')).toBe(false);
+  });
+
+  it('merges repeated _meta.lody.task progress into a single subagent_task item', async () => {
+    const { doc, readHistory } = createDoc();
+    // `task_progress.description` is required and activity-scoped — it changes on
+    // essentially every tick — so the fixture changes it too.
+    const progress = (lastToolName: string) =>
+      parseSessionNotification({
+        sessionId: 'acp-session',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: `task:task-2`,
+          title: `Explore: running ${lastToolName}`,
+          kind: 'think',
+          status: 'in_progress',
+          _meta: lodyTaskMeta({
+            taskId: 'task-2',
+            status: 'in_progress',
+            actor: 'Explore',
+            description: `running ${lastToolName}`,
+            lastToolName,
+          }),
+        },
+      });
+
+    await handleACPUpdateMessage(
+      doc,
+      [
+        parseSessionNotification({
+          sessionId: 'acp-session',
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'task:task-2',
+            title: 'Explore: Auditing history',
+            kind: 'think',
+            status: 'in_progress',
+            _meta: lodyTaskMeta({
+              taskId: 'task-2',
+              status: 'in_progress',
+              actor: 'Explore',
+              description: 'Auditing history',
+            }),
+          },
+        }),
+        ...['Read', 'Bash', 'Grep'].map(progress),
+        parseSessionNotification({
+          sessionId: 'acp-session',
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'task:task-2',
+            title: 'Explore: Auditing history',
+            kind: 'think',
+            status: 'completed',
+            _meta: lodyTaskMeta({
+              taskId: 'task-2',
+              status: 'completed',
+              actor: 'Explore',
+              summary: 'Audit done',
+            }),
+          },
+        }),
+      ],
+      { getCurrentSessionTurnId: () => 'turn-1' }
+    );
+
+    const items = readHistory()[0]?.items as MessageContent[] | undefined;
+    const tasks = items?.filter((item) => item.type === 'subagent_task') ?? [];
+    // Keeping every tick costs no extra item: the applier merges in place by taskId.
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      taskId: 'task-2',
+      status: 'completed',
+      summary: 'Audit done',
+      // a progress tick's activity description wins and survives the terminal event,
+      // matching the legacy-carrier expectation pinned above
+      description: 'running Grep',
+      // the last progress tick wins, and survives the terminal event that omits it
+      lastToolName: 'Grep',
+    });
+  });
+
+  it('keeps a real workflow run named through the shipped adapter stream', async () => {
+    const { doc, readHistory } = createDoc();
+    // The six `_meta.lody.task` notifications of one workflow run, transcribed from a
+    // capture of the bundled adapter driven over ACP (Claude Code 2.1.258, the pinned
+    // runtime). Only `task_started` carries an identity source, so every later event
+    // falls through to the producer's placeholder.
+    const shippedStream = [
+      { status: 'in_progress', sessionUpdate: 'tool_call', task: { actor: 'e2e-probe', description: 'verify task lifecycle reaches history', kind: 'background', status: 'in_progress' } },
+      { status: 'in_progress', sessionUpdate: 'tool_call_update', task: { actor: 'Claude task', description: 'Check: checker', kind: 'background', lastToolName: 'checker', status: 'in_progress', summary: 'verify task lifecycle reaches history', usage: { durationMs: 33, toolUses: 0, totalTokens: 0 } } },
+      { status: 'in_progress', sessionUpdate: 'tool_call_update', task: { actor: 'Claude task', description: 'Check: checker', kind: 'background', lastToolName: 'checker', status: 'in_progress', summary: 'verify task lifecycle reaches history', usage: { durationMs: 1714, toolUses: 0, totalTokens: 26781 } } },
+      { status: 'completed', sessionUpdate: 'tool_call_update', task: { actor: 'Claude task', kind: 'background', status: 'completed' } },
+      { status: 'completed', sessionUpdate: 'tool_call_update', task: { actor: 'Claude task', kind: 'background', status: 'completed', summary: 'Dynamic workflow "verify task lifecycle reaches history" completed', usage: { durationMs: 1738, toolUses: 0, totalTokens: 26781 } } },
+    ].map((n) =>
+      parseSessionNotification({
+        sessionId: 'acp-session',
+        update: {
+          sessionUpdate: n.sessionUpdate as 'tool_call' | 'tool_call_update',
+          toolCallId: 'task:w5ftatomx',
+          title: 'workflow',
+          kind: 'think',
+          status: n.status as 'in_progress' | 'completed',
+          _meta: lodyTaskMeta({
+            taskId: 'w5ftatomx',
+            parentToolCallId: 'toolu_01VGYjhBXHoAAc9a8dBx3Upu',
+            ...n.task,
+          }),
+        },
+      })
+    );
+
+    await handleACPUpdateMessage(doc, shippedStream, {
+      getCurrentSessionTurnId: () => 'turn-1',
+    });
+
+    const items = readHistory()[0]?.items as MessageContent[] | undefined;
+    const task = items?.find(
+      (item): item is Extract<MessageContent, { type: 'subagent_task' }> =>
+        item.type === 'subagent_task'
+    );
+    expect(task).toMatchObject({
+      taskId: 'w5ftatomx',
+      // the run keeps its own name; every event after the first says "Claude task"
+      actor: 'e2e-probe',
+      status: 'completed',
+      lastToolName: 'checker',
+      usage: { totalTokens: 26781 },
+    });
+    expect(task?.actor).not.toBe('Claude task');
+  });
+
+  it('ignores a non-terminal tick that lands after the task settled', async () => {
+    const { doc, readHistory } = createDoc();
+    const settledThenLateTick = [
+      parseSessionNotification({
+        sessionId: 'acp-session',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'task:task-6',
+          title: 'Explore: done',
+          kind: 'think',
+          status: 'completed',
+          _meta: lodyTaskMeta({
+            taskId: 'task-6',
+            status: 'completed',
+            kind: 'subagent',
+            actor: 'Explore',
+            summary: 'Explored',
+          }),
+        },
+      }),
+      // A tick whose registry entry the producer has already pruned re-derives
+      // `kind: 'background'`, which would badge a finished subagent Background.
+      parseSessionNotification({
+        sessionId: 'acp-session',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'task:task-6',
+          title: 'Claude task: running Grep',
+          kind: 'think',
+          status: 'in_progress',
+          _meta: lodyTaskMeta({
+            taskId: 'task-6',
+            status: 'in_progress',
+            kind: 'background',
+            actor: 'Claude task',
+            description: 'running Grep',
+            lastToolName: 'Grep',
+          }),
+        },
+      }),
+    ];
+
+    await handleACPUpdateMessage(doc, settledThenLateTick, {
+      getCurrentSessionTurnId: () => 'turn-1',
+    });
+
+    const items = readHistory()[0]?.items as MessageContent[] | undefined;
+    const task = items?.find(
+      (item): item is Extract<MessageContent, { type: 'subagent_task' }> =>
+        item.type === 'subagent_task'
+    );
+    expect(task).toMatchObject({
+      taskId: 'task-6',
+      status: 'completed',
+      summary: 'Explored',
+      actor: 'Explore',
+      taskKind: 'subagent',
+    });
+    expect(task?.isBackgrounded).not.toBe(true);
+    expect(task?.lastToolName).toBeUndefined();
+  });
+
+  it('does not let a late progress tick resurrect a settled subagent_task', async () => {
+    const { doc, readHistory } = createDoc();
+    const tick = (status: 'in_progress' | 'completed', extra: Record<string, unknown>) =>
+      parseSessionNotification({
+        sessionId: 'acp-session',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'task:task-5',
+          title: 'Explore: late tick',
+          kind: 'think',
+          status,
+          _meta: lodyTaskMeta({ taskId: 'task-5', status, actor: 'Explore', ...extra }),
+        },
+      });
+
+    await handleACPUpdateMessage(
+      doc,
+      [
+        tick('completed', { summary: 'All done' }),
+        // `claudeTaskStatus` reports `in_progress` for every task_progress, so a tick
+        // that lands after the terminal event would restart a finished spinner.
+        tick('in_progress', { description: 'running Grep', lastToolName: 'Grep' }),
+      ],
+      { getCurrentSessionTurnId: () => 'turn-1' }
+    );
+
+    const items = readHistory()[0]?.items as MessageContent[] | undefined;
+    const tasks = items?.filter((item) => item.type === 'subagent_task') ?? [];
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({ taskId: 'task-5', status: 'completed', summary: 'All done' });
+  });
+
+  it('persists a backgrounding task_updated without letting it rename the task', async () => {
+    const { doc, readHistory } = createDoc();
+
+    await handleACPUpdateMessage(
+      doc,
+      [
+        parseSessionNotification({
+          sessionId: 'acp-session',
+          update: {
+            sessionUpdate: 'tool_call',
+            toolCallId: 'task:task-3',
+            title: 'Explore: Initial prompt',
+            kind: 'think',
+            status: 'in_progress',
+            _meta: lodyTaskMeta({
+              taskId: 'task-3',
+              status: 'in_progress',
+              actor: 'Explore',
+              description: 'Initial prompt',
+            }),
+          },
+        }),
+        // A real `task_updated` carries only `{task_id, patch}`. A backgrounding patch is
+        // the one that changes something observable — the producer's actor chain still
+        // has no input and falls through to its placeholder.
+        parseSessionNotification({
+          sessionId: 'acp-session',
+          update: {
+            sessionUpdate: 'tool_call_update',
+            toolCallId: 'task:task-3',
+            title: 'Claude task',
+            kind: 'think',
+            status: 'in_progress',
+            _meta: lodyTaskMeta({
+              taskId: 'task-3',
+              status: 'in_progress',
+              kind: 'background',
+              actor: 'Claude task',
+            }),
+          },
+        }),
+      ],
+      { getCurrentSessionTurnId: () => 'turn-1' }
+    );
+
+    const items = readHistory()[0]?.items as MessageContent[] | undefined;
+    const task = items?.find(
+      (item): item is Extract<MessageContent, { type: 'subagent_task' }> =>
+        item.type === 'subagent_task'
+    );
+    // the backgrounding reaches history, and the earlier identity survives it
+    expect(task).toMatchObject({
+      taskId: 'task-3',
+      status: 'in_progress',
+      taskKind: 'background',
+      isBackgrounded: true,
+      actor: 'Explore',
+    });
+  });
+
+  it('keeps dropping an in-progress tool_call_update whose _meta carries no task snapshot', async () => {
+    const { doc, readHistory } = createDoc();
+
+    await handleACPUpdateMessage(
+      doc,
+      parseSessionNotification({
+        sessionId: 'acp-session',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'shell-9',
+          kind: 'execute',
+          status: 'in_progress',
+          rawOutput: { aggregated_output: 'x'.repeat(4096) },
+          _meta: { lody: { activity: 'running' } },
+        },
+      }),
+      { getCurrentSessionTurnId: () => 'turn-1' }
+    );
+
+    expect(readHistory()).toEqual([]);
+  });
+
   it('creates the explicit target assistant entry instead of appending to another open entry', async () => {
     const { doc, readHistory } = createDoc([
       {

--- a/apps/cli/src/lib/acp/history.ts
+++ b/apps/cli/src/lib/acp/history.ts
@@ -8,6 +8,7 @@ import type {
 } from '@lody/shared';
 import {
   getServerNow,
+  parseLodyTaskMeta,
   sanitizeGoalObjective,
   truncateTerminalOutputForHistory,
 } from '@lody/shared';
@@ -834,8 +835,9 @@ const filterNotificationsForHistory = (
     }
     if (update.sessionUpdate !== 'tool_call_update') return true;
     // Tool call updates are often "full snapshots" (especially terminal output). Persisting all
-    // intermediate snapshots causes the CRDT history to blow up. We keep only terminal state
-    // transitions that represent a finished tool call.
+    // intermediate snapshots causes the CRDT history to blow up. We keep terminal state
+    // transitions, plus the non-terminal updates the applier extracts something durable
+    // from — the clauses below.
     if (update.status === 'completed' || update.status === 'failed') return true;
 
     // Claude Code sends rawInput in a tool_call_update (~14% of Bash calls, ~50% of Read/Grep,
@@ -857,6 +859,13 @@ const filterNotificationsForHistory = (
         }
       }
     }
+
+    // `lastToolName` rides only on task progress, so dropping non-terminal task snapshots
+    // left the panel unable to show the running tool. Reusing the applier's own parser
+    // makes the predicate exact — kept iff it will materialize a `subagent_task` item —
+    // and the cost stays bounded because `upsertSubagentTask` merges by `taskId` into one
+    // item, so a kept tick is a few small `LoroMap.set` ops rather than a new snapshot.
+    if (parseLodyTaskMeta(meta) !== null) return true;
 
     return false;
   };

--- a/packages/shared/src/acp/history-apply.ts
+++ b/packages/shared/src/acp/history-apply.ts
@@ -1740,7 +1740,29 @@ class NotificationOnHistoryApplier {
     if (idx >= 0) {
       const prev = items[idx] as Extract<MessageContent, { type: 'subagent_task' }>;
       // Later events win per field, earlier-only fields (subagentType/description) survive.
-      items[idx] = { ...mergeSubagentTaskPayload(prev, incoming), type: 'subagent_task' };
+      //
+      // A settled row ignores non-terminal snapshots entirely. `task_progress` reports
+      // `in_progress` and re-derives `taskKind`/`isBackgrounded` from state the producer
+      // has already pruned, so a tick landing after the terminal event would restart a
+      // finished spinner and badge it Background. Non-terminal snapshots only began
+      // reaching this merge when the history filter started keeping them.
+      const settled = prev.status === 'completed' || prev.status === 'failed';
+      const nonTerminal = incoming.status !== 'completed' && incoming.status !== 'failed';
+      if (settled && nonTerminal) return;
+
+      // `actor` is the task's identity, derived from `subagent_type` / `workflow_name` /
+      // `task_type`. `workflow_name` and `task_type` ride only `task_started`, and
+      // `subagent_type` reaches no event but `task_started` and `task_progress` — so
+      // every other event falls through to the producer's placeholder, and for a
+      // workflow every event after the first does. Because it is materialized
+      // unconditionally it is never absent, so the absence-based preservation this merge
+      // documents cannot protect it. This predates the filter change: the terminal event
+      // carries none of the three either, so it already clobbered a settled row.
+      items[idx] = {
+        ...mergeSubagentTaskPayload(prev, incoming),
+        ...(prev.actor !== undefined ? { actor: prev.actor } : {}),
+        type: 'subagent_task',
+      };
       this.changed = true;
       return;
     }

--- a/packages/shared/tests/acp-history-apply.test.ts
+++ b/packages/shared/tests/acp-history-apply.test.ts
@@ -89,6 +89,74 @@ const ACP_NOTIFICATION_FIXTURES = [
 ] as const;
 
 describe('acp history apply', () => {
+  const taskUpdate = (
+    sessionUpdate: 'tool_call' | 'tool_call_update',
+    status: 'in_progress' | 'completed',
+    task: Record<string, unknown>
+  ) =>
+    makeNotification({
+      sessionUpdate,
+      toolCallId: 'task:t1',
+      title: 'task',
+      kind: 'think',
+      status,
+      _meta: { lody: { task: { version: 1, taskId: 't1', status, ...task } } },
+    });
+
+  it('keeps the task identity a later event cannot re-derive', () => {
+    // Only the first event carries an identity source; every later one falls through to
+    // the producer's placeholder, so later-wins would rename the task.
+    const history = applyNotificationOnHistory(
+      [],
+      [
+        taskUpdate('tool_call', 'in_progress', { kind: 'background', actor: 'my-workflow' }),
+        taskUpdate('tool_call_update', 'in_progress', {
+          kind: 'background',
+          actor: 'Claude task',
+          lastToolName: 'checker',
+        }),
+        taskUpdate('tool_call_update', 'completed', {
+          kind: 'background',
+          actor: 'Claude task',
+          summary: 'done',
+        }),
+      ]
+    );
+    const task = history[0]?.items?.find((i) => i.type === 'subagent_task');
+    expect(task).toMatchObject({
+      taskId: 't1',
+      status: 'completed',
+      actor: 'my-workflow',
+      summary: 'done',
+      lastToolName: 'checker',
+    });
+  });
+
+  it('ignores a non-terminal snapshot that arrives after the task settled', () => {
+    const history = applyNotificationOnHistory(
+      [],
+      [
+        taskUpdate('tool_call', 'in_progress', { kind: 'subagent', actor: 'Explore' }),
+        taskUpdate('tool_call_update', 'completed', { kind: 'subagent', actor: 'Explore', summary: 'done' }),
+        // a late tick reports in_progress and re-derives kind from a pruned registry
+        taskUpdate('tool_call_update', 'in_progress', {
+          kind: 'background',
+          actor: 'Claude task',
+          lastToolName: 'Grep',
+        }),
+      ]
+    );
+    const task = history[0]?.items?.find((i) => i.type === 'subagent_task');
+    expect(task).toMatchObject({
+      taskId: 't1',
+      status: 'completed',
+      summary: 'done',
+      taskKind: 'subagent',
+    });
+    expect((task as { isBackgrounded?: boolean } | undefined)?.isBackgrounded).not.toBe(true);
+    expect((task as { lastToolName?: string } | undefined)?.lastToolName).toBeUndefined();
+  });
+
   it('persists the provider turn id on the assistant entry', () => {
     const history = applyNotificationOnHistory(
       [],


### PR DESCRIPTION
## Related issue

Closes #445

## Problem / pressure

The subagent task panel's "Running {{tool}}" line can never appear, for any provider.

`last_tool_name` reaches Lody on exactly one message — the SDK declares it on `SDKTaskProgressMessage` and nowhere else. The bundled adapter emits that as an `in_progress` `tool_call_update` whose only payload is `_meta.lody.task`, with no `rawInput` key at all (`packages/acp-extension-claude/src/acp-agent.ts:242-245`, `:300-309`; its own test pins the shape at `src/tests/acp-agent.test.ts:8727`). `filterNotificationsForHistory` keeps a `tool_call_update` only when terminal (`:839`), when it carries a non-empty `rawInput` (`:844-847`), or when it carries `_meta.claudeCode.toolResponse` (`:851-859`) — line numbers at the base commit f90842d6, since this section describes the pre-fix state — so every non-terminal task snapshot was dropped before `applyNotificationOnHistory`. The panel reads only persisted history (`view.tsx:807`, `:3381`; no client-side applier exists), so the field never arrived.

The same drop also lost non-terminal `task_updated` snapshots, so mid-flight status and in-progress `usage` never landed either.

This survived because the only existing coverage (`history.test.ts:233`) exercises the legacy `rawInput.lodyClaudeTaskLifecycle` carrier, which passes the non-empty-`rawInput` branch. The shipped `_meta.lody.task` carrier had no history coverage.

## Summary

One guard at the shared predicate, immediately before the final `return false`:

```
if (parseLodyTaskMeta(meta) !== null) return true;
```

Reusing the applier's own parser — the exact function `history-apply.ts:1106` calls — makes the predicate "kept iff it will materialize a `subagent_task` item". A malformed or future-shaped carrier is still dropped, and no update is kept that produces nothing.

Non-terminal snapshots therefore reach `upsertSubagentTask`, so a settled row now ignores them outright — one early return rather than pinning fields one by one. `task_progress` reports `in_progress` and re-derives `taskKind`/`isBackgrounded` from a registry the producer has already pruned, so a late tick would restart a finished spinner and badge a completed subagent Background.

`actor` needs a separate guard, and that hazard predates this change. It is derived from `subagent_type` / `workflow_name` / `task_type` — which the producer reliably sees only on `task_started`; every other event falls through to a `"Claude task"` placeholder. Being materialized unconditionally it is never absent, so the merge's absence-based preservation cannot protect it, and the terminal event already replaced a workflow's own name with the placeholder. Keeping the first value repairs that and stops non-terminal ticks doing the same mid-run. Every other field still lets the later event win; the pre-existing legacy-carrier test pins that a progress tick's `description` reaches the settled row.

The gate is recorded in `apps/cli/src/lib/acp/AGENTS.md`, since a new `_meta.lody.*` carrier needing mid-flight persistence has to know it must ride a `tool_call` or a terminal update.

The filter's blow-up warning does not transfer to this carrier, and the code comment says why rather than restating the code. The concern is per-tick payload **bytes** in the oplog, not item count — `upsertToolCall` merges in place too. What differs is the payload: a task snapshot is a handful of small scalars, so a kept tick is a few `LoroMap.set` ops on the single `subagent_task` item `upsertSubagentTask` keeps per `taskId`, not the repeated full-string replacement a terminal-output snapshot costs.

### Before / after

| Carrier | Before | After |
| --- | --- | --- |
| `task_started` → `tool_call` | persisted | persisted (unchanged) |
| `task_progress` → in-progress `tool_call_update` with `_meta.lody.task` | dropped | persisted, merged into the same item |
| non-terminal `task_updated` with `_meta.lody.task` | dropped | persisted, merged |
| terminal `task_notification` | persisted | persisted (unchanged) |
| in-progress `tool_call_update` with no task snapshot | dropped | dropped (unchanged) |
| a workflow's persisted `actor` once settled | `"Claude task"` (the terminal event clobbered it) | its own name |
| a progress tick arriving after the terminal event | dropped | ignored — no status, badge or tool-name churn on a settled row. **Defensive: no producer is known to emit this ordering.** It is guarded because the filter change is what would let one through |
| a mid-run row with no `lastToolName` | `Working…` | the task's `summary`, which every real `task_progress` carries and which now reaches history (`subagent-task-panel.tsx:93`) |
| any settled task's description column | the task's purpose, e.g. `verify task lifecycle reaches history` | the last progress tick's activity, e.g. `Check: checker`. `description` is required on every `task_progress`, so this is not workflow-only: a subagent row settles on its last activity string too. The terminal event carries no `description` to restore the purpose |

## Test plan

Ran on Linux, Node 22, at f90842d6 plus this commit.

- `pnpm --filter lody run test src/lib/acp/history.test.ts` — 29 passed (seven added; the file's other tests are untouched).
- Red-before/green-after demonstrated, not asserted: `git stash push -- apps/cli/src/lib/acp/history.ts` leaves only the tests in the tree; the suite then reports **4 failed / 25 passed**. Restoring them returns 29/29.
- One added test is a negative control that passes in **both** states ("keeps dropping an in-progress tool_call_update whose `_meta` carries no task snapshot"), so the guard is shown not to have widened past its intent.
- The identity regression is pinned against the SHIPPED lane: the five `_meta.lody.task` notifications of one workflow run, transcribed verbatim from a capture of the bundled adapter driven over ACP (Claude Code 2.1.258, the pinned runtime — its `system/init` confirms the version). Only the first carries an identity source; every later one says `"Claude task"`. Reverting the merge guard turns it red.
- `packages/shared/tests/acp-history-apply.test.ts` gains two tests so the applier change is covered in its own package; both fail against the base applier.
- `pnpm --filter @lody/shared run test` — 1030 passed.
- `pnpm --filter lody run test` — full package: **2503 passed, 1 skipped, 0 failed**.
- `pnpm --filter lody run typecheck` — clean.
- `pnpm lint` — 0 errors (9822 pre-existing warnings, unchanged by this diff).
- `pnpm check:public-boundary` — passed, 4207 files / 22 manifests.

Not run, and why: no desktop-UI verification. `loro-data-plane-relay.test.mjs` is the only electron-runtime test and cannot run in this checkout (the electron binary was never downloaded), and the recursive `pnpm check` chain stops earlier on an unrelated submodule build, so packages were checked individually. The defect and the fix were established at the code and unit level; the panel-rendering half is inferred from `subagent-task-panel.tsx:88-91` reading `task.lastToolName`, not observed in a running app.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `upsertSubagentTask` in `packages/shared/src/acp/history-apply.ts`. Two rules sit there: a settled row drops non-terminal snapshots wholesale, and `actor` is pinned on every event. Judge whether they belong at the call site or in the merge.
- **Decisions to challenge:** `description` was left later-wins. The argument for pinning `actor` applies to it verbatim; the only evidence the other way is `history.test.ts:233`, a maintainer-written test on a carrier with no producer in the tree. It was followed as the sole expressed intent rather than overridden — overrule it if that reading is wrong.
- **Plausible failures / evidence gaps:** the settled-row guard is defensive — no producer is known to emit a non-terminal snapshot after a terminal one. A completed subagent can still be badged Background by a route this PR does not touch: the adapter prunes its registry on the terminal `task_updated`, so the following `task_notification` re-derives `kind: 'background'`. No running-app check; the panel half is inferred from source.

### Authoring context

- **User goal / directives:** fix the task panel's missing running-tool line at its root cause, in the public tree, with a change the author would be willing to defend in review.
- **Constraints / non-goals:** no submodule edits (all `packages/acp-extension-*` are submodules); no change to `LodyTaskKind`, `LodyTaskStatus`, or any `acp-extension-core` contract; no widening of `LodyTaskMetaSchema` — an earlier attempt at that was dropped after review showed the lane it fixed has no shipped producer.
- **Risk-bearing decisions:** more notifications now persist into session history. Bounded by the in-place upsert at `history-apply.ts:1737-1749`, which keeps one `subagent_task` item per `taskId`; the per-tick cost is a few small `LoroMap.set` ops.
- **Destructive or irreversible behavior:** none — no migration, no rewrite of existing history, no deletion. Sessions recorded before this change simply keep the fields they already have.
- **Deliberately not done or tested:** the desktop UI was not launched; `packages/components` was not modified, so the panel is exercised only through the shape of the stored item. The sibling legacy lane (`apps/cli/src/agent/claude-task-lifecycle.ts`) was not edited, but its non-terminal ticks now persist too, through the same guards. A pre-existing clobber of `actor` at the terminal event is repaired by the same guard rather than left half-fixed.
- **Unknowns / confidence:** high confidence in the drop and the fix (each hop read on the shipped path, plus red-before/green-after). Lower confidence that the rendered line is the only user-visible improvement — mid-flight `usage` and status now persist too, and those surfaces were not inspected.

<!-- context-handoff:end -->


