### PR TITLE
fix(components): bound meta reconnect recovery

### DIFF
--- a/packages/components/src/providers/AGENTS.md
+++ b/packages/components/src/providers/AGENTS.md
@@ -48,6 +48,10 @@ again. Contract test: `packages/shared/tests/session-doc-forward-compat.test.ts`
 - Cloud Electron waits for the first **Run local agent** setting snapshot before creating
   its workspace runtime. Enabled uses dual sync; disabled uses cloud-only sync and must
   not attach the local data plane or surface its reconnect state.
+- Meta-room attachment is single-flight per runtime. Token, network, and visibility edges may
+  force one immediate recovery attempt, but they must preserve the current outage's retry history;
+  only a sustained healthy dwell resets backoff. Every attempt after the first is a `recovery`
+  phase, including one prompted by a rotated token.
 - Workspace-level rooms without a machine owner use the platform fallback. Task rooms and
   the Task Index depend on this behavior; returning no transport silently disables task
   synchronization.

--- a/packages/components/src/providers/create-workspace-runtime.ts
+++ b/packages/components/src/providers/create-workspace-runtime.ts
@@ -466,6 +466,7 @@ export async function createWorkspaceRuntime(deps: RuntimeDeps): Promise<Workspa
   let machineRpcStreamsClientReady: Promise<LoroStreamsJsonStreamClient> | null = null;
   let transportStreamsBaseUrl: string | null = null;
   let detachMetaRoomStatusListener: (() => void) | null = null;
+  let metaRoomJoinPromise: Promise<void> | null = null;
   // Meta room health tracker, registered in roomSyncRegistry like every other
   // room (durable sessions, presence). Recreated fresh on each
   // ensureMetaRoomSynced cycle so stale first-sync/status state from a
@@ -2955,7 +2956,7 @@ export async function createWorkspaceRuntime(deps: RuntimeDeps): Promise<Workspa
     streamsTokenProvider = null;
   };
 
-  const ensureMetaRoomSynced = async (syncPhase: 'initial' | 'recovery' = 'initial') => {
+  const joinAndWatchMetaRoom = async (syncPhase: 'initial' | 'recovery') => {
     if (metaSub) {
       return;
     }
@@ -3161,8 +3162,28 @@ export async function createWorkspaceRuntime(deps: RuntimeDeps): Promise<Workspa
     void watchMetaFirstSync(
       'Failed to sync repo meta room',
       'Timed out waiting for repo meta room initial sync',
-      'initial'
+      syncPhase
     );
+  };
+
+  const ensureMetaRoomSynced = async (syncPhase: 'initial' | 'recovery' = 'initial') => {
+    if (metaSub) {
+      return;
+    }
+    if (metaRoomJoinPromise) {
+      await metaRoomJoinPromise;
+      return;
+    }
+
+    const pendingJoin = joinAndWatchMetaRoom(syncPhase);
+    metaRoomJoinPromise = pendingJoin;
+    try {
+      await pendingJoin;
+    } finally {
+      if (metaRoomJoinPromise === pendingJoin) {
+        metaRoomJoinPromise = null;
+      }
+    }
   };
 
   const restartDurableTransportForMetaSyncRecovery = async (reason: string): Promise<void> => {
@@ -3264,13 +3285,11 @@ export async function createWorkspaceRuntime(deps: RuntimeDeps): Promise<Workspa
           initialMetaSyncFailed,
         }
       );
-      if (!metaSub) {
-        await ensureMetaRoomSynced();
-      }
       notifyConnectionStateInputsChanged();
       // A fresh token is a hard reconnect signal: connections that died on 401
       // while the old token was stale (e.g. wake after a long sleep) can only
-      // recover now. trigger() resets the retry backoff and reconciles.
+      // recover now. The forced run is immediate but remains part of the same
+      // recovery episode, so repeated rotations cannot erase its backoff.
       localReconnectLoop?.trigger('token-refresh');
       return;
     }
@@ -3410,6 +3429,12 @@ export async function createWorkspaceRuntime(deps: RuntimeDeps): Promise<Workspa
               ? { transportIds: ['local'], resetBackoff: true }
               : { resetBackoff: true }
           );
+          // A failed repo-level meta attach leaves no subscription for
+          // repo.reconnect() to revive. Rejoin it through the same recovery
+          // episode instead of letting auth refresh start a new initial sync.
+          if (!metaSub && !disposePromise) {
+            await ensureMetaRoomSynced('recovery');
+          }
         }
       }
       if (

--- a/packages/components/src/providers/local-reconnect-loop.ts
+++ b/packages/components/src/providers/local-reconnect-loop.ts
@@ -238,9 +238,7 @@ export function createLocalReconnectLoop(options: LocalReconnectLoopOptions): Lo
     inFlight = true;
     options.onStateChange();
     try {
-      await options.reconnect(
-        triggerReason === undefined ? { force } : { force, triggerReason }
-      );
+      await options.reconnect(triggerReason === undefined ? { force } : { force, triggerReason });
     } catch (error) {
       options.onError?.(error);
     } finally {
@@ -259,7 +257,6 @@ export function createLocalReconnectLoop(options: LocalReconnectLoopOptions): Lo
         scheduleBackoffResetWait();
       }
       if (pendingForcedRun) {
-        retryAttempt = 0;
         void run(true);
       } else {
         update();
@@ -275,7 +272,10 @@ export function createLocalReconnectLoop(options: LocalReconnectLoopOptions): Lo
       recordPendingTrigger(reason);
       cancelPendingWait();
       cancelBackoffResetWait();
-      retryAttempt = 0;
+      // A forced edge gets an immediate attempt, but it is still part of the
+      // current outage. Only a sustained healthy dwell may forgive the retry
+      // history; otherwise repeated token/online/visibility signals can pin a
+      // broken connection to the first backoff step forever.
       void run(true);
     },
     stop: () => {

--- a/packages/components/tests/create-workspace-runtime-meta-recovery.test.ts
+++ b/packages/components/tests/create-workspace-runtime-meta-recovery.test.ts
@@ -411,6 +411,128 @@ describe('createWorkspaceRuntime meta recovery lifecycle', () => {
     await runtime.dispose();
   });
 
+  it('keeps repeated token rotations inside one backoff-controlled meta recovery episode', async () => {
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0.5);
+    const analyticsEvents: Array<{
+      name: string;
+      properties?: Record<string, unknown>;
+    }> = [];
+    mocks.joinMetaRoom.mockRejectedValue(new Error('transport connection failed'));
+
+    const runtime = await createWorkspaceRuntime({
+      workspaceSlug: 'workspace',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      apiBaseUrl: 'https://api.example.test',
+      onAnalyticsEvent: (event) => analyticsEvents.push(event),
+    });
+
+    // Reproduce the field incident without manufacturing an 800ms token loop:
+    // seven genuinely different auth tokens arrive over roughly two minutes
+    // while every meta-room join fails immediately with a transport error.
+    // A token may prompt one immediate recovery, but it must not turn the same
+    // outage back into a fresh initial-sync episode or forgive accumulated
+    // retry history.
+    for (let index = 0; index < 7; index += 1) {
+      await runtime.setAuthToken(`auth-token-${index}`);
+      await flushPromises();
+      if (index < 6) {
+        await vi.advanceTimersByTimeAsync(17_000);
+      }
+    }
+    await vi.advanceTimersByTimeAsync(18_000);
+    await flushPromises();
+
+    await runtime.dispose();
+    random.mockRestore();
+
+    const metaSyncFailures = analyticsEvents.filter(
+      (event) => event.name === 'workspace/meta_sync_failed'
+    );
+    const initialFailures = metaSyncFailures.filter(
+      (event) => event.properties?.phase === 'initial'
+    );
+
+    // One outage has one initial attempt. Everything after it is recovery,
+    // including retries prompted by a newly issued credential.
+    expect.soft(initialFailures).toHaveLength(1);
+    // With a 30s capped exponential backoff, seven external credential edges
+    // plus scheduled recovery cannot legitimately produce hundreds of joins
+    // in this two-minute window. Keep this assertion generous enough for
+    // jitter and boundary-aligned timers while still catching a reset storm.
+    expect(metaSyncFailures.length).toBeLessThanOrEqual(20);
+  });
+
+  it('shares an in-flight meta join across overlapping token rotations', async () => {
+    let resolveMetaJoin!: (sub: FakeMetaSub) => void;
+    const pendingMetaJoin = new Promise<FakeMetaSub>((resolve) => {
+      resolveMetaJoin = resolve;
+    });
+    mocks.joinMetaRoom.mockReturnValue(pendingMetaJoin);
+
+    const runtime = await createWorkspaceRuntime({
+      workspaceSlug: 'workspace',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      apiBaseUrl: 'https://api.example.test',
+    });
+
+    const initialAttach = runtime.setAuthToken('auth-token-1');
+    await flushPromises();
+    expect(mocks.joinMetaRoom).toHaveBeenCalledTimes(1);
+
+    const overlappingRotation = runtime.setAuthToken('auth-token-2');
+    await flushPromises();
+    expect(mocks.joinMetaRoom).toHaveBeenCalledTimes(1);
+
+    resolveMetaJoin(createMetaSub(Promise.resolve()));
+    await Promise.all([initialAttach, overlappingRotation]);
+    await flushPromises();
+
+    expect(mocks.joinMetaRoom).toHaveBeenCalledTimes(1);
+    await runtime.dispose();
+  });
+
+  it('reports first-sync failures after a rejoin as recovery', async () => {
+    let rejectInitialSync!: (error: Error) => void;
+    let rejectRecoverySync!: (error: Error) => void;
+    const initialSync = new Promise<void>((_resolve, reject) => {
+      rejectInitialSync = reject;
+    });
+    const recoverySync = new Promise<void>((_resolve, reject) => {
+      rejectRecoverySync = reject;
+    });
+    const analyticsEvents: Array<{
+      name: string;
+      properties?: Record<string, unknown>;
+    }> = [];
+    mocks.joinMetaRoom
+      .mockResolvedValueOnce(createMetaSub(initialSync))
+      .mockResolvedValueOnce(createMetaSub(recoverySync));
+
+    const runtime = await createWorkspaceRuntime({
+      workspaceSlug: 'workspace',
+      workspaceId: 'workspace-1' as WorkspaceId,
+      apiBaseUrl: 'https://api.example.test',
+      token: 'auth-token',
+      onAnalyticsEvent: (event) => analyticsEvents.push(event),
+    });
+
+    rejectInitialSync(new Error('initial transport failure'));
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(0);
+    await flushPromises();
+    expect(mocks.joinMetaRoom).toHaveBeenCalledTimes(2);
+
+    rejectRecoverySync(new Error('recovery transport failure'));
+    await flushPromises();
+
+    const failurePhases = analyticsEvents
+      .filter((event) => event.name === 'workspace/meta_sync_failed')
+      .map((event) => event.properties?.phase);
+    expect(failurePhases).toEqual(['initial', 'recovery']);
+
+    await runtime.dispose();
+  });
+
   it('delays ACP capability refresh until meta and presence stay synced', async () => {
     mocks.joinMetaRoom.mockResolvedValueOnce(createMetaSub(Promise.resolve()));
 

--- a/packages/components/tests/local-reconnect-loop.test.ts
+++ b/packages/components/tests/local-reconnect-loop.test.ts
@@ -86,10 +86,7 @@ describe('createLocalReconnectLoop', () => {
           loop.update();
           yield* TestClock.adjust(Duration.millis(0));
           yield* flushMicrotasks;
-          expect(calls).toEqual([
-            { force: true },
-            { force: false },
-          ]);
+          expect(calls).toEqual([{ force: true }, { force: false }]);
         }),
       {
         onReconnect: ({ force }, harness) => {
@@ -107,6 +104,31 @@ describe('createLocalReconnectLoop', () => {
         loop.trigger('visibility-wake');
         yield* flushMicrotasks;
         expect(calls).toEqual([{ force: true, triggerReason: 'visibility-wake' }]);
+      })
+    );
+  });
+
+  it('does not forgive retry history when an external trigger forces an immediate attempt', async () => {
+    await withTestLoop(({ loop, calls, setHasProblem }) =>
+      Effect.gen(function* () {
+        setHasProblem(true);
+        loop.update();
+        yield* TestClock.adjust(Duration.millis(0));
+        yield* flushMicrotasks;
+        expect(calls).toHaveLength(1);
+
+        // A fresh credential deserves an immediate attempt, but the outage is
+        // still the same one. After that forced attempt, retry 3 must retain
+        // the accumulated 2s delay instead of restarting at 1s.
+        loop.trigger('token-refresh');
+        yield* flushMicrotasks;
+        expect(calls).toHaveLength(2);
+        yield* TestClock.adjust(Duration.millis(1_999));
+        yield* flushMicrotasks;
+        expect(calls).toHaveLength(2);
+        yield* TestClock.adjust(Duration.millis(1));
+        yield* flushMicrotasks;
+        expect(calls).toHaveLength(3);
       })
     );
   });


### PR DESCRIPTION
## Summary

- preserve reconnect backoff history when token, network, or visibility signals force an immediate retry
- serialize meta-room joins and route token rotation through the existing recovery loop
- classify first-sync failures after the initial attempt as `recovery`

## Failure mode

A persistent meta transport error could repeatedly rebuild the meta subscription. External auth-ready signals reset the outer retry attempt, while overlapping callers could start additional joins. This kept the outage near the first retry interval and emitted a new `workspace/meta_sync_failed` event for each cycle.

The incident regression test drives seven distinct token rotations across two minutes while every meta join fails. Before the fix it produced seven `initial` failures and 42 total failures; after the fix the outage has one initial attempt and remains bounded by the accumulated backoff.

## Validation

- `pnpm --filter @lody/components exec vitest run tests/local-reconnect-loop.test.ts tests/create-workspace-runtime-meta-recovery.test.ts` (22 tests passed)
- `pnpm --filter @lody/components typecheck`
- `pnpm exec prettier --check packages/components/src/providers/local-reconnect-loop.ts packages/components/src/providers/create-workspace-runtime.ts packages/components/tests/local-reconnect-loop.test.ts packages/components/tests/create-workspace-runtime-meta-recovery.test.ts packages/components/src/providers/AGENTS.md`

## Review focus

- forced reconnects remain immediate but do not forgive the current outage retry history
- missing meta subscriptions rejoin through the single-flight recovery path
- telemetry distinguishes the one initial attempt from later recovery attempts