### PR TITLE
fix: detect available launchers in settings

### DIFF
--- a/packages/components/src/components/settings/path-launchers-setting.tsx
+++ b/packages/components/src/components/settings/path-launchers-setting.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
 import { usePostHog } from '@posthog/react';
@@ -24,6 +24,7 @@ import {
 } from '@/ui/select';
 import { getPathLauncherIcon } from '@/components/icons/path-launcher-icon';
 import { capturePostHogEvent } from '@/lib/posthog-analytics';
+import { getIpcServices } from '@/lib/electron-ipc-client';
 import { cn } from '@/lib/utils';
 import { useIsMobile } from '@/hooks/use-mobile';
 import {
@@ -36,6 +37,7 @@ import {
 } from '@/ui/sheet';
 import {
   createCustomPathLauncherId,
+  buildPathLauncherProbes,
   DEFAULT_PATH_LAUNCHER_PREFERENCE,
   getAvailablePathLauncherOptions,
   getCustomPathLauncherOptionId,
@@ -83,7 +85,7 @@ export function PathLaunchersSettings({
   const [selectOpen, setSelectOpen] = useState(false);
   const [draft, setDraft] = useState<PathLauncherDraft | null>(null);
 
-  const pathLauncherOptions = useMemo(
+  const launcherCandidates = useMemo(
     () =>
       getAvailablePathLauncherOptions({
         customLaunchers: preference.customLaunchers,
@@ -92,11 +94,57 @@ export function PathLaunchersSettings({
       }),
     [isElectron, platform, preference.customLaunchers]
   );
+  const [availableLaunchers, setAvailableLaunchers] = useState<{
+    candidates: typeof launcherCandidates;
+    ids: Set<string>;
+  } | null>(null);
+  useEffect(() => {
+    if (!isElectron) return;
+    const services = getIpcServices();
+    if (!services) return;
+
+    let cancelled = false;
+    const launchers = buildPathLauncherProbes(
+      launcherCandidates.filter((launcher) => launcher.kind !== 'custom'),
+      PREVIEW_SAMPLE_PATH,
+      platform
+    );
+    void services.app.probePathLaunchers({ launchers }).then(
+      (result) => {
+        if (!cancelled) {
+          setAvailableLaunchers({
+            candidates: launcherCandidates,
+            ids: new Set(result.availableIds),
+          });
+        }
+      },
+      () => {
+        if (!cancelled) {
+          setAvailableLaunchers({ candidates: launcherCandidates, ids: new Set() });
+        }
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [isElectron, platform, launcherCandidates, selectOpen]);
+  const pathLauncherOptions = useMemo(
+    () =>
+      launcherCandidates.filter(
+        (launcher) =>
+          !isElectron ||
+          launcher.kind === 'custom' ||
+          (availableLaunchers?.candidates === launcherCandidates &&
+            availableLaunchers.ids.has(getPathLauncherId(launcher)))
+      ),
+    [isElectron, launcherCandidates, availableLaunchers]
+  );
   const selectedLauncher = useMemo(
     () => resolveSelectedPathLauncher(preference.selectedLauncherId, pathLauncherOptions),
     [pathLauncherOptions, preference.selectedLauncherId]
   );
-  const selectedLauncherId = getPathLauncherId(selectedLauncher);
+  const selectedLauncherId =
+    pathLauncherOptions.length > 0 ? getPathLauncherId(selectedLauncher) : '';
 
   const templateValidation = useMemo(
     () =>
@@ -201,8 +249,10 @@ export function PathLaunchersSettings({
               aria-label={t('settings.pathLaunchers.default.label', 'Default launcher')}
               className="w-full sm:w-[220px]"
             >
-              <SelectValue>
-                <LauncherOptionContent launcher={selectedLauncher} />
+              <SelectValue
+                placeholder={t('settings.pathLaunchers.default.label', 'Default launcher')}
+              >
+                {selectedLauncherId ? <LauncherOptionContent launcher={selectedLauncher} /> : null}
               </SelectValue>
             </SelectTrigger>
             <SelectContent>

--- a/packages/components/src/components/settings/path-launchers-setting.tsx
+++ b/packages/components/src/components/settings/path-launchers-setting.tsx
@@ -99,9 +99,9 @@ export function PathLaunchersSettings({
     ids: Set<string>;
   } | null>(null);
   useEffect(() => {
-    if (!isElectron) return;
+    if (!isElectron) return undefined;
     const services = getIpcServices();
-    if (!services) return;
+    if (!services) return undefined;
 
     let cancelled = false;
     const launchers = buildPathLauncherProbes(

--- a/packages/components/tests/path-launchers-setting.test.tsx
+++ b/packages/components/tests/path-launchers-setting.test.tsx
@@ -15,6 +15,11 @@ vi.mock('@posthog/react', () => ({
   usePostHog: () => null,
 }));
 
+const { probePathLaunchers } = vi.hoisted(() => ({ probePathLaunchers: vi.fn() }));
+vi.mock('../src/lib/electron-ipc-client', () => ({
+  getIpcServices: () => ({ app: { probePathLaunchers } }),
+}));
+
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
@@ -35,6 +40,7 @@ describe('PathLaunchersSettings', () => {
   beforeEach(async () => {
     await initI18n('en');
     localStorage.clear();
+    probePathLaunchers.mockReset().mockResolvedValue({ availableIds: ['vscode', 'cursor'] });
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1024 });
     Object.defineProperty(window, 'matchMedia', {
       configurable: true,
@@ -136,6 +142,32 @@ describe('PathLaunchersSettings', () => {
     expect(sheet?.className).toContain('bottom-0');
     expect(sheet?.className).toContain('slide-in-from-bottom');
     expect(sheet?.textContent).toContain('Edit launcher');
+  });
+
+  it('filters uninstalled built-ins and refreshes availability when opening the menu', async () => {
+    probePathLaunchers.mockResolvedValue({ availableIds: ['cursor'] });
+    await renderSettings();
+    expect(getSelectTrigger().textContent).toContain('Cursor');
+    expect(readStoredPathLauncherPreference().selectedLauncherId).toBe('vscode');
+
+    probePathLaunchers.mockResolvedValue({ availableIds: ['zed'] });
+    await openSelect();
+    const labels = Array.from(document.querySelectorAll('[role="option"]')).map(
+      (option) => option.textContent
+    );
+    expect(labels).toContain('Zed');
+    expect(labels).not.toContain('Cursor');
+    expect(labels).not.toContain('VS Code');
+  });
+
+  it('does not display a fallback editor when the probe fails and still allows creation', async () => {
+    probePathLaunchers.mockRejectedValue(new Error('Probe unavailable'));
+    await renderSettings();
+    expect(getSelectTrigger().textContent).not.toContain('VS Code');
+    await openSelect();
+    expect(document.querySelectorAll('[role="option"]')).toHaveLength(1);
+    await chooseOption('Custom launcher');
+    expect(document.querySelector('[role="dialog"]')?.textContent).toContain('Add custom launcher');
   });
 
   async function renderSettings(): Promise<void> {


### PR DESCRIPTION
## Related issue

Refs #138

## Problem / pressure

Follow-up to #73 for the settings surface. Path launcher settings still listed every platform-compatible editor after #73 added installation detection to the Session header.

## Summary

Use the existing Electron probe to filter built-in settings options on mount and menu state changes. Preserve custom launcher editing, stored preferences, and non-Electron behavior. Show a placeholder when no launcher is available instead of the resolver's VS Code fallback.

## Before / after

Actual settings component rendered before and after this change, using the same macOS props and a mocked probe result where only Cursor is available. These screenshots demonstrate UI filtering, not native installation detection.

| Before | After |
| :--: | :--: |
| Lists all platform-compatible built-in editors. | Lists only the detected built-in editor and preserves custom launcher creation. |
| <img width="430" alt="Before: settings lists all built-in launchers" src="https://raw.githubusercontent.com/Pleasurecruise/Lody/ea3ea133e78058c6d7e4808ace83a0b33ba83986/launcher-before.png" /> | <img width="430" alt="After: settings lists Cursor and Custom launcher" src="https://raw.githubusercontent.com/Pleasurecruise/Lody/ea3ea133e78058c6d7e4808ace83a0b33ba83986/launcher-after.png" /> |

## Test plan

- `pnpm check:quick` passed, including type-aware lint, i18n, and all three import/platform/public boundary guards. Settings tests (5) and formatting checks passed.
- Settings tests: 5 passed after removing a redundant test; launcher utility tests: 16 passed.
- Components typecheck, targeted oxlint, Prettier check, and git diff check passed.
- Tests used NODE_OPTIONS=--no-experimental-webstorage for Node 26 compatibility with jsdom.
- Full pnpm check stopped in acp-extension-core build on dependency declaration conflicts (WebCodecs, filesystem access, and missing JSX namespace), before reaching the changed component.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check availability filtering and empty selection rendering in path-launchers-setting.tsx.
- **Decisions to challenge:** Custom commands remain visible for editing even when unavailable; installed built-ins follow the existing cached probe.
- **Plausible failures / evidence gaps:** Native installation detection was reused without a desktop smoke test; full repository validation is blocked by dependency type errors.

### Authoring context

- **User goal / directives:** Extend #73 detection to settings with a small diff and only necessary comments and tests.
- **Constraints / non-goals:** Keep native probing and cloud/local composition unchanged.
- **Risk-bearing decisions:** Ignore stale asynchronous results and preserve stored defaults when availability changes.
- **Destructive or irreversible behavior:** No data migration or automatic preference rewrite; changes only filter displayed built-ins.
- **Deliberately not done or tested:** No native platform smoke tests; targeted component validation covers the changed surface.
- **Unknowns / confidence:** UI regression tests pass; platform discovery retains the existing implementation and cache limitations.

<!-- context-handoff:end -->


