### PR TITLE
fix: exclude symbol fonts from appearance settings

### DIFF
--- a/packages/components/src/atoms/settings.ts
+++ b/packages/components/src/atoms/settings.ts
@@ -2,6 +2,7 @@ import { atom } from 'jotai';
 import { atomWithStorage } from 'jotai/utils';
 import type { MachineId, SupportedLanguage } from '@lody/shared';
 import type { MobileKeyboardAction } from '@/lib/mobile-keyboard-action';
+import { isSymbolFontFamily } from '@/lib/local-fonts';
 import {
   SETTINGS_DEFAULT_TAB,
   type SettingsTabId,
@@ -46,7 +47,9 @@ export const conversationFontSizeAtom = atom(
 export const INTERFACE_FONT_FAMILY_MAX_LENGTH = 100;
 
 export function normalizeInterfaceFontFamily(value: unknown): string {
-  return typeof value === 'string' ? value.trim().slice(0, INTERFACE_FONT_FAMILY_MAX_LENGTH) : '';
+  return typeof value === 'string' && !isSymbolFontFamily(value)
+    ? value.trim().slice(0, INTERFACE_FONT_FAMILY_MAX_LENGTH)
+    : '';
 }
 
 const interfaceFontFamilyStorageAtom = atomWithStorage<unknown>('lody-interface-font-family', '');
@@ -64,7 +67,9 @@ export const TERMINAL_FONT_SIZE_MAX = 24;
 export const TERMINAL_FONT_FAMILY_MAX_LENGTH = 100;
 
 export function normalizeTerminalFontFamily(value: unknown): string {
-  return typeof value === 'string' ? value.trim().slice(0, TERMINAL_FONT_FAMILY_MAX_LENGTH) : '';
+  return typeof value === 'string' && !isSymbolFontFamily(value)
+    ? value.trim().slice(0, TERMINAL_FONT_FAMILY_MAX_LENGTH)
+    : '';
 }
 
 export function normalizeTerminalFontSize(value: unknown): number {

--- a/packages/components/src/components/settings/AGENTS.md
+++ b/packages/components/src/components/settings/AGENTS.md
@@ -18,5 +18,8 @@ Parent `AGENTS.md` files also apply. `CLAUDE.md` is a symlink to this file; edit
   verification.
 - Keep optional three.js/R3F usage behind the lazy usage-calendar module so lightweight
   and SSR consumers do not evaluate its renderer graph.
+- Interface and terminal font choices exclude the known symbol families in
+  `lib/local-fonts.ts`; persisted selections use the same filter. Font option names
+  use the default interface font so they remain readable.
 - The Codex reset forecast chip in the provider row must not fetch on mount and must
   pass `nestedInDialog` for its dialog: [../codex-reset/AGENTS.md](../codex-reset/AGENTS.md).

--- a/packages/components/src/components/settings/appearance-setting.tsx
+++ b/packages/components/src/components/settings/appearance-setting.tsx
@@ -20,7 +20,7 @@ import { MobileAppearanceSettings } from '@/components/mobile/mobile-appearance-
 import { OptionSelector, type OptionSelectorOption } from '@/components/shared/option-selector';
 import { buildTerminalFontPreviewFamily } from '@/components/terminal/terminal-theme';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { buildInterfaceFontFamily, listSystemFontFamilies } from '@/lib/local-fonts';
+import { listSystemFontFamilies } from '@/lib/local-fonts';
 import { Input } from '@/ui/input';
 import { LanguageSelector } from '../../i18n';
 import { useTheme, type Theme } from '../../theme-provider';
@@ -207,7 +207,7 @@ export function AppearanceSettingsView({
               renderTriggerValue={(option) => (
                 <span
                   className="truncate font-normal"
-                  style={{ fontFamily: buildInterfaceFontFamily(option?.value ?? '') }}
+                  style={{ fontFamily: 'var(--font-sans-default)' }}
                 >
                   {option?.label ?? interfaceFontFamily}
                 </span>
@@ -215,7 +215,7 @@ export function AppearanceSettingsView({
               renderOption={(option) => (
                 <span
                   className="min-w-0 flex-1 truncate"
-                  style={{ fontFamily: buildInterfaceFontFamily(option.value) }}
+                  style={{ fontFamily: 'var(--font-sans-default)' }}
                 >
                   {option.label}
                 </span>
@@ -275,7 +275,7 @@ export function AppearanceSettingsView({
               renderTriggerValue={(option) => (
                 <span
                   className="truncate font-normal"
-                  style={{ fontFamily: buildTerminalFontPreviewFamily(option?.value ?? '') }}
+                  style={{ fontFamily: 'var(--font-sans-default)' }}
                 >
                   {option?.label ?? terminalFontFamily}
                 </span>
@@ -283,7 +283,7 @@ export function AppearanceSettingsView({
               renderOption={(option) => (
                 <span
                   className="min-w-0 flex-1 truncate"
-                  style={{ fontFamily: buildTerminalFontPreviewFamily(option.value) }}
+                  style={{ fontFamily: 'var(--font-sans-default)' }}
                 >
                   {option.label}
                 </span>

--- a/packages/components/src/lib/local-fonts.ts
+++ b/packages/components/src/lib/local-fonts.ts
@@ -6,6 +6,10 @@ export type QueryLocalFonts = () => Promise<readonly LocalFontMetadata[]>;
 
 export const INTERFACE_FONT_CSS_VARIABLE = '--lody-interface-font-family';
 
+export function isSymbolFontFamily(family: string): boolean {
+  return /^(?:Webdings|Wingdings(?:\s*[23])?|Symbol|Zapf\s*Dingbats)$/i.test(family.trim());
+}
+
 function quoteCssFontFamily(fontFamily: string): string {
   return `"${fontFamily.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
 }
@@ -47,7 +51,7 @@ export async function listSystemFontFamilies(
 
   for (const font of fonts) {
     const family = font.family.trim();
-    if (!family) continue;
+    if (!family || isSymbolFontFamily(family)) continue;
     const key = family.toLowerCase();
     if (!families.has(key)) families.set(key, family);
   }

--- a/packages/components/tests/interface-font-controller.test.tsx
+++ b/packages/components/tests/interface-font-controller.test.tsx
@@ -11,7 +11,7 @@ import {
   normalizeInterfaceFontFamily,
 } from '../src/atoms/settings';
 import { InterfaceFontController } from '../src/components/interface-font-controller';
-import { INTERFACE_FONT_CSS_VARIABLE } from '../src/lib/local-fonts';
+import { INTERFACE_FONT_CSS_VARIABLE, listSystemFontFamilies } from '../src/lib/local-fonts';
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -46,6 +46,36 @@ describe('InterfaceFontController', () => {
       normalizeInterfaceFontFamily('a'.repeat(INTERFACE_FONT_FAMILY_MAX_LENGTH + 10))
     ).toHaveLength(INTERFACE_FONT_FAMILY_MAX_LENGTH);
     expect(normalizeInterfaceFontFamily(null)).toBe('');
+  });
+
+  it('excludes symbol fonts while retaining and deduplicating text fonts', async () => {
+    const families = [
+      'Webdings',
+      'Wingdings',
+      'Wingdings 2',
+      'Wingdings 3',
+      'Symbol',
+      'Zapf Dingbats',
+    ];
+    expect(
+      await listSystemFontFamilies(async () =>
+        [...families, 'Inter', ' inter ', 'Wawati SC', 'Zilla Slab'].map((family) => ({ family }))
+      )
+    ).toEqual(['Inter', 'Wawati SC', 'Zilla Slab']);
+  });
+
+  it('recovers a persisted symbol font without applying it to the interface', async () => {
+    window.localStorage.setItem('lody-interface-font-family', JSON.stringify('Wingdings 2'));
+    const store = createStore();
+    await act(async () => {
+      root?.render(
+        <Provider store={store}>
+          <InterfaceFontController enabled />
+        </Provider>
+      );
+    });
+    expect(store.get(interfaceFontFamilyAtom)).toBe('');
+    expect(document.documentElement.style.getPropertyValue(INTERFACE_FONT_CSS_VARIABLE)).toBe('');
   });
 
   it('updates the global interface font immediately when enabled', async () => {

--- a/packages/components/tests/terminal-settings.test.ts
+++ b/packages/components/tests/terminal-settings.test.ts
@@ -30,6 +30,7 @@ describe('terminal appearance settings', () => {
       normalizeTerminalFontFamily('a'.repeat(TERMINAL_FONT_FAMILY_MAX_LENGTH + 10))
     ).toHaveLength(TERMINAL_FONT_FAMILY_MAX_LENGTH);
     expect(normalizeTerminalFontFamily(null)).toBe('');
+    expect(normalizeTerminalFontFamily('  Webdings  ')).toBe('');
 
     expect(normalizeTerminalFontSize(undefined)).toBe(DEFAULT_TERMINAL_FONT_SIZE);
     expect(normalizeTerminalFontSize(TERMINAL_FONT_SIZE_MIN - 4)).toBe(TERMINAL_FONT_SIZE_MIN);


### PR DESCRIPTION
## Related issue

Closes #453

## Problem / pressure

Selecting Webdings or Wingdings makes interface letters render as pictograms, while copied text remains unchanged. Appearance settings currently offer these symbol fonts and render their names using the selected family, making recovery difficult.

## Summary

- Exclude known legacy symbol families (Webdings, Wingdings/2/3, Symbol, and Zapf Dingbats) from system font enumeration.
- Reuse that rule when reading and writing interface and terminal font settings, so existing symbol-font selections resolve to Default without rewriting unrelated preferences.
- Render font option names with the default interface font; terminal sample text still previews the selected font.

## Before / after

Actual appearance components rendered in Chrome on macOS with the same controlled Wingdings 2 selection and font list. The after view uses the new normalization and enumeration filter; this is a component reproduction, not a full Electron session.

| Before | After |
| ------ | ----- |
| Known symbol fonts are selectable and can make the interface unreadable across restarts. | Known symbol fonts are filtered, saved selections resolve to Default, and option names remain readable. |
| <img width="430" alt="Before: Wingdings 2 renders interface text as symbols" src="https://raw.githubusercontent.com/Pleasurecruise/Lody/fd958c910ae7cca80948b94881f81f75d1606b41/fonts-before.png" /> | <img width="430" alt="After: the blocked selection resolves to Default and text is readable" src="https://raw.githubusercontent.com/Pleasurecruise/Lody/fd958c910ae7cca80948b94881f81f75d1606b41/fonts-after.png" /> |

## Test plan

- 15 tests passed across interface-font-controller, terminal-settings, and appearance-settings, including symbol filtering and persisted selection recovery.
- Components typecheck and pnpm check:quick passed (type-aware lint, i18n, and import/platform/public boundary guards).
- git diff --check passed; unrelated existing formatting was preserved.
- Full pnpm check stopped during acp-extension-core build on existing dependency declaration conflicts involving WebCodecs, filesystem access, and the JSX namespace.
- Tests ran with NODE_OPTIONS=--no-experimental-webstorage for Node 26/jsdom compatibility. The component reproduction was visually checked in Chrome; no full Electron smoke test was performed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check shared symbol-family filtering in local-fonts.ts and persisted selection normalization in atoms/settings.ts.
- **Decisions to challenge:** The filter matches specific known legacy symbol families rather than rejecting broad name substrings or parsing font binaries.
- **Plausible failures / evidence gaps:** Unlisted third-party symbol fonts remain selectable; native desktop rendering was not smoke-tested.

### Authoring context

- **User goal / directives:** Fix unreadable font choices on a separate branch while keeping every change necessary and avoiding gratuitous helpers or tests.
- **Constraints / non-goals:** No new dependencies, native font parser, or changes to normal font application and terminal preview.
- **Risk-bearing decisions:** One predicate is shared by enumeration and both persisted settings; blocked saved values resolve to Default on read.
- **Destructive or irreversible behavior:** No storage migration or bulk preference deletion; unrelated preferences remain intact.
- **Deliberately not done or tested:** Arbitrary third-party symbol-font classification and native platform smoke testing remain outside this small fix.
- **Unknowns / confidence:** Focused tests and static checks pass; coverage is intentionally limited to the named legacy symbol families.

<!-- context-handoff:end -->
