### PR TITLE
feat(e2e): run the daily desktop regression on Linux and Windows

### DIFF
--- a/.github/scripts/e2e-daily-policy.mjs
+++ b/.github/scripts/e2e-daily-policy.mjs
@@ -5,6 +5,7 @@ import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ACTIONS_BOT_LOGIN = 'github-actions[bot]';
+const CANONICAL_DAILY_OS = 'macos-15';
 
 export function isActionsBot(record) {
   return record?.user?.login === ACTIONS_BOT_LOGIN && record.user.type === 'Bot';
@@ -33,18 +34,32 @@ export function hasCompleteOwnedComment(comments, marker, expectedVideos) {
 }
 
 export function findDailyEvidenceArtifact(artifacts, runId) {
-  const supported = new Map([
+  if (!/^\d+$/u.test(String(runId))) throw new Error('runId must be numeric');
+  const legacy = new Map([
     [`desktop-e2e-daily-full-${runId}`, 'full'],
     [`desktop-e2e-daily-smoke-${runId}`, 'smoke'],
     [`desktop-e2e-daily-${runId}`, 'unknown'],
   ]);
-  const matches = artifacts.filter(
-    (artifact) => !artifact.expired && supported.has(String(artifact.name ?? ''))
-  );
-  if (matches.length !== 1) return undefined;
+  const perOs = new RegExp(`^desktop-e2e-daily-(full|smoke)-([a-z0-9-]+)-${runId}$`, 'u');
+  const matches = [];
+  for (const artifact of artifacts) {
+    if (artifact.expired) continue;
+    const name = String(artifact.name ?? '');
+    if (legacy.has(name)) {
+      matches.push({ artifact, suite: legacy.get(name), os: null });
+      continue;
+    }
+    const parsed = perOs.exec(name);
+    if (parsed) matches.push({ artifact, suite: parsed[1], os: parsed[2] });
+  }
+  // The macOS leg is the canonical Daily evidence while the Linux and Windows
+  // legs are a trial lane; prefer it when the matrix uploaded several.
+  const canonical = matches.filter((match) => match.os === CANONICAL_DAILY_OS);
+  const candidates = canonical.length > 0 ? canonical : matches;
+  if (candidates.length !== 1) return undefined;
   return {
-    artifact: matches[0],
-    suite: supported.get(matches[0].name),
+    artifact: candidates[0].artifact,
+    suite: candidates[0].suite,
   };
 }
 

--- a/.github/scripts/e2e-daily-policy.test.mjs
+++ b/.github/scripts/e2e-daily-policy.test.mjs
@@ -101,6 +101,45 @@ void test('rejects ambiguous and expired Daily evidence artifacts', () => {
   );
 });
 
+void test('prefers the macOS artifact from a per-OS Daily matrix upload', () => {
+  const artifacts = [
+    { id: 7, name: 'desktop-e2e-daily-full-macos-15-123', expired: false },
+    { id: 8, name: 'desktop-e2e-daily-full-ubuntu-latest-123', expired: false },
+    { id: 9, name: 'desktop-e2e-daily-full-windows-latest-123', expired: false },
+  ];
+  assert.deepEqual(findDailyEvidenceArtifact(artifacts, 123), {
+    artifact: artifacts[0],
+    suite: 'full',
+  });
+});
+
+void test('accepts a single non-macOS Daily artifact and rejects same-OS ambiguity', () => {
+  assert.equal(
+    findDailyEvidenceArtifact(
+      [{ id: 8, name: 'desktop-e2e-daily-smoke-ubuntu-latest-123', expired: false }],
+      123
+    )?.suite,
+    'smoke'
+  );
+  assert.equal(
+    findDailyEvidenceArtifact(
+      [
+        { id: 7, name: 'desktop-e2e-daily-full-macos-15-123', expired: false },
+        { id: 8, name: 'desktop-e2e-daily-smoke-macos-15-123', expired: false },
+      ],
+      123
+    ),
+    undefined
+  );
+  assert.equal(
+    findDailyEvidenceArtifact(
+      [{ id: 7, name: 'desktop-e2e-daily-full-macos-15-123', expired: true }],
+      123
+    ),
+    undefined
+  );
+});
+
 void test('only a successful full Daily can close the shared failure Issue', () => {
   assert.equal(canCloseDailyFailureIssue('success', 'full'), true);
   assert.equal(canCloseDailyFailureIssue('success', 'smoke'), false);

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -25,9 +25,13 @@ env:
 
 jobs:
   regression:
-    name: Desktop E2E daily (${{ github.event.inputs.suite == 'smoke' && 'smoke' || 'full' }})
-    runs-on: macos-15
-    timeout-minutes: 45
+    name: Desktop E2E daily (${{ matrix.os }}, ${{ github.event.inputs.suite == 'smoke' && 'smoke' || 'full' }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 60 || 45 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,7 +57,18 @@ jobs:
       - name: Build OSS desktop and bundled CLI
         run: pnpm --dir apps/electron build
 
+      - name: Run desktop journeys (Linux under Xvfb)
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        env:
+          SUITE: ${{ github.event.inputs.suite == 'smoke' && 'smoke' || 'full' }}
+        run: |
+          set -o pipefail
+          mkdir -p e2e/artifacts
+          xvfb-run -a pnpm --filter @lody/e2e "$SUITE" 2>&1 | tee e2e/artifacts/cucumber-output.log
+
       - name: Run desktop journeys
+        if: matrix.os != 'ubuntu-latest'
         shell: bash
         env:
           SUITE: ${{ github.event.inputs.suite == 'smoke' && 'smoke' || 'full' }}
@@ -72,7 +87,10 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-e2e-daily-${{ github.event.inputs.suite == 'smoke' && 'smoke' || 'full' }}-${{ github.run_id }}
+          # The artifact name carries the OS. The Daily failure reconciler uses
+          # the macOS artifact as its canonical evidence; Linux and Windows
+          # evidence stays in Actions artifacts until the lane proves stable.
+          name: desktop-e2e-daily-${{ github.event.inputs.suite == 'smoke' && 'smoke' || 'full' }}-${{ matrix.os }}-${{ github.run_id }}
           path: e2e/artifacts/
           if-no-files-found: warn
           retention-days: 30

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -55,7 +55,10 @@ also applies.
   screenshot, Playwright trace, renderer/main logs, CLI backlog, process and
   memory snapshot, and machine-readable failure index.
 - Daily regression records each scenario independently, deletes passing videos,
-  and retains one `failure.webm` per failed scenario. The read-only runner only
+  and retains one `failure.webm` per failed scenario. It runs one macOS, Linux,
+  and Windows matrix per suite; the failure-issue reconciler treats the macOS
+  artifact as canonical evidence until the other legs prove stable. The
+  read-only runner only
   uploads evidence; a trusted default-branch reconciler validates and attaches
   every bounded WebM to an independently retryable Daily failure Issue comment.
   Only a successful full Daily may close that Issue; smoke success never clears

--- a/e2e/src/support/electron-harness.ts
+++ b/e2e/src/support/electron-harness.ts
@@ -142,6 +142,9 @@ export class ElectronHarness {
     this.app = await _electron.launch({
       args: [
         '--js-flags=--expose-gc',
+        // GitHub-hosted Linux runners restrict unprivileged user namespaces,
+        // which breaks Electron's SUID sandbox from an unpacked dev tree.
+        ...(process.platform === 'linux' && process.env.CI ? ['--no-sandbox'] : []),
         MAIN_ENTRY,
         `--user-data-dir=${electronUserDataDir}`,
         '--lang=en-US',


### PR DESCRIPTION
## What

Matrix the Desktop E2E Daily workflow across `macos-15`, `ubuntu-latest`, and `windows-latest` (fail-fast disabled), so the scheduled regression covers all three desktop platforms instead of macOS only.

## Changes

- `.github/workflows/e2e-daily.yml`: OS matrix; Linux leg runs Cucumber under `xvfb-run`; Windows leg gets a 60-minute timeout; evidence artifact names carry the OS.
- `e2e/src/support/electron-harness.ts`: pass `--no-sandbox` on Linux CI, where hosted runners restrict unprivileged user namespaces and break Electron's SUID sandbox from an unpacked dev tree.
- `.github/scripts/e2e-daily-policy.mjs`: recognize per-OS Daily artifact names and prefer the macOS artifact as the reconciler's canonical evidence; legacy names keep working.
- `e2e/AGENTS.md`: document the matrix lane.

## Scope note

The failure-Issue reconciler is unchanged in behavior: it still attaches macOS failure videos only. Linux/Windows evidence stays in Actions artifacts until those legs prove stable; per-OS reconcile reporting is a deliberate follow-up.

## Validation

- `node --test .github/scripts/e2e-daily-policy.test.mjs` — 11 pass, including new per-OS selection cases.
- `pnpm --filter @lody/e2e check` — suite contract, tsc, and harness tests pass.
- A `workflow_dispatch` smoke run on this branch exercises the Linux and Windows legs end to end.

Model: kimi-k2