### PR TITLE
docs: cap community PRs at 1000 lines unless assigned

### DIFF
--- a/.agents/notes/implemented/process/2026-09-07-community-pr-size.md
+++ b/.agents/notes/implemented/process/2026-09-07-community-pr-size.md
@@ -1,0 +1,42 @@
+# Community PR size and team identity
+
+Status: implemented
+Translation: current
+
+English | [中文](2026-09-07-community-pr-size.zh.md)
+
+## Abstract
+
+Unsolicited community pull requests that rewrite large parts of Lody are expensive to review and can silently break invariants. Community PRs are therefore capped at 1000 changed lines unless a maintainer assigned the linked Issue. Agents decide team vs community with one check against a short GitHub-login roster or an explicit user claim, so Lody team sessions do not spend tokens re-deriving identity.
+
+## Problem
+
+Enthusiastic contributors, often with little open-source experience and often using coding agents, opened large patches as gifts. Reviewing them well enough to protect local/cloud, catalog, and protocol invariants was not realistic, and rejecting them without a public rule looked arbitrary.
+
+The same agent-facing files are read by Lody team sessions. A rule that said "community contributors must..." without a cheap identity test caused team agents to treat maintainers as outsiders and burn tokens on the distinction.
+
+## Decision
+
+- Binding agent rule: root `AGENTS.md` (entry) and `.github/AGENTS.md` (PR path).
+- Human explanation and conventions: `CONTRIBUTING.md`.
+- Enforcement: fork PRs over 1000 additions plus deletions need a maintainer assignment on the linked Issue; over 200 without an Issue reference still fail as before. Same-repository branches remain `internal`.
+
+Identity is one-shot, then stop:
+
+1. The user says they are Lody team, or
+2. GitHub login is `zxch3n`, `Leeeon233`, or `wibus-wee` (also git `user.name` Zixuan Chen, Leon Zhao, or Wibus Wu).
+
+Otherwise community. Do not probe remotes, org APIs, or `author_association`.
+
+The roster is the write/admin collaborators on `LodyAI/Lody` as of 2026-09-07. Unknown logins default to community until the list is updated. Team members should push same-repository branches; a fork stays external even for a team login, matching existing PR policy.
+
+## Alternatives rejected
+
+- **No numeric cap, review case by case:** already failed; the cost is paid before a maintainer can say no.
+- **Classify from `author_association` or origin URL:** forks from owners stay external by design; a clone of `LodyAI/Lody` is a common community starting point, so origin alone false-positives.
+- **Live org-member API as the agent check:** extra calls, token spend, and flaky auth in contributor environments.
+- **Emails in the public roster:** unnecessary personal data; GitHub logins are already public.
+
+## Limits
+
+The 1000-line figure is GitHub additions plus deletions, including lockfiles. Assignment is an explicit maintainer action, like `status:pr-policy-bypass`. The roster will drift when membership changes; conservative default is community.

--- a/.agents/notes/implemented/process/2026-09-07-community-pr-size.zh.md
+++ b/.agents/notes/implemented/process/2026-09-07-community-pr-size.zh.md
@@ -1,0 +1,42 @@
+# 社区 PR 规模与团队身份
+
+Status: implemented
+Translation: current
+
+[English](2026-09-07-community-pr-size.md) | 中文
+
+## 摘要
+
+社区贡献者提交的超大 PR 很难安全 review，也容易悄悄破坏既有 invariant。因此，除非维护者在对应 Issue 上 assign 了作者，社区 PR 必须控制在 1000 行改动以内。Agent 用一份很短的 GitHub 登录名名单，或用户的明确声明，一次判定是否为 Lody 团队，避免团队会话把维护者误当成外部贡献者并浪费 token。
+
+## 问题
+
+热心贡献者（不少缺少开源协作经验，且常通过 coding agent 提交）会把大规模改动当作礼物发来。要在不破坏 local/cloud、catalog、协议等 invariant 的前提下 review 这些补丁并不现实；若没有公开规则就拒绝，又显得武断。
+
+同一套 Agent 文档也会被 Lody 团队自己的会话读到。如果只写“社区贡献者必须……”，却没有便宜的身份判定，团队 Agent 会把自己当成外部贡献者，并在身份问题上消耗大量 token。
+
+## 决定
+
+- Agent 约束：根目录 `AGENTS.md`（入口）和 `.github/AGENTS.md`（创建 PR 的路径）。
+- 给人类看的惯例说明：`CONTRIBUTING.md`。
+- 执行：fork PR 超过 1000 行（新增 + 删除）时，需要维护者在关联 Issue 上 assign 作者；超过 200 行且缺少 Issue 引用的规则保持不变。同仓库分支仍视为 `internal`。
+
+身份判定只做一次：
+
+1. 用户声明自己是 Lody 团队，或
+2. GitHub 登录名是 `zxch3n`、`Leeeon233` 或 `wibus-wee`（git `user.name` 为 Zixuan Chen、Leon Zhao 或 Wibus Wu 亦可）。
+
+否则视为社区贡献者。不要再查 remote、组织 API 或 `author_association`。
+
+名单取自 2026-09-07 时 `LodyAI/Lody` 的 write/admin collaborator。未知登录名默认按社区处理，直到名单更新。团队成员应推送同仓库分支；即使作者是团队登录名，fork 仍按外部贡献处理，这与既有 PR 策略一致。
+
+## 未采用的方案
+
+- **不定数字上限、个案 review：** 已经失败；成本发生在维护者说不之前。
+- **用 `author_association` 或 origin URL 分类：** owner 的 fork 按设计仍是外部贡献；直接 clone `LodyAI/Lody` 是常见社区起点，只看 origin 会误判。
+- **让 Agent 现场查组织成员 API：** 额外请求、消耗 token，且贡献者环境里认证不稳定。
+- **把邮箱写进公开名单：** 没有必要的个人数据；GitHub 登录名已经公开。
+
+## 限制
+
+1000 行按 GitHub 的 additions + deletions 计算，包含 lockfile。assign 是维护者的显式动作，类似于 `status:pr-policy-bypass`。成员变动后名单会过时；保守默认仍是社区贡献者。

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -25,6 +25,16 @@ Workflow-file security constraints live in
 
 ## Contribution contract
 
+- One-shot identity: Lody team if the user says so, or GitHub login is
+  `zxch3n`, `Leeeon233`, or `wibus-wee` (`gh api user --jq .login`, or git
+  `user.name` Zixuan Chen, Leon Zhao, or Wibus Wu). Otherwise community; do
+  not keep checking. Same-repository branches stay `internal` regardless of
+  login.
+- Community PRs stay under 1000 changed lines (additions + deletions) unless a
+  maintainer assigned the linked Issue to the author. Larger work: file an
+  Issue with analysis and wait to be assigned; do not open the PR. Maintainers
+  review small focused changes; large unsolicited patches hide invariant breaks.
+  Humans: `CONTRIBUTING.md`.
 - `gh pr create --body` silently skips `PULL_REQUEST_TEMPLATE.md`. Draft the PR
   body from the template and validate it with
   `node .github/scripts/check-pr-body.mjs --body-file <file>`.
@@ -82,12 +92,13 @@ valid <-> status:needs-pr-attention (invalid-since) -> status:pr-policy-expired 
 ```
 
 All template and size findings share the same comment, label, timestamp, and
-seven-day correction period. A change over 200 additions plus deletions without
-its prior Issue reference adds a size-specific finding; it does not create a
-second status. A valid edit or a skipped disposition clears managed enforcement
-state. An expired external PR is closed again when reopened; bypass or internal
-classification clears the expired state instead. Before closing an overdue PR,
-the audit must re-read and revalidate the latest PR.
+seven-day correction period. A change over 1000 additions plus deletions
+without a maintainer assignment on the linked Issue adds a size-specific
+finding; over 200 without its prior Issue reference still does. Neither
+creates a second status. A valid edit or a skipped disposition clears managed
+enforcement state. An expired external PR is closed again when reopened;
+bypass or internal classification clears the expired state instead. Before
+closing an overdue PR, the audit must re-read and revalidate the latest PR.
 
 Issue-link normalization and cleanup after a valid or skipped disposition are
 best-effort feedback. The current validation result alone decides whether an

--- a/.github/ISSUE_TEMPLATE/01-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug-report.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve Lody. Please provide a small, reproducible report.
+        Thanks for helping improve Lody. Please provide a small, reproducible report. Analysis is welcome; do not open a community PR over 1000 changed lines unless a maintainer assigns you this Issue.
 
         Keep every required section and confirmation. Issues that bypass or remove the form are marked `status:needs-issue-body` until corrected; only repository owners and automated bots are exempt.
 

--- a/.github/ISSUE_TEMPLATE/02-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature-request.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping shape Lody. Start with the problem and desired outcome; a complete implementation design is not required.
+        Thanks for helping shape Lody. Start with the problem and desired outcome; a complete implementation design is not required. Analysis of a large change is welcome here. Do not open a community PR over 1000 changed lines unless a maintainer assigns you this Issue.
 
         Keep every required section and confirmation. Issues that bypass or remove the form are marked `status:needs-issue-body` until corrected; only repository owners and automated bots are exempt.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,9 @@
 <!--
 Fork-based contributions must reference a Lody issue below. Keep the change focused:
-all policy findings share one seven-day correction period. A change over 200
-lines (additions + deletions) without its prior Issue adds a size-specific finding.
-Same-repository branches do not create an Issue solely for contribution intake.
+all policy findings share one seven-day correction period. Community PRs over 1000
+lines (additions + deletions) need a maintainer assignment on the linked Issue;
+over 200 without its prior Issue adds a size-specific finding. Same-repository
+branches do not create an Issue solely for contribution intake.
 
 The Issue is for tracking context; maintainers review the contribution through
 the normal PR process. Context handoff is public and cannot use N/A or redacted

--- a/.github/scripts/pr-issue-link.mjs
+++ b/.github/scripts/pr-issue-link.mjs
@@ -46,10 +46,25 @@ function parseIssueLine(line) {
   };
 }
 
-export function hasRelatedIssueLink(body) {
+export function relatedIssueNumbers(body) {
   const lines = (body ?? '').split(/\r?\n/);
   const range = relatedIssueSectionRange(lines);
-  return Boolean(range && lines.slice(range.start, range.end).some(parseIssueLine));
+  if (!range) {
+    return [];
+  }
+
+  const numbers = [];
+  for (const line of lines.slice(range.start, range.end)) {
+    const parsed = parseIssueLine(line);
+    if (parsed) {
+      numbers.push(parsed.issueNumber);
+    }
+  }
+  return numbers;
+}
+
+export function hasRelatedIssueLink(body) {
+  return relatedIssueNumbers(body).length > 0;
 }
 
 export function normalizeRelatedIssueLink(body) {

--- a/.github/scripts/pr-issue-link.test.mjs
+++ b/.github/scripts/pr-issue-link.test.mjs
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { hasRelatedIssueLink, normalizeRelatedIssueLink } from './pr-issue-link.mjs';
+import {
+  hasRelatedIssueLink,
+  normalizeRelatedIssueLink,
+  relatedIssueNumbers,
+} from './pr-issue-link.mjs';
 
 const body = (reference) => `## Related issue
 
@@ -32,6 +36,8 @@ void describe('pull request issue links', () => {
     );
     assert.equal(hasRelatedIssueLink(body('LodyAI/Lody#121')), true);
     assert.equal(hasRelatedIssueLink(body('Issue 121')), false);
+    assert.deepEqual(relatedIssueNumbers(body('Closes #121')), [121]);
+    assert.deepEqual(relatedIssueNumbers(body('Issue 121')), []);
   });
 
   void it('is idempotent after adding the native closing keyword', () => {

--- a/.github/scripts/pr-policy.mjs
+++ b/.github/scripts/pr-policy.mjs
@@ -1,9 +1,10 @@
 import { checkPullRequestBody, hasRelatedIssueReference } from './check-pr-body.mjs';
-import { normalizeRelatedIssueLink } from './pr-issue-link.mjs';
+import { normalizeRelatedIssueLink, relatedIssueNumbers } from './pr-issue-link.mjs';
 
 const GRACE_PERIOD_DAYS = 7;
 const GRACE_PERIOD_MS = GRACE_PERIOD_DAYS * 24 * 60 * 60 * 1_000;
 const MAX_EXTERNAL_CHANGED_LINES = 200;
+const MAX_COMMUNITY_REVIEW_LINES = 1000;
 
 export const PULL_REQUEST_DISPOSITION = Object.freeze({
   BOT: 'bot',
@@ -133,16 +134,54 @@ function changedLines(pullRequest) {
   return Number(pullRequest.additions ?? 0) + Number(pullRequest.deletions ?? 0);
 }
 
-function checkPullRequestPolicy(pullRequest) {
+function checkPullRequestPolicy(pullRequest, { authorAssignedToRelatedIssue = false } = {}) {
   const result = checkPullRequestBody(pullRequest.body);
   const findings = [...result.findings];
   const lines = changedLines(pullRequest);
-  if (lines > MAX_EXTERNAL_CHANGED_LINES && !hasRelatedIssueReference(pullRequest.body)) {
+  if (lines > MAX_COMMUNITY_REVIEW_LINES && !authorAssignedToRelatedIssue) {
+    findings.push(
+      `PR changes ${lines} lines; community PRs over ${MAX_COMMUNITY_REVIEW_LINES} lines require a maintainer assignment on the linked Issue before review.`
+    );
+  } else if (lines > MAX_EXTERNAL_CHANGED_LINES && !hasRelatedIssueReference(pullRequest.body)) {
     findings.push(
       `PR changes ${lines} lines; changes over ${MAX_EXTERNAL_CHANGED_LINES} lines require the prior Lody Issue reference in ## Related issue.`
     );
   }
   return { ok: findings.length === 0, findings };
+}
+
+async function resolveAuthorAssignedToRelatedIssue({
+  github,
+  owner,
+  repo,
+  pullRequest,
+  warnings,
+}) {
+  const lines = changedLines(pullRequest);
+  if (lines <= MAX_COMMUNITY_REVIEW_LINES) {
+    return false;
+  }
+
+  const login = (pullRequest.user?.login ?? '').toLowerCase();
+  const numbers = relatedIssueNumbers(pullRequest.body);
+  if (!login || numbers.length === 0) {
+    return false;
+  }
+
+  for (const issueNumber of numbers) {
+    try {
+      const issue = (await github.rest.issues.get({ owner, repo, issue_number: issueNumber })).data;
+      const assignees = issue.assignees ?? (issue.assignee ? [issue.assignee] : []);
+      if (assignees.some((assignee) => (assignee.login ?? '').toLowerCase() === login)) {
+        return true;
+      }
+    } catch (error) {
+      if (error.status !== 404) {
+        warnings.push(`Could not read assignees for #${issueNumber}: ${warningMessage(error)}`);
+      }
+    }
+  }
+  return false;
 }
 
 function invalidSinceFromComment(body) {
@@ -167,7 +206,7 @@ export function formatCheckerFindings(result) {
     '',
     ...result.findings.map((finding) => `- ${finding}`),
     '',
-    'See `.github/PULL_REQUEST_TEMPLATE.md`.',
+    'See `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md`.',
   ].join('\n');
 }
 
@@ -525,7 +564,16 @@ export async function reconcilePullRequest({
     return { disposition, state: 'expired', validation: null, warnings };
   }
 
-  const validation = checkPullRequestPolicy(currentPullRequest);
+  const assigned = await resolveAuthorAssignedToRelatedIssue({
+    github,
+    owner,
+    repo,
+    pullRequest: currentPullRequest,
+    warnings,
+  });
+  const validation = checkPullRequestPolicy(currentPullRequest, {
+    authorAssignedToRelatedIssue: assigned,
+  });
   if (validation.ok) {
     try {
       await clearInvalidPullRequest({ ...input, pullRequest: currentPullRequest });
@@ -561,7 +609,15 @@ export async function reconcilePullRequest({
           latest.state === 'open' &&
           pullRequestDisposition(latest) === PULL_REQUEST_DISPOSITION.EXTERNAL &&
           hasPullRequestLabel(latest, NEEDS_ATTENTION_LABEL.name) &&
-          !checkPullRequestPolicy(latest).ok
+          !checkPullRequestPolicy(latest, {
+            authorAssignedToRelatedIssue: await resolveAuthorAssignedToRelatedIssue({
+              github,
+              owner,
+              repo,
+              pullRequest: latest,
+              warnings,
+            }),
+          }).ok
         );
       },
     });

--- a/.github/scripts/pr-policy.test.mjs
+++ b/.github/scripts/pr-policy.test.mjs
@@ -71,11 +71,12 @@ function apiError(status) {
   return Object.assign(new Error(`HTTP ${status}`), { status });
 }
 
-function createGithub({ comments = [], latestPullRequest = null } = {}) {
+function createGithub({ comments = [], latestPullRequest = null, issues = new Map() } = {}) {
   const activity = {
     addedLabels: [],
     createdComments: [],
     deletedComments: [],
+    issueReads: [],
     pullUpdates: [],
     removedLabels: [],
     updatedComments: [],
@@ -86,6 +87,14 @@ function createGithub({ comments = [], latestPullRequest = null } = {}) {
     paginate: async () => comments,
     rest: {
       issues: {
+        get: async (input) => {
+          activity.issueReads.push(input);
+          const issue = issues.get(input.issue_number);
+          if (!issue) {
+            throw apiError(404);
+          }
+          return { data: issue };
+        },
         addLabels: async (input) => activity.addedLabels.push(input),
         createComment: async (input) => {
           const comment = {
@@ -172,6 +181,49 @@ void describe('pull request validation', () => {
     assert.equal(result.state, 'invalid');
     assert.ok(result.validation.findings.some((finding) => finding.includes('PR body is empty')));
     assert.ok(result.validation.findings.some((finding) => finding.includes('changes 201 lines')));
+    assert.ok(
+      result.validation.findings.some((finding) =>
+        finding.includes('require the prior Lody Issue reference')
+      )
+    );
+  });
+
+  void it('rejects community PRs over 1000 lines without an Issue assignment', async () => {
+    const { activity, github } = createGithub();
+    const result = await reconcilePullRequest({
+      github,
+      owner: 'LodyAI',
+      repo: 'Lody',
+      pullRequest: { ...externalPullRequest, body: validBody, additions: 900, deletions: 101 },
+      defaultBranch: 'main',
+    });
+
+    assert.equal(result.state, 'invalid');
+    assert.ok(
+      result.validation.findings.some((finding) =>
+        finding.includes('require a maintainer assignment on the linked Issue')
+      )
+    );
+    assert.deepEqual(activity.issueReads, [
+      { owner: 'LodyAI', repo: 'Lody', issue_number: 121 },
+    ]);
+  });
+
+  void it('accepts community PRs over 1000 lines when the author is assigned', async () => {
+    const issues = new Map([
+      [121, { assignees: [{ login: 'contributor' }] }],
+    ]);
+    const { github } = createGithub({ issues });
+    const result = await reconcilePullRequest({
+      github,
+      owner: 'LodyAI',
+      repo: 'Lody',
+      pullRequest: { ...externalPullRequest, body: validBody, additions: 900, deletions: 101 },
+      defaultBranch: 'main',
+    });
+
+    assert.equal(result.state, 'valid');
+    assert.equal(result.validation.ok, true);
   });
 });
 
@@ -192,6 +244,7 @@ void describe('pull request reconciliation', () => {
       addedLabels: [],
       createdComments: [],
       deletedComments: [],
+      issueReads: [],
       pullUpdates: [],
       removedLabels: [],
       updatedComments: [],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,13 @@ new scopes need `CLAUDE.md` symlinks). Per
 [document maintenance](.agents/README.md), Specs need human review while
 `.agents/` and directory READMEs explain. Private records stay private.
 
+## Community contributions
+
+One-shot: Lody team if the user says so or GitHub login is `zxch3n`,
+`Leeeon233`, or `wibus-wee`; otherwise community. Community PRs stay under
+1000 changed lines unless a maintainer assigned the linked Issue. Larger
+work: file an Issue with analysis; wait to be assigned. `.github/AGENTS.md`.
+
 ## Repository boundary
 
 Standalone public source tree: `apps/{cli,electron}` and the packages they
@@ -35,10 +42,11 @@ and Web/mobile app sources.
   not accept or discover staging/production deployment presets.
 - Local CLI, renderer, and Electron-main telemetry is hard-disabled even when
   unrelated PostHog variables exist in the caller's shell.
-- Client workflows that require daemon support negotiate integer protocol versions through
-  `MachineMeta.protocolCapabilities`; never infer support from the CLI release version. Missing
-  capabilities mean legacy/unsupported. Advertised set and version checks share one binding in
-  `packages/shared/src/machine-protocol-capabilities.ts` so a key never travels without its version.
+- Daemon-backed workflows negotiate versions through
+  `MachineMeta.protocolCapabilities`; never infer from the CLI release. Missing
+  capabilities mean unsupported. Set and version checks share one binding in
+  `packages/shared/src/machine-protocol-capabilities.ts` so a key never travels
+  without its version.
 - Managed runtime downloads default to the public R2-backed channel owned by
   `packages/platform/src/runtime-artifacts.ts`; local and cloud assembly must use that
   same constant. `LODY_RUNTIME_BASE_URL` is only an explicit mirror override.
@@ -94,15 +102,12 @@ bundled CLI), `packages/components` (shared UI), `packages/platform` (ports),
 
 ## Checks and commits
 
-Use Node.js 22+ and the pnpm version pinned in `package.json`. Install with
-`pnpm install`. A parent pnpm workspace owns nested checkouts; the public
-preinstall guard rejects a second install. Use a separate clone for standalone
-public development. `pnpm start:local` is the canonical desktop command; root
-`pnpm build` is the same local composition. Before committing, normally run
-`pnpm check` and `pnpm format`. If asked to skip tests, report the narrower
-type/build/static validation instead. Conventional Commits (`feat:`, `fix:`,
-`docs:`, `chore:`, `test:`); AI commits end with `Model: <runtime-model-id>`.
-CI uses `pnpm install --frozen-lockfile`, so manifest changes update
+Node.js 22+ and the pnpm in `package.json`. `pnpm install`; nested checkouts
+skip it. Standalone work uses a separate clone. `pnpm start:local` is desktop;
+root `pnpm build` is the same local composition. Before commit: `pnpm check`
+and `pnpm format` (if skipping tests, report type/build/static checks).
+Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `test:`); AI
+commits end with `Model: <runtime-model-id>`. Manifest changes update
 `pnpm-lock.yaml`.
 
 ## Test quality
@@ -114,9 +119,8 @@ Assert observable behavior, not mock call counts.
 ## Editing discipline
 
 Keep changes traceable to the request. Preserve unrelated user work. Prefer a
-small explicit contract over hidden fallbacks, and remove only code the change
-makes unused. Update the nearest public `AGENTS.md` when an invariant or
-repository boundary changes. Do not copy internal design records here.
+small explicit contract over hidden fallbacks; remove only unused code. Update
+the nearest public `AGENTS.md` when an invariant or boundary changes.
 
 ## Code Review Rules
 
@@ -126,5 +130,4 @@ P0/P1 remains, react 👍. See `.github/codex-review.md`.
 - P0: exploitable security, secret leak, auth/capability bypass, data loss, or
   a broken public/cloud/local boundary.
 - P1: likely shipped breakage or a durable catalog/session contract violation.
-- Skip style, nits, P2+, extreme edge cases, extra tests, and duplication
-  under 100 lines of near-identical code in this diff. Leave lint to CI.
+- Skip style, nits, P2+, extra tests, and duplication under 100 lines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,19 @@ By submitting a pull request, patch, or other contribution to Lody, you agree to
 - Lody may use contributions in open-source and commercial products and services, subject to the Apache License.
 - If you cannot agree to these terms, please do not submit the contribution. A separate written agreement with Lody takes precedence over these terms.
 
+## What we can review
+
+Thank you for wanting to help. Lody is a production codebase with invariants that are easy to break in a large diff and expensive to rediscover (the local/cloud boundary, catalog contracts, protocol capabilities). A large unsolicited patch often cannot be reviewed safely, even when the intent is generous.
+
+This is ordinary open-source practice: maintainers own the architecture. The most useful first contribution is often a clear Issue with reproduction or analysis, not a rewrite. Small, focused pull requests that change one thing are welcome. Closing a large PR is a statement about review capacity and risk, not about your effort.
+
+**Community contributors** (anyone who is not a Lody team member, and who has not been assigned the corresponding Issue by a maintainer):
+
+1. Keep the pull request under **1000 changed lines** (GitHub additions + deletions). We only review community PRs under that size.
+2. If the work would exceed 1000 lines, open an Issue with your analysis first. Those reports are welcome. Do not open a larger PR unless a maintainer assigns you that Issue.
+
+Lody team members work on same-repository branches and are not subject to this cap. A fork remains an external contribution even when the author is a team member.
+
 ## Before You Start
 
 1. Search existing issues and pull requests to avoid duplicate work.
@@ -90,7 +103,7 @@ continue to live in the nearest `AGENTS.md`.
 
 If an Agent prepares a fork-based contribution, it must explain that the Context handoff is public and an invalid PR receives seven days to be corrected before closure. An Agent preparing a same-repository branch must not create an Issue solely to satisfy contribution intake.
 
-A fork-based pull request that does not meet the contribution requirements is marked `status:needs-pr-attention`. All findings share one comment and one seven-day correction period. A change over 200 additions plus deletions without its prior Issue reference adds a size-specific finding rather than a separate status. A valid edit clears the managed state automatically.
+A fork-based pull request that does not meet the contribution requirements is marked `status:needs-pr-attention`. All findings share one comment and one seven-day correction period. A change over 1000 additions plus deletions without a maintainer assignment on the linked Issue, or over 200 without its prior Issue reference, adds a size-specific finding rather than a separate status. A valid edit clears the managed state automatically.
 
 If the PR remains invalid after seven days, it is marked `status:pr-policy-expired` and closed. Continue through a new pull request using the current template. A maintainer may apply `status:pr-policy-bypass` for an exceptional PR; while present, automation does not modify its Issue reference or enforce contribution requirements, and it clears prior managed policy state. Removing the label resumes normal enforcement.
 

--- a/README.md
+++ b/README.md
@@ -154,4 +154,4 @@ Lody is still moving toward full local-first support.
 - `packages/shared` — Shared schemas, protocols, and utilities
 - `site-docs` — Website, documentation, and blog
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) to get started with development.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and the community PR size policy.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -165,4 +165,4 @@ Lody 仍在走向完整的 local-first 支持。
 - `packages/shared` — 共享 Schema、协议与工具
 - `site-docs` — 官网、文档与博客
 
-如果希望参与开发，请阅读 [CONTRIBUTING.md](./CONTRIBUTING.md)。
+如果希望参与开发，请阅读 [CONTRIBUTING.md](./CONTRIBUTING.md)（含社区 PR 规模限制）。


### PR DESCRIPTION
## Related issue

## Problem / pressure

Community contributors, often via coding agents and without much open-source practice, open large unsolicited patches. Those diffs are not reviewable against Lody invariants and are expensive to maintain. Team agents reading the same AGENTS.md also wasted tokens treating maintainers as external contributors.

## Summary

Cap community PRs at 1000 changed lines unless a maintainer assigned the linked Issue. Document a one-shot Lody-team identity check (`zxch3n`, `Leeeon233`, `wibus-wee`, or an explicit user claim). Enforce the cap in PR policy for fork PRs; keep the existing 200-line Issue-reference finding. Explain the convention in CONTRIBUTING.md and the PR/Issue templates.

## Before / after

| Before | After |
| ------ | ----- |
| No public size cap; large unsolicited PRs arrive unannounced | Community PRs over 1000 lines need Issue assignment before review |
| Agents re-derived whether the author was Lody team | One-shot login/user-claim check; otherwise community |

## Test plan

- `node --test .github/scripts/pr-policy.test.mjs .github/scripts/pr-issue-link.test.mjs .github/scripts/check-pr-template.test.mjs .github/scripts/check-issue-body.test.mjs`
- `pnpm run docs check` (AGENTS.md files remain under the 8 KiB gate)
- Did not run full `pnpm check`; this change is contribution policy and docs

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Root and `.github/AGENTS.md` identity wording, `pr-policy.mjs` 1000-line assignment check, and CONTRIBUTING.md explanation of why large gifts are closed.
- **Decisions to challenge:** Hardcoded collaborator logins vs live org lookup; assignment as the large-PR exception rather than bypass-only.
- **Plausible failures / evidence gaps:** Roster will drift when membership changes; GitHub additions+deletions include lockfiles.

### Authoring context

- **User goal / directives:** Publish a community PR size cap and a cheap team-identity check so agents and humans both see it at the repo entry.
- **Constraints / non-goals:** Do not classify PRs from `author_association`. Do not apply the cap to same-repository branches. Keep AGENTS.md under 8 KiB.
- **Risk-bearing decisions:** Fork PRs over 1000 lines without Issue assignment enter needs-attention and can expire; unknown logins default to community.
- **Destructive or irreversible behavior:** Expired invalid external PRs still close after seven days; this adds a new size finding on that path.
- **Deliberately not done or tested:** No live GitHub assignment API run; policy tests use fakes. No full `pnpm check`.
- **Unknowns / confidence:** High on local policy tests; membership roster is a snapshot of write/admin collaborators on 2026-09-07.

<!-- context-handoff:end -->
