### PR TITLE
fix(cli): skip Streams reconnect while a meta room join is in flight

### DIFF
--- a/apps/cli/src/lib/loro/connection-recovery.test.ts
+++ b/apps/cli/src/lib/loro/connection-recovery.test.ts
@@ -354,4 +354,45 @@ describe('LoroConnectionRecoveryController watchdog room sweep', () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(metaSynced).toHaveBeenCalledTimes(1);
   });
+
+  it('does not tear down a connected transport while the meta room join is in flight', async () => {
+    // #399: a slow meta-room join (~900ms in the field) keeps aggregate health
+    // at `recovering`. The watchdog then called repo.reconnect() against a
+    // transport that was already `connected`, which restarted the join and
+    // prevented it from ever completing.
+    const reconnect = vi.fn(async () => {});
+    const metaSub = createMetaSub('joined');
+    const instance = createController(
+      { reconnect, joinMetaRoom: vi.fn(), transportRooms: () => [] },
+      metaSub
+    );
+
+    metaSub.emitStatus('reconnecting');
+    expect(instance.getStreamsHealth()).toBe('recovering');
+    expect(instance.isRecovering()).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(reconnect).not.toHaveBeenCalled();
+    expect(metaSub.rejoin).not.toHaveBeenCalled();
+
+    // The post-watchdog backoff used to fire again at ~2s and tear the
+    // transport down. A join still in flight must not schedule that.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(reconnect).not.toHaveBeenCalled();
+
+    metaSub.emitStatus('joined');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(instance.getStreamsHealth()).toBe('connected');
+    expect(instance.isRecovering()).toBe(false);
+  });
+
+  it('still reconnects the transport when the meta room has actually failed', async () => {
+    const reconnect = vi.fn(async () => {});
+    const metaSub = createMetaSub('joined');
+    createController({ reconnect, joinMetaRoom: vi.fn(), transportRooms: () => [] }, metaSub);
+
+    metaSub.emitStatus('disconnected');
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(reconnect).toHaveBeenCalled();
+  });
 });

--- a/apps/cli/src/lib/loro/connection-recovery.ts
+++ b/apps/cli/src/lib/loro/connection-recovery.ts
@@ -796,6 +796,18 @@ export class LoroConnectionRecoveryController {
     }
   }
 
+  /**
+   * Meta-room `connecting`/`reconnecting` means a join is already running.
+   * `repo.reconnect()` would tear down a live transport and restart that join
+   * (#399). Transport `disconnected` is a real failure and still reconnects.
+   */
+  private shouldPreserveInFlightMetaJoin(): boolean {
+    return (
+      this.transportStatus !== 'disconnected' &&
+      (this.metaRoomStatus === 'connecting' || this.metaRoomStatus === 'reconnecting')
+    );
+  }
+
   private updateBackoffAfterReconnect(reason: string, options: ReconnectOptions): void {
     if (this.isCleanedUp) {
       return;
@@ -810,6 +822,10 @@ export class LoroConnectionRecoveryController {
       // `force` already passes `resetBackoff: true` down to repo.reconnect();
       // it must NOT additionally erase this controller's flap history, or a
       // caller-triggered reconnect would hand the loop its base delay back.
+      return;
+    }
+
+    if (this.shouldPreserveInFlightMetaJoin()) {
       return;
     }
 
@@ -830,6 +846,13 @@ export class LoroConnectionRecoveryController {
       // supervises it, so CLI-authored ops for the room never reach the cloud
       // until a daemon restart. Sweep instead of returning early.
       await this.sweepRooms(reason);
+      return;
+    }
+
+    if (!options.force && this.shouldPreserveInFlightMetaJoin()) {
+      this.logger.debug(
+        `[${this.workspaceId}] Skipping Loro streams transport reconnect while the meta room join is in flight (reason=${reason}, health=${this.getStreamsHealth()}, transport=${this.transportStatus}, metaRoom=${this.metaRoomStatus ?? 'unknown'})`
+      );
       return;
     }
 

--- a/apps/cli/tests/reconnect-storm-repro.test.ts
+++ b/apps/cli/tests/reconnect-storm-repro.test.ts
@@ -347,4 +347,32 @@ describe('reconnect storm repro', () => {
     expect(scans).toBeLessThanOrEqual(3);
     expect(reconciles).toBeLessThanOrEqual(3 * SESSION_ROOM_COUNT);
   });
+
+  it('SCENARIO E: a connected transport is not torn down while the meta room join is slower than backoff', async () => {
+    // Field shape for #399: transport already `connected`, meta room still
+    // `reconnecting`, join ~900ms, first backoff ~2.1s. repo.reconnect() used
+    // to restart the join and pin the loop at attempts 2-3.
+    const reconnectAtMs: number[] = [];
+    const reconnect = vi.fn(async () => {
+      reconnectAtMs.push(Date.now());
+    });
+    const metaSub = createMetaSub('joined');
+    const instance = createController({ reconnect, transportRooms: () => [] }, metaSub);
+
+    metaSub.emitStatus('reconnecting');
+    instance.setTransportStatus('connected');
+    expect(instance.getStreamsHealth()).toBe('recovering');
+
+    await vi.advanceTimersByTimeAsync(ONE_MINUTE_MS);
+    // eslint-disable-next-line no-console
+    console.log(
+      `[SCENARIO E] reconnects/min=${reconnect.mock.calls.length} (pre-fix: watchdog + backoff tear-down of a live transport)`
+    );
+    expect(reconnect).not.toHaveBeenCalled();
+    expect(reconnectAtMs).toEqual([]);
+
+    metaSub.emitStatus('joined');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(instance.getStreamsHealth()).toBe('connected');
+  });
 });


### PR DESCRIPTION
## Related issue

Closes #399

## Problem / pressure

The Streams watchdog treated a meta-room join that had not finished as a failed transport. It called `repo.reconnect()` while `transport=connected` and `metaRoom=reconnecting`, which restarted the join. A join that needed about 900ms could not complete because the backoff (about 2s) tore the live transport down first.

## Summary

`runReconnect` skips `repo.reconnect()` when the transport is not `disconnected` and the meta room is `connecting` or `reconnecting`. `updateBackoffAfterReconnect` does not treat that skip as a failed recovery, so the short backoff cannot restart the join. Meta-room `disconnected` and `error` still take the full reconnect path. Forced reconnects are unchanged.

## Before / after

| Before | After |
| ------ | ----- |
| Watchdog called `repo.reconnect()` on a connected transport because the meta room was still joining. | The in-flight join is left running. |
| Backoff then retried every few seconds and kept the join from completing. | That skip is not charged as a failed recovery. |
| A true meta-room failure still needed a transport reconnect. | `disconnected` and `error` still reconnect. |

## Test plan

- `corepack pnpm exec vitest run src/lib/loro/connection-recovery.test.ts tests/reconnect-storm-repro.test.ts --pool=forks --maxWorkers=1` — 18 tests passed.
- New unit test failed before the skip (one `repo.reconnect()` at the 30s watchdog) and passed after.
- New reconnect-storm Scenario E failed with 6 reconnects per minute before the skip and 0 after.
- Existing reconnect-storm scenarios A–D still pass.
- A live degraded Streams session was not run.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `apps/cli/src/lib/loro/connection-recovery.ts` `shouldPreserveInFlightMetaJoin` / `runReconnect` / `updateBackoffAfterReconnect`, plus the two new tests that pin transport=connected and metaRoom=reconnecting.
- **Decisions to challenge:** Skipping transport reconnect during `connecting`/`reconnecting` instead of adding a separate room-join backoff; a join stuck in those states forever is no longer kicked by `repo.reconnect()`.
- **Plausible failures / evidence gaps:** A meta room that never leaves `reconnecting` now waits for `error`/`disconnected` or a forced reconnect; live packet-loss was not reproduced, only the controller fake-timer shape from #399.

### Authoring context

- **User goal / directives:** Open a fork PR that fixes Lody issue #399 using the repository pull-request template.
- **Constraints / non-goals:** Do not change presence, Flock freshness, or MCP error classification. Do not add a second recovery scheduler. Do not reconnect on `force`.
- **Risk-bearing decisions:** Recovery now trusts an in-flight meta join on a live transport; a stuck join is no longer cleared by tearing the transport down.
- **Destructive or irreversible behavior:** None. The change only withholds `repo.reconnect()` in one health shape; cleanup and forced reconnect still tear the transport down.
- **Deliberately not done or tested:** No live Streams packet-loss run. No room-level `rejoin()` after a join timeout. `apps/cli/src/lib/loro/AGENTS.md` was left unchanged because it is already near the 8 KiB cap.
- **Unknowns / confidence:** High confidence on the controller fake-timer repro. Lower confidence that a real loro-repo join uses only `connecting`/`reconnecting` for an in-flight meta room.

<!-- context-handoff:end -->
