### PR TITLE
fix(components): keep presence snapshots across bounded reconnect stop

### DIFF
--- a/packages/components/src/providers/workspace-presence-transport.ts
+++ b/packages/components/src/providers/workspace-presence-transport.ts
@@ -129,7 +129,11 @@ export class WorkspacePresenceTransport extends EphemeralRoomTransport<
 
   protected onStoreChange(store: PresenceStoreLike): void {
     this.lastSnapshotAtMs = Date.now();
-    this.options.onSnapshot?.(parseLodyPresenceStates(store.getAllStates()));
+    const states = parseLodyPresenceStates(store.getAllStates());
+    if (!Object.values(states).some((state) => state.kind === 'machine')) {
+      return;
+    }
+    this.options.onSnapshot?.(states);
   }
 
   protected override onRoomStarted(store: PresenceStoreLike): void {

--- a/packages/components/src/providers/workspace-presence-transport.ts
+++ b/packages/components/src/providers/workspace-presence-transport.ts
@@ -157,7 +157,6 @@ export class WorkspacePresenceTransport extends EphemeralRoomTransport<
 
   protected override onBeforeStop(): void {
     this.lastSnapshotAtMs = null;
-    this.options.onSnapshot?.({});
   }
 
   private startViewingHeartbeat(): void {

--- a/packages/components/tests/workspace-presence-transport.test.ts
+++ b/packages/components/tests/workspace-presence-transport.test.ts
@@ -117,7 +117,7 @@ describe('WorkspacePresenceTransport', () => {
     }
   });
 
-  it('emits parsed snapshots from the ephemeral store and clears them on stop', async () => {
+  it('emits parsed snapshots from the ephemeral store and keeps them on stop', async () => {
     const stores: FakePresenceStore[] = [];
     const transports: FakePresenceTransport[] = [];
     const snapshots: unknown[] = [];
@@ -166,7 +166,15 @@ describe('WorkspacePresenceTransport', () => {
 
     await presence.stop();
 
-    expect(snapshots.at(-1)).toEqual({});
+    expect(snapshots.at(-1)).toEqual({
+      [key]: {
+        kind: 'machine',
+        machineId,
+        instanceId,
+        updatedAt: 100,
+      },
+    });
+    expect(presence.getSyncState()).toBe('idle');
     expect(transports[0]?.close).toHaveBeenCalledTimes(1);
     expect(stores[0]?.destroy).toHaveBeenCalledTimes(1);
   });

--- a/packages/components/tests/workspace-presence-transport.test.ts
+++ b/packages/components/tests/workspace-presence-transport.test.ts
@@ -177,6 +177,35 @@ describe('WorkspacePresenceTransport', () => {
     expect(presence.getSyncState()).toBe('idle');
     expect(transports[0]?.close).toHaveBeenCalledTimes(1);
     expect(stores[0]?.destroy).toHaveBeenCalledTimes(1);
+
+    presence.start({ baseUrl: 'https://streams.example.test', auth: async () => 'token' });
+    expect(snapshots.at(-1)).toEqual({
+      [key]: {
+        kind: 'machine',
+        machineId,
+        instanceId,
+        updatedAt: 100,
+      },
+    });
+    expect(stores).toHaveLength(2);
+
+    stores[1]?.setStates({
+      [key]: {
+        kind: 'machine',
+        machineId,
+        instanceId,
+        updatedAt: 200,
+      },
+    });
+    expect(snapshots.at(-1)).toEqual({
+      [key]: {
+        kind: 'machine',
+        machineId,
+        instanceId,
+        updatedAt: 200,
+      },
+    });
+    await presence.stop();
   });
 
   it('exposes the current ephemeral store on window for debugging', async () => {


### PR DESCRIPTION
## Related issue

Closes #480

## Problem / pressure

#449 bounded renderer meta reconnect backoff. Each retry still stops the presence transport, which published `{}`. The UI then treated a live PC as offline. That is the renderer side of the same cluster as #398 / #399.

## Summary

`WorkspacePresenceTransport` no longer publishes a snapshot with no `kind: 'machine'` entries. `stop()` does not emit `{}`. A reconnect `start()` on an empty store does not either. Wake detection still stamps `lastSnapshotAtMs`. Last machine heartbeats remain until a new machine snapshot or the 90s TTL.

## Before / after

| Before | After |
| ------ | ----- |
| `stop()` or the next empty `start()` emitted `{}` and lists showed the PC offline. | Those paths keep the last machine snapshot. Sync state is `idle`. |
| #449 bounded retry rate only. | Bounded retries no longer wipe liveness. |

## Test plan

- `corepack pnpm exec vitest run tests/workspace-presence-transport.test.ts tests/local-reconnect-loop.test.ts tests/create-workspace-runtime-meta-recovery.test.ts` from `packages/components` — 34 passed.
- The presence-stop test failed first (`{}` vs last machine snapshot) and passed after the skip.
- #449 reconnect-loop tests still pass.
- No live desktop reconnect session was run.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `onBeforeStop` and `onStoreChange` in `workspace-presence-transport.ts`, plus the keep-on-stop / restart-empty case in `workspace-presence-transport.test.ts`.
- **Decisions to challenge:** Skip any snapshot with no `kind: 'machine'` instead of a UI `.has()` sweep. Viewing-only updates no longer notify `onSnapshot`.
- **Plausible failures / evidence gaps:** A machine that truly leaves can look online until TTL (90s). Viewing presence in the UI snapshot can lag across reconnect until the next machine heartbeat. Workspace switch still clears via `clearLodyPresenceStatesAtom`.

### Authoring context

- **User goal / directives:** File a brief bug that cites #449 and open a matching fix PR for the remaining false-offline wipe during bounded renderer reconnect.
- **Constraints / non-goals:** Do not retune #449 backoff. Do not change CLI watchdog (#399 / #478), Flock freshness (#398), or MCP error codes (#400). Do not sweep every UI `.has()` call site.
- **Risk-bearing decisions:** Stale cloud presence can linger up to the 90s TTL after stop. Local-origin merge is unchanged.
- **Destructive or irreversible behavior:** None. Stop still tears the room down; it only stops publishing an empty map.
- **Deliberately not done or tested:** No live Electron reconnect. No MCP `MACHINE_OFFLINE` change. No three-state UI sweep.
- **Unknowns / confidence:** High on the transport unit test. Medium that every consumer reads the last snapshot rather than treating `idle` as empty.

<!-- context-handoff:end -->
