### PR TITLE
fix: preserve informational agent results

### DIFF
--- a/.agents/notes/proposed/bug-fix/2026-09-08-agent-informational-results.md
+++ b/.agents/notes/proposed/bug-fix/2026-09-08-agent-informational-results.md
@@ -1,0 +1,50 @@
+# Preserve informational agent results
+
+Status: proposed
+Translation: pending
+
+## Abstract
+
+A Pi command can finish successfully without starting a model turn. Desktop
+acceptance showed that answered questions had saved their answers, but Lody marked
+the command as failed because the adapter sent no visible result. The proposed
+fix projects native completion through Core's existing informational notice and
+completes Lody's consumer of that contract. It preserves the protection against
+adapters that silently swallow model failures.
+
+## Ownership and evidence
+
+[The behavior draft](../../../../specs/agent-informational-notices.md) describes
+what the user should observe. Pi owns native completion: command handler return,
+followed by accepted RPC, drained events and no started or pending agent run.
+Errors and cancellation remain separate outcomes. Core already defines notice
+levels; Lody owns their persistence and presentation through its existing notice
+queue and history gate.
+
+Real Pi experiments confirmed four branches: answered command and consumed input
+had no updates before the fix and each produced an info notice in the candidate;
+a throwing command still rejected, and an empty model result still had no
+completion notice. An informational result describes input processing only, not
+success of arbitrary external side effects.
+
+The current Host accepts the info schema but discards its notification. Its
+warning recorder also deduplicates equal messages across a session. The same
+pipeline should retain severity and each informational occurrence while keeping
+legacy warning behavior. The durable agent_warning name remains compatible; no
+second store, queue or migration is needed.
+
+## Alternatives and limits
+
+A completed tool call would incorrectly imply a model-requested operation. A
+fallback assistant message would misattribute the result. An empty update would
+only bypass the output counter, and a new response outcome protocol would add a
+contract and still leave the user without a result. Counting a displayed question
+as success would hide errors that occur after the answer.
+
+This Host change is independent of MCP opt-out and Stop/steer ownership. It belongs
+to the Pi integration tracked by [#451](https://github.com/LodyAI/Lody/issues/451).
+A single consumer round-trip regression protects repeated informational results,
+old warning compatibility and schema preservation; deleting the level schema
+field makes it fail. Independent consumer review passed 145 related tests with
+no P0/P1. Full workspace checks, formatting and documentation checks passed.
+Final desktop acceptance remains pending.

--- a/apps/cli/src/agent/agent-client.ts
+++ b/apps/cli/src/agent/agent-client.ts
@@ -10,6 +10,7 @@ import {
   LODY_TOOL_NAMES,
   type LodyExtensionCapabilities,
   type LodyElicitationMeta,
+  type LodyNotice,
   type LodySubagentTask,
   type RateLimit,
   type RateLimitsGetRequest,
@@ -415,6 +416,7 @@ const LodySessionTitleSchema = z.object({
 export type AgentSessionWarning = {
   message: string;
   source?: string;
+  level?: LodyNotice['level'];
 };
 
 const LodySubagentTaskSchema = z.object({
@@ -1036,12 +1038,7 @@ export class AgentClient implements acp.Client {
     const lodyMeta = notification.update._meta?.lody;
     const canonical = LodyNoticeSchema.safeParse(lodyMeta);
     if (canonical.success) {
-      if (canonical.data.notice.level === 'warning' || canonical.data.notice.level === 'error') {
-        this.options.onAgentWarning?.({
-          message: canonical.data.notice.message,
-          ...(canonical.data.notice.source ? { source: canonical.data.notice.source } : {}),
-        });
-      }
+      this.options.onAgentWarning?.(canonical.data.notice);
       return;
     }
 

--- a/apps/cli/src/lib/acp/AGENTS.md
+++ b/apps/cli/src/lib/acp/AGENTS.md
@@ -74,3 +74,8 @@ first `await awaitTurnHistoryGate(sessionId)` — see
 `../../session/turn-history-gate.ts`. Add the same await to any NEW code path that
 appends or positions history entries during a turn; map-keyed status/meta writes stay
 ungated.
+
+Core notices use the existing session notice queue and history gate. Preserve each
+`info` occurrence and its level; legacy notices without a level remain warnings.
+Keep notice text out of assistant prose, and do not weaken silent-model failure
+checks to accept a command whose completion the adapter has not established.

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -8941,6 +8941,7 @@ export class MessageHandler {
         meta: {
           message: warning.message,
           ...(warning.source ? { source: warning.source } : {}),
+          ...(warning.level ? { level: warning.level } : {}),
         },
       };
       const systemNotice: SessionHistoryInput = {
@@ -8953,14 +8954,17 @@ export class MessageHandler {
         items: [noticeItem],
       };
       await sessionDoc.updateHistory((prevHistory) => {
-        const alreadyRecorded = prevHistory.some((entry) =>
-          entry.items?.some(
-            (item) =>
-              item?.type === 'system_notice' &&
-              item.name === 'agent_warning' &&
-              (item.meta as AgentWarningMeta | undefined)?.message === warning.message
-          )
-        );
+        const alreadyRecorded =
+          warning.level !== 'info' &&
+          prevHistory.some((entry) =>
+            entry.items?.some((item) => {
+              if (item?.type !== 'system_notice' || item.name !== 'agent_warning') {
+                return false;
+              }
+              const meta = item.meta as AgentWarningMeta | undefined;
+              return meta?.level !== 'info' && meta?.message === warning.message;
+            })
+          );
         return alreadyRecorded ? prevHistory : [...prevHistory, systemNotice];
       });
     } catch (error) {

--- a/apps/cli/tests/message-handler-agent-notice.test.ts
+++ b/apps/cli/tests/message-handler-agent-notice.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LoroRepo } from 'loro-repo';
+import type { SessionNotification } from '@agentclientprotocol/sdk';
+
+import {
+  MessageContentSchema,
+  type ACPSessionId,
+  type SessionId,
+  type WorkspaceId,
+} from '@lody/shared';
+
+import { AgentClient, type AgentSessionWarning } from '../src/agent/agent-client';
+import { MessageHandler } from '../src/lib/message-handler';
+import { SessionDocument } from '../src/lib/loro/doc';
+import type { LoroDocumentManager } from '../src/lib/loro/doc';
+import type { SessionManager } from '../src/session/session-manager';
+import type { Logger } from '../src/utils/logger';
+import { createTestCloudPort } from './test-cloud-port';
+
+const createSilentLogger = (): Logger => ({
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  success: () => {},
+  debug: () => {},
+  setLevel: () => {},
+  child: () => createSilentLogger(),
+  close: async () => {},
+});
+
+type MessageHandlerHost = {
+  flushThreadGoalHistoryPersists(sessionId: SessionId): Promise<void>;
+};
+
+const sessionInfoNotification = (meta: Record<string, unknown>): SessionNotification =>
+  ({
+    sessionId: 'acp-test',
+    update: { sessionUpdate: 'session_info_update', _meta: meta },
+  }) as unknown as SessionNotification;
+
+describe('MessageHandler agent notices', () => {
+  let repo: LoroRepo | undefined;
+
+  afterEach(async () => {
+    if (repo) {
+      await repo.destroy();
+      repo = undefined;
+    }
+  });
+
+  it('persists every info occurrence while preserving warning deduplication', async () => {
+    const sessionId = 'notice-session' as SessionId;
+    repo = await LoroRepo.create({});
+    const doc = new SessionDocument(repo, sessionId);
+    await doc.initOffline();
+
+    let onAgentWarning:
+      | ((eventSessionId: SessionId, warning: AgentSessionWarning) => void)
+      | undefined;
+    const sessionManager = {
+      on: vi.fn((event: string, listener: unknown) => {
+        if (event === 'onAgentWarning') {
+          onAgentWarning = listener as (
+            eventSessionId: SessionId,
+            warning: AgentSessionWarning
+          ) => void;
+        }
+      }),
+      setRequestPermissionHandler: vi.fn(),
+      getSession: vi.fn(() => null),
+    };
+    const workspaceDocument = {
+      isTransportConnected: vi.fn(() => true),
+      markMachineFlockDocDirty: vi.fn(),
+      registerMachine: vi.fn(),
+      repo: {
+        watch: vi.fn(() => ({ unsubscribe: vi.fn() })),
+        getDocMeta: vi.fn(async () => ({
+          meta: { needToArchiveSessions: {}, needToDeleteSessions: {} },
+        })),
+      },
+      getOrCreateSessionDoc: vi.fn(async () => doc),
+    };
+    const logger = createSilentLogger();
+    const handler = new MessageHandler(
+      sessionManager as unknown as SessionManager,
+      workspaceDocument as unknown as LoroDocumentManager,
+      logger,
+      {
+        token: 't',
+        workspaceId: 'ws-1' as WorkspaceId,
+        userId: 'u-1',
+        machineId: 'm-1',
+        machineName: 'machine',
+        cliVersion: '0.0.0',
+        cloudPort: createTestCloudPort(),
+      }
+    ) as unknown as MessageHandlerHost;
+
+    const client = new AgentClient({
+      sessionId,
+      logger,
+      terminalManager: {} as never,
+      agentConfig: { cliType: 'builtin', agentType: 'codex' },
+      onUpdateMessage: vi.fn(),
+      onRequestPermission: vi.fn(async () => ({ outcome: { outcome: 'cancelled' as const } })),
+      onAgentWarning: (warning) => onAgentWarning?.(sessionId, warning),
+    });
+    // @ts-expect-error - accessing private field for test setup
+    client.acpSessionId = 'acp-test' as ACPSessionId;
+
+    const message = 'Pi processed this input without starting a model turn.';
+    const info = sessionInfoNotification({
+      lody: { notice: { level: 'info', message, source: 'pi' } },
+    });
+    await client.sessionUpdate(info);
+    await client.sessionUpdate(info);
+    await client.sessionUpdate(
+      sessionInfoNotification({
+        lody: { notice: { level: 'warning', message, source: 'pi' } },
+      })
+    );
+    const legacyWarning = sessionInfoNotification({
+      codex: { warning: { message: 'Legacy warning', source: 'warning' } },
+    });
+    await client.sessionUpdate(legacyWarning);
+    await client.sessionUpdate(legacyWarning);
+    await handler.flushThreadGoalHistoryPersists(sessionId);
+
+    const notices = (await doc.getHistory()).flatMap((entry) =>
+      (entry.items ?? [])
+        .filter((item) => item.type === 'system_notice' && item.name === 'agent_warning')
+        .map((item) => MessageContentSchema.parse(item).meta)
+    );
+    expect(notices).toEqual([
+      { level: 'info', message, source: 'pi' },
+      { level: 'info', message, source: 'pi' },
+      { level: 'warning', message, source: 'pi' },
+      { message: 'Legacy warning', source: 'warning' },
+    ]);
+  });
+});

--- a/locales/en.json
+++ b/locales/en.json
@@ -2155,6 +2155,7 @@
   "sessions.systemNotices.resumeFromExternalChatHistory.tooltip": "Native ACP resume is not yet supported (WIP). Context is restored from chat history.",
   "sessions.systemNotices.resumeFromExternalChatHistory.truncatedSuffix": "(History truncated due to length)",
   "sessions.systemNotices.agentWarning.title": "Agent warning",
+  "sessions.systemNotices.agentWarning.infoTitle": "Agent notice",
   "sessions.tabs.archivedTabs": "Archived tabs",
   "sessions.tabs.archivedCount": "Archived ({{count}})",
   "sessions.tabs.closeConfirm": "Close this tab?",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -2155,6 +2155,7 @@
   "sessions.systemNotices.resumeFromExternalChatHistory.tooltip": "原生 ACP 恢复尚未支持（开发中）。当前上下文来自聊天记录。",
   "sessions.systemNotices.resumeFromExternalChatHistory.truncatedSuffix": "（由于长度限制，聊天记录已截断）",
   "sessions.systemNotices.agentWarning.title": "Agent 警告",
+  "sessions.systemNotices.agentWarning.infoTitle": "Agent 提示",
   "sessions.tabs.archivedTabs": "已归档标签页",
   "sessions.tabs.archivedCount": "已归档（{{count}}）",
   "sessions.tabs.closeConfirm": "关闭此标签页？",

--- a/packages/components/src/components/ai-gui/view.tsx
+++ b/packages/components/src/components/ai-gui/view.tsx
@@ -36,6 +36,7 @@ import { getRpcDeliveredTurnKey, rpcDeliveredTurnsAtom } from '@/atoms/session-d
 import { selectAtom } from 'jotai/utils';
 import { Virtualizer, type VirtualizerHandle } from 'virtua';
 import {
+  type AgentWarningMeta,
   type AgentConfigCliType,
   type ChatFailedCode,
   type ClientToServer,
@@ -2512,21 +2513,37 @@ const AgentWarningNoticeView = ({
   notice: Extract<MessageContent, { type: 'system_notice' }>;
 }) => {
   const { t } = useTranslation();
-  const meta = notice.meta as { message?: string; source?: string } | undefined;
+  const meta = notice.meta as AgentWarningMeta | undefined;
   if (!meta?.message) {
     return null;
   }
+  const isInfo = meta.level === 'info';
+  const icon = isInfo ? (
+    <Info className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+  ) : (
+    <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-status-warning" aria-hidden="true" />
+  );
 
   return (
     <div className="py-1 @[640px]:pl-3">
       <div
-        role="alert"
-        className="flex w-fit max-w-full items-start gap-2 rounded-md border border-status-warning/30 bg-status-warning/10 px-2.5 py-1.5"
+        role={isInfo ? 'status' : 'alert'}
+        className={cn(
+          'flex w-fit max-w-full items-start gap-2 rounded-md border px-2.5 py-1.5',
+          isInfo ? 'border-border/60 bg-muted/30' : 'border-status-warning/30 bg-status-warning/10'
+        )}
       >
-        <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0 text-status-warning" aria-hidden="true" />
+        {icon}
         <div className="flex min-w-0 flex-col gap-0.5">
-          <span className="text-xs font-medium leading-4 text-status-warning">
-            {t('sessions.systemNotices.agentWarning.title', 'Agent warning')}
+          <span
+            className={cn(
+              'text-xs font-medium leading-4',
+              isInfo ? 'text-muted-foreground' : 'text-status-warning'
+            )}
+          >
+            {isInfo
+              ? t('sessions.systemNotices.agentWarning.infoTitle', 'Agent notice')
+              : t('sessions.systemNotices.agentWarning.title', 'Agent warning')}
           </span>
           <span className="min-w-0 whitespace-pre-wrap break-words text-xs leading-5 text-muted-foreground">
             {meta.message}

--- a/packages/components/src/stories/AgentNotice.stories.tsx
+++ b/packages/components/src/stories/AgentNotice.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { SessionHistoryParsed, SessionId } from '@lody/shared';
+
+import { MessageRowView } from '@/components/ai-gui/view';
+import { ConversationColumn } from '@/components/shared/conversation-column';
+
+const meta = {
+  title: 'Sessions/AgentNotice',
+  component: MessageRowView,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="w-[720px] max-w-[100vw] bg-background py-6">
+        <ConversationColumn>
+          <Story />
+        </ConversationColumn>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof MessageRowView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sessionId = 'agent-notice-session' as SessionId;
+const informationalMessage = {
+  id: 'agent-notice-info',
+  role: 'system',
+  timestamp: '2026-09-08T00:00:00.000Z',
+  read: true,
+  items: [
+    {
+      type: 'system_notice',
+      name: 'agent_warning',
+      meta: {
+        level: 'info',
+        source: 'pi',
+        message: 'Pi processed this input without starting a model turn.',
+      },
+    },
+  ],
+} as SessionHistoryParsed;
+
+export const Informational: Story = {
+  args: {
+    sessionId,
+    message: informationalMessage,
+  },
+};

--- a/packages/components/tests/agent-warning-notice.test.tsx
+++ b/packages/components/tests/agent-warning-notice.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { createStore, Provider } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { SessionHistoryParsed, SessionId } from '@lody/shared';
+
+import { MessageRowView } from '../src/components/ai-gui/view';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const sessionId = 'agent-warning-session' as SessionId;
+
+function warningMessage(meta: Record<string, unknown>): SessionHistoryParsed {
+  return {
+    id: 'agent-warning-notice',
+    role: 'system',
+    timestamp: '2026-09-08T00:00:00.000Z',
+    read: true,
+    items: [
+      {
+        type: 'system_notice',
+        name: 'agent_warning',
+        meta,
+      },
+    ],
+  } as SessionHistoryParsed;
+}
+
+describe('Agent warning notices', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  async function render(meta: Record<string, unknown>) {
+    await act(async () => {
+      root.render(
+        <Provider store={createStore()}>
+          <MessageRowView message={warningMessage(meta)} sessionId={sessionId} />
+        </Provider>
+      );
+    });
+  }
+
+  it('announces informational outcomes without warning treatment', async () => {
+    await render({ message: 'Command exited with status 1.', level: 'info' });
+
+    expect(container.querySelector('[role="status"]')?.textContent).toContain(
+      'Command exited with status 1.'
+    );
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.textContent).toContain('Agent notice');
+  });
+
+  it('keeps legacy notices as warnings when level is absent', async () => {
+    await render({ message: 'Agent needs attention.' });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'Agent needs attention.'
+    );
+    expect(container.textContent).toContain('Agent warning');
+  });
+});

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -6,6 +6,7 @@ import {
   ToolCallStatus,
 } from '@agentclientprotocol/sdk';
 import type { ToolCallContent as AcpToolCallContent, SessionMode } from '@agentclientprotocol/sdk';
+import type { LodyNotice } from 'acp-extension-core';
 import type { PermissionOutcome } from './message';
 import type { AgentConfigId, AgentRoleId, McpServerId, SessionId } from './ids';
 import type { MessageTextSpan } from './message-text-spans';
@@ -1151,6 +1152,7 @@ export type ChatFailedMeta = {
 export type AgentWarningMeta = {
   message: string;
   source?: string;
+  level?: LodyNotice['level'];
 };
 
 export type SessionForkOriginMeta = {

--- a/packages/shared/src/message-schemas.ts
+++ b/packages/shared/src/message-schemas.ts
@@ -3089,6 +3089,7 @@ export const ResumeFromExternalChatHistoryMetaSchema = z.object({
 export const AgentWarningMetaSchema = z.object({
   message: z.string(),
   source: z.string().optional(),
+  level: z.enum(['info', 'warning', 'error']).optional(),
 });
 
 // Who authored a history item; agent-authored content cannot use turn-level userId.

--- a/specs/agent-informational-notices.md
+++ b/specs/agent-informational-notices.md
@@ -1,0 +1,30 @@
+# Agent informational results
+
+Status: draft
+Translation: pending
+
+A user can invoke an agent command that processes input without asking a model to
+respond. When the agent reports that processing completed, the conversation shows
+an informational result rather than a failed turn or invented model response.
+
+Core's existing notice contract identifies the message and its severity. The
+adapter may announce completion only after its native command has returned
+successfully. A question being answered, a request being accepted, or an empty
+model response is not by itself proof of completion.
+
+Lody retains and displays each informational occurrence, including repeated
+identical results on different turns. Informational notices use neutral styling.
+Existing warning records without a severity retain their warning meaning and
+existing repeated-warning suppression. Notice text stays separate from assistant
+text and is not used as model-generated prose for titles or prompt replay.
+
+A command error remains an error. A model turn ending without observable output
+continues to receive the existing silent-failure handling. This change does not
+add a command outcome protocol or change the meaning of ordinary ACP end_turn.
+
+## Evidence and limits
+
+The existing Core LodyNotice contract defines info, warning and error. Real Pi
+0.85.1 experiments distinguished handled input, handler failure and empty model
+output. Host consumption and original desktop acceptance remain under review;
+this draft does not assert completed end-to-end verification.


### PR DESCRIPTION
## Related issue

Refs #451

## Problem / pressure

Pi can successfully handle a command without starting a model turn. Desktop acceptance answered an extension question and confirmed its saved answer, but Lody marked the turn as failed because no visible result reached the conversation. Retrying such a command can repeat its side effects.

Core already defines informational notices; Lody parses their level but forwards only warnings and errors.

## Summary

Consume `info` through the existing agent notice pipeline, preserve each occurrence and render it neutrally. Retain the existing history discriminant and the default warning meaning for old records. Informational results do not suppress a later warning with the same text.

The Pi producer is in LodyAI/acp-extension-pi#1. It emits the notice only after native input handling completes without starting a model run. This consumer requires no new Core release and is independent of MCP opt-out #479 and Stop/steer #471.

## Visual explanation

The adapter owns proof of native input completion. This PR completes the existing Lody notice consumer across CLI, shared history and UI:

```mermaid
flowchart TD
    A["Adapter: establish native input completion"] --> N["Core LodyNotice: level, message, source"]
    subgraph CLI["Lody CLI"]
        N --> V["AgentClient validates notice"]
        V -. "Before: info discarded here" .-> X["No visible informational result"]
        V -->|"After: forward all notice levels"| Q["Existing notice queue + history gate"]
        Q --> I{"Informational?"}
        I -->|Yes| E["Retain every occurrence"]
        I -->|No| W["Keep warning deduplication; ignore info matches"]
    end
    subgraph History["Shared durable history"]
        E --> H["system_notice / agent_warning<br/>Preserve optional level"]
        W --> H
    end
    subgraph UI["Conversation UI"]
        H --> L{"level = info?"}
        L -->|Yes| P["Neutral notice; role=status"]
        L -->|"No / legacy missing level"| G["Warning presentation; role=alert"]
    end
```

Notice text stays separate from assistant prose. Empty model output still follows the existing silent-failure check.

## Before / after

| Before | After |
| ------ | ----- |
| A successful command with no model reply can appear as a failed turn. | Its explicit informational result is retained and shown without pretending to be model prose. |
| Repeated identical notices share warning-style session deduplication. | Each informational occurrence is retained; existing warning suppression remains. |
| Empty model responses receive silent-failure handling. | The same protection remains. |

## Test plan

- `pnpm check`, `pnpm format` and `pnpm run docs check` passed.
- Independent consumer review passed 145 related tests with no P0/P1.
- Astra removed a duplicate schema-only test: the single ACP-to-history regression parses the stored result through the public schema and fails if level is stripped.
- Real Pi experiments separated successful command/input handling, handler errors and empty model output. No completion notice is emitted for the latter two branches.
- The checks above describe head `b8b3614`. No combined Electron acceptance at this head is claimed; later native-CLI adapter checks do not revalidate this consumer branch.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Follow Core notice severity through AgentClient, the existing queued history writer, the shared schema and `agent_warning` renderer.
- **Decisions to challenge:** Retain the legacy discriminant and warning defaults while recording each info occurrence; do not add a second notice queue or command outcome protocol.
- **Plausible failures / evidence gaps:** Check repeated equal info messages, an equal-text warning after info and old records; original desktop acceptance remains pending.

### Authoring context

- **User goal / directives:** Validate a usable Pi adapter end to end and fix actual authority or contract gaps using independent review and Astra design experiments.
- **Constraints / non-goals:** No change to the silent-model-output guard, invented assistant text, model tool calls, MCP implementation or Stop ownership.
- **Risk-bearing decisions:** Native command completion is the producer's authority; Host consumes the existing severity contract and keeps notice text separate from assistant prose.
- **Destructive or irreversible behavior:** No migration or history rewrite. New records add optional severity, and rollback leaves their existing notice discriminator readable.
- **Deliberately not done or tested:** No generic command outcome protocol or inference from answered questions; neither proves a completed native command.
- **Unknowns / confidence:** Real Pi discrimination experiments support the producer boundary; consumer tests passed; combined desktop acceptance determines readiness. This PR remains Draft.

### Original user prompt

The triggering end-to-end acceptance directive exposed this integration defect.

<details>
<summary>Show original prompt</summary>

````text
可以的，我觉得都要验证一遍，把行为都验证过了才行。
````

</details>

<!-- context-handoff:end -->
