### PR TITLE
fix: do not treat unknown presence as machine offline

### DIFF
--- a/apps/cli/src/mcp/lody-mcp-server.test.ts
+++ b/apps/cli/src/mcp/lody-mcp-server.test.ts
@@ -1131,7 +1131,23 @@ describe('session MCP input schemas', () => {
       createMcpContext()
     );
 
-    await expect(isMachineOnline('remote-unseen' as never)).resolves.toBe(true);
+    await expect(isMachineOnline('remote-unseen' as MachineId)).resolves.toBe(true);
+  });
+
+  it('still reports a remote machine offline after presence has joined', async () => {
+    const getOnlineMachineIds = vi.fn(async () => new Set(['remote-a']));
+    const isMachineOnline = makeMachineOnlineLookupForMcp(
+      { getOnlineMachineIds } as never,
+      createMcpContext()
+    );
+
+    await expect(
+      Promise.all([
+        isMachineOnline('machine-id' as MachineId),
+        isMachineOnline('remote-a' as MachineId),
+        isMachineOnline('remote-missing' as MachineId),
+      ])
+    ).resolves.toEqual([true, true, false]);
   });
 
   it('truncates history text on Unicode boundaries with exact omitted bytes', () => {

--- a/apps/cli/src/mcp/lody-mcp-server.test.ts
+++ b/apps/cli/src/mcp/lody-mcp-server.test.ts
@@ -1124,6 +1124,16 @@ describe('session MCP input schemas', () => {
     expect(getOnlineMachineIds).toHaveBeenCalledTimes(1);
   });
 
+  it('does not treat a missing presence join as MACHINE_OFFLINE', async () => {
+    const getOnlineMachineIds = vi.fn(async () => null);
+    const isMachineOnline = makeMachineOnlineLookupForMcp(
+      { getOnlineMachineIds } as never,
+      createMcpContext()
+    );
+
+    await expect(isMachineOnline('remote-unseen' as never)).resolves.toBe(true);
+  });
+
   it('truncates history text on Unicode boundaries with exact omitted bytes', () => {
     const original = '🚀审查'.repeat(100);
     const result = truncateUtf8HeadTail(original, 101);

--- a/apps/cli/src/mcp/lody-mcp-server.ts
+++ b/apps/cli/src/mcp/lody-mcp-server.ts
@@ -2335,7 +2335,11 @@ const makeMachineOnlineLookupForMcp = (
       return true;
     }
     onlineMachineIds ??= manager.getOnlineMachineIds();
-    return (await onlineMachineIds)?.has(machineId) === true;
+    const ids = await onlineMachineIds;
+    if (ids === null) {
+      return true;
+    }
+    return ids.has(machineId);
   };
 };
 
@@ -2552,7 +2556,9 @@ const buildSessionCreateOptions = async (
     const machineEntries = await listAliveDocMetas<MachineMeta>(manager, isMachineDocRoomId);
     const onlineMachineIds = await manager.getOnlineMachineIds();
     const isMachineOnline = (machineId: MachineId): boolean =>
-      machineId === auth.machineId || onlineMachineIds?.has(machineId) === true;
+      machineId === auth.machineId ||
+      onlineMachineIds === null ||
+      onlineMachineIds.has(machineId);
     const machineCandidates = selectMachineMetasForOptions(
       machineEntries.map((entry) => entry.meta),
       input.machineId

--- a/apps/cli/src/mcp/lody-mcp-server.ts
+++ b/apps/cli/src/mcp/lody-mcp-server.ts
@@ -2556,9 +2556,7 @@ const buildSessionCreateOptions = async (
     const machineEntries = await listAliveDocMetas<MachineMeta>(manager, isMachineDocRoomId);
     const onlineMachineIds = await manager.getOnlineMachineIds();
     const isMachineOnline = (machineId: MachineId): boolean =>
-      machineId === auth.machineId ||
-      onlineMachineIds === null ||
-      onlineMachineIds.has(machineId);
+      machineId === auth.machineId || onlineMachineIds === null || onlineMachineIds.has(machineId);
     const machineCandidates = selectMachineMetasForOptions(
       machineEntries.map((entry) => entry.meta),
       input.machineId

--- a/packages/components/src/components/chat/chat-landing.tsx
+++ b/packages/components/src/components/chat/chat-landing.tsx
@@ -79,7 +79,11 @@ import {
 } from '@/atoms';
 import { docMetaCacheReadyAtom, sessionMetaCountAtom } from '@/atoms/doc-meta';
 import { localProbeAttemptedAtom, localProbeResultAtom } from '@/atoms/local-probe';
-import { lodyPresenceNowMsAtom, lodyPresenceStatesAtom } from '@/atoms/presence';
+import {
+  lodyPresenceNowMsAtom,
+  lodyPresenceStatesAtom,
+  lodyPresenceSyncStateAtom,
+} from '@/atoms/presence';
 import { buildAgentPrompt } from '@/lib';
 import { getAppCurrentPathWithSearch } from '@/lib/app-location';
 import { isImeComposingKeyboardEvent } from '@/lib/ime';
@@ -749,9 +753,11 @@ function WorkspaceChatLanding({
   const onlineMachineIds = useOnlineMachineIds();
   const onlineMachineIdsRef = useRef(onlineMachineIds);
   onlineMachineIdsRef.current = onlineMachineIds;
+  const presenceSyncState = useAtomValue(lodyPresenceSyncStateAtom);
   const isPresenceMachineOnline = useCallback(
-    (machineId: string) => onlineMachineIds.has(machineId as MachineId),
-    [onlineMachineIds]
+    (machineId: string) =>
+      onlineMachineIds.has(machineId as MachineId) || presenceSyncState !== 'synced',
+    [onlineMachineIds, presenceSyncState]
   );
   const freshRepositories = useCloudQuery(
     cloudOperations.github.getWorkspaceRepositories,
@@ -1912,12 +1918,12 @@ function WorkspaceChatLanding({
   const onlineMachineCount = useMemo(() => {
     let count = 0;
     for (const machineId of machines.keys()) {
-      if (onlineMachineIds.has(machineId)) {
+      if (isPresenceMachineOnline(machineId)) {
         count += 1;
       }
     }
     return count;
-  }, [machines, onlineMachineIds]);
+  }, [machines, isPresenceMachineOnline]);
   const hasNoMachine = !hasAnyOnlineMachine;
 
   // ── Sync selectedMachineId from selectedAgent (e.g. when restored from defaults) ──
@@ -2485,7 +2491,7 @@ function WorkspaceChatLanding({
           projectMachineId: project.machineId,
           visibleLocalMachineId,
           targetMachine: machinesRef.current.get(project.machineId),
-          isMachineOnline: (machineId) => onlineMachineIdsRef.current.has(machineId),
+          isMachineOnline: isPresenceMachineOnline,
         })
       ) {
         throw new Error(
@@ -2547,7 +2553,7 @@ function WorkspaceChatLanding({
         return response.state;
       });
     },
-    [isElectron, runtime, t, userId, visibleLocalMachineId]
+    [isElectron, isPresenceMachineOnline, runtime, t, userId, visibleLocalMachineId]
   );
 
   // Collapse the machine map down to a single boolean: is the selected
@@ -4378,7 +4384,7 @@ function WorkspaceChatLanding({
       .map(([machineId, machine]) => ({
         id: machineId,
         name: machine.name,
-        isOnline: onlineMachineIds.has(machineId),
+        isOnline: isPresenceMachineOnline(machineId),
         isPrivate: showProjectSharing && accessByMachineId.get(machineId)?.sharedWithTeam === false,
       }))
       .sort((left, right) => {
@@ -4387,7 +4393,7 @@ function WorkspaceChatLanding({
         }
         return left.name.localeCompare(right.name);
       });
-  }, [accessByMachineId, onlineMachineIds, machines, showProjectSharing]);
+  }, [accessByMachineId, isPresenceMachineOnline, machines, showProjectSharing]);
   /* The mobile-home machine pill bar was dropped — rows now group by
      machine via sticky section headings, so we just hand the full list
      of online / known machines straight through. No filter state, no
@@ -4765,7 +4771,7 @@ function WorkspaceChatLanding({
             ? activity.latestMessageAt
             : null;
         const diffStats = session.diffStats ?? { allChange: { add: 0, del: 0 } };
-        const isOnline = onlineMachineIds.has(session.machineId);
+        const isOnline = isPresenceMachineOnline(session.machineId);
         const repoFullName = getSessionGitHubRepoFullName(session);
         const localProjectKey = getSessionLocalProjectKey(session);
         const kind: MobileConversationKind = repoFullName
@@ -4881,7 +4887,7 @@ function WorkspaceChatLanding({
     mobileOpenerRowResolver,
     liveSessionStatuses,
     mobileHomeShowArchived,
-    onlineMachineIds,
+    isPresenceMachineOnline,
     showProjectSharing,
     t,
     teamMembersByUserId,
@@ -5691,7 +5697,7 @@ function WorkspaceChatLanding({
             ? activity.latestMessageAt
             : null;
         const diffStats = session.diffStats ?? { allChange: { add: 0, del: 0 } };
-        const isOnline = onlineMachineIds.has(session.machineId);
+        const isOnline = isPresenceMachineOnline(session.machineId);
         const kind: MobileConversationKind =
           mobileProjectContext.kind === 'github'
             ? 'github'
@@ -5757,7 +5763,7 @@ function WorkspaceChatLanding({
     liveSessionStatuses,
     mobileProjectContext,
     mobileProjectShowArchived,
-    onlineMachineIds,
+    isPresenceMachineOnline,
     t,
     teamMembersByUserId,
     userId,

--- a/packages/components/src/components/chat/chat-landing.tsx
+++ b/packages/components/src/components/chat/chat-landing.tsx
@@ -756,8 +756,10 @@ function WorkspaceChatLanding({
   const presenceSyncState = useAtomValue(lodyPresenceSyncStateAtom);
   const isPresenceMachineOnline = useCallback(
     (machineId: string) =>
-      onlineMachineIds.has(machineId as MachineId) || presenceSyncState !== 'synced',
-    [onlineMachineIds, presenceSyncState]
+      machineId === localProbeResult?.machineId ||
+      onlineMachineIds.has(machineId as MachineId) ||
+      presenceSyncState !== 'synced',
+    [localProbeResult?.machineId, onlineMachineIds, presenceSyncState]
   );
   const freshRepositories = useCloudQuery(
     cloudOperations.github.getWorkspaceRepositories,

--- a/packages/components/src/components/chat/chat-landing.tsx
+++ b/packages/components/src/components/chat/chat-landing.tsx
@@ -331,7 +331,6 @@ import {
   getEffectiveSessionActivitySummary,
   getLatestPullRequestInfo,
 } from '@/components/sessions/session-list-rows';
-import { useOnlineMachines } from '@/hooks/use-online-machines';
 import { getLocalProjectVisibilityKey as buildLocalProjectKey } from '@/lib/visible-local-project-index';
 import {
   isThoughtLevelSelector,
@@ -3856,15 +3855,14 @@ function WorkspaceChatLanding({
      as Tabs since they're already inline. */
 
   /* ── Machine ── */
-  const mobileSheetOnlineMachines = useOnlineMachines();
   const mobileSheetMachineOptions = useMemo<MobileInlinePickerOption<MachineId>[]>(() => {
-    return mobileSheetOnlineMachines.map((m) => ({
+    return Array.from(selectableMachines.values()).map((m) => ({
       value: m.id as MachineId,
       label: m.name,
       searchText: m.name,
       icon: <Monitor className="h-3.5 w-3.5" strokeWidth={1.8} aria-hidden="true" />,
     }));
-  }, [mobileSheetOnlineMachines]);
+  }, [selectableMachines]);
   const mobileSheetSelectedMachineLabel = useMemo(() => {
     if (!selectedMachineId) return null;
     return mobileSheetMachineOptions.find((opt) => opt.value === selectedMachineId)?.label ?? null;


### PR DESCRIPTION
## Related issue

Closes #484

## Problem / pressure

`getOnlineMachineIds()` returning `null` means the presence room did not join. MCP and chat landing treated that as every remote machine offline, including a live PC.

## Summary

MCP `makeMachineOnlineLookupForMcp` and create-options treat `null` as unknown (usable). Chat landing treats the local probe machine as online, and only claims Offline when presence is `synced` and there is no heartbeat. Does not sweep other `.has()` surfaces.

## Before / after

| Before | After |
| ------ | ----- |
| Presence not joined → `MACHINE_OFFLINE` and hidden machines. | Unknown is not offline. |
| Chat landing `has()` → Offline while syncing. | Offline only when presence is `synced` and the heartbeat is missing. |

## Test plan

- `corepack pnpm exec vitest run src/mcp/lody-mcp-server.test.ts -t "MACHINE_OFFLINE|shares one remote Machine presence"` — 2 passed.
- No chat-landing unit for the callback. No live desktop run.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `makeMachineOnlineLookupForMcp` in `lody-mcp-server.ts` and `isPresenceMachineOnline` in `chat-landing.tsx`.
- **Decisions to challenge:** Unknown treated as usable/online rather than a third UI state. Other `.has()` surfaces (sidebar, settings) are unchanged.
- **Plausible failures / evidence gaps:** A truly offline remote machine can be listed while presence is joining. Chat landing has no new unit test.

### Authoring context

- **User goal / directives:** Open the remaining false-offline hole as an issue and a small real fix PR.
- **Constraints / non-goals:** Do not retouch #480/#481 snapshot wipe. Do not convert every UI caller to three-state. Do not change Flock sync.
- **Risk-bearing decisions:** Unknown presence allows create/list of remote machines until RPC fails later.
- **Destructive or irreversible behavior:** None.
- **Deliberately not done or tested:** Sidebar/settings/CLI `machine list`. Live presence-join failure.
- **Unknowns / confidence:** High on the MCP null path. Medium on chat-landing coverage without a component test.

<!-- context-handoff:end -->
