### PR TITLE
fix(cli): treat machine Flock freshness sync as best-effort

### DIFF
--- a/apps/cli/src/commands/session.test.ts
+++ b/apps/cli/src/commands/session.test.ts
@@ -1111,6 +1111,47 @@ describe('session command helpers', () => {
     }
   });
 
+  it('resolves a local project from the replica when Flock freshness sync fails', async () => {
+    const syncFlockDocOrThrow = vi.fn(async () => {
+      throw new Error('Streams sync failed: network_error');
+    });
+    const manager = {
+      syncFlockDocOrThrow,
+      repo: {
+        getDocMeta: vi.fn(async () => ({
+          meta: {
+            localProjects: {
+              'local-project-1': {
+                id: 'local-project-1',
+                name: 'lody',
+                rootPath: '/workspace/lody',
+                createdAtMs: 1,
+              },
+            },
+          },
+        })),
+        openFlockDoc: vi.fn(async () => ({
+          flock: {
+            scan: () => [],
+          },
+        })),
+      },
+    } as unknown as Parameters<typeof resolveLocalProjectRefOrThrow>[0];
+
+    await expect(
+      resolveLocalProjectRefOrThrow(
+        manager,
+        'workspace-1' as WorkspaceId,
+        'machine-id' as MachineId,
+        'lody'
+      )
+    ).resolves.toEqual({
+      kind: 'local',
+      localProjectId: 'local-project-1',
+    });
+    expect(syncFlockDocOrThrow).toHaveBeenCalled();
+  });
+
   it('does not synthesize a branch for non-git local projects', async () => {
     const rootPath = mkdtempSync(path.join(os.tmpdir(), 'lody-session-non-git-'));
     try {

--- a/apps/cli/src/commands/session.ts
+++ b/apps/cli/src/commands/session.ts
@@ -983,13 +983,19 @@ async function syncMachineFlockDocsForRead(
   machineIds: readonly MachineId[],
   reason: string
 ): Promise<void> {
+  const logger = getLogger('session');
   await Promise.all(
-    Array.from(new Set(machineIds)).map(
-      async (machineId) =>
+    Array.from(new Set(machineIds)).map(async (machineId) => {
+      try {
         await manager.syncFlockDocOrThrow(getMachineFlockDocId(workspaceId, machineId), {
           reason: `${reason}:${machineId}`,
-        })
-    )
+        });
+      } catch (error) {
+        logger.warn(
+          `Machine Flock freshness sync was not confirmed (${reason}:${machineId}); continuing from the local replica: ${formatErrorMessage(error)}`
+        );
+      }
+    })
   );
 }
 


### PR DESCRIPTION
## Related issue

Closes #485

## Problem / pressure

`syncMachineFlockDocsForRead` threw on a failed Flock freshness round trip. Session create/chat/options then died even when the local replica already had the project and agent config. #411 wraps one caller. The helper still hard-failed the rest.

## Summary

The helper logs a warning and continues from the local replica. `syncFlockDocOrThrow` itself is unchanged. Explicit `lody sync`, archive/delete confirm, and Operation `syncRemoteDocOrThrow` stay hard-fail.

## Before / after

| Before | After |
| ------ | ----- |
| Any `syncMachineFlockDocsForRead` caller aborted on `network_error`. | Callers read the local Flock replica. |

## Test plan

- `corepack pnpm exec vitest run src/commands/session.test.ts -t "Flock freshness sync fails"` — 1 passed.
- Existing local-project resolve test still applies.
- No live degraded Streams run.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `syncMachineFlockDocsForRead` in `apps/cli/src/commands/session.ts` and the new replica-fallback test.
- **Decisions to challenge:** Best-effort for every caller of this helper, including remote-machine reads. A missing remote replica can still surface as "not found" without the sync error attached.
- **Plausible failures / evidence gaps:** Overlaps #411. MCP `syncFlockDocOrThrow` call sites that do not go through this helper are unchanged.

### Authoring context

- **User goal / directives:** Open opportunistic local Flock reads as an issue and a helper-level fix, not a full sync rewrite.
- **Constraints / non-goals:** Do not change `lody sync`, meta write confirmation, or Operation remote catch-up. Do not close #398 from this PR.
- **Risk-bearing decisions:** Remote-machine freshness failure is no longer fatal at this helper.
- **Destructive or irreversible behavior:** None. Local replica is only read.
- **Deliberately not done or tested:** Attaching the sync cause to a later not-found error. Direct MCP `syncFlockDocOrThrow` in create_options/role catalog.
- **Unknowns / confidence:** High for the helper test. Medium that remaining MCP OrThrow sites still block some creates.

<!-- context-handoff:end -->
