### PR TITLE
fix(components): enable machine picker before doc-meta scan finishes

### DIFF
--- a/packages/components/src/components/chat/chat-landing-derived.ts
+++ b/packages/components/src/components/chat/chat-landing-derived.ts
@@ -388,11 +388,11 @@ export function getChatLandingInitialDataLoading({
   localMachineStateAttempted,
   hasSelectableMachine,
 }: ChatLandingInitialDataLoadingArgs): boolean {
-  if (isRuntimeInitializing || !isDocMetaCacheReady || !localMachineStateAttempted) {
+  if (isRuntimeInitializing || !localMachineStateAttempted) {
     return true;
   }
 
-  return isVisibleMachinesLoading && !hasSelectableMachine;
+  return (!isDocMetaCacheReady || isVisibleMachinesLoading) && !hasSelectableMachine;
 }
 
 export function getChatLandingLocalProjectAvailability({

--- a/packages/components/tests/chat-landing-derived.test.ts
+++ b/packages/components/tests/chat-landing-derived.test.ts
@@ -416,7 +416,7 @@ describe('getChatLandingInitialDataLoading', () => {
         localMachineStateAttempted: true,
         hasSelectableMachine: true,
       })
-    ).toBe(true);
+    ).toBe(false);
 
     expect(
       getChatLandingInitialDataLoading({
@@ -425,6 +425,18 @@ describe('getChatLandingInitialDataLoading', () => {
         isDocMetaCacheReady: true,
         localMachineStateAttempted: false,
         hasSelectableMachine: true,
+      })
+    ).toBe(true);
+  });
+
+  it('keeps loading while doc metadata is pending and no selectable machine exists', () => {
+    expect(
+      getChatLandingInitialDataLoading({
+        isRuntimeInitializing: false,
+        isVisibleMachinesLoading: false,
+        isDocMetaCacheReady: false,
+        localMachineStateAttempted: true,
+        hasSelectableMachine: false,
       })
     ).toBe(true);
   });


### PR DESCRIPTION
## Related issue

Closes #496

Refs #317

## Problem / pressure

`getChatLandingInitialDataLoading` treats `!isDocMetaCacheReady` as always loading, even when a selectable machine already exists. The picker stays disabled through the full metadata scan after local runtime is up.

## Summary

The gate now matches the visibility fail-open: wait on runtime init and local probe, then wait on doc-meta or visibility only when there is no selectable machine. `useChatLandingDefaults` still waits on doc-meta for stored agent restore. Does not take #317's mobile sync ladder.

## Before / after

| Before | After |
| ------ | ----- |
| `!isDocMetaCacheReady` disables the picker even with a selectable machine. | Picker enables once a selectable machine exists. |
| Visibility already fail-opened. Doc-meta did not. | Both wait only when `hasSelectableMachine` is false. |

## Test plan

- `pnpm exec vitest run tests/chat-landing-derived.test.ts` — includes the flipped `hasSelectableMachine` + `!isDocMetaCacheReady` case and a still-loading case when no machine exists.
- No live desktop cold-start run.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `getChatLandingInitialDataLoading` in `chat-landing-derived.ts` and the two tests around `isDocMetaCacheReady`.
- **Decisions to challenge:** Fail-open when one selectable machine exists rather than waiting for the full catalog. Not bundling #317's staged eager-sync.
- **Plausible failures / evidence gaps:** The machine list can grow after the picker enables. No live cold-start screenshot.

### Authoring context

- **User goal / directives:** Ship the remaining landing-picker fail-open as a ready PR, not a draft, without taking #317's full ladder.
- **Constraints / non-goals:** Do not change defaults restore. Do not retouch presence-unknown mobile sheet (#486). Do not close #317.
- **Risk-bearing decisions:** Users can open the picker before last-used agent restore finishes.
- **Destructive or irreversible behavior:** None.
- **Deliberately not done or tested:** Live Electron cold start. Mobile sheet `useOnlineMachines` on this `main` snapshot.
- **Unknowns / confidence:** High on the pure function. Medium on how often `hasSelectableMachine` is true before the scan ends on phone vs desktop.

<!-- context-handoff:end -->
