### PR TITLE
perf(components): pace Capacitor eager-sync below desktop

### DIFF
--- a/packages/components/src/providers/background-sync-coordinator.ts
+++ b/packages/components/src/providers/background-sync-coordinator.ts
@@ -1,4 +1,5 @@
 import { getSessionRoomId, type SessionId, type SessionStatus } from '@lody/shared';
+import type { EagerSyncPolicy } from './eager-sync-policy';
 
 /**
  * Background progressive eager-sync of session docs.
@@ -88,52 +89,16 @@ export interface BackgroundSyncCoordinatorDeps {
   logger?: { debug(...args: unknown[]): void };
 }
 
-export interface EagerSyncPolicy {
-  /** Max concurrent prefetches. */
-  concurrency: number;
-  /** Max prefetches to start before yielding to a cooldown. */
-  batchSize: number;
-  /** Delay before starting the next prefetch batch. */
-  batchCooldownMs: number;
-  /** Burst-coalesce window: skip re-syncing a room synced within this window. */
-  freshnessTtlMs: number;
-  /** Max coordinator-warmed docs kept before LRU eviction. */
-  maxWarmDocs: number;
-  /** Only eager-sync the top-N candidates; Infinity means all candidates. */
-  candidateWindow: number;
-  /** Abort a prefetch that has not settled within this window. */
-  prefetchTimeoutMs: number;
-}
-
-export type EagerSyncSurface = 'web' | 'desktop' | 'mobile';
-
-export const WEB_EAGER_SYNC_CANDIDATE_WINDOW = 20;
-export const FULL_EAGER_SYNC_CANDIDATE_WINDOW = Number.POSITIVE_INFINITY;
-
-export const WEB_EAGER_SYNC_POLICY: EagerSyncPolicy = {
-  concurrency: 2,
-  batchSize: 4,
-  batchCooldownMs: 1_500,
-  freshnessTtlMs: 15_000,
-  maxWarmDocs: 20,
-  candidateWindow: WEB_EAGER_SYNC_CANDIDATE_WINDOW,
-  prefetchTimeoutMs: 20_000,
-};
-
-export const FULL_EAGER_SYNC_POLICY: EagerSyncPolicy = {
-  concurrency: 3,
-  batchSize: 8,
-  batchCooldownMs: 750,
-  freshnessTtlMs: 15_000,
-  maxWarmDocs: 96,
-  candidateWindow: FULL_EAGER_SYNC_CANDIDATE_WINDOW,
-  prefetchTimeoutMs: 20_000,
-};
-
-export const DEFAULT_EAGER_SYNC_POLICY = WEB_EAGER_SYNC_POLICY;
-
-export const resolveEagerSyncPolicy = (surface: EagerSyncSurface): EagerSyncPolicy =>
-  surface === 'web' ? WEB_EAGER_SYNC_POLICY : FULL_EAGER_SYNC_POLICY;
+export type { EagerSyncPolicy, EagerSyncSurface } from './eager-sync-policy';
+export {
+  DEFAULT_EAGER_SYNC_POLICY,
+  FULL_EAGER_SYNC_CANDIDATE_WINDOW,
+  FULL_EAGER_SYNC_POLICY,
+  MOBILE_EAGER_SYNC_POLICY,
+  WEB_EAGER_SYNC_CANDIDATE_WINDOW,
+  WEB_EAGER_SYNC_POLICY,
+  resolveEagerSyncPolicy,
+} from './eager-sync-policy';
 
 export interface BackgroundSyncCoordinator {
   start(): void;

--- a/packages/components/src/providers/eager-sync-policy.ts
+++ b/packages/components/src/providers/eager-sync-policy.ts
@@ -1,0 +1,52 @@
+export interface EagerSyncPolicy {
+  concurrency: number;
+  batchSize: number;
+  batchCooldownMs: number;
+  freshnessTtlMs: number;
+  maxWarmDocs: number;
+  candidateWindow: number;
+  prefetchTimeoutMs: number;
+}
+
+export type EagerSyncSurface = 'web' | 'desktop' | 'mobile';
+
+export const WEB_EAGER_SYNC_CANDIDATE_WINDOW = 20;
+export const FULL_EAGER_SYNC_CANDIDATE_WINDOW = Number.POSITIVE_INFINITY;
+
+export const WEB_EAGER_SYNC_POLICY: EagerSyncPolicy = {
+  concurrency: 2,
+  batchSize: 4,
+  batchCooldownMs: 1_500,
+  freshnessTtlMs: 15_000,
+  maxWarmDocs: 20,
+  candidateWindow: WEB_EAGER_SYNC_CANDIDATE_WINDOW,
+  prefetchTimeoutMs: 20_000,
+};
+
+export const FULL_EAGER_SYNC_POLICY: EagerSyncPolicy = {
+  concurrency: 3,
+  batchSize: 8,
+  batchCooldownMs: 750,
+  freshnessTtlMs: 15_000,
+  maxWarmDocs: 96,
+  candidateWindow: FULL_EAGER_SYNC_CANDIDATE_WINDOW,
+  prefetchTimeoutMs: 20_000,
+};
+
+export const MOBILE_EAGER_SYNC_POLICY: EagerSyncPolicy = {
+  concurrency: 1,
+  batchSize: 3,
+  batchCooldownMs: 3_000,
+  freshnessTtlMs: 15_000,
+  maxWarmDocs: 12,
+  candidateWindow: FULL_EAGER_SYNC_CANDIDATE_WINDOW,
+  prefetchTimeoutMs: 20_000,
+};
+
+export const DEFAULT_EAGER_SYNC_POLICY = WEB_EAGER_SYNC_POLICY;
+
+export const resolveEagerSyncPolicy = (surface: EagerSyncSurface): EagerSyncPolicy => {
+  if (surface === 'web') return WEB_EAGER_SYNC_POLICY;
+  if (surface === 'mobile') return MOBILE_EAGER_SYNC_POLICY;
+  return FULL_EAGER_SYNC_POLICY;
+};

--- a/packages/components/tests/background-sync-coordinator.test.ts
+++ b/packages/components/tests/background-sync-coordinator.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { getSessionRoomId, type SessionId, type SessionStatus } from '@lody/shared';
 import {
   createBackgroundSyncCoordinator,
-  resolveEagerSyncPolicy,
   type BackgroundSyncCoordinatorDeps,
   type EagerSyncHighWaterStore,
   type EagerSyncPolicy,
   type PrefetchOutcome,
   type SessionActivitySnapshot,
 } from '../src/providers/background-sync-coordinator';
+import { resolveEagerSyncPolicy } from '../src/providers/eager-sync-policy';
 
 const sid = (id: string) => id as SessionId;
 const room = (id: string) => getSessionRoomId(sid(id));
@@ -231,7 +231,7 @@ function setup(
 }
 
 describe('createBackgroundSyncCoordinator', () => {
-  it('uses a bounded web policy and full desktop/mobile policy', () => {
+  it('uses a bounded web policy, full desktop policy, and paced mobile policy', () => {
     expect(resolveEagerSyncPolicy('web')).toMatchObject({
       concurrency: 2,
       batchSize: 4,
@@ -246,7 +246,13 @@ describe('createBackgroundSyncCoordinator', () => {
       candidateWindow: Number.POSITIVE_INFINITY,
       maxWarmDocs: 96,
     });
-    expect(resolveEagerSyncPolicy('mobile')).toBe(resolveEagerSyncPolicy('desktop'));
+    expect(resolveEagerSyncPolicy('mobile')).toMatchObject({
+      concurrency: 1,
+      batchSize: 3,
+      batchCooldownMs: 3_000,
+      candidateWindow: Number.POSITIVE_INFINITY,
+      maxWarmDocs: 12,
+    });
   });
 
   it('prefetches a recently-active session on start', async () => {

--- a/packages/components/tests/eager-sync-policy.test.ts
+++ b/packages/components/tests/eager-sync-policy.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveEagerSyncPolicy } from '../src/providers/eager-sync-policy';
+
+describe('resolveEagerSyncPolicy', () => {
+  it('uses a bounded web policy, full desktop policy, and paced mobile policy', () => {
+    expect(resolveEagerSyncPolicy('web')).toMatchObject({
+      concurrency: 2,
+      batchSize: 4,
+      batchCooldownMs: 1_500,
+      candidateWindow: 20,
+      maxWarmDocs: 20,
+    });
+    expect(resolveEagerSyncPolicy('desktop')).toMatchObject({
+      concurrency: 3,
+      batchSize: 8,
+      batchCooldownMs: 750,
+      candidateWindow: Number.POSITIVE_INFINITY,
+      maxWarmDocs: 96,
+    });
+    expect(resolveEagerSyncPolicy('mobile')).toMatchObject({
+      concurrency: 1,
+      batchSize: 3,
+      batchCooldownMs: 3_000,
+      candidateWindow: Number.POSITIVE_INFINITY,
+      maxWarmDocs: 12,
+    });
+  });
+});


### PR DESCRIPTION
## Related issue

Closes #497

Refs #317

## Problem / pressure

Capacitor is classified `'mobile'` then given `FULL_EAGER_SYNC_POLICY` because `resolveEagerSyncPolicy` only branches on `'web'`. Prefetch hydrates Loro on the main thread at desktop concurrency.

## Summary

Adds `MOBILE_EAGER_SYNC_POLICY` (concurrency 1, batch 3 / 3s, maxWarmDocs 12, still unbounded `candidateWindow`) in `eager-sync-policy.ts`. Desktop stays FULL. Web stays bounded. Does not add #317's staged ladder or interaction port.

## Before / after

| Before | After |
| ------ | ----- |
| Mobile policy is the desktop FULL object. | Mobile uses its own slower constants. |
| `candidateWindow` Infinity on native. | Unchanged, so eventual offline coverage remains. |

## Test plan

- `pnpm exec vitest run tests/background-sync-coordinator.test.ts` — policy object assertions for web, desktop, and mobile.
- No Capacitor device run.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `MOBILE_EAGER_SYNC_POLICY` and `resolveEagerSyncPolicy` in `background-sync-coordinator.ts`.
- **Decisions to challenge:** Constants-only pacing instead of #317's ladder. Keeping `candidateWindow: Infinity` on mobile.
- **Plausible failures / evidence gaps:** Prefetch still eventually hydrates every session, just slower. No phone trace.

### Authoring context

- **User goal / directives:** Ship the remaining mobile eager-sync constants as a ready PR, not a draft, without duplicating #317's ladder.
- **Constraints / non-goals:** Do not add interaction deferral or landing-selector changes here. Do not close #317.
- **Risk-bearing decisions:** First open of a never-warmed session on phone may wait on live catch-up until later stages would have run in #317. Eventual Infinity still prefetches everything, slowly.
- **Destructive or irreversible behavior:** None. IndexedDB copies are not deleted.
- **Deliberately not done or tested:** Capacitor device freeze repro. Ladder / `eager-sync-interaction.ts`.
- **Unknowns / confidence:** High that mobile no longer shares the desktop object. Medium on whether concurrency 1 is enough without interaction yield.

<!-- context-handoff:end -->
