### PR TITLE
fix: raise asynchronous chain depth limit to 32

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-08-raise-async-chain-depth.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-08-raise-async-chain-depth.md
@@ -1,0 +1,32 @@
+# Raise the asynchronous delegation chain limit
+
+Status: implemented
+Translation: current
+
+[中文](2026-09-08-raise-async-chain-depth.zh.md)
+
+## Abstract
+
+The MCP asynchronous delegation guard rejected a command once its causal chain
+reached five hops, which stopped deeper delegated work before an Operation or
+target Session could start. The shared limit is now 32, and the executable
+Operation model and review automation explanation use the same value. The guard
+remains fixed and non-retryable at the boundary, so the larger budget increases
+available delegation depth without removing the recursion protection.
+
+## Decision and scope
+
+- Set `LODY_MAX_CHAIN_DEPTH` to 32 in the shared orchestration contract.
+- Replace hard-coded model checks with that shared constant and update the cap
+  regression assertions.
+- Keep `parentSessionId` rules and machine-side Review Automation ownership
+  unchanged; this change concerns causal async hops only.
+- Record the new behavior in the draft session-orchestration Spec for human
+  review.
+
+## Evidence and limits
+
+The source and model changes were inspected with `rg` and `git diff --check`.
+Targeted Vitest execution was attempted but could not start because this
+checkout has no installed `node_modules` and therefore no `vitest` binary.
+Deployed-client and long-chain runtime acceptance remains open.

--- a/.agents/notes/implemented/bug-fix/2026-09-08-raise-async-chain-depth.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-08-raise-async-chain-depth.zh.md
@@ -1,0 +1,27 @@
+# 提高异步委派链上限
+
+Status: implemented
+Translation: current
+
+[English](2026-09-08-raise-async-chain-depth.md)
+
+## 摘要
+
+MCP 异步委派保护在因果链达到五次跳转后拒绝命令，使更深的委派工作无法在
+创建 Operation 或目标 Session 前启动。现在共享上限改为 32，可执行
+Operation 模型和 Review Automation 说明也使用同一数值。边界仍保持固定且
+不可重试，因此只是扩大可用委派深度，没有移除递归保护。
+
+## 决定与范围
+
+- 在共享编排契约中将 `LODY_MAX_CHAIN_DEPTH` 设为 32。
+- 用共享常量替换模型中的硬编码检查，并更新上限回归断言。
+- 保持 `parentSessionId` 规则和机器侧 Review Automation 的归属不变；本次只
+  修改异步因果跳转上限。
+- 在待人工审核的会话编排 Spec 中记录新行为。
+
+## 证据与限制
+
+已用 `rg` 和 `git diff --check` 检查源码与模型变更。尝试运行定向 Vitest，
+但当前工作树没有安装 `node_modules`，因此找不到 `vitest` 可执行文件。
+已发布客户端和长链运行时验收仍待补充。

--- a/apps/cli/src/lib/review-automation/README.md
+++ b/apps/cli/src/lib/review-automation/README.md
@@ -23,15 +23,16 @@ the reasoning behind those rules.
 
 Two hard constraints, not preferences:
 
-- `LODY_MAX_CHAIN_DEPTH = 5` (`packages/shared/src/session-orchestration.ts`) is
-  fixed and explicitly non-configurable. A loop that can run several rounds cannot
-  be built from MCP session calls — it dies at depth 5.
+- `LODY_MAX_CHAIN_DEPTH = 32` (`packages/shared/src/session-orchestration.ts`) is
+  fixed and explicitly non-configurable. MCP session calls remain bounded by this
+  causal hop limit, so a loop that may need more hops must not depend on nested MCP
+  calls for its progress.
 - `specs/session-orchestration.md`: "MCP observes only Lody-owned state. GitHub,
   CI, webhooks... are outside this contract." This loop is mostly a reaction to
   exactly those.
 
-Stepping around the chain-depth guard is what makes the run's own budgets
-load-bearing: they are the replacement safety mechanism.
+Keeping the loop on the machine side lets it react to GitHub and CI state while
+its own budgets remain the load-bearing safety mechanism.
 
 ## Two modes, one engine
 

--- a/apps/cli/src/lib/review-automation/review-automation-engine.ts
+++ b/apps/cli/src/lib/review-automation/review-automation-engine.ts
@@ -28,10 +28,10 @@ import { nextStateForAction, planReviewStep, type ReviewAction } from './review-
  *
  * It lives on the machine, not in MCP, for two reasons that are both hard
  * constraints rather than preferences. The orchestration contract caps a chain
- * at `LODY_MAX_CHAIN_DEPTH` (5) hops from the last human input, so a loop that
- * can run a dozen rounds cannot be built out of MCP session calls at all. And
- * that same contract observes only Lody-owned state — GitHub, CI, and webhooks
- * are explicitly outside it, while this loop is mostly a reaction to them.
+ * at `LODY_MAX_CHAIN_DEPTH` (32) hops from the last human input, so a loop that
+ * may need more hops cannot depend on nested MCP session calls. That same
+ * contract observes only Lody-owned state — GitHub, CI, and webhooks are
+ * explicitly outside it, while this loop is mostly a reaction to them.
  *
  * Stepping around the chain-depth guard is what makes the run's own budgets
  * load-bearing: they are the replacement safety mechanism, not a convenience.

--- a/apps/cli/src/orchestration/operation-model.test.ts
+++ b/apps/cli/src/orchestration/operation-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { LODY_MAX_CHAIN_DEPTH } from '@lody/shared';
 
 import {
   assertOrchestrationModelSafety,
@@ -256,7 +257,7 @@ describe('Operation delivery executable model', () => {
   });
 
   it('rejects a new machine Command at the fixed chain-depth cap', () => {
-    const capped = { ...initialOrchestrationModelState(), chainDepth: 5 };
+    const capped = { ...initialOrchestrationModelState(), chainDepth: LODY_MAX_CHAIN_DEPTH };
     expect(stepOrchestrationModel(capped, 'accept').operation).toBe('absent');
   });
 
@@ -270,7 +271,7 @@ describe('Operation delivery executable model', () => {
     expect(() =>
       assertOrchestrationModelSafety({
         ...initialOrchestrationModelState(),
-        chainDepth: 6,
+        chainDepth: LODY_MAX_CHAIN_DEPTH + 1,
       })
     ).toThrow(/exceeded the fixed depth cap/);
     expect(() =>

--- a/apps/cli/src/orchestration/operation-model.ts
+++ b/apps/cli/src/orchestration/operation-model.ts
@@ -1,3 +1,5 @@
+import { LODY_MAX_CHAIN_DEPTH } from '@lody/shared';
+
 /**
  * Small executable contract model for Operation/Delivery scheduling races.
  * It deliberately omits storage fields and models only state that can change a
@@ -76,7 +78,7 @@ export const stepOrchestrationModel = (
   const next = { ...state };
   switch (action) {
     case 'accept':
-      if (next.operation === 'absent' && next.chainDepth < 5) {
+      if (next.operation === 'absent' && next.chainDepth < LODY_MAX_CHAIN_DEPTH) {
         next.operation = 'active';
         next.targetInput = 'missing';
         next.progress = 'pending';
@@ -311,7 +313,7 @@ export const assertOrchestrationModelSafety = (state: OrchestrationModelState): 
   if (state.deliveryAttempts > 2) {
     throw new Error('a Delivery exceeded its bounded attempt count');
   }
-  if (state.chainDepth > 5) {
+  if (state.chainDepth > LODY_MAX_CHAIN_DEPTH) {
     throw new Error('machine-originated chain exceeded the fixed depth cap');
   }
 };

--- a/packages/shared/src/session-orchestration.ts
+++ b/packages/shared/src/session-orchestration.ts
@@ -10,7 +10,7 @@ export const LODY_OPERATION_MIN_DEADLINE_SECONDS = 60;
 export const LODY_OPERATION_MAX_DEADLINE_SECONDS = 604_800;
 export const LODY_OPERATION_COMMAND_MAX_BYTES = 256 * 1024;
 export const LODY_OPERATION_COMPLETION_MAX_BYTES = 64 * 1024;
-export const LODY_MAX_CHAIN_DEPTH = 5;
+export const LODY_MAX_CHAIN_DEPTH = 32;
 
 export const LodyOperationIdSchema = z
   .string()

--- a/specs/session-orchestration.md
+++ b/specs/session-orchestration.md
@@ -1,0 +1,32 @@
+# Session orchestration chain depth
+
+Status: draft
+Translation: current
+
+[中文](session-orchestration.zh.md)
+
+When an Agent delegates asynchronous work through Lody, each delegated target
+continues the causal chain from the driving human turn. Lody accepts at most 32
+such hops. A command issued by a turn already at depth 32 is rejected before an
+Operation or target Session is created, with the non-retryable
+`CHAIN_DEPTH_EXCEEDED` error.
+
+The depth is a causal delegation count, not a general `parentSessionId` tree
+depth. Creating a Session, sending work to another Session, and delivering an
+Operation continuation each advance the target turn by one. A missing depth on
+an ordinary human turn starts at zero. The limit remains fixed in the shared
+protocol contract; changing it requires updating every producer, recovery path,
+executable model, and this Spec.
+
+Machine-side review automation runs outside this MCP delegation chain. It keeps
+its own round, token, and authority budgets while reacting to external review and
+CI state.
+
+## Evidence
+
+The implementation guard is `apps/cli/src/mcp/lody-mcp-server.ts`, the shared
+limit is `packages/shared/src/session-orchestration.ts`, and the executable
+Operation model is `apps/cli/src/orchestration/operation-model.ts`.
+
+This draft records the requested limit of 32. Runtime and deployed-client
+acceptance remain to be verified after dependencies are installed.

--- a/specs/session-orchestration.zh.md
+++ b/specs/session-orchestration.zh.md
@@ -1,0 +1,29 @@
+# 会话编排异步链深度
+
+Status: draft
+Translation: current
+
+[English](session-orchestration.md)
+
+Agent 通过 Lody 委派异步工作时，每个委派目标都会从发起它的人类 Turn
+继续同一条因果链。Lody 最多接受 32 次这样的跳转。已经处于深度 32 的
+Turn 再发起命令时，会在创建 Operation 或目标 Session 之前被拒绝，并返回
+不可重试的 `CHAIN_DEPTH_EXCEEDED` 错误。
+
+这个深度表示因果委派次数，不是通用的 `parentSessionId` 树深度。创建
+Session、向另一个 Session 发送工作、以及投递 Operation 完成通知，都会让
+目标 Turn 增加一层。普通人类 Turn 缺少深度时从零开始。这个上限仍是共享
+协议中的固定值；修改它必须同步更新所有生产者、恢复路径、可执行模型和本
+Spec。
+
+机器侧 Review Automation 在这条 MCP 委派链之外运行。它自己管理轮数、
+Token 和权限预算，并根据外部的 Review 与 CI 状态推进。
+
+## 证据
+
+实现检查位于 `apps/cli/src/mcp/lody-mcp-server.ts`，共享上限位于
+`packages/shared/src/session-orchestration.ts`，可执行 Operation 模型位于
+`apps/cli/src/orchestration/operation-model.ts`。
+
+本草稿记录将上限改为 32 的请求。依赖安装后仍需补充运行时和已发布客户端
+验收。


### PR DESCRIPTION
## Summary

- Raise `LODY_MAX_CHAIN_DEPTH` from 5 to 32 for asynchronous causal delegation.
- Keep the runtime guard fixed and non-retryable, and synchronize the executable Operation model and regression assertions with the shared constant.
- Update the bilingual session-orchestration Spec and implementation note.

## Validation

- `pnpm run docs check` — passed with no errors; existing AGENTS size warnings remain.
- `git diff --check` — passed.
- `pnpm --filter lody test src/mcp/lody-mcp-server.test.ts src/orchestration/operation-model.test.ts` — not started because this checkout has no `node_modules` and `vitest` is unavailable.
- `pnpm --filter lody typecheck` — not started because this checkout has no `node_modules` and `tsgo` is unavailable.
