### PR TITLE
fix(components): subtract permissionWaitMs from Worked-for duration

### DIFF
--- a/packages/components/src/components/ai-gui/build-chat-stream-items.ts
+++ b/packages/components/src/components/ai-gui/build-chat-stream-items.ts
@@ -61,6 +61,7 @@ function canReuseCachedMessageItem(
     cached.item.message.read === (entry.read ?? false) &&
     cached.item.message.timestamp === entry.timestamp &&
     cached.item.message.endedAt === entry.endedAt &&
+    cached.item.message.permissionWaitMs === entry.permissionWaitMs &&
     cached.item.message.userId === entry.userId &&
     cached.rawModelInfo === entry.modelInfo &&
     cached.rawFileDiff === entry.fileDiff &&
@@ -156,6 +157,7 @@ export function buildChatStreamItems(
       read: entry.read ?? false,
       timestamp: entry.timestamp,
       endedAt: entry.endedAt,
+      permissionWaitMs: entry.permissionWaitMs,
       userId: entry.userId,
       acpTurnId: entry.acpTurnId,
       modelInfo: entry.modelInfo,

--- a/packages/components/src/lib/session-history-duration.ts
+++ b/packages/components/src/lib/session-history-duration.ts
@@ -1,7 +1,13 @@
 import type { SessionHistoryParsed } from '@lody/shared';
 
+/**
+ * Wall-clock span minus time spent waiting on permission, when that wait was
+ * recorded. Schema: effective work = (endedAt - timestamp) - permissionWaitMs.
+ * A missing wait field is treated as 0 so turns without a permission card
+ * stay endedAt - timestamp.
+ */
 export const resolveSessionHistoryDurationMs = (
-  message: Pick<SessionHistoryParsed, 'endedAt' | 'timestamp'>
+  message: Pick<SessionHistoryParsed, 'endedAt' | 'timestamp' | 'permissionWaitMs'>
 ): number | null => {
   const endedAt = message.endedAt;
   if (typeof endedAt !== 'number' || !Number.isFinite(endedAt)) return null;
@@ -10,5 +16,8 @@ export const resolveSessionHistoryDurationMs = (
   if (!Number.isFinite(parsed)) return null;
 
   if (endedAt < parsed) return null;
-  return endedAt - parsed;
+  const span = endedAt - parsed;
+  const wait = message.permissionWaitMs;
+  if (typeof wait !== 'number' || !Number.isFinite(wait) || wait <= 0) return span;
+  return Math.max(0, span - wait);
 };

--- a/packages/components/tests/build-chat-stream-items.test.ts
+++ b/packages/components/tests/build-chat-stream-items.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { SessionHistory, SessionId } from '@lody/shared';
 import { buildChatStreamItems } from '../src/components/ai-gui/build-chat-stream-items';
+import { resolveSessionHistoryDurationMs } from '../src/lib/session-history-duration';
 
 const sessionId = 'session-test' as SessionId;
 
@@ -139,6 +140,50 @@ describe('buildChatStreamItems', () => {
     );
 
     expect(lastAssistantMessageId).toBe('a1');
+  });
+
+  it('copies permissionWaitMs onto rendered assistant messages so Worked-for can subtract it', () => {
+    const opened = '2026-06-18T00:00:00.000Z';
+    const { items } = buildChatStreamItems(
+      [
+        {
+          ...entry({ id: 'assistant-1', role: 'assistant', items: [text('done')] }),
+          timestamp: opened,
+          endedAt: Date.parse(opened) + 87_000,
+          permissionWaitMs: 62_269,
+          finished: true,
+        },
+      ],
+      sessionId
+    );
+
+    const item = items[0];
+    expect(item?.type).toBe('message');
+    if (item?.type !== 'message') return;
+    expect(item.message.permissionWaitMs).toBe(62_269);
+    expect(resolveSessionHistoryDurationMs(item.message)).toBe(87_000 - 62_269);
+  });
+
+  it('does not reuse a cached item when permissionWaitMs changes', () => {
+    const opened = '2026-06-18T00:00:00.000Z';
+    const base = {
+      ...entry({ id: 'assistant-1', role: 'assistant', items: [text('done')] }),
+      timestamp: opened,
+      endedAt: Date.parse(opened) + 87_000,
+      finished: true,
+    };
+    const first = buildChatStreamItems([{ ...base, permissionWaitMs: 1_000 }], sessionId);
+    const second = buildChatStreamItems(
+      [{ ...base, permissionWaitMs: 62_269 }],
+      sessionId,
+      first.cache
+    );
+
+    expect(second.items[0]).not.toBe(first.items[0]);
+    expect(second.items[0]).toMatchObject({
+      type: 'message',
+      message: { permissionWaitMs: 62_269 },
+    });
   });
 
   it('reuses unchanged message item objects across shallow history array copies', () => {

--- a/packages/components/tests/session-history-duration.test.ts
+++ b/packages/components/tests/session-history-duration.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveSessionHistoryDurationMs } from '../src/lib/session-history-duration';
+
+const OPENED = '2026-01-01T00:00:00.000Z';
+const OPENED_MS = Date.parse(OPENED);
+
+describe('resolveSessionHistoryDurationMs', () => {
+  it('returns endedAt - timestamp when no permission wait was recorded', () => {
+    expect(
+      resolveSessionHistoryDurationMs({
+        timestamp: OPENED,
+        endedAt: OPENED_MS + 29_000,
+      })
+    ).toBe(29_000);
+  });
+
+  it('subtracts a recorded permission wait from Worked-for', () => {
+    // Live: 1 minute at the plan card (62269ms) plus ~25s of actual work.
+    expect(
+      resolveSessionHistoryDurationMs({
+        timestamp: OPENED,
+        endedAt: OPENED_MS + 87_000,
+        permissionWaitMs: 62_269,
+      })
+    ).toBe(87_000 - 62_269);
+  });
+
+  it('clamps to 0 when the wait is longer than the span', () => {
+    expect(
+      resolveSessionHistoryDurationMs({
+        timestamp: OPENED,
+        endedAt: OPENED_MS + 10_000,
+        permissionWaitMs: 12_000,
+      })
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

An AI agent found the mismatch and implemented the subtraction. A human reviewed the live OSS runs, the schema/renderer comparison, and this patch before submit.

## Related issue

Closes #512

Distinct from closed #260 (that restamped `endedAt` after quit/reopen). This change is the live Worked-for label on a turn that never quit.

## Problem / pressure

The Worked-for duration display includes permission wait time. Only turns that actually wait on a permission card are affected.

The schema already stores the wait and documents the formula (`packages/shared/src/schema.ts`):

> Effective agent working time = (`endedAt` - `Date.parse(timestamp)`) - `permissionWaitMs`

CLI writes `permissionWaitMs` when a permission resolves. `resolveSessionHistoryDurationMs` only `Pick`s `endedAt` and `timestamp`, so the number on screen is wall clock, including time spent at `Implement this plan?`.

Live OSS 0.76.0, Codex `5.6-Sol`, Plan on, Auto review (so a second file-permission wait does not stack). After Yes, implementation was ~15s in each group.

| Wait after the plan card | Logged / persisted `permissionWaitMs` | On-screen 工作了 |
| --- | --- | --- |
| Click Yes immediately | 474ms | **29秒** |
| Wait 1 minute | 62269ms | **1分 27秒** |
| Wait 10 minutes | 601318ms | **10分 28秒** |

Immediate Yes (control):

![Worked for 29 seconds after clicking Yes immediately](https://raw.githubusercontent.com/ladydd/Lody/screenshots/permission-wait-duration/worked-for-immediate-yes.png)

Wait 1 minute, then Yes:

![Worked for 1 minute 27 seconds after waiting one minute](https://raw.githubusercontent.com/ladydd/Lody/screenshots/permission-wait-duration/worked-for-wait-1-minute.png)

Wait 10 minutes, then Yes:

![Worked for 10 minutes 28 seconds after waiting ten minutes](https://raw.githubusercontent.com/ladydd/Lody/screenshots/permission-wait-duration/worked-for-wait-10-minutes.png)

Repro: OSS desktop, Codex, Plan on. Send a prompt that pops `Implement this plan?`. Do not quit. Wait, click Yes, let the file write finish. Worked-for tracks the wait, not the ~15s of work.

## Summary

`resolveSessionHistoryDurationMs` now subtracts a finite `permissionWaitMs` and clamps a negative remainder to 0. Turns with no wait field stay `endedAt - timestamp`. `endedAt` is not restamped.

`buildChatStreamItems` copies `permissionWaitMs` onto the parsed message and invalidates the stream cache when the field changes, so the production chat path actually reaches the helper.

## Before / after

| Before | After |
| ------ | ----- |
| Worked-for = `endedAt - timestamp` (wall clock, wait included) | Worked-for = that span minus finite `permissionWaitMs`, clamped to 0 |
| Immediate Yes, ~15s of work → 29秒 | Unchanged order of magnitude (no meaningful wait) |
| Wait 1 / 10 minutes at the plan card → 1分27秒 / 10分28秒 | Those waits subtracted; label should match remaining work |

## Test plan

On `fix/subtract-permission-wait-duration` after rebase onto `origin/main` `084ddb86`:

```
corepack pnpm --filter @lody/components exec vitest run tests/session-history-duration.test.ts
```

Result: **3 passed** (no wait unchanged; recorded wait subtracted; wait longer than the span → 0).

```
corepack pnpm --filter @lody/components exec vitest run tests/build-chat-stream-items.test.ts
```

Result: **15 passed**, including copying `permissionWaitMs` onto the rendered message and not reusing a cached item when the wait changes.

Live OSS after the projection fix, same 1-minute wait recipe: **工作了 38秒**, not 1分27秒. Screenshot in the review-thread reply.

## Context handoff

Context handoff is public. An invalid fork PR body receives seven days to be corrected before closure.

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `packages/components/src/lib/session-history-duration.ts` and `packages/components/tests/session-history-duration.test.ts`; `view.tsx` still consumes a number or null from this helper.
- **Decisions to challenge:** Subtract in the duration helper rather than restamping `endedAt` (#260 / #409). Clamp an oversize wait to 0 instead of returning null.
- **Plausible failures / evidence gaps:** Turns with no `permissionWaitMs` must stay wall-clock. Unit tests do not drive Electron; live evidence is the three OSS screenshots.

### Authoring context

- **User goal / directives:** Make Worked-for match the schema formula so permission wait is not shown as agent work. Human reviewed the live runs and this patch.
- **Constraints / non-goals:** Display math only. Do not restamp `endedAt`. Do not change permission UX, title overwrite, or dead Yes buttons.
- **Risk-bearing decisions:** Read-only use of already-persisted `permissionWaitMs`. Missing or non-finite wait is treated as 0.
- **Destructive or irreversible behavior:** None. No history rewrite, no migration, no rollback path required.
- **Deliberately not done or tested:** Full components suite and Electron e2e; three unit tests plus the live OSS screenshots above.
- **Unknowns / confidence:** High for the helper. Multi-permission stacked waits were excluded from the live table (Auto review) and are not claimed here.

<!-- context-handoff:end -->

