### PR TITLE
fix(e2e): restore Windows and Linux Daily bootstrap

### DIFF
--- a/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.md
+++ b/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.md
@@ -2,6 +2,7 @@
 
 Status: implemented
 Translation: current
+PR: https://github.com/LodyAI/Lody/pull/514
 
 English | [中文](2026-09-08-desktop-daily-platform-bootstrap.zh.md)
 

--- a/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.md
+++ b/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.md
@@ -15,6 +15,8 @@ Xvfb authorization path before launching Electron. Coverage checks now treat
 CRLF and LF as the same generated content, and the isolated Electron environment
 retains `XAUTHORITY`. This restores platform bootstrap without weakening registry
 validation or broadening the process environment inherited by the application.
+The first verification run also exposed a latent POSIX-only path expectation in
+the suite-contract tests; that expectation now uses Node's platform path resolver.
 
 ## Evidence
 
@@ -24,6 +26,12 @@ on commit `a07eeba2bf97faa40ba501000ab9c3296dc4a031` was the first scheduled run
 matrix. macOS passed. Windows stopped in the suite contract because its CRLF
 checkout did not equal the LF-only string returned by `renderCoverage()`. The
 registry and generated Markdown were otherwise identical.
+
+After the coverage fix allowed the Windows suite contract to continue, hosted
+[smoke run 34206280687](https://github.com/LodyAI/Lody/actions/runs/34206280687)
+exposed a second infrastructure failure. The journey-author environment test
+expected a literal `/tmp/validation-home/tmp`, while the production helper
+correctly returned a Windows path through `path.resolve()`.
 
 All four Linux scenarios failed before opening a window. Electron logged
 `Authorization required, but no authorization protocol specified` followed by an
@@ -40,6 +48,10 @@ normalizes CRLF to LF before comparing generated coverage. It still rejects ever
 other content difference, including added text, missing rows, and whitespace not
 caused by Windows line endings. Both the suite checker and the standalone coverage
 checker use this contract.
+
+The journey-author test derives its expected temporary directory with the same
+platform path semantics promised by `buildValidationEnvironment()`. It continues
+to assert the isolated home and exact environment allowlist.
 
 The Electron harness adds only `XAUTHORITY` to its inherited environment allowlist.
 Passing the entire runner environment would expose unrelated CI variables to the

--- a/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.md
+++ b/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.md
@@ -1,0 +1,63 @@
+# Desktop Daily platform bootstrap fixes
+
+Status: implemented
+Translation: current
+
+English | [中文](2026-09-08-desktop-daily-platform-bootstrap.zh.md)
+
+## Abstract
+
+The first scheduled three-platform Desktop Daily reported unrelated Windows and
+Linux infrastructure failures as one generic Issue. Windows rejected generated
+coverage solely because checkout line endings differed, while Linux removed the
+Xvfb authorization path before launching Electron. Coverage checks now treat
+CRLF and LF as the same generated content, and the isolated Electron environment
+retains `XAUTHORITY`. This restores platform bootstrap without weakening registry
+validation or broadening the process environment inherited by the application.
+
+## Evidence
+
+[Daily run 34197006995](https://github.com/LodyAI/Lody/actions/runs/34197006995)
+on commit `a07eeba2bf97faa40ba501000ab9c3296dc4a031` was the first scheduled run after
+[PR 459](https://github.com/LodyAI/Lody/pull/459) added Linux and Windows to the
+matrix. macOS passed. Windows stopped in the suite contract because its CRLF
+checkout did not equal the LF-only string returned by `renderCoverage()`. The
+registry and generated Markdown were otherwise identical.
+
+All four Linux scenarios failed before opening a window. Electron logged
+`Authorization required, but no authorization protocol specified` followed by an
+X11 platform initialization failure. `xvfb-run` supplied `DISPLAY` and a temporary
+`XAUTHORITY`, but [`createIsolatedEnvironment()`](../../../../e2e/src/support/electron-harness.ts)
+retained only the former. The Linux artifact contains a four-row
+`failure-index.json`, so the failures share the same launch boundary rather than
+four product assertions.
+
+## Decision
+
+[`coverageMatchesRegistry()`](../../../../e2e/scripts/journey-registry.mjs)
+normalizes CRLF to LF before comparing generated coverage. It still rejects every
+other content difference, including added text, missing rows, and whitespace not
+caused by Windows line endings. Both the suite checker and the standalone coverage
+checker use this contract.
+
+The Electron harness adds only `XAUTHORITY` to its inherited environment allowlist.
+Passing the entire runner environment would expose unrelated CI variables to the
+application process and its descendants. Keeping the allowlist preserves the
+isolation boundary while allowing Electron to authenticate to the X server named
+by `DISPLAY`.
+
+## Reporting limit
+
+[Issue 507](https://github.com/LodyAI/Lody/issues/507) says that zero scenarios
+were indexed because the Daily reconciler deliberately selected the successful
+macOS artifact as canonical evidence. The failed Linux artifact did contain all
+four scenario IDs. This change fixes the platform failures; it does not change the
+reconciler's macOS-first reporting policy introduced by PR 459. Per-platform
+failure aggregation remains separate work.
+
+## Verification
+
+Unit coverage proves that CRLF generated output matches while changed content
+does not, and that `DISPLAY` plus `XAUTHORITY` cross the Electron allowlist while
+an unrelated variable does not. Local macOS verification cannot reproduce a
+GitHub-hosted Xvfb session, so a Linux Actions run remains the end-to-end proof.

--- a/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.md
+++ b/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.md
@@ -72,5 +72,7 @@ failure aggregation remains separate work.
 
 Unit coverage proves that CRLF generated output matches while changed content
 does not, and that `DISPLAY` plus `XAUTHORITY` cross the Electron allowlist while
-an unrelated variable does not. Local macOS verification cannot reproduce a
-GitHub-hosted Xvfb session, so a Linux Actions run remains the end-to-end proof.
+an unrelated variable does not. Hosted
+[smoke run 34207183958](https://github.com/LodyAI/Lody/actions/runs/34207183958)
+passed the complete suite-contract, build, and Desktop Journey flow on Ubuntu,
+Windows, and macOS.

--- a/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.zh.md
+++ b/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.zh.md
@@ -8,13 +8,18 @@ PR: https://github.com/LodyAI/Lody/pull/514
 
 ## 摘要
 
-首次定时运行的三平台 Desktop Daily 把互不相关的 Windows 与 Linux 基础设施故障汇总到同一张 Issue。Windows 仅因 checkout 换行符不同而拒绝生成的 coverage，Linux 则在启动 Electron 前丢弃了 Xvfb 授权路径。现在 coverage 检查将 CRLF 与 LF 视为相同的生成内容，隔离后的 Electron 环境会保留 `XAUTHORITY`。这恢复了平台启动，同时没有放宽 registry 校验，也没有扩大应用继承的进程环境范围。
+首次定时运行的三平台 Desktop Daily 把互不相关的 Windows 与 Linux 基础设施故障汇总到同一张 Issue。Windows 仅因 checkout 换行符不同而拒绝生成的 coverage，Linux 则在启动 Electron 前丢弃了 Xvfb 授权路径。现在 coverage 检查将 CRLF 与 LF 视为相同的生成内容，隔离后的 Electron 环境会保留 `XAUTHORITY`。这恢复了平台启动，同时没有放宽 registry 校验，也没有扩大应用继承的进程环境范围。首次验证还暴露了 suite-contract 测试中潜藏的 POSIX-only 路径预期；该预期现在使用 Node 的平台路径解析器。
 
 ## 证据
 
 commit `a07eeba2bf97faa40ba501000ab9c3296dc4a031` 上的
 [Daily run 34197006995](https://github.com/LodyAI/Lody/actions/runs/34197006995)
 是 [PR 459](https://github.com/LodyAI/Lody/pull/459) 将 Linux 和 Windows 加入矩阵后的首次定时运行。macOS 通过。Windows 停在 suite contract，因为 CRLF checkout 与 `renderCoverage()` 返回的纯 LF 字符串不相等；registry 与生成的 Markdown 除此之外完全一致。
+
+coverage 修复让 Windows suite contract 得以继续执行后，hosted
+[smoke run 34206280687](https://github.com/LodyAI/Lody/actions/runs/34206280687)
+暴露了第二个基础设施故障。journey-author 环境测试硬编码预期
+`/tmp/validation-home/tmp`，而生产 helper 通过 `path.resolve()` 正确返回了 Windows 路径。
 
 四个 Linux scenario 都在窗口打开前失败。Electron 先记录
 `Authorization required, but no authorization protocol specified`，随后记录 X11 平台初始化失败。`xvfb-run` 提供了 `DISPLAY` 和临时 `XAUTHORITY`，但
@@ -25,6 +30,8 @@ commit `a07eeba2bf97faa40ba501000ab9c3296dc4a031` 上的
 
 [`coverageMatchesRegistry()`](../../../../e2e/scripts/journey-registry.mjs)
 在比较生成 coverage 前将 CRLF 规范化为 LF。其他内容差异仍会失败，包括新增文本、缺失行，以及并非 Windows 换行符导致的空白差异。suite checker 和独立 coverage checker 都使用这一契约。
+
+journey-author 测试使用与 `buildValidationEnvironment()` 契约相同的平台路径语义推导临时目录预期，同时继续断言隔离 home 与精确的环境 allowlist。
 
 Electron harness 只把 `XAUTHORITY` 加入继承环境 allowlist。把 runner 的整个环境传给应用进程及其子进程会暴露无关 CI 变量。保留 allowlist 既维持隔离边界，也允许 Electron 向 `DISPLAY` 指定的 X server 完成认证。
 

--- a/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.zh.md
+++ b/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.zh.md
@@ -2,6 +2,7 @@
 
 Status: implemented
 Translation: current
+PR: https://github.com/LodyAI/Lody/pull/514
 
 [English](2026-09-08-desktop-daily-platform-bootstrap.md) | 中文
 

--- a/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.zh.md
+++ b/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.zh.md
@@ -41,4 +41,6 @@ Electron harness 只把 `XAUTHORITY` 加入继承环境 allowlist。把 runner �
 
 ## 验证
 
-单元测试证明 CRLF 生成内容能够匹配，而内容变化仍会失败；也证明 `DISPLAY` 和 `XAUTHORITY` 会通过 Electron allowlist，无关变量不会。macOS 本地验证无法复现 GitHub-hosted Xvfb session，因此 Linux Actions run 仍是端到端证明。
+单元测试证明 CRLF 生成内容能够匹配，而内容变化仍会失败；也证明 `DISPLAY` 和 `XAUTHORITY` 会通过 Electron allowlist，无关变量不会。Hosted
+[smoke run 34207183958](https://github.com/LodyAI/Lody/actions/runs/34207183958)
+在 Ubuntu、Windows 和 macOS 上完整通过了 suite-contract、build 与 Desktop Journey 流程。

--- a/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.zh.md
+++ b/.agents/notes/implemented/testing/2026-09-08-desktop-daily-platform-bootstrap.zh.md
@@ -1,0 +1,36 @@
+# Desktop Daily 平台启动修复
+
+Status: implemented
+Translation: current
+
+[English](2026-09-08-desktop-daily-platform-bootstrap.md) | 中文
+
+## 摘要
+
+首次定时运行的三平台 Desktop Daily 把互不相关的 Windows 与 Linux 基础设施故障汇总到同一张 Issue。Windows 仅因 checkout 换行符不同而拒绝生成的 coverage，Linux 则在启动 Electron 前丢弃了 Xvfb 授权路径。现在 coverage 检查将 CRLF 与 LF 视为相同的生成内容，隔离后的 Electron 环境会保留 `XAUTHORITY`。这恢复了平台启动，同时没有放宽 registry 校验，也没有扩大应用继承的进程环境范围。
+
+## 证据
+
+commit `a07eeba2bf97faa40ba501000ab9c3296dc4a031` 上的
+[Daily run 34197006995](https://github.com/LodyAI/Lody/actions/runs/34197006995)
+是 [PR 459](https://github.com/LodyAI/Lody/pull/459) 将 Linux 和 Windows 加入矩阵后的首次定时运行。macOS 通过。Windows 停在 suite contract，因为 CRLF checkout 与 `renderCoverage()` 返回的纯 LF 字符串不相等；registry 与生成的 Markdown 除此之外完全一致。
+
+四个 Linux scenario 都在窗口打开前失败。Electron 先记录
+`Authorization required, but no authorization protocol specified`，随后记录 X11 平台初始化失败。`xvfb-run` 提供了 `DISPLAY` 和临时 `XAUTHORITY`，但
+[`createIsolatedEnvironment()`](../../../../e2e/src/support/electron-harness.ts)
+只保留了前者。Linux artifact 包含四行 `failure-index.json`，因此这些失败共享同一个启动边界，并非四个产品断言分别回归。
+
+## 决策
+
+[`coverageMatchesRegistry()`](../../../../e2e/scripts/journey-registry.mjs)
+在比较生成 coverage 前将 CRLF 规范化为 LF。其他内容差异仍会失败，包括新增文本、缺失行，以及并非 Windows 换行符导致的空白差异。suite checker 和独立 coverage checker 都使用这一契约。
+
+Electron harness 只把 `XAUTHORITY` 加入继承环境 allowlist。把 runner 的整个环境传给应用进程及其子进程会暴露无关 CI 变量。保留 allowlist 既维持隔离边界，也允许 Electron 向 `DISPLAY` 指定的 X server 完成认证。
+
+## 报告限制
+
+[Issue 507](https://github.com/LodyAI/Lody/issues/507) 声称索引到零个 scenario，是因为 Daily reconciler 按既定策略选择了成功的 macOS artifact 作为 canonical evidence；失败的 Linux artifact 实际包含全部四个 scenario ID。本次变更修复平台故障，不改变 PR 459 引入的 macOS 优先报告策略。按平台聚合 failure 仍是独立工作。
+
+## 验证
+
+单元测试证明 CRLF 生成内容能够匹配，而内容变化仍会失败；也证明 `DISPLAY` 和 `XAUTHORITY` 会通过 Electron allowlist，无关变量不会。macOS 本地验证无法复现 GitHub-hosted Xvfb session，因此 Linux Actions run 仍是端到端证明。

--- a/e2e/scripts/check-suite.mjs
+++ b/e2e/scripts/check-suite.mjs
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loadJourneyRegistry, renderCoverage } from './journey-registry.mjs';
+import { coverageMatchesRegistry, loadJourneyRegistry } from './journey-registry.mjs';
 
 const e2eRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const featureDir = join(e2eRoot, 'src', 'features');
@@ -159,7 +159,7 @@ for (const stableId of scenarioContracts.keys()) {
 }
 
 const coverage = readFileSync(coveragePath, 'utf8');
-if (coverage !== renderCoverage(registry)) {
+if (!coverageMatchesRegistry(coverage, registry)) {
   fail('COVERAGE.md is stale; run `pnpm --filter @lody/e2e journey:coverage`');
 }
 

--- a/e2e/scripts/generate-coverage.mjs
+++ b/e2e/scripts/generate-coverage.mjs
@@ -1,7 +1,11 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loadJourneyRegistry, renderCoverage } from './journey-registry.mjs';
+import {
+  coverageMatchesRegistry,
+  loadJourneyRegistry,
+  renderCoverage,
+} from './journey-registry.mjs';
 
 const e2eRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const coveragePath = resolve(e2eRoot, 'COVERAGE.md');
@@ -10,13 +14,14 @@ if (!['--check', '--write'].includes(mode) || process.argv.length > 3) {
   throw new Error('Usage: node scripts/generate-coverage.mjs [--check|--write]');
 }
 
-const expected = renderCoverage(loadJourneyRegistry());
+const registry = loadJourneyRegistry();
+const expected = renderCoverage(registry);
 if (mode === '--write') {
   writeFileSync(coveragePath, expected, 'utf8');
   console.log('Updated COVERAGE.md from journeys/registry.json.');
 } else {
   const actual = readFileSync(coveragePath, 'utf8');
-  if (actual !== expected) {
+  if (!coverageMatchesRegistry(actual, registry)) {
     console.error('COVERAGE.md is stale. Run `pnpm --filter @lody/e2e journey:coverage`.');
     process.exitCode = 1;
   } else {

--- a/e2e/scripts/journey-registry.mjs
+++ b/e2e/scripts/journey-registry.mjs
@@ -286,6 +286,10 @@ export function renderCoverage(registry) {
   return lines.join('\n');
 }
 
+export function coverageMatchesRegistry(coverage, registry) {
+  return coverage.replaceAll('\r\n', '\n') === renderCoverage(registry);
+}
+
 function normalizePath(path) {
   return path.trim().replaceAll('\\', '/').replace(/^\.\//u, '');
 }

--- a/e2e/scripts/journey-registry.test.mjs
+++ b/e2e/scripts/journey-registry.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+  coverageMatchesRegistry,
   journeyFingerprint,
   ownerPathMatches,
   renderCoverage,
@@ -182,5 +183,16 @@ void describe('journey registry', () => {
     });
     assert.ok(markdown.indexOf('LODY-BACKLOG-001') < markdown.indexOf('LODY-BACKLOG-002'));
     assert.match(markdown, /This file is generated from/u);
+  });
+
+  void it('accepts CRLF checkout line endings in generated coverage', () => {
+    const registry = {
+      schemaVersion: 1,
+      scoring,
+      journeys: [journey()],
+    };
+    const coverage = renderCoverage(registry);
+    assert.equal(coverageMatchesRegistry(coverage.replaceAll('\n', '\r\n'), registry), true);
+    assert.equal(coverageMatchesRegistry(`${coverage}stale`, registry), false);
   });
 });

--- a/e2e/scripts/run-journey-author.test.mjs
+++ b/e2e/scripts/run-journey-author.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import test from 'node:test';
 
 import {
@@ -124,7 +124,7 @@ void test('validates reviewed code with an isolated home and no caller secrets',
     PATH: '/bin',
     CI: '1',
     HOME: '/tmp/validation-home',
-    TMPDIR: '/tmp/validation-home/tmp',
+    TMPDIR: resolve('/tmp/validation-home', 'tmp'),
   });
 });
 

--- a/e2e/src/support/README.md
+++ b/e2e/src/support/README.md
@@ -13,3 +13,7 @@
 | `pages/session-page.ts`                   | Deterministic ACP conversation and Stop lifecycle                   |
 | `pages/work-session-page.ts`              | Worktree Session, terminal, deletion, and cleanup contract          |
 | `fixtures/work-session-fixture.ts`        | Synthetic Git workspace and scripted ACP evidence                   |
+
+The harness passes only an explicit environment allowlist into Electron. Linux
+runs under `xvfb-run`, so both its `DISPLAY` endpoint and generated `XAUTHORITY`
+file must cross that isolation boundary.

--- a/e2e/src/support/electron-harness.test.ts
+++ b/e2e/src/support/electron-harness.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createIsolatedEnvironment } from './electron-harness.js';
+
+void describe('Electron harness environment', () => {
+  void it('inherits the Xvfb display authorization without leaking unrelated variables', () => {
+    const env = createIsolatedEnvironment(
+      { NODE_ENV: 'test' },
+      {
+        DISPLAY: ':99',
+        LODY_PRIVATE_VALUE: 'excluded',
+        XAUTHORITY: '/tmp/xvfb-auth',
+      }
+    );
+
+    assert.deepEqual(env, {
+      DISPLAY: ':99',
+      XAUTHORITY: '/tmp/xvfb-auth',
+      NODE_ENV: 'test',
+    });
+  });
+});

--- a/e2e/src/support/electron-harness.ts
+++ b/e2e/src/support/electron-harness.ts
@@ -81,13 +81,17 @@ const INHERITED_ENV_ALLOWLIST = [
   'USERPROFILE',
   'WAYLAND_DISPLAY',
   'WINDIR',
+  'XAUTHORITY',
   'XDG_RUNTIME_DIR',
 ] as const;
 
-function createIsolatedEnvironment(overrides: Record<string, string>): Record<string, string> {
+export function createIsolatedEnvironment(
+  overrides: Record<string, string>,
+  inherited: NodeJS.ProcessEnv = process.env
+): Record<string, string> {
   const env: Record<string, string> = {};
   for (const name of INHERITED_ENV_ALLOWLIST) {
-    const value = process.env[name];
+    const value = inherited[name];
     if (value !== undefined) env[name] = value;
   }
   return { ...env, ...overrides };


### PR DESCRIPTION
## Related issue

Refs #507

## Problem / pressure

Desktop E2E Daily run 34197006995 reported two platform bootstrap failures: Windows rejected a correct generated coverage file because its checkout used CRLF, and Ubuntu stripped the Xvfb authorization path before Electron launched. Once the coverage check advanced on Windows, hosted verification exposed a second POSIX-only path assertion in the suite-contract tests.

## Summary

Normalize CRLF to LF only for generated coverage comparisons in both suite checkers. Preserve XAUTHORITY in the Electron harness environment allowlist, with tests covering Xvfb variables and exclusion of unrelated environment values. Derive the journey-author TMPDIR expectation with Node path semantics so it is valid on Windows.

The accompanying Agent Note records why Issue #507 indexed zero failures even though the Linux artifact contained four scenario IDs. Changing the macOS-first reconciler policy remains separate work.

## Before / after

| Before | After |
| ------ | ----- |
| Windows stopped on a line-ending-only coverage difference, then a POSIX-only TMPDIR assertion. | CRLF and LF coverage compare equal, and the environment assertion uses the host path format. |
| Ubuntu Electron received DISPLAY without XAUTHORITY and failed before opening a window. | DISPLAY and the matching Xvfb authorization file cross the environment isolation boundary. |

## Test plan

- pnpm --filter @lody/e2e check
- pnpm --dir apps/electron build
- pnpm --filter @lody/e2e smoke (3 scenarios, 18 steps)
- pnpm check with Node 22 and process-local Git signing disabled
- pnpm format
- pnpm run docs check
- Desktop E2E Daily smoke run 34206280687: Ubuntu and macOS passed; Windows exposed the platform-specific TMPDIR assertion
- Desktop E2E Daily smoke run 34207183958: Ubuntu, Windows, and macOS all passed suite contract, build, and desktop journeys

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check coverageMatchesRegistry, createIsolatedEnvironment, and the journey-author TMPDIR assertion for narrow platform compatibility.
- **Decisions to challenge:** Verify that normalizing only CRLF, allowlisting only XAUTHORITY, and resolving the expected path preserve existing contracts.
- **Plausible failures / evidence gaps:** Hosted smoke passed all three platforms; the next scheduled full run remains coverage for the non-smoke scenario.

### Authoring context

- **User goal / directives:** Separate and fix the Windows suite-contract failures and the Ubuntu journey launch failure behind #507.
- **Constraints / non-goals:** Keep product behavior and the Daily reconciler evidence policy unchanged.
- **Risk-bearing decisions:** XAUTHORITY is exposed to Electron so it can authenticate to the X server named by DISPLAY.
- **Destructive or irreversible behavior:** None; the change only affects comparisons, one test expectation, and process environment construction.
- **Deliberately not done or tested:** Per-platform failure aggregation is excluded because it is independent from platform bootstrap; hosted verification used the smoke suite.
- **Unknowns / confidence:** The exact failure boundaries now have unit coverage and passed hosted Ubuntu, Windows, and macOS smoke journeys.

<!-- context-handoff:end -->