### PR TITLE
fix(cli): clear completed Session fork operations safely

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-08-session-fork-operation-clear.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-08-session-fork-operation-clear.md
@@ -1,0 +1,24 @@
+# Clear completed Session fork operations without deleting their Loro root
+
+Status: implemented
+Translation: current
+
+[中文](./2026-09-08-session-fork-operation-clear.zh.md)
+
+## Abstract
+
+A new-worktree Session fork could prepare its Git worktree and ACP runtime but fail during the final commit with `Map value must be an object`. The failure occurred when `SessionDocument.setForkOperation(undefined)` asked loro-mirror to delete the optional `forkOperation` root map. Loro root containers are permanent, so the Session document now clears that map through the Loro API and commits the change. Schema parsing continues to expose an empty map as an absent operation.
+
+## Decision and scope
+
+Writes and phase transitions continue through loro-mirror. Completion clears the existing root `LoroMap` directly and commits it, preserving the container so a later fork can reuse it. This changes no Session protocol or schema and needs no data migration.
+
+The regression test uses a real Loro document and Mirror. It covers initial creation, the transition to `committing`, successful clearing, and reuse by a later operation.
+
+## Evidence and alternatives
+
+The desktop `LODY-FORK-001` journey reached worktree and ACP creation before the root deletion threw. Replacing the value with `{}` also avoids root deletion, but that value violates the declared operation shape and would rely on disabled update validation. Clearing the underlying map follows Loro's root-container model while keeping reads schema-validated.
+
+The focused Loro regression and Session fork service suites pass. The desktop journey has not been rerun on this branch because its implementation remains on a separate, unmerged E2E branch.
+
+The fix is limited to `forkOperation`. Other optional root-container removals should use the same model when they need a clear operation, but they are outside this defect's observed path.

--- a/.agents/notes/implemented/bug-fix/2026-09-08-session-fork-operation-clear.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-08-session-fork-operation-clear.zh.md
@@ -1,0 +1,24 @@
+# 清除已完成的 Session Fork 操作时保留 Loro 根容器
+
+Status: implemented
+Translation: current
+
+[English](./2026-09-08-session-fork-operation-clear.md)
+
+## 摘要
+
+新 worktree Session Fork 能完成 Git worktree 和 ACP runtime 的准备，却会在最终提交阶段以 `Map value must be an object` 失败。原因是 `SessionDocument.setForkOperation(undefined)` 通过 loro-mirror 删除可选的 `forkOperation` 根 map，而 Loro 根容器不能被删除。Session 文档现在通过 Loro API 清空该 map 并提交变更；schema 解析仍会把空 map 视为操作不存在。
+
+## 决策与范围
+
+Fork 操作的写入和阶段迁移继续通过 loro-mirror 完成。操作完成时直接清空现有根 `LoroMap` 并提交，保留容器以供后续 Fork 复用。这个改动不改变 Session 协议或 schema，也不需要数据迁移。
+
+回归测试使用真实的 Loro 文档和 Mirror，覆盖首次创建、迁移到 `committing`、成功清除，以及后续操作复用。
+
+## 证据与替代方案
+
+桌面 `LODY-FORK-001` 用户旅程在创建 worktree 和 ACP 后，于删除根容器时抛错。把值替换为 `{}` 也能绕过根容器删除，但该值不符合声明的操作结构，并依赖关闭更新校验。清空底层 map 符合 Loro 的根容器模型，同时保留读取时的 schema 校验。
+
+聚焦的 Loro 回归测试和 Session Fork 服务测试均已通过。桌面旅程的实现仍位于另一个尚未合并的 E2E 分支，因此本分支尚未重跑该旅程。
+
+本修复仅处理 `forkOperation`。其他可选根容器如需清除，也应遵循相同模型，但不在这次已观测缺陷的范围内。

--- a/apps/cli/src/lib/loro/doc-fork-operation.test.ts
+++ b/apps/cli/src/lib/loro/doc-fork-operation.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Loro } from 'loro-crdt';
+import { Mirror } from 'loro-mirror';
+import { sessionDocSchema, type SessionForkOperation, type SessionId } from '@lody/shared';
+import type { LoroRepo, RepoDocHandle } from 'loro-repo';
+import type { Logger } from '@/utils/logger';
+import { SessionDocument } from './doc';
+
+const createDocument = () => {
+  const doc = new SessionDocument({} as LoroRepo, 'fork-target' as SessionId, async () => {}, {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as Logger);
+  const loro = new Loro();
+  doc.handle = { doc: loro } as RepoDocHandle;
+  doc.mirror = new Mirror({
+    doc: loro,
+    schema: sessionDocSchema,
+    initialState: {
+      session: { id: doc.sessionId },
+      history: [],
+    },
+  });
+  return doc;
+};
+
+const operation = (phase: SessionForkOperation['phase']): SessionForkOperation => ({
+  id: 'session-fork:fork-target',
+  sourceSessionId: 'fork-source' as SessionId,
+  sourceTurnId: 'assistant-turn-1',
+  requestedByUserId: 'user-1',
+  targetContext: 'new-worktree',
+  capturedHeadSha: 'a'.repeat(40),
+  sourceWasDirty: false,
+  state: 'preparing',
+  phase,
+  createdAt: '2026-09-08T00:00:00.000Z',
+  updatedAt: '2026-09-08T00:00:00.000Z',
+});
+
+describe('SessionDocument fork operation', () => {
+  it('clears the root map after commit and permits a later fork operation', () => {
+    const doc = createDocument();
+
+    doc.setForkOperation(operation('preparing-worktree'));
+    doc.setForkOperation(operation('committing'));
+
+    expect(() => doc.setForkOperation(undefined)).not.toThrow();
+    expect(doc.getForkOperation()).toBeUndefined();
+    expect(doc.handle?.doc.getMap('forkOperation').toJSON()).toEqual({});
+
+    doc.setForkOperation(operation('preparing-worktree'));
+    expect(doc.getForkOperation()).toEqual(operation('preparing-worktree'));
+  });
+});

--- a/apps/cli/src/lib/loro/doc.ts
+++ b/apps/cli/src/lib/loro/doc.ts
@@ -2180,15 +2180,20 @@ export class SessionDocument implements LoroDocument<SessionDocMeta, SessionMeta
     if (!this.mirror) {
       throw new Error('SessionDocument not initialized');
     }
-    this.mirror.setState((prev) => {
-      if (operation) {
-        // Mirror exposes readonly state to callers, but setState supplies its mutable draft.
-        // @ts-expect-error mutable Mirror draft
-        prev.forkOperation = operation;
-      } else {
-        // @ts-expect-error mutable Mirror draft
-        delete prev.forkOperation;
+    if (!operation) {
+      if (!this.handle) {
+        throw new Error('SessionDocument not initialized');
       }
+      // Loro root containers are permanent. Clear the operation's fields while
+      // keeping the root map available for a later fork on this Session.
+      this.handle.doc.getMap('forkOperation').clear();
+      this.handle.doc.commit();
+      return;
+    }
+    this.mirror.setState((prev) => {
+      // Mirror exposes readonly state to callers, but setState supplies its mutable draft.
+      // @ts-expect-error mutable Mirror draft
+      prev.forkOperation = operation;
       return prev;
     });
   }


### PR DESCRIPTION
## Related issue

Internal fix discovered by the `LODY-FORK-001` desktop journey; no linked Issue is required for this same-repository branch.

## Problem / pressure

Forking a completed Session into a new worktree prepared the target Git worktree and ACP runtime, then failed during final publication with `Map value must be an object`. Clearing the durable operation marker attempted to delete a Loro root map, but Loro root containers are permanent.

## Summary

- Clear the existing `forkOperation` root `LoroMap` and commit the mutation instead of deleting the root container through loro-mirror.
- Add a real Loro/Mirror regression test covering creation, the `committing` transition, clearing, and reuse by a later fork.
- Record the persistence decision and verification limits in the bilingual Agent Note.

## Before / after

| Before | After |
| ------ | ----- |
| The accepted worktree Fork failed while clearing `forkOperation`, so the target Session was compensated before publication. | The operation fields are cleared while the root map remains reusable, allowing final publication to continue. |

## Test plan

- `pnpm format`
- `pnpm run docs check`
- `pnpm --filter lody exec vitest run src/lib/loro/doc-fork-operation.test.ts src/session/session-fork-service.test.ts` (28 passed)
- `pnpm check` completed typecheck and lint with 0 lint errors, then stopped in `packages/components`: 3189 tests passed and 86 failed because the reused local dependency environment did not provide `localStorage` to the browser test setup.
- The desktop `LODY-FORK-001` journey was not rerun here because its implementation remains on a separate unmerged E2E branch.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check `SessionDocument.setForkOperation` and the real Loro/Mirror regression for clear, commit, and reuse semantics.
- **Decisions to challenge:** Confirm that direct `LoroMap.clear()` is the correct boundary for an optional schema value backed by a permanent root container.
- **Plausible failures / evidence gaps:** The desktop journey was not rerun on this branch, and the complete repository test command hit unrelated browser-environment failures in `packages/components`.

### Authoring context

- **User goal / directives:** Fix the reproduced worktree Session Fork failure locally and open a ready-for-review PR.
- **Constraints / non-goals:** Preserve the Session schema and protocol, avoid an upstream dependency change, and keep source Session behavior unchanged.
- **Risk-bearing decisions:** Reads continue schema parsing an empty root map as no active operation; phase writes remain on loro-mirror while clearing uses the raw Loro document.
- **Destructive or irreversible behavior:** The change clears only transient operation fields on the target Session; worktree compensation and source Session retention remain unchanged.
- **Deliberately not done or tested:** No migration was added because the physical root map already exists by design; the separate desktop E2E branch was not imported into this PR.
- **Unknowns / confidence:** The focused real-document test covers the original exception and reuse path; residual confidence is limited by the unrun desktop journey and local browser-test environment failures.

<!-- context-handoff:end -->
