### PR TITLE
fix(cli): retry transient machine access checks

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-08-session-access-retry-diagnostics.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-08-session-access-retry-diagnostics.md
@@ -1,0 +1,39 @@
+# Preserve transient machine-access failures across Session commands
+
+Status: implemented
+Translation: current
+PR: not created
+
+[中文](2026-09-08-session-access-retry-diagnostics.zh.md)
+
+## Abstract
+
+A temporary control-plane network failure aborted Session creation before the target Machine or
+Agent was contacted, while the MCP boundary reported the failure as a permanent command or input
+rejection and hid the underlying network cause. Command-side access checks now retry transport
+failures within a bounded window and report exhausted failures as retryable with their nested cause.
+Authorization stays fail-closed, and definitive denials still stop immediately.
+
+## Decision and scope
+
+- The access query is idempotent, so command validation retries only transport-shaped failures at
+  250 ms, 1 second, and 2 seconds. Schema, identity, and other non-transport failures do not retry.
+- The existing daemon dispatch loop remains independently interruptible and unbounded because it
+  protects an already-durable user turn. Command validation is bounded because it sits before work
+  is accepted or dispatched.
+- Exhausted transport failures use `MACHINE_ACCESS_UNAVAILABLE` with `retryable: true` for MCP
+  single and batch create/chat paths. A machine-access failure is no longer `COMMAND_REJECTED` or
+  `INVALID_ITEM`.
+- Diagnostics walk nested `cause` and `AggregateError.errors` values, retaining common network
+  codes and messages. They do not include credentials or change the access request payload.
+- Presence remains a separate signal. No online heartbeat bypasses or substitutes for the access
+  query.
+
+## Evidence and limits
+
+Deterministic tests inject the delay function and cover recovery, immediate non-transport failure,
+and exhausted nested `ECONNRESET` diagnostics. CLI typecheck, lint, formatting, and broader checks
+are recorded in the change handoff. This does not prove recovery in a released desktop build or
+identify the affected user's original proxy, DNS, or TLS failure.
+
+See the [draft behavior contract](../../../../specs/session-access-verification.md).

--- a/.agents/notes/implemented/bug-fix/2026-09-08-session-access-retry-diagnostics.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-08-session-access-retry-diagnostics.zh.md
@@ -1,0 +1,34 @@
+# 在 Session 命令中保留可重试的机器访问失败
+
+Status: implemented
+Translation: current
+PR: not created
+
+[English](2026-09-08-session-access-retry-diagnostics.md)
+
+## 摘要
+
+控制面短暂网络失败会在联系目标机器或启动 Agent 之前中断 Session 创建；MCP 边界还会把它
+报告成永久的命令或输入拒绝，并隐藏底层网络原因。现在命令侧访问校验会在有界时间内重试
+传输失败，耗尽后以可重试错误返回并保留嵌套原因。鉴权仍然 fail-closed，明确拒绝仍立即停止。
+
+## 决定与范围
+
+- 访问查询是幂等的，因此命令校验只对传输类失败按 250 毫秒、1 秒、2 秒重试。schema、
+  身份及其他非传输错误不重试。
+- daemon 已派发消息的重试循环保持独立、可中断且无上限，因为它保护的是已经持久化的用户消息。
+  命令校验位于工作被接受或派发之前，所以重试必须有上限。
+- MCP 单项和批量 create/chat 路径把耗尽的传输失败报告为
+  `MACHINE_ACCESS_UNAVAILABLE` 和 `retryable: true`。机器访问失败不再归类为
+  `COMMAND_REJECTED` 或 `INVALID_ITEM`。
+- 诊断会遍历嵌套的 `cause` 和 `AggregateError.errors`，保留常见网络错误码和消息；
+  不包含凭证，也不改变访问请求内容。
+- presence 仍是独立信号；任何在线心跳都不能绕过或替代访问校验。
+
+## 证据与限制
+
+确定性测试通过注入延迟函数，覆盖重试后恢复、非传输错误立即失败，以及耗尽重试后保留嵌套
+`ECONNRESET` 诊断。CLI 类型检查、lint、格式化和更广检查会记录在变更交接中。
+这些证据不代表已在发布版桌面端完成恢复验收，也不能确定受影响用户原始的代理、DNS 或 TLS 原因。
+
+见[行为契约草稿](../../../../specs/session-access-verification.zh.md)。

--- a/apps/cli/src/commands/session.ts
+++ b/apps/cli/src/commands/session.ts
@@ -124,6 +124,7 @@ import { captureSessionCommandEvent } from './analytics-events';
 import { LODY_AUTH_SITE_URL, LODY_AUTH_URL } from '@/utils/const';
 import { createCloudBillingPort, createCloudStreamsTokenPort } from '@/lib/cloud-cli-port';
 import { getCliHttpFetch } from '@/utils/http-transport';
+import { readMachineAccessWithBoundedRetry } from '@/session/session-access-retry';
 
 type CommonOptions = CommonCommandOptions;
 
@@ -1919,22 +1920,25 @@ async function readResolvedSessionMachineAccess(args: {
   requester: ResolvedSessionRequester;
   localProjectId?: string;
 }): Promise<MachineAccessCheckResult> {
-  try {
-    const readAccess = args.requester.isDelegated
-      ? canUseMachineForCliToken
-      : canRequestMachineForCliToken;
-    return await readAccess({
-      token: args.auth.token,
-      workspaceId: args.workspaceId,
-      machineId: args.machineId,
-      requesterUserId: args.requester.userId,
-      ...(args.localProjectId ? { localProjectId: args.localProjectId } : {}),
-    });
-  } catch (error) {
-    throw new Error(`Could not verify machine access: ${formatErrorMessage(error)}`, {
-      cause: error,
-    });
-  }
+  const readAccess = args.requester.isDelegated
+    ? canUseMachineForCliToken
+    : canRequestMachineForCliToken;
+  return await readMachineAccessWithBoundedRetry({
+    verify: async () =>
+      await readAccess({
+        token: args.auth.token,
+        workspaceId: args.workspaceId,
+        machineId: args.machineId,
+        requesterUserId: args.requester.userId,
+        ...(args.localProjectId ? { localProjectId: args.localProjectId } : {}),
+      }),
+    onRetry: ({ attempt, maxAttempts, delayMs, error }) => {
+      getLogger('session').warn(
+        `Machine access verification unavailable; retrying ` +
+          `(attempt=${attempt}/${maxAttempts} delayMs=${delayMs}): ${error}`
+      );
+    },
+  });
 }
 
 async function assertMachineAccess(args: {

--- a/apps/cli/src/mcp/lody-mcp-server.ts
+++ b/apps/cli/src/mcp/lody-mcp-server.ts
@@ -134,6 +134,7 @@ import type {
   SessionTurnOutputEvent,
   StructuredSessionOutputMode,
 } from '@/commands/session-output';
+import { toMachineAccessMcpError } from '@/mcp/machine-access-error';
 import { MAX_AGENT_FEEDBACK_LENGTH, submitAgentFeedback } from '@/lib/feedback';
 import {
   getLodyOperationStorePath,
@@ -1019,6 +1020,14 @@ const normalizeMcpError = (error: unknown) => {
   }
   if (error instanceof WorkspaceSyncUnavailableError) {
     return error.toLodyError();
+  }
+  const machineAccessError = toMachineAccessMcpError(error);
+  if (machineAccessError) {
+    return makeLodyError(
+      machineAccessError.code,
+      machineAccessError.message,
+      machineAccessError.retryable
+    );
   }
   return makeLodyError('INTERNAL_ERROR', formatMcpErrorMessage(error), false);
 };
@@ -2726,6 +2735,14 @@ const startSessionCreateOperation = async (args: SessionCreateCommandInput): Pro
       if (error instanceof LocalDaemonAvailabilityError) {
         throw error;
       }
+      const machineAccessError = toMachineAccessMcpError(error);
+      if (machineAccessError) {
+        throw new LodyOperationStoreError(
+          machineAccessError.code,
+          machineAccessError.message,
+          machineAccessError.retryable
+        );
+      }
       throw new LodyOperationStoreError('COMMAND_REJECTED', formatMcpErrorMessage(error), false);
     }
     const preallocatedSessionId = randomUUID() as SessionId;
@@ -2871,6 +2888,14 @@ const startSessionChatOperation = async (args: SessionChatToolInput): Promise<un
     } catch (error) {
       if (error instanceof WorkspaceSyncUnavailableError) {
         throw error;
+      }
+      const machineAccessError = toMachineAccessMcpError(error);
+      if (machineAccessError) {
+        throw new LodyOperationStoreError(
+          machineAccessError.code,
+          machineAccessError.message,
+          machineAccessError.retryable
+        );
       }
       throw new LodyOperationStoreError('COMMAND_REJECTED', formatMcpErrorMessage(error), false);
     }
@@ -3248,6 +3273,18 @@ const startSessionCreateManyOperation = async (
               dispatchConfig: null,
             };
           }
+          const machineAccessError = toMachineAccessMcpError(error);
+          if (machineAccessError) {
+            return {
+              operationItem: batchFailure(
+                machineAccessError.code,
+                machineAccessError.message,
+                machineAccessError.retryable,
+                label
+              ),
+              dispatchConfig: null,
+            };
+          }
           return {
             operationItem: batchFailure('INVALID_ITEM', formatMcpErrorMessage(error), false, label),
             dispatchConfig: null,
@@ -3445,6 +3482,15 @@ const startSessionChatManyOperation = async (args: SessionChatManyToolInput): Pr
         } catch (error) {
           if (error instanceof WorkspaceSyncUnavailableError) {
             throw error;
+          }
+          const machineAccessError = toMachineAccessMcpError(error);
+          if (machineAccessError) {
+            return batchFailure(
+              machineAccessError.code,
+              machineAccessError.message,
+              machineAccessError.retryable,
+              item.label
+            );
           }
           return batchFailure('INVALID_ITEM', formatMcpErrorMessage(error), false, item.label);
         }

--- a/apps/cli/src/mcp/machine-access-error.test.ts
+++ b/apps/cli/src/mcp/machine-access-error.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { MachineAccessVerificationError } from '@/session/session-access-retry';
+import { toMachineAccessMcpError } from './machine-access-error';
+
+describe('toMachineAccessMcpError', () => {
+  it('preserves the retryable access error contract', () => {
+    const error = new MachineAccessVerificationError(
+      true,
+      4,
+      Object.assign(new Error('socket closed'), { code: 'ECONNRESET' })
+    );
+
+    expect(toMachineAccessMcpError(error)).toEqual({
+      code: 'MACHINE_ACCESS_UNAVAILABLE',
+      message: error.message,
+      retryable: true,
+    });
+  });
+
+  it('ignores unrelated errors', () => {
+    expect(toMachineAccessMcpError(new Error('access denied'))).toBeNull();
+  });
+});

--- a/apps/cli/src/mcp/machine-access-error.ts
+++ b/apps/cli/src/mcp/machine-access-error.ts
@@ -1,0 +1,12 @@
+import { MachineAccessVerificationError } from '@/session/session-access-retry';
+
+export interface MachineAccessMcpError {
+  readonly code: MachineAccessVerificationError['code'];
+  readonly message: string;
+  readonly retryable: boolean;
+}
+
+export const toMachineAccessMcpError = (error: unknown): MachineAccessMcpError | null =>
+  error instanceof MachineAccessVerificationError
+    ? { code: error.code, message: error.message, retryable: error.retryable }
+    : null;

--- a/apps/cli/src/session/README.md
+++ b/apps/cli/src/session/README.md
@@ -38,7 +38,8 @@ CLI/MCP orchestration contract is specs/session-orchestration.md.
   D11). It may allow owner-cached turns from the catalog snapshot, deny `remote_missing`
   workspaces, or return `remote` to preserve the existing Convex three-state path. Catalog read
   failures degrade to `remote`, never to an error.
-- `session-access-retry.ts` — remote machine access verification with transient retry.
+- `session-access-retry.ts` — remote machine access verification: bounded retries at command
+  validation boundaries and interruptible unbounded retries for an already-durable dispatch.
 - `session-user-resolver.ts` + `git-identity.ts` — the requesting user's commit identity.
 - `worktree/` — repo checkouts, worktrees, branch allocation, setup scripts
   ([AGENTS.md](worktree/AGENTS.md)).

--- a/apps/cli/src/session/session-access-retry.ts
+++ b/apps/cli/src/session/session-access-retry.ts
@@ -1,5 +1,131 @@
 import { Data, Duration, Effect, Schedule } from 'effect';
 import type { MachineAccessCheckResult } from '@/lib/workspace';
+import { formatErrorWithCauses } from '@/utils/format-error';
+
+const DEFAULT_BOUNDED_RETRY_DELAYS_MS = [250, 1_000, 2_000] as const;
+const RETRYABLE_NETWORK_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ENETDOWN',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+const RETRYABLE_NETWORK_ERROR_MESSAGE =
+  /\b(fetch failed|failed to fetch|network error|socket hang up|connection (?:reset|refused)|timed? out|econnrefused|econnreset|enetdown|enetunreach|enotfound|eai_again|etimedout)\b/iu;
+
+type ErrorRecord = {
+  cause?: unknown;
+  code?: unknown;
+  errors?: unknown;
+  message?: unknown;
+  status?: unknown;
+  statusCode?: unknown;
+};
+
+const isRetryableHttpStatus = (value: unknown): boolean =>
+  typeof value === 'number' && (value === 408 || value === 429 || value >= 500);
+
+const isRetryableMachineAccessCause = (
+  error: unknown,
+  seen: ReadonlySet<unknown> = new Set()
+): boolean => {
+  if (seen.has(error) || (typeof error !== 'object' && typeof error !== 'string')) {
+    return false;
+  }
+  if (typeof error === 'string') {
+    return RETRYABLE_NETWORK_ERROR_MESSAGE.test(error);
+  }
+
+  const nextSeen = new Set(seen);
+  nextSeen.add(error);
+  const record = error as ErrorRecord;
+  if (typeof record.code === 'string' && RETRYABLE_NETWORK_ERROR_CODES.has(record.code)) {
+    return true;
+  }
+  if (isRetryableHttpStatus(record.status) || isRetryableHttpStatus(record.statusCode)) {
+    return true;
+  }
+  if (typeof record.message === 'string' && RETRYABLE_NETWORK_ERROR_MESSAGE.test(record.message)) {
+    return true;
+  }
+  if (Array.isArray(record.errors)) {
+    for (const nested of record.errors) {
+      if (isRetryableMachineAccessCause(nested, nextSeen)) return true;
+    }
+  }
+  return record.cause !== undefined && isRetryableMachineAccessCause(record.cause, nextSeen);
+};
+
+export class MachineAccessVerificationError extends Error {
+  readonly code: 'MACHINE_ACCESS_UNAVAILABLE' | 'MACHINE_ACCESS_CHECK_FAILED';
+
+  constructor(
+    readonly retryable: boolean,
+    readonly attempts: number,
+    cause: unknown
+  ) {
+    const attemptSuffix = attempts > 1 ? ` after ${attempts} attempts` : '';
+    super(`Could not verify machine access${attemptSuffix}: ${formatErrorWithCauses(cause)}`, {
+      cause,
+    });
+    this.name = 'MachineAccessVerificationError';
+    this.code = retryable ? 'MACHINE_ACCESS_UNAVAILABLE' : 'MACHINE_ACCESS_CHECK_FAILED';
+  }
+}
+
+export interface BoundedMachineAccessRetryOptions {
+  readonly verify: () => Promise<MachineAccessCheckResult>;
+  readonly retryDelaysMs?: readonly number[];
+  readonly sleep?: (delayMs: number) => Promise<void>;
+  readonly onRetry?: (event: {
+    attempt: number;
+    maxAttempts: number;
+    delayMs: number;
+    error: string;
+  }) => void;
+}
+
+/**
+ * Retry an idempotent command-boundary access query for a short, bounded window.
+ * Definitive access results return immediately; only transport-shaped failures retry.
+ */
+export async function readMachineAccessWithBoundedRetry(
+  options: BoundedMachineAccessRetryOptions
+): Promise<MachineAccessCheckResult> {
+  const retryDelaysMs = options.retryDelaysMs ?? DEFAULT_BOUNDED_RETRY_DELAYS_MS;
+  const maxAttempts = retryDelaysMs.length + 1;
+  const sleep =
+    options.sleep ??
+    (async (delayMs: number) => {
+      await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+    });
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await options.verify();
+    } catch (error) {
+      const retryable = isRetryableMachineAccessCause(error);
+      const delayMs = retryDelaysMs[attempt - 1];
+      if (!retryable || delayMs === undefined) {
+        throw new MachineAccessVerificationError(retryable, attempt, error);
+      }
+      options.onRetry?.({
+        attempt,
+        maxAttempts,
+        delayMs,
+        error: formatErrorWithCauses(error),
+      });
+      await sleep(delayMs);
+    }
+  }
+
+  throw new Error('Machine access retry loop exited without a result.');
+}
 
 /**
  * Verifying whether a requester may run a turn on this machine has three

--- a/apps/cli/src/utils/format-error.ts
+++ b/apps/cli/src/utils/format-error.ts
@@ -54,6 +54,12 @@ const formatErrorWithCausesInternal = (error: unknown, seen: ReadonlySet<unknown
     if (typeof code === 'string' && code.length > 0) {
       parts.push(`code=${code}`);
     }
+    if (error instanceof AggregateError && error.errors.length > 0) {
+      const nested = error.errors
+        .slice(0, 3)
+        .map((entry) => formatErrorWithCausesInternal(entry, nextSeen));
+      parts.push(`errors=[${nested.join('; ')}]`);
+    }
     const cause = (error as { cause?: unknown }).cause;
     if (cause !== undefined) {
       parts.push(`cause=${formatErrorWithCausesInternal(cause, nextSeen)}`);

--- a/apps/cli/tests/session-access-retry.test.ts
+++ b/apps/cli/tests/session-access-retry.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { Cause, Duration, Effect, Exit, Fiber, Option, TestClock, TestContext } from 'effect';
 import {
   AccessDenied,
+  MachineAccessVerificationError,
+  readMachineAccessWithBoundedRetry,
   verifyMachineAccessWithRetry,
   type MachineAccessVerification,
 } from '../src/session/session-access-retry';
@@ -174,5 +176,73 @@ describe('verifyMachineAccessWithRetry', () => {
 
     expect(Exit.isInterrupted(exit)).toBe(true);
     expect(onAuthEscalation).not.toHaveBeenCalled();
+  });
+});
+
+describe('readMachineAccessWithBoundedRetry', () => {
+  it('retries transient fetch failures and returns the definitive result', async () => {
+    const verify = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockRejectedValueOnce(Object.assign(new Error('connect reset'), { code: 'ECONNRESET' }))
+      .mockResolvedValue({ allowed: true });
+    const sleep = vi.fn(async () => undefined);
+
+    await expect(
+      readMachineAccessWithBoundedRetry({
+        verify,
+        retryDelaysMs: [10, 20],
+        sleep,
+      })
+    ).resolves.toEqual({ allowed: true });
+
+    expect(verify).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls).toEqual([[10], [20]]);
+  });
+
+  it('does not retry a non-transport failure', async () => {
+    const verify = vi.fn(async () => {
+      throw new Error('Authenticated CLI user does not match the session requester.');
+    });
+    const sleep = vi.fn(async () => undefined);
+
+    const error = await readMachineAccessWithBoundedRetry({ verify, sleep }).catch(
+      (cause: unknown) => cause
+    );
+
+    expect(error).toBeInstanceOf(MachineAccessVerificationError);
+    expect(error).toMatchObject({
+      attempts: 1,
+      code: 'MACHINE_ACCESS_CHECK_FAILED',
+      retryable: false,
+    });
+    expect(verify).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('preserves the nested network cause when bounded retries are exhausted', async () => {
+    const lowLevel = Object.assign(new Error('socket closed'), { code: 'ECONNRESET' });
+    const verify = vi.fn(async () => {
+      throw new TypeError('fetch failed', {
+        cause: new AggregateError([lowLevel], 'connection attempts failed'),
+      });
+    });
+
+    const error = await readMachineAccessWithBoundedRetry({
+      verify,
+      retryDelaysMs: [10, 20],
+      sleep: async () => undefined,
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(MachineAccessVerificationError);
+    expect(error).toMatchObject({
+      attempts: 3,
+      code: 'MACHINE_ACCESS_UNAVAILABLE',
+      retryable: true,
+    });
+    expect((error as Error).message).toContain('after 3 attempts');
+    expect((error as Error).message).toContain('ECONNRESET');
+    expect((error as Error).message).toContain('socket closed');
+    expect(verify).toHaveBeenCalledTimes(3);
   });
 });

--- a/specs/session-access-verification.md
+++ b/specs/session-access-verification.md
@@ -1,0 +1,33 @@
+# Session machine access verification
+
+Status: draft
+Translation: current
+
+[中文](session-access-verification.zh.md)
+
+Creating a Session or sending a message may need the Lody control plane to verify that the
+requester can use the target Machine. A definitive allow continues and a definitive denial stops
+immediately. A transport failure is not a denial: command validation retries it for a short,
+bounded window, then returns a retryable `MACHINE_ACCESS_UNAVAILABLE` result without creating or
+dispatching work.
+
+Machine presence and access verification answer different questions. A fresh Loro Streams
+presence heartbeat means the Machine was recently reachable through the presence channel; it does
+not prove that the control-plane access query is reachable. The UI and agents must not use an
+`online` label as evidence that access verification succeeded.
+
+When retries are exhausted, diagnostics preserve the nested transport cause and error code when
+the runtime provides them, such as `ECONNRESET`, `ENOTFOUND`, or `ETIMEDOUT`. Retryable failures
+remain fail-closed: callers may retry the same command, but the CLI never treats an unavailable
+authorization service as permission.
+
+## Evidence
+
+The bounded command retry and diagnostics are implemented in
+`apps/cli/src/session/session-access-retry.ts`. Command access checks enter it through
+`apps/cli/src/commands/session.ts`; MCP single and batch results preserve retryability through
+`apps/cli/src/mcp/machine-access-error.ts`. Deterministic coverage is in
+`apps/cli/tests/session-access-retry.test.ts` and
+`apps/cli/src/mcp/machine-access-error.test.ts`.
+
+This draft records the requested behavior. Tests do not establish deployed-client recovery.

--- a/specs/session-access-verification.zh.md
+++ b/specs/session-access-verification.zh.md
@@ -1,0 +1,28 @@
+# Session 机器访问校验
+
+Status: draft
+Translation: current
+
+[English](session-access-verification.md)
+
+创建 Session 或发送消息时，Lody 可能需要通过控制面校验请求者是否能使用目标机器。
+明确允许时继续，明确拒绝时立即停止。传输失败不等于拒绝：命令校验会在短暂且有上限的
+时间内重试；仍失败时返回可重试的 `MACHINE_ACCESS_UNAVAILABLE`，并且不创建或派发工作。
+
+机器 presence 和访问校验回答的是两个不同问题。Loro Streams 中的新鲜心跳只表示该机器
+最近能通过 presence 通道连接；它不能证明控制面的访问校验接口可达。界面和 Agent
+不能把 `online` 标签当作访问校验成功的证据。
+
+重试耗尽后，如果运行时提供了底层传输原因和错误码，诊断信息必须保留它们，例如
+`ECONNRESET`、`ENOTFOUND` 或 `ETIMEDOUT`。可重试错误仍然保持 fail-closed：调用方可以重试
+同一个命令，但 CLI 不能在鉴权服务不可用时视为已获得权限。
+
+## 证据
+
+有界命令重试和诊断实现在 `apps/cli/src/session/session-access-retry.ts`。命令访问校验通过
+`apps/cli/src/commands/session.ts` 进入该逻辑；MCP 单项和批量结果通过
+`apps/cli/src/mcp/machine-access-error.ts` 保留可重试属性。确定性测试位于
+`apps/cli/tests/session-access-retry.test.ts` 和
+`apps/cli/src/mcp/machine-access-error.test.ts`。
+
+本草稿记录本次要求的行为；测试不代表已完成发布端恢复验收。


### PR DESCRIPTION
## Related issue

## Problem / pressure

Session creation stopped before contacting the target machine when the control-plane access check hit a transient network failure such as `fetch failed`. The MCP response then classified the failure as a permanent command or input rejection, while the UI could still show the independent machine-presence signal as online.

## Summary

- Retry idempotent machine-access checks after 250 ms, 1 second, and 2 seconds when the failure has a transport-shaped cause.
- Keep definitive authorization denials fail-closed and immediate.
- Preserve nested causes, including `AggregateError` network codes, in diagnostics.
- Return `MACHINE_ACCESS_UNAVAILABLE` with `retryable: true` from MCP single and batch create/chat paths after retries are exhausted.
- Document the access-verification contract and implementation decision in English and Chinese.

## Visual explanation

```mermaid
flowchart TD
    Command[Create Session or send message] --> Access{Control-plane access check}
    Access -->|allowed| Availability{Machine presence}
    Access -->|denied| Denied[Stop: access denied]
    Access -->|transport failure| Retry[Retry after 250 ms, 1 s, and 2 s]
    Retry -->|attempt remains| Access
    Retry -->|exhausted| Unavailable[MACHINE_ACCESS_UNAVAILABLE<br/>retryable: true]
    Presence[Loro Streams heartbeat] --> Availability
    Availability -->|online| Dispatch[Dispatch to Agent]
    Availability -->|offline| Offline[Stop: machine unavailable]
```

## Before / after

| Before | After |
| ------ | ----- |
| One transient access-query failure aborted Session creation and appeared permanent. | Transient failures receive bounded retries and remain explicitly retryable if the short window is exhausted. |
| `online` presence could appear inconsistent with an unexplained access failure. | Diagnostics retain the network cause, while the contract keeps presence and authorization as separate signals. |

## Test plan

- `pnpm --dir apps/cli exec vitest run tests/session-access-retry.test.ts src/mcp/machine-access-error.test.ts` — 12 tests passed.
- Targeted Prettier formatting completed for all changed source, test, Spec, and Note files.
- Targeted Oxlint completed with 0 errors; six existing warnings remain in `lody-mcp-server.ts`.
- `pnpm run docs check` passed with no documentation errors.
- `git diff --check` passed.
- Full CLI typecheck and the large Session/MCP suites could not start in this nested checkout because ACP workspace packages, `@loro-dev/streams-client`, and generated `loro_wasm` are absent. `pnpm check:public-boundary` is blocked by the same missing ACP workspace packages.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check transport-error classification in `session-access-retry.ts` and all four MCP single/batch mappings.
- **Decisions to challenge:** Assess whether four total attempts over 3.25 seconds are suitable for command validation before work is accepted.
- **Plausible failures / evidence gaps:** Full integration suites did not start in this nested checkout because required workspace packages and generated WASM are absent.

### Authoring context

- **User goal / directives:** Prevent transient machine-access fetch failures from prematurely stopping Session creation and expose a useful retryable result.
- **Constraints / non-goals:** Preserve fail-closed authorization and keep the existing unbounded retry policy for already-durable dispatches unchanged.
- **Risk-bearing decisions:** Only transport-shaped failures retry; schema, identity, and definitive access-denial results do not.
- **Destructive or irreversible behavior:** The change performs no migration, deletion, overwrite, or remote mutation beyond normal command retries.
- **Deliberately not done or tested:** No released desktop build or live affected-account recovery test was available in this checkout.
- **Unknowns / confidence:** Unit coverage confirms retry, exhaustion, nested diagnostics, and MCP mapping; the original user's exact proxy, DNS, or TLS cause remains unknown.

<!-- context-handoff:end -->
