### PR TITLE
feat: require visual explanations for complex PRs

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -150,4 +150,6 @@ Place visuals beside short explanations, mark conceptual sketches, and keep real
 paths accurate. Diagrams are maintained facts too. Use HTML only when a static
 view cannot explain the point; prose must remain independently understandable.
 Worked examples live in [visual explanations](docs/visual-explanations.md); the
-PR template points there so outside authors need nothing installed.
+PR template points there so outside authors need nothing installed. Every PR fills
+its visual-explanation section; changes over 200 lines must include a structural
+view, while semantic complexity remains a reviewer judgment.

--- a/.agents/docs/visual-explanations.md
+++ b/.agents/docs/visual-explanations.md
@@ -5,8 +5,15 @@ makes the key point clear, and keep the surrounding prose brief. These examples
 are conceptual; the rules that govern them are in
 [structural explanations](../README.md#structural-explanations).
 
-Authors of a pull request: apply this in the Summary or the Before / after table.
-Nothing needs to be installed.
+Authors of a pull request: apply this in `## Visual explanation`. Nothing needs
+to be installed.
+
+Every pull request fills `## Visual explanation`. Agents invoke `$show-me` before
+writing it. A change is complex when it crosses component, runtime, or authority
+boundaries; changes multi-step control or data flow; or exceeds 200 changed lines.
+Complex changes include one of the structural views below. For a simple change,
+write `Simple change: <why a visual would not help review>` instead. The PR policy
+automatically enforces the 200-line floor; reviewers enforce the semantic cases.
 
 - Show logic or an algorithm as pseudocode:
 
@@ -112,8 +119,8 @@ For a state or control-flow change:
 
 ```ts
 function expandSkill(command: string): string {
-  const skillName = command.slice(1)
-  return `use the ${skillName} skill`
+  const skillName = command.slice(1);
+  return `use the ${skillName} skill`;
 }
 ```
 
@@ -133,5 +140,5 @@ Keep each view at one abstraction level.
 Indentation means directory containment, component containment, or calls; do not
 mix these relationships in one tree. Expand a module in a separate focused view
 when needed. In a PR, any supporting artifact must be accessible to reviewers;
-opening a local HTML file alone does not make it accessible. Small fixes can use
-just a concise sentence or the existing table. Do not add visuals for ceremony.
+opening a local HTML file alone does not make it accessible. Do not add visuals
+for ceremony.

--- a/.agents/notes/implemented/process/2026-09-08-required-pr-visual-explanations.md
+++ b/.agents/notes/implemented/process/2026-09-08-required-pr-visual-explanations.md
@@ -1,0 +1,40 @@
+# Require visual explanations for complex pull requests
+
+Status: implemented
+Translation: current
+PR: not created
+
+[中文](2026-09-08-required-pr-visual-explanations.zh.md)
+
+## Abstract
+
+The pull request template now invokes `$show-me`, requires every author to address visual
+explanation, and mechanically rejects large external changes that provide prose without a
+structural view.
+
+## Decision
+
+Every pull request template now contains a required `## Visual explanation` section. Agents are
+directed to invoke `$show-me` and use its smallest useful structural view. Simple changes may
+instead provide a concise reason that a visual would not help review.
+
+The scoped GitHub authoring rule applies that instruction to same-repository PRs as well. Their
+bodies remain outside external-contribution policy enforcement, but the authoring Agent must still
+follow the template and visual requirement.
+
+A pull request is semantically complex when it crosses component, runtime, or authority
+boundaries or changes multi-step control or data flow. The policy also defines an automatically
+enforceable floor: changes above 200 added plus deleted lines must include a supported fenced
+structural view, Markdown image, or linked HTML artifact. Reviewers remain responsible for
+requiring a visual from smaller changes that are semantically complex.
+
+## Enforcement
+
+`check-pr-body.mjs` owns structural-view detection and accepts the changed-line count directly,
+through `--changed-lines`, or from a pull-request event payload. `pr-policy.mjs` passes the current
+GitHub additions and deletions into that validator. This keeps the body rule deterministic without
+claiming that line count captures every form of complexity.
+
+Supported fenced views follow the `$show-me` shapes: Mermaid, text trees or pseudocode, structural
+diffs, and TS/JS component or code shapes. The checker also accepts Markdown images and reviewable
+HTML links.

--- a/.agents/notes/implemented/process/2026-09-08-required-pr-visual-explanations.md
+++ b/.agents/notes/implemented/process/2026-09-08-required-pr-visual-explanations.md
@@ -2,7 +2,7 @@
 
 Status: implemented
 Translation: current
-PR: not created
+PR: https://github.com/LodyAI/Lody/pull/520
 
 [中文](2026-09-08-required-pr-visual-explanations.zh.md)
 

--- a/.agents/notes/implemented/process/2026-09-08-required-pr-visual-explanations.zh.md
+++ b/.agents/notes/implemented/process/2026-09-08-required-pr-visual-explanations.zh.md
@@ -1,0 +1,34 @@
+# 复杂 Pull Request 必须提供可视化说明
+
+Status: implemented
+Translation: current
+PR: not created
+
+[English](2026-09-08-required-pr-visual-explanations.md)
+
+## 摘要
+
+Pull Request 模板现在会调用 `$show-me`，要求每位作者说明可视化选择，并自动拒绝只有文字说明、
+没有结构图的大型外部改动。
+
+## 决定
+
+Pull Request 模板现在固定包含必填的 `## Visual explanation`。Agent 必须调用 `$show-me`，
+并选择最小且有助于评审的结构图。简单改动可以改为简短说明为什么图不会帮助评审。
+
+GitHub scope 的 authoring 规则也会把这个要求应用于同仓库 PR。它们仍不受外部贡献策略自动检查，
+但负责撰写的 Agent 必须遵循模板和可视化要求。
+
+当改动跨越 component、runtime 或 authority 边界，或者改变多步控制流、数据流时，它在语义上
+属于复杂改动。策略同时定义了可自动执行的下限：新增与删除合计超过 200 行时，必须提供受支持的
+结构化代码块、Markdown 图片或可供评审访问的 HTML 链接。少于 200 行但语义复杂的情况仍由
+评审者要求补图。
+
+## 执行方式
+
+`check-pr-body.mjs` 负责识别结构图，并可直接接收改动行数、通过 `--changed-lines` 接收，或从
+Pull Request event 中读取。`pr-policy.mjs` 会把 GitHub 当前记录的 additions 和 deletions 传给
+校验器。这样能保持正文规则确定，同时不会假装行数能识别所有复杂度。
+
+支持的代码块与 `$show-me` 的形式一致：Mermaid、text 树或伪代码、结构化 diff，以及 TS/JS
+component 或代码结构。校验器也接受 Markdown 图片和可评审的 HTML 链接。

--- a/.agents/notes/implemented/process/2026-09-08-required-pr-visual-explanations.zh.md
+++ b/.agents/notes/implemented/process/2026-09-08-required-pr-visual-explanations.zh.md
@@ -2,7 +2,7 @@
 
 Status: implemented
 Translation: current
-PR: not created
+PR: https://github.com/LodyAI/Lody/pull/520
 
 [English](2026-09-08-required-pr-visual-explanations.md)
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -35,8 +35,8 @@ Workflow-file security constraints live in
   Issue with analysis and wait to be assigned; do not open the PR. Maintainers
   review small focused changes; large unsolicited patches hide invariant breaks.
   Humans: `CONTRIBUTING.md`.
-- `gh pr create --body` silently skips `PULL_REQUEST_TEMPLATE.md`. Draft the PR
-  body from the template and validate it with
+- Draft every PR from `PULL_REQUEST_TEMPLATE.md`; complex changes use `$show-me`.
+  Validate external bodies with
   `node .github/scripts/check-pr-body.mjs --body-file <file>`.
 - An Agent opens every pull request as a draft (`gh pr create --draft`) and then
   tells its user to mark it ready for review once they judge it ready for

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,12 +29,20 @@ normalized to `Closes #123` by the PR policy workflow.
 
 <!-- What changed in response to that pressure. Keep this about the change set, not the motivation. -->
 
+## Visual explanation
+
 <!--
-Optional: a diagram, tree, or structural diff often explains a change faster than
-prose. Put it directly in Summary or Before / after. Examples and the rules for
-choosing a view: .agents/docs/visual-explanations.md
+Required. Agents: invoke `$show-me` and place its smallest useful view here.
+
+Complex changes must include a structural view: Mermaid, pseudocode/call tree,
+component/file tree, structural diff, image, or a linked reviewable HTML artifact.
+A change is complex when it crosses component/runtime/authority boundaries, changes
+multi-step control or data flow, or exceeds 200 changed lines. The automated policy
+enforces the 200-line floor; reviewers enforce the semantic cases.
+
+For a simple change, write `Simple change: <why a visual would not help review>`.
+Examples and selection rules: .agents/docs/visual-explanations.md
 Any supporting artifact must be reachable by reviewers; a local HTML file is not.
-Small fixes need no visual. Do not add one for ceremony.
 -->
 
 ## Before / after

--- a/.github/scripts/check-pr-body.mjs
+++ b/.github/scripts/check-pr-body.mjs
@@ -9,9 +9,21 @@ const REQUIRED_HEADINGS = [
   '## Related issue',
   '## Problem / pressure',
   '## Summary',
+  '## Visual explanation',
   '## Test plan',
   '## Context handoff',
 ];
+export const COMPLEX_CHANGE_LINE_THRESHOLD = 200;
+const STRUCTURAL_VIEW_LANGUAGES = new Set([
+  'diff',
+  'javascript',
+  'jsx',
+  'mermaid',
+  'text',
+  'ts',
+  'tsx',
+  'typescript',
+]);
 const CONTEXT_HANDOFF_BEGIN = '<!-- context-handoff:begin -->';
 const CONTEXT_HANDOFF_END = '<!-- context-handoff:end -->';
 const REQUIRED_CONTEXT_HEADINGS = [
@@ -39,6 +51,7 @@ function parseArgs(argv) {
   const options = {
     body: process.env.PR_BODY ?? '',
     bodyFile: null,
+    changedLines: null,
     eventFile: null,
   };
 
@@ -48,6 +61,12 @@ function parseArgs(argv) {
       options.body = argv[++index] ?? '';
     } else if (argument === '--body-file') {
       options.bodyFile = argv[++index] ?? null;
+    } else if (argument === '--changed-lines') {
+      const value = Number(argv[++index]);
+      if (!Number.isInteger(value) || value < 0) {
+        throw new Error('--changed-lines must be a non-negative integer.');
+      }
+      options.changedLines = value;
     } else if (argument === '--event-file') {
       options.eventFile = argv[++index] ?? null;
     } else if (argument === '--help' || argument === '-h') {
@@ -108,11 +127,27 @@ function isCompleteContext(value) {
   return isFilledSection(normalized) && !WITHHELD_CONTEXT.test(normalized);
 }
 
+function hasStructuralView(section) {
+  if (!section) {
+    return false;
+  }
+  for (const match of section.matchAll(/```([^\n]*)\n([\s\S]*?)```/g)) {
+    const language = match[1].trim().toLowerCase();
+    if (STRUCTURAL_VIEW_LANGUAGES.has(language) && match[2].trim()) {
+      return true;
+    }
+  }
+  if (/!\[[^\]]*\]\([^\s)]+\)/.test(section)) {
+    return true;
+  }
+  return /\[[^\]]+\]\([^\s)]+\.html(?:[?#][^\s)]*)?\)/i.test(section);
+}
+
 export function hasRelatedIssueReference(body) {
   return hasRelatedIssueLink(body);
 }
 
-export function checkPullRequestBody(body) {
+export function checkPullRequestBody(body, { changedLines = null } = {}) {
   const text = (body ?? '').replace(/\r\n/g, '\n');
   const findings = [];
 
@@ -142,12 +177,28 @@ export function checkPullRequestBody(body) {
     );
   }
 
-  for (const heading of ['## Problem / pressure', '## Summary', '## Test plan']) {
+  for (const heading of [
+    '## Problem / pressure',
+    '## Summary',
+    '## Visual explanation',
+    '## Test plan',
+  ]) {
     if (requiredHeadingCounts.get(heading) === 1 && !isFilledSection(sectionBody(text, heading))) {
       findings.push(
         `${heading} must contain meaningful content, not only comments or placeholders.`
       );
     }
+  }
+
+  const visualExplanation = sectionBody(text, '## Visual explanation');
+  if (
+    Number.isInteger(changedLines) &&
+    changedLines > COMPLEX_CHANGE_LINE_THRESHOLD &&
+    !hasStructuralView(visualExplanation)
+  ) {
+    findings.push(
+      `## Visual explanation must include a structural view because this PR changes ${changedLines} lines, above the ${COMPLEX_CHANGE_LINE_THRESHOLD}-line complexity floor.`
+    );
   }
 
   const contextHeadingCounts = new Map();
@@ -198,15 +249,21 @@ export function checkPullRequestBody(body) {
   return { ok: findings.length === 0, findings };
 }
 
-function bodyFromOptions(options) {
+function inputFromOptions(options) {
   if (options.eventFile) {
     const event = JSON.parse(readFileSync(options.eventFile, 'utf8'));
-    return event.pull_request?.body ?? '';
+    const pullRequest = event.pull_request ?? {};
+    return {
+      body: pullRequest.body ?? '',
+      changedLines:
+        options.changedLines ??
+        Number(pullRequest.additions ?? 0) + Number(pullRequest.deletions ?? 0),
+    };
   }
   if (options.bodyFile) {
-    return readFileSync(options.bodyFile, 'utf8');
+    return { body: readFileSync(options.bodyFile, 'utf8'), changedLines: options.changedLines };
   }
-  return options.body;
+  return { body: options.body, changedLines: options.changedLines };
 }
 
 function main() {
@@ -220,12 +277,13 @@ function main() {
 
   if (options.help) {
     console.log(
-      'Usage: node .github/scripts/check-pr-body.mjs [--event-file event.json | --body-file body.md | --body text]'
+      'Usage: node .github/scripts/check-pr-body.mjs [--event-file event.json | --body-file body.md | --body text] [--changed-lines count]'
     );
     return;
   }
 
-  const result = checkPullRequestBody(bodyFromOptions(options));
+  const input = inputFromOptions(options);
+  const result = checkPullRequestBody(input.body, { changedLines: input.changedLines });
   if (result.ok) {
     console.log('PR body format OK');
     return;

--- a/.github/scripts/check-pr-template.test.mjs
+++ b/.github/scripts/check-pr-template.test.mjs
@@ -6,6 +6,22 @@ import { checkPullRequestBody } from './check-pr-body.mjs';
 const templateUrl = new URL('../PULL_REQUEST_TEMPLATE.md', import.meta.url);
 const template = readFileSync(templateUrl, 'utf8');
 
+function completedTemplate(visualExplanation) {
+  return template
+    .replace('## Related issue', '## Related issue\n\nRefs #123')
+    .replace(
+      '## Problem / pressure',
+      '## Problem / pressure\n\nRepeated routing errors obscure ownership.'
+    )
+    .replace('## Summary', '## Summary\n\nDocument the local route and state owner.')
+    .replace('## Visual explanation', `## Visual explanation\n\n${visualExplanation}`)
+    .replace('## Test plan', '## Test plan\n\nChecked the routing example against source.')
+    .replace(
+      /(- \*\*[^\n]+?:\*\*)\s*<!--[^\n]*-->/g,
+      '$1 Reviewed local routing only; no runtime behavior changes.'
+    );
+}
+
 void test('the unedited template is not a valid PR body', () => {
   const result = checkPullRequestBody(template);
   assert.equal(result.ok, false);
@@ -28,18 +44,26 @@ void test('every repository path the template names resolves', () => {
 });
 
 void test('an author who fills every required field passes', () => {
-  const body = template
-    .replace('## Related issue', '## Related issue\n\nRefs #123')
-    .replace(
-      '## Problem / pressure',
-      '## Problem / pressure\n\nRepeated routing errors obscure ownership.'
-    )
-    .replace('## Summary', '## Summary\n\nDocument the local route and state owner.')
-    .replace('## Test plan', '## Test plan\n\nChecked the routing example against source.')
-    .replace(
-      /(- \*\*[^\n]+?:\*\*)\s*<!--[^\n]*-->/g,
-      '$1 Reviewed local routing only; no runtime behavior changes.'
-    );
+  const body = completedTemplate('Simple change: one documentation sentence changed.');
   const result = checkPullRequestBody(body);
+  assert.equal(result.ok, true, result.findings.join('\n'));
+});
+
+void test('a large change requires a structural visual', () => {
+  const body = completedTemplate('Simple change: one documentation sentence changed.');
+  const boundary = checkPullRequestBody(body, { changedLines: 200 });
+  assert.equal(boundary.ok, true, boundary.findings.join('\n'));
+
+  const result = checkPullRequestBody(body, { changedLines: 201 });
+  assert.equal(result.ok, false);
+  assert.ok(result.findings.some((finding) => finding.includes('structural view')));
+});
+
+void test('a Mermaid view satisfies the large-change requirement', () => {
+  const body = completedTemplate(`\`\`\`mermaid
+flowchart LR
+    UI --> Daemon
+\`\`\``);
+  const result = checkPullRequestBody(body, { changedLines: 201 });
   assert.equal(result.ok, true, result.findings.join('\n'));
 });

--- a/.github/scripts/pr-policy.mjs
+++ b/.github/scripts/pr-policy.mjs
@@ -135,9 +135,9 @@ function changedLines(pullRequest) {
 }
 
 function checkPullRequestPolicy(pullRequest, { authorAssignedToRelatedIssue = false } = {}) {
-  const result = checkPullRequestBody(pullRequest.body);
-  const findings = [...result.findings];
   const lines = changedLines(pullRequest);
+  const result = checkPullRequestBody(pullRequest.body, { changedLines: lines });
+  const findings = [...result.findings];
   if (lines > MAX_COMMUNITY_REVIEW_LINES && !authorAssignedToRelatedIssue) {
     findings.push(
       `PR changes ${lines} lines; community PRs over ${MAX_COMMUNITY_REVIEW_LINES} lines require a maintainer assignment on the linked Issue before review.`

--- a/.github/scripts/pr-policy.test.mjs
+++ b/.github/scripts/pr-policy.test.mjs
@@ -23,6 +23,13 @@ Policy state was duplicated.
 
 Use one policy state.
 
+## Visual explanation
+
+\`\`\`mermaid
+flowchart LR
+    Event --> Policy
+\`\`\`
+
 ## Test plan
 
 Run policy tests.


### PR DESCRIPTION
## Related issue

## Problem / pressure

The PR template treated structural explanations as optional, so complex changes could reach review with prose that hid control flow, ownership, or boundary changes. Agents also had no explicit instruction to invoke `$show-me` while authoring a PR.

## Summary

- Add a required `## Visual explanation` section that invokes `$show-me` for Agent-authored PRs.
- Define semantic complexity as crossing component, runtime, or authority boundaries or changing multi-step control/data flow.
- Use more than 200 changed lines as the deterministic minimum for automatic enforcement.
- Accept Mermaid, text trees/pseudocode, structural diffs, TS/JS shapes, Markdown images, and reviewable HTML links.
- Let simple changes provide a concise reason that a diagram would not help review.

## Visual explanation

```mermaid
flowchart TD
    Template[PR template] --> Section[Required Visual explanation]
    Agent[Authoring Agent] -->|invoke| ShowMe[$show-me]
    ShowMe --> Section
    Section --> Validator[PR body validator]
    Metadata[GitHub additions + deletions] --> Validator
    Validator -->|200 lines or fewer| Rationale[Simple rationale or structural view]
    Validator -->|over 200 + structural view| Pass[Pass]
    Validator -->|over 200 + prose only| Finding[Needs PR attention]
    Reviewer[Reviewer] --> Semantic[Enforce smaller semantic-complexity cases]
```

## Before / after

| Before | After |
| ------ | ----- |
| Visuals were optional guidance inside Summary. | Every PR addresses a dedicated visual-explanation section. |
| “Complex” had no enforceable lower bound. | PRs over 200 changed lines require a recognized structural view automatically. |
| Agents could author PRs without consulting `$show-me`. | Scoped authoring rules and the template explicitly invoke `$show-me`. |

## Test plan

- `node --test .github/scripts/*.test.mjs` — 101 tests passed.
- Added exact 200-line acceptance and 201-line rejection coverage.
- Added Mermaid acceptance coverage for a 201-line change.
- Changed script lint completed with 0 warnings and 0 errors.
- `pnpm run docs check` passed.
- `git diff --check` passed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check that `check-pr-body.mjs` recognizes only reviewable structural forms and that `pr-policy.mjs` passes current GitHub line counts.
- **Decisions to challenge:** Assess the 200-line automatic floor separately from the semantic complexity rules enforced by authors and reviewers.
- **Plausible failures / evidence gaps:** Internal PRs remain outside external policy reconciliation, so their requirement is enforced through scoped authoring instructions rather than a bot finding.

### Authoring context

- **User goal / directives:** Embed `$show-me` in the PR template and make visual explanations mandatory for complex changes.
- **Constraints / non-goals:** Avoid pretending that changed-line count can identify every semantically complex change.
- **Risk-bearing decisions:** Large external PRs become invalid when their visual section contains prose but no recognized structural view.
- **Destructive or irreversible behavior:** Invalid external PRs enter the existing correction workflow; this change adds no new deletion or closure mechanism.
- **Deliberately not done or tested:** The policy does not automatically inspect changed paths to infer cross-boundary semantic complexity.
- **Unknowns / confidence:** Script tests cover the exact numeric boundary and Mermaid path; reviewer judgment is still required below the automatic floor.

<!-- context-handoff:end -->
