### PR TITLE
fix(components): hide outgoing intro copy under reduced motion

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-09-onboarding-reduced-motion-copy.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-onboarding-reduced-motion-copy.md
@@ -1,0 +1,44 @@
+# Hide departing intro copy without animation
+
+Status: implemented
+Translation: pending
+
+## Abstract
+
+Reduced motion disables the onboarding intro's exit animation, leaving the
+previous headline and description visible over the final beat. The departing
+copy now has an explicit zero-opacity resting state. Normal CSS animations
+override that state during the crossfade, so the existing timing is preserved.
+This fixes the rendering defect reported in [issue 207](https://github.com/LodyAI/Lody/issues/207)
+without changing the ceremony lifecycle.
+
+## Decision
+
+`intro-sequence.tsx` owns both the exit animation and the reduced-motion override.
+Attach a dedicated class to the outgoing layer and declare its resting opacity
+beside the keyframes. Keep `aria-hidden` and the incoming layer unchanged.
+
+Keeping an almost-zero animation duration was considered in the issue, but
+an explicit resting state also works when the animation does not run at all.
+No timers, animation-end cleanup, dependencies, or state transitions are added.
+The separate stage-departure transform remains outside this issue's scope.
+
+## Evidence and limits
+
+Chromium rendered the real component and illustrations from base `158030ea`
+plus this fix, using an isolated Vite harness with host utilities stubbed and
+existing local dependencies. Playwright controlled the clock at each beat.
+At 1180 x 620 and 390 x 844, all three transitions produced outgoing opacity
+zero and incoming opacity one in both reduced and normal motion. Normal
+animation samples at 0, 160, and 320 milliseconds retained the crossfade.
+Skipping the intro and the setup callback also passed.
+
+Removing only the new CSS declaration reproduced outgoing opacity one and
+the overlapping final copy. Before/after screenshots were visually inspected.
+This was renderer-only verification, not a packaged Electron test.
+
+The changed TSX passes Prettier and Oxlint. Full `pnpm check` and `pnpm format`
+were attempted but stopped because the isolated worktree lacks the complete
+workspace dependencies and initialized adapter submodules. No full-suite
+success is claimed; the browser harness is local verification, not a new
+committed regression suite.

--- a/packages/components/src/components/onboarding/ceremony/intro-sequence.tsx
+++ b/packages/components/src/components/onboarding/ceremony/intro-sequence.tsx
@@ -142,6 +142,9 @@ const INTRO_MOTION_CSS = `
   from { opacity: 1; transform: translateY(0); }
   to { opacity: 0; transform: translateY(-8px); }
 }
+/* Keep departing copy hidden when reduced motion removes its animation.
+   A running animation still overrides this resting state for the crossfade. */
+.lody-intro-copy-leaving { opacity: 0; }
 @media (prefers-reduced-motion: reduce) {
   .lody-intro-motion { animation: none !important; transition-duration: 0ms !important; }
 }
@@ -370,7 +373,7 @@ export function IntroSequence({
               <div
                 key={`out-${outgoing}`}
                 aria-hidden
-                className="lody-intro-motion absolute inset-0 flex flex-col justify-center"
+                className="lody-intro-motion lody-intro-copy-leaving absolute inset-0 flex flex-col justify-center"
                 style={{ animation: 'lody-intro-copy-out 320ms ease both' }}
               >
                 <IntroCopy chinese={chinese} {...copyFor(outgoing)} />


### PR DESCRIPTION
## Related issue

Closes #207

Maintainer confirmation: https://github.com/LodyAI/Lody/issues/207#issuecomment-5581451920

## Problem / pressure

With `prefers-reduced-motion: reduce`, the intro disables its animations. The
outgoing copy relies entirely on animation fill to become transparent, so the
previous headline and description remain visible over the final beat indefinitely.

## Summary

- Give the departing copy an explicit `opacity: 0` resting state through a dedicated class.
- Preserve the existing crossfade: the running animation overrides the resting opacity.
- Record the rendering constraint and verification limits in a short Agent Note.

## Visual explanation

```text
Departing copy
  normal motion:  exit keyframes override resting opacity, 1 -> 0
  reduced motion: animation removed, resting opacity remains 0
```

The screenshots below are the existing before/after captures attached to #207
on August 31. Fresh renderer checks against `158030ea` plus this patch confirmed
the same result at desktop and narrow viewports.

Before:

<img width="1180" height="620" alt="Reduced motion before: departing and final copy overlap" src="https://github.com/user-attachments/assets/3a4ea532-901a-44c2-a24b-9a722a851609" />

After:

<img width="1180" height="620" alt="Reduced motion after: only the final headline is visible" src="https://github.com/user-attachments/assets/588f6893-de35-4e0a-aed1-f7693fb920d4" />

## Before / after

| Before | After |
| ------ | ----- |
| Reduced motion leaves the departing layer at opacity 1 over the final copy. | Departing opacity is 0; current opacity is 1. |
| Normal mode fades the departing copy through animation fill. | The same 320ms crossfade overrides the declared resting state. |

## Test plan

- Passed: Chromium + Playwright rendering the real `IntroSequence` and assets in an isolated Vite harness, with renderer-host utilities stubbed and existing local dependencies.
- Passed: all three timed transitions at 1180 x 620 and 390 x 844, in `reduce` and `no-preference`, with outgoing/current computed opacity 0/1.
- Passed: normal animation samples at 0, 160, and 320ms; final screen after advancing the clock by another 60 seconds; Skip intro; Configure Lody callback.
- Passed: removing only the new CSS declaration reproduces outgoing opacity 1 and overlapping final copy. Before/after screenshots visually inspected.
- Passed: changed-file Prettier check and Oxlint; `git diff --check`.
- Full `pnpm check` and `pnpm format` attempted but blocked by incomplete worktree dependencies (`tsgo` / `prettier` unavailable in other packages) and uninitialized adapter submodules. No packaged Electron or full-suite result is claimed.
- The harness is local verification, not a committed automated regression suite.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the outgoing layer and reduced-motion cascade in `packages/components/src/components/onboarding/ceremony/intro-sequence.tsx`.
- **Decisions to challenge:** Confirm that a zero-opacity resting class preserves normal keyframe precedence without requiring extra component state or cleanup.
- **Plausible failures / evidence gaps:** Browser verification isolates renderer-host utilities; packaged Electron and full workspace checks remain unverified.

### Authoring context

- **User goal / directives:** Submit the prepared fix for issue 207 after the maintainer requested a PR with `Closes #207`.
- **Constraints / non-goals:** Keep the change focused on overlapping outgoing copy; preserve illustrations, timing, translations, accessibility attributes, and setup flow.
- **Risk-bearing decisions:** Rely on normal CSS animation precedence over a non-important resting opacity; leave the reduced-motion animation override unchanged.
- **Destructive or irreversible behavior:** None; this renderer-only CSS change does not write user data, change protocols, or migrate state.
- **Deliberately not done or tested:** The stage-departure transform is a separate issue; no packaged Electron test or complete workspace suite was run successfully.
- **Unknowns / confidence:** High confidence for the isolated copy defect from computed-style checks and a mutation reproducing the bug; integration confidence is limited by the incomplete local workspace toolchain.

<!-- context-handoff:end -->
