### PR TITLE
fix(cli): do not let Codex explicit titles replace generated names

### DIFF
--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -8939,9 +8939,7 @@ export class MessageHandler {
           const agentConfigMeta = await this.workspaceDocument.getAgentConfigById(
             meta.agentConfigId
           );
-          if (
-            usesAcpProvidedSessionTitle(agentConfigMeta?.cliType, agentConfigMeta?.agentType)
-          ) {
+          if (usesAcpProvidedSessionTitle(agentConfigMeta?.cliType, agentConfigMeta?.agentType)) {
             allowedSources.push('generated');
           }
         } catch (error) {
@@ -8950,11 +8948,7 @@ export class MessageHandler {
           );
         }
       }
-      const applied = await sessionDoc.setTitleIfSourceIn(
-        sanitized,
-        'generated',
-        allowedSources
-      );
+      const applied = await sessionDoc.setTitleIfSourceIn(sanitized, 'generated', allowedSources);
       if (applied) {
         this.logger.debug(`[${sessionId}] Session title updated from agent: ${sanitized}`);
       }

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -8934,19 +8934,10 @@ export class MessageHandler {
         return;
       }
       const allowedSources: SessionTitleSource[] = ['draft'];
-      if (meta?.agentConfigId) {
-        try {
-          const agentConfigMeta = await this.workspaceDocument.getAgentConfigById(
-            meta.agentConfigId
-          );
-          if (usesAcpProvidedSessionTitle(agentConfigMeta?.cliType, agentConfigMeta?.agentType)) {
-            allowedSources.push('generated');
-          }
-        } catch (error) {
-          this.logger.debug(
-            `[${sessionId}] Failed to load agent config ${meta.agentConfigId} for title source policy: ${formatErrorMessage(error)}`
-          );
-        }
+      // SessionMeta.cliType/agentType are required; agentConfigId is optional on
+      // legacy sessions. Policy must not depend on a catalog lookup.
+      if (usesAcpProvidedSessionTitle(meta?.cliType, meta?.agentType)) {
+        allowedSources.push('generated');
       }
       const applied = await sessionDoc.setTitleIfSourceIn(sanitized, 'generated', allowedSources);
       if (applied) {

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -48,6 +48,7 @@ import {
   type MachineMeta,
   type MachineResourceInfo,
   SessionMeta,
+  type SessionTitleSource,
   LocalProjectId,
   type NeedToDeleteSessionQueueItem,
   getMachineRoomId,
@@ -8912,10 +8913,14 @@ export class MessageHandler {
   }
 
   /**
-   * Stores a session title pushed by the agent via ACP session_info_update
+   * Stores a session title pushed by the agent via ACP session_info_update.
    * Builtin Claude skips the isolated local generator, so the pushed title is
-   * its only generated source. Never overwrites a user-set title; the conditional
-   * write guards against renames racing in via sync.
+   * its only generated source and may replace an earlier generated title.
+   * Codex (and other isolated-generator agents) already have a generated title
+   * from title-generator.ts; an explicit Codex thread name must not replace it
+   * — that path used to retitle a resumed conversation from the latest prompt.
+   * Never overwrites a user-set title; the conditional write also guards
+   * against renames racing in via sync.
    */
   private async maybeStoreAgentSessionTitle(sessionId: SessionId, title: string): Promise<void> {
     try {
@@ -8928,10 +8933,28 @@ export class MessageHandler {
       if (meta?.title?.trim() === sanitized) {
         return;
       }
-      const applied = await sessionDoc.setTitleIfSourceIn(sanitized, 'generated', [
-        'draft',
+      const allowedSources: SessionTitleSource[] = ['draft'];
+      if (meta?.agentConfigId) {
+        try {
+          const agentConfigMeta = await this.workspaceDocument.getAgentConfigById(
+            meta.agentConfigId
+          );
+          if (
+            usesAcpProvidedSessionTitle(agentConfigMeta?.cliType, agentConfigMeta?.agentType)
+          ) {
+            allowedSources.push('generated');
+          }
+        } catch (error) {
+          this.logger.debug(
+            `[${sessionId}] Failed to load agent config ${meta.agentConfigId} for title source policy: ${formatErrorMessage(error)}`
+          );
+        }
+      }
+      const applied = await sessionDoc.setTitleIfSourceIn(
+        sanitized,
         'generated',
-      ]);
+        allowedSources
+      );
       if (applied) {
         this.logger.debug(`[${sessionId}] Session title updated from agent: ${sanitized}`);
       }

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -41,6 +41,7 @@ import {
   isManagedBuiltinAgentType,
   sanitizeLodyInternalInstructions,
   usesAcpProvidedSessionTitle,
+  resolveSessionAgentIdentity,
   SessionCreateResponse,
   SessionChatResponse,
   SessionStatusFactory,
@@ -8934,9 +8935,11 @@ export class MessageHandler {
         return;
       }
       const allowedSources: SessionTitleSource[] = ['draft'];
-      // SessionMeta.cliType/agentType are required; agentConfigId is optional on
-      // legacy sessions. Policy must not depend on a catalog lookup.
-      if (usesAcpProvidedSessionTitle(meta?.cliType, meta?.agentType)) {
+      // getMetaState() is a raw cast: resume-time docs can still store
+      // agentType-only or cliType=claude|codex. Normalize before the Claude
+      // title predicate. Do not look up the agent-config catalog.
+      const identity = resolveSessionAgentIdentity(meta?.cliType, meta?.agentType);
+      if (usesAcpProvidedSessionTitle(identity?.cliType, identity?.agentType)) {
         allowedSources.push('generated');
       }
       const applied = await sessionDoc.setTitleIfSourceIn(sanitized, 'generated', allowedSources);

--- a/apps/cli/tests/message-handler-title.test.ts
+++ b/apps/cli/tests/message-handler-title.test.ts
@@ -527,4 +527,47 @@ describe('MessageHandler title generation', () => {
     ]);
     expect(await sessionDoc.setTitleIfSourceIn.mock.results[0]?.value).toBe(true);
   });
+
+  it('still lets a legacy Claude session with only agentType replace a generated title', async () => {
+    const { handler, sessionDoc } = await createHandler(
+      'Earlier generated title',
+      'generated',
+      undefined,
+      { sessionAgentType: 'claude' }
+    );
+    const titleHost = handler as unknown as {
+      maybeStoreAgentSessionTitle: (sessionId: SessionId, title: string) => Promise<void>;
+    };
+
+    await titleHost.maybeStoreAgentSessionTitle(
+      's-claude-agent-only' as SessionId,
+      'Fix login bug'
+    );
+
+    expect(sessionDoc.setTitleIfSourceIn).toHaveBeenCalledWith('Fix login bug', 'generated', [
+      'draft',
+      'generated',
+    ]);
+    expect(await sessionDoc.setTitleIfSourceIn.mock.results[0]?.value).toBe(true);
+  });
+
+  it('still lets a legacy Claude session with cliType claude and no agentType replace a generated title', async () => {
+    const { handler, sessionDoc } = await createHandler(
+      'Earlier generated title',
+      'generated',
+      undefined,
+      { sessionCliType: 'claude' }
+    );
+    const titleHost = handler as unknown as {
+      maybeStoreAgentSessionTitle: (sessionId: SessionId, title: string) => Promise<void>;
+    };
+
+    await titleHost.maybeStoreAgentSessionTitle('s-claude-cli-only' as SessionId, 'Fix login bug');
+
+    expect(sessionDoc.setTitleIfSourceIn).toHaveBeenCalledWith('Fix login bug', 'generated', [
+      'draft',
+      'generated',
+    ]);
+    expect(await sessionDoc.setTitleIfSourceIn.mock.results[0]?.value).toBe(true);
+  });
 });

--- a/apps/cli/tests/message-handler-title.test.ts
+++ b/apps/cli/tests/message-handler-title.test.ts
@@ -36,7 +36,11 @@ const createHandler = async (
   latestMeta?: { title?: string; titleSource?: SessionTitleSource },
   options?: {
     agentConfigId?: string;
-    agentConfigMeta?: { titleGeneration?: { configOptionValues: Record<string, string> } } | null;
+    agentConfigMeta?: {
+      titleGeneration?: { configOptionValues: Record<string, string> };
+      cliType?: string;
+      agentType?: string;
+    } | null;
   }
 ) => {
   const logger = createSilentLogger();
@@ -365,7 +369,6 @@ describe('MessageHandler title generation', () => {
 
     expect(sessionDoc.setTitleIfSourceIn).toHaveBeenCalledWith('Fix flaky login', 'generated', [
       'draft',
-      'generated',
     ]);
   });
 
@@ -406,5 +409,90 @@ describe('MessageHandler title generation', () => {
     expect(mockedGenerateTitleIsolated).toHaveBeenCalledWith(
       expect.objectContaining({ titleConfig: undefined })
     );
+  });
+
+  it('does not let a Codex explicit title replace an already generated title', async () => {
+    const { handler, sessionDoc, workspaceDocument } = await createHandler(
+      'Exact ping5 reply',
+      'generated'
+    );
+    const titleHost = handler as unknown as {
+      maybeStoreAgentSessionTitle: (sessionId: SessionId, title: string) => Promise<void>;
+    };
+
+    await titleHost.maybeStoreAgentSessionTitle(
+      's-codex-resume' as SessionId,
+      'Single-word ping5b response'
+    );
+
+    expect(workspaceDocument.getAgentConfigById).not.toHaveBeenCalled();
+    expect(sessionDoc.setTitleIfSourceIn).toHaveBeenCalledWith(
+      'Single-word ping5b response',
+      'generated',
+      ['draft']
+    );
+    expect(await sessionDoc.setTitleIfSourceIn.mock.results[0]?.value).toBe(false);
+  });
+
+  it('still lets a Codex explicit title name a draft new session', async () => {
+    const { handler, sessionDoc } = await createHandler(undefined, 'draft');
+    const titleHost = handler as unknown as {
+      maybeStoreAgentSessionTitle: (sessionId: SessionId, title: string) => Promise<void>;
+    };
+
+    await titleHost.maybeStoreAgentSessionTitle(
+      's-codex-new' as SessionId,
+      'Single-word alpha7k reply'
+    );
+
+    expect(sessionDoc.setTitleIfSourceIn).toHaveBeenCalledWith(
+      'Single-word alpha7k reply',
+      'generated',
+      ['draft']
+    );
+    expect(await sessionDoc.setTitleIfSourceIn.mock.results[0]?.value).toBe(true);
+  });
+
+  it('does not let an agent title replace a user rename', async () => {
+    const { handler, sessionDoc } = await createHandler('KeepPong7k', 'user');
+    const titleHost = handler as unknown as {
+      maybeStoreAgentSessionTitle: (sessionId: SessionId, title: string) => Promise<void>;
+    };
+
+    await titleHost.maybeStoreAgentSessionTitle(
+      's-user' as SessionId,
+      'Exact pong7k response request'
+    );
+
+    expect(sessionDoc.setTitleIfSourceIn).toHaveBeenCalledWith(
+      'Exact pong7k response request',
+      'generated',
+      ['draft']
+    );
+    expect(await sessionDoc.setTitleIfSourceIn.mock.results[0]?.value).toBe(false);
+  });
+
+  it('still lets builtin Claude replace a generated title', async () => {
+    const { handler, sessionDoc, workspaceDocument } = await createHandler(
+      'Earlier generated title',
+      'generated',
+      undefined,
+      {
+        agentConfigId: 'agent-config-1',
+        agentConfigMeta: { cliType: 'builtin', agentType: 'claude' },
+      }
+    );
+    const titleHost = handler as unknown as {
+      maybeStoreAgentSessionTitle: (sessionId: SessionId, title: string) => Promise<void>;
+    };
+
+    await titleHost.maybeStoreAgentSessionTitle('s-claude' as SessionId, 'Fix login bug');
+
+    expect(workspaceDocument.getAgentConfigById).toHaveBeenCalledWith('agent-config-1');
+    expect(sessionDoc.setTitleIfSourceIn).toHaveBeenCalledWith('Fix login bug', 'generated', [
+      'draft',
+      'generated',
+    ]);
+    expect(await sessionDoc.setTitleIfSourceIn.mock.results[0]?.value).toBe(true);
   });
 });

--- a/apps/cli/tests/message-handler-title.test.ts
+++ b/apps/cli/tests/message-handler-title.test.ts
@@ -36,6 +36,8 @@ const createHandler = async (
   latestMeta?: { title?: string; titleSource?: SessionTitleSource },
   options?: {
     agentConfigId?: string;
+    sessionCliType?: string;
+    sessionAgentType?: string;
     agentConfigMeta?: {
       titleGeneration?: { configOptionValues: Record<string, string> };
       cliType?: string;
@@ -52,6 +54,8 @@ const createHandler = async (
         title: metaTitle ?? undefined,
         titleSource,
         agentConfigId: options?.agentConfigId,
+        cliType: options?.sessionCliType,
+        agentType: options?.sessionAgentType,
       })
       .mockResolvedValue(latestMeta ?? { title: metaTitle ?? undefined, titleSource }),
     setTitle: vi.fn(async () => {}),
@@ -414,7 +418,9 @@ describe('MessageHandler title generation', () => {
   it('does not let a Codex explicit title replace an already generated title', async () => {
     const { handler, sessionDoc, workspaceDocument } = await createHandler(
       'Exact ping5 reply',
-      'generated'
+      'generated',
+      undefined,
+      { sessionCliType: 'builtin', sessionAgentType: 'codex' }
     );
     const titleHost = handler as unknown as {
       maybeStoreAgentSessionTitle: (sessionId: SessionId, title: string) => Promise<void>;
@@ -435,7 +441,10 @@ describe('MessageHandler title generation', () => {
   });
 
   it('still lets a Codex explicit title name a draft new session', async () => {
-    const { handler, sessionDoc } = await createHandler(undefined, 'draft');
+    const { handler, sessionDoc } = await createHandler(undefined, 'draft', undefined, {
+      sessionCliType: 'builtin',
+      sessionAgentType: 'codex',
+    });
     const titleHost = handler as unknown as {
       maybeStoreAgentSessionTitle: (sessionId: SessionId, title: string) => Promise<void>;
     };
@@ -479,6 +488,8 @@ describe('MessageHandler title generation', () => {
       undefined,
       {
         agentConfigId: 'agent-config-1',
+        sessionCliType: 'builtin',
+        sessionAgentType: 'claude',
         agentConfigMeta: { cliType: 'builtin', agentType: 'claude' },
       }
     );
@@ -488,7 +499,28 @@ describe('MessageHandler title generation', () => {
 
     await titleHost.maybeStoreAgentSessionTitle('s-claude' as SessionId, 'Fix login bug');
 
-    expect(workspaceDocument.getAgentConfigById).toHaveBeenCalledWith('agent-config-1');
+    expect(workspaceDocument.getAgentConfigById).not.toHaveBeenCalled();
+    expect(sessionDoc.setTitleIfSourceIn).toHaveBeenCalledWith('Fix login bug', 'generated', [
+      'draft',
+      'generated',
+    ]);
+    expect(await sessionDoc.setTitleIfSourceIn.mock.results[0]?.value).toBe(true);
+  });
+
+  it('still lets a legacy Claude session without agentConfigId replace a generated title', async () => {
+    const { handler, sessionDoc, workspaceDocument } = await createHandler(
+      'Earlier generated title',
+      'generated',
+      undefined,
+      { sessionCliType: 'builtin', sessionAgentType: 'claude' }
+    );
+    const titleHost = handler as unknown as {
+      maybeStoreAgentSessionTitle: (sessionId: SessionId, title: string) => Promise<void>;
+    };
+
+    await titleHost.maybeStoreAgentSessionTitle('s-claude-legacy' as SessionId, 'Fix login bug');
+
+    expect(workspaceDocument.getAgentConfigById).not.toHaveBeenCalled();
     expect(sessionDoc.setTitleIfSourceIn).toHaveBeenCalledWith('Fix login bug', 'generated', [
       'draft',
       'generated',

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -47,6 +47,40 @@ export const usesAcpProvidedSessionTitle = (
   agentType: AgentType | null | undefined
 ): boolean => cliType === 'builtin' && agentType === 'claude';
 
+const isLegacyBuiltinAgentName = (value: string): value is 'claude' | 'codex' =>
+  value === 'claude' || value === 'codex';
+
+/**
+ * Resume-time session meta can still carry pre-#1221 encodings: only
+ * `agentType: claude|codex`, or `cliType: claude|codex` with no agentType.
+ * `getMetaState()` returns that raw shape. Same cases as
+ * `normalizeAcpTarget` in local-session-control.
+ */
+export const resolveSessionAgentIdentity = (
+  cliTypeValue: AgentConfigCliType | string | null | undefined,
+  agentTypeValue: AgentType | string | null | undefined
+): { cliType: AgentConfigCliType; agentType: string } | null => {
+  const cliType = typeof cliTypeValue === 'string' ? cliTypeValue.trim() : '';
+  const agentType = typeof agentTypeValue === 'string' ? agentTypeValue.trim() : '';
+
+  if (
+    (cliType === 'builtin' || cliType === 'registry' || cliType === 'custom') &&
+    agentType.length > 0
+  ) {
+    return { cliType, agentType };
+  }
+  if (!cliType && isLegacyBuiltinAgentName(agentType)) {
+    return { cliType: 'builtin', agentType };
+  }
+  if (isLegacyBuiltinAgentName(cliType) && !agentType) {
+    return { cliType: 'builtin', agentType: cliType };
+  }
+  if (isLegacyBuiltinAgentName(cliType) && isLegacyBuiltinAgentName(agentType)) {
+    return { cliType: 'builtin', agentType };
+  }
+  return null;
+};
+
 /**
  * User-defined ACP launch spec for `cliType: 'custom'` providers: the exact
  * executable + args the CLI spawns on the owning machine. Env vars come from

--- a/packages/shared/tests/title-generation-defaults.test.ts
+++ b/packages/shared/tests/title-generation-defaults.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   computeTitleGenerationDefaults,
   getBuiltinTitleGenerationDefaults,
+  resolveSessionAgentIdentity,
   usesAcpProvidedSessionTitle,
   type AcpConfigOptionSummary,
 } from '../src/ai';
@@ -128,5 +129,53 @@ describe('usesAcpProvidedSessionTitle', () => {
     expect(usesAcpProvidedSessionTitle('builtin', 'kimi')).toBe(false);
     expect(usesAcpProvidedSessionTitle('registry', 'codex')).toBe(false);
     expect(usesAcpProvidedSessionTitle('custom', 'claude')).toBe(false);
+  });
+});
+
+describe('resolveSessionAgentIdentity', () => {
+  it('keeps current builtin/registry/custom encodings', () => {
+    expect(resolveSessionAgentIdentity('builtin', 'claude')).toEqual({
+      cliType: 'builtin',
+      agentType: 'claude',
+    });
+    expect(resolveSessionAgentIdentity('registry', 'codex')).toEqual({
+      cliType: 'registry',
+      agentType: 'codex',
+    });
+  });
+
+  it('maps pre-#1221 agentType-only Claude/Codex to builtin', () => {
+    expect(resolveSessionAgentIdentity(undefined, 'claude')).toEqual({
+      cliType: 'builtin',
+      agentType: 'claude',
+    });
+    expect(resolveSessionAgentIdentity('', 'codex')).toEqual({
+      cliType: 'builtin',
+      agentType: 'codex',
+    });
+  });
+
+  it('maps transitional cliType=claude|codex with no agentType to builtin', () => {
+    expect(resolveSessionAgentIdentity('claude', undefined)).toEqual({
+      cliType: 'builtin',
+      agentType: 'claude',
+    });
+    expect(resolveSessionAgentIdentity('codex', '')).toEqual({
+      cliType: 'builtin',
+      agentType: 'codex',
+    });
+  });
+
+  it('maps both-legacy encodings to builtin using agentType', () => {
+    expect(resolveSessionAgentIdentity('claude', 'codex')).toEqual({
+      cliType: 'builtin',
+      agentType: 'codex',
+    });
+  });
+
+  it('returns null for unknown or incomplete identities', () => {
+    expect(resolveSessionAgentIdentity(undefined, undefined)).toBeNull();
+    expect(resolveSessionAgentIdentity('builtin', '')).toBeNull();
+    expect(resolveSessionAgentIdentity('kimi', undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
## Author type

- [x] I am an Agent (check this if an LLM agent authored this PR)
- [ ] I am a human

An AI agent found the allowlist mismatch and implemented the guard. A human reviewed the live OSS runs (three overwrites, two negative controls), a Windows hand check that did not hit, and this patch before submit.

## Related issue

Closes #535

Distinct from open #211 (title-generation *model*) and open #522 (skip the isolated generator for Codex/Grok entirely). This change is the current `main` path where Lody still generates a title and Codex later publishes `explicit`.

## Problem / pressure

A Codex conversation that already had a Lody-generated title was retitled from the latest prompt the first time Codex itself named the thread.

This is not every follow-up. A live session whose Codex thread already has a name keeps it. The rewrite happens when Codex's `thread.name` is still empty (typical of conversations Lody titled with the isolated generator) and Codex later publishes an `explicit` `session_info_update`. The host then overwrites `titleSource: generated`.

`maybeStoreAgentSessionTitle` used `allowedSources: ['draft', 'generated']` for every agent. That matches Builtin Claude (the pushed title is its only generated source) and is wrong for Codex, which already ran the isolated generator.

| Session | Lody title before | After Codex named the thread |
| --- | --- | --- |
| `e6123484` | ping4 response | Single-word ping4b reply |
| `3c9c580d` | Add todo.txt | Recover a single word |
| `d009662f` | Exact ping5 reply | Single-word ping5b response |

`~/.codex/session_index.jsonl` had **no** `thread_name` for those three until that rewrite. The first index row is the new name.

Controls that did **not** retitle:

- New session `ebf8494b`: Codex named it on the first turn (`Single-word alpha7k reply`). Same-process follow-up and quit+resume follow-up left the title alone.
- User rename `KeepPong7k` (`a73f239f`): Lody kept the user title. Codex still wrote `thread_name` into the index; the host did not apply it.
- Two new-chat hand checks on Windows 11 also did not rewrite, matching the first-turn Codex-names-while-draft path.

## Summary

Codex (and other isolated-generator agents) may only replace a `draft` title. Builtin Claude still uses `['draft', 'generated']` via `usesAcpProvidedSessionTitle`. User titles stay blocked. The production write is `maybeStoreAgentSessionTitle` → `setTitleIfSourceIn`; this PR changes that allowlist.

## Visual explanation

```text
sidebar titleSource
  draft  --isolated generator--> generated     (Codex today)
  draft  --Codex explicit------> generated     (still allowed)
  generated --Codex explicit--> generated      (this PR: blocked)
  generated --Claude ACP------> generated      (still allowed)
  user      --any agent-------> user           (still blocked)
```

No screenshot: the failure is a sidebar rename, recorded as the three-session table above. A Windows new-chat miss is the `draft --Codex explicit--> generated` path, not this guard.

## Before / after

| Before | After |
| ------ | ----- |
| Codex `explicit` may replace `titleSource: generated` | Codex `explicit` may replace `draft` only |
| First-turn Codex name on a draft session still applies | Unchanged |
| User rename blocked | Unchanged |
| Builtin Claude may replace `generated` | Unchanged |

## Test plan

On `fix/codex-title-allowlist` after cherry-pick onto `origin/main` `e12cb225`:

```
corepack pnpm exec vitest run tests/message-handler-title.test.ts
```

(from `apps/cli`)

Result: **16 passed**, including:

1. A generated Codex title is not replaced by a later explicit name.
2. A draft new session can still take a Codex explicit name.
3. A user rename is not replaced.
4. Builtin Claude can still replace a generated title.

Live OSS 0.76.0, Linux, Codex `5.6-Sol`: the three overwrite sessions and two negative controls above. Windows 11: two new chats did not hit (Codex named first). No Electron e2e for this allowlist.

## Context handoff

Context handoff is public. An invalid fork PR body receives seven days to be corrected before closure.

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `apps/cli/src/lib/message-handler.ts` `maybeStoreAgentSessionTitle` and `apps/cli/tests/message-handler-title.test.ts`; `usesAcpProvidedSessionTitle` is still Claude-only on `main`.
- **Decisions to challenge:** Guard Codex with `allowedSources: ['draft']` rather than skipping the isolated generator (#522). Keep Claude able to replace `generated`.
- **Plausible failures / evidence gaps:** Sessions without `agentConfigId` default to draft-only, which is the safe Codex path. This does not fire on every new chat; Codex naming while still `draft` is a miss, not a disproof.

### Authoring context

- **User goal / directives:** Stop Codex's first `thread.name` from replacing a Lody-generated sidebar title. Human reviewed the live table, the Windows misses, and this patch.
- **Constraints / non-goals:** Allowlist only. Do not skip the isolated generator. Do not change user-rename, Claude, permission wait (#509), or dead Yes buttons.
- **Risk-bearing decisions:** Read-only use of existing `titleSource`. Missing agent config fails closed (draft-only).
- **Destructive or irreversible behavior:** None. No history rewrite, no migration, no rollback path required.
- **Deliberately not done or tested:** Full CLI suite and Electron e2e; 16 title tests plus the live OSS table. Windows misses recorded, not claimed as a hit.
- **Unknowns / confidence:** High for the allowlist. Race with Codex first-turn naming is documented. #522 would remove the isolated Codex generator and make this guard mostly a no-op for new Codex chats.

<!-- context-handoff:end -->
