### PR TITLE
fix(terminal): resolve colors without reduced-motion transitions

### DIFF
--- a/.agents/notes/proposed/bug-fix/2026-09-09-terminal-reduced-motion-colors.md
+++ b/.agents/notes/proposed/bug-fix/2026-09-09-terminal-reduced-motion-colors.md
@@ -1,0 +1,41 @@
+# Resolve terminal colors without transitions
+
+Status: proposed
+Translation: pending
+
+## Abstract
+
+With reduced motion enabled, the terminal's synchronous CSS color probe can
+return the background color for its foreground, cursor, and ANSI palette,
+making a working terminal appear blank. This patch disables transitions on
+the disposable probe before it enters the document. Chromium reproduces the
+failure on the unchanged resolver and passes with the patch in both motion
+modes, including a dark-to-light palette change. The global accessibility
+styles and terminal lifecycle remain unchanged.
+
+## Decision
+
+`buildTerminalTheme` owns CSS-to-xterm color resolution for both terminal
+creation and theme updates. The global reduced-motion rule sets a nonzero
+`transition-duration` on every element; the probe's default transition property
+is `all`. Each immediate computed-style read can therefore observe the start
+of a color transition instead of the requested token.
+
+Set `transitionProperty` to `none` on the probe before appending it. Changing
+the global reduced-motion rule would affect unrelated components, while
+waiting for a transition would make a synchronous resolver asynchronous.
+
+## Evidence and limits
+
+The Playwright regression uses the real stylesheet and resolver through the
+existing Storybook server, with synthetic CSS tokens. It checks foreground,
+cursor, red/green ANSI colors, alpha selection color, a palette change, and
+probe cleanup under `reduce` and `no-preference`.
+
+Before the patch, only the reduced-motion case fails; after the patch, both
+cases pass. This is Chromium renderer verification, not a rebuilt desktop
+release or verification of every terminal renderer and operating system.
+
+`pnpm check` passes with Node 22.22.2, including the existing component suite.
+`pnpm format` and `pnpm run docs check` pass; unrelated formatter output was
+excluded from the patch, preserving the resolver's existing formatting.

--- a/packages/components/src/components/terminal/terminal-theme.ts
+++ b/packages/components/src/components/terminal/terminal-theme.ts
@@ -50,6 +50,8 @@ export function buildTerminalTheme(host: HTMLElement): ITheme {
   probe.style.position = 'absolute';
   probe.style.visibility = 'hidden';
   probe.style.pointerEvents = 'none';
+  // Global reduced-motion styles must not animate synchronous color reads.
+  probe.style.transitionProperty = 'none';
   host.appendChild(probe);
   try {
     const theme: ITheme = {};

--- a/packages/components/tests/e2e/terminal-theme.spec.ts
+++ b/packages/components/tests/e2e/terminal-theme.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+
+for (const reducedMotion of ['reduce', 'no-preference'] as const) {
+  test(`resolves terminal colors synchronously with ${reducedMotion} motion`, async ({ page }) => {
+    await page.emulateMedia({ reducedMotion });
+    await page.route('**/terminal-theme-test', (route) =>
+      route.fulfill({ contentType: 'text/html', body: '<!doctype html><body></body>' })
+    );
+    await page.goto('/terminal-theme-test');
+
+    const themes = await page.evaluate(async () => {
+      // Use the real stylesheet and resolver served by Storybook's Vite server.
+      const stylesheet = '/src/tailwind/index.css';
+      const modulePath = '/src/components/terminal/terminal-theme.ts';
+      await import(stylesheet);
+      const { buildTerminalTheme } = await import(modulePath);
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      try {
+        return ['#101010', '#ffffff'].map((background) => {
+          const foreground = background === '#101010' ? '#ffffff' : '#101010';
+          host.style.setProperty('--terminal-background', background);
+          host.style.setProperty('--terminal-foreground', foreground);
+          host.style.setProperty('--terminal-cursor', foreground);
+          host.style.setProperty('--terminal-ansi-red', '#f87171');
+          host.style.setProperty('--terminal-ansi-green', '#4ade80');
+          host.style.setProperty('--terminal-selection', 'rgba(100, 120, 140, 0.4)');
+          return { theme: buildTerminalTheme(host), remainingChildren: host.childElementCount };
+        });
+      } finally {
+        host.remove();
+      }
+    });
+
+    expect(themes).toMatchObject([
+      {
+        theme: {
+          background: 'rgb(16, 16, 16)',
+          foreground: 'rgb(255, 255, 255)',
+          cursor: 'rgb(255, 255, 255)',
+          red: 'rgb(248, 113, 113)',
+          green: 'rgb(74, 222, 128)',
+          selectionBackground: 'rgba(100, 120, 140, 0.4)',
+        },
+        remainingChildren: 0,
+      },
+      {
+        theme: {
+          background: 'rgb(255, 255, 255)',
+          foreground: 'rgb(16, 16, 16)',
+          cursor: 'rgb(16, 16, 16)',
+          red: 'rgb(248, 113, 113)',
+          green: 'rgb(74, 222, 128)',
+          selectionBackground: 'rgba(100, 120, 140, 0.4)',
+        },
+        remainingChildren: 0,
+      },
+    ]);
+  });
+}


### PR DESCRIPTION
## Related issue

Closes #541

## Problem / pressure

With Reduce motion enabled, the embedded terminal can appear blank because its
foreground, cursor, and ANSI colors resolve to its background color. The global
`0.01ms` transition duration affects the hidden span used by `buildTerminalTheme`,
so immediate computed-style reads can return the start of a color transition.

## Summary

Disable transitions on the disposable color probe before appending it. This
keeps terminal creation and theme updates synchronous and leaves the global
reduced-motion behavior intact. Add a Chromium regression using the real
stylesheet and resolver, plus a short decision note.

## Visual explanation

```diff
 const probe = document.createElement('span');
 // Existing positioning, visibility, and pointer-event styles.
+probe.style.transitionProperty = 'none';
 host.appendChild(probe);
 // Assign each color token, then read getComputedStyle(probe).color immediately.
```

## Before / after

| Before | After |
| ------ | ----- |
| Reduced motion can make foreground, cursor, ANSI colors, and selection match the background. | Each token resolves to its requested color, including alpha selection colors. |
| Normal motion resolves the palette correctly. | Normal motion retains the same palette, and subsequent palette changes resolve correctly. |

## Test plan

- Chromium regression command: `VITE_PREVIEW_PUBLIC_BASE_DOMAIN=example.invalid pnpm --filter @lody/components exec playwright test tests/e2e/terminal-theme.spec.ts --workers=1 --reporter=line`.
- Before the source fix: the reduced-motion case failed and the normal-motion case passed. After the fix: both cases passed.
- Both cases verify dark and light palettes on the same host, foreground/cursor/red/green colors, selection alpha, and probe cleanup; they load the actual shared stylesheet and resolver without mocking computed style or waiting on timers.
- `pnpm check` passed with Node 22.22.2, including typechecks, lint, existing tests, and boundary guards; the component suite passed 445 files / 3306 tests.
- `pnpm format`, formatting checks for the new test and note, `pnpm run docs check`, and `git diff --check` passed. Unrelated formatter output was excluded, preserving the resolver's existing formatting.
- The packaged desktop app and non-Chromium engines were not rebuilt or tested; the bug and patch were exercised directly in Chromium using the public renderer source.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check the probe setup in `terminal-theme.ts` and the browser regression's use of the real reduced-motion stylesheet, since both initial and later terminal themes use this resolver.
- **Decisions to challenge:** Disabling only the probe's transition property preserves the global accessibility rule and synchronous API without timers.
- **Plausible failures / evidence gaps:** The Playwright test covers Chromium rendering, not a packaged Electron lifecycle, and belongs to the existing opt-in `test:e2e` suite rather than root Vitest CI.

### Authoring context

- **User goal / directives:** Contribute a permanent fix for an embedded terminal that appears blank when the system Reduce motion preference is enabled.
- **Constraints / non-goals:** Keep the patch local to color resolution; leave global accessibility preferences, terminal fonts, shell processes, and theme tokens unchanged.
- **Risk-bearing decisions:** Exclude the disposable probe from CSS transitions before attachment so sequential computed-style reads return target colors; retain the existing cleanup and theme-update paths.
- **Destructive or irreversible behavior:** The code affects a temporary DOM element and adds no persistent-data operations; reverting the commit restores the previous resolver behavior.
- **Deliberately not done or tested:** No desktop release build or cross-engine run; browser verification targets the CSS transition behavior with the real public source and synthetic color tokens.
- **Unknowns / confidence:** High confidence in the reproduced color-resolution fix from the failing-before/passing-after browser test; packaging and full desktop lifecycle remain outside that evidence.

<!-- context-handoff:end -->
