### PR TITLE
feat(ui): add the @lody/ui token gallery

### DIFF
--- a/.agents/notes/implemented/feature/2026-09-09-ui-token-gallery.md
+++ b/.agents/notes/implemented/feature/2026-09-09-ui-token-gallery.md
@@ -1,0 +1,128 @@
+# UI token gallery
+
+Status: implemented
+Translation: pending
+
+## Abstract
+
+`@lody/ui` shipped tokens and a Button with no place to see them: the design
+reference for PR [#305](https://github.com/LodyAI/Lody/pull/305) was an external
+Claude artifact that nobody in the repository can open, so the visual system had
+no in-repo authority. This note records rebuilding that board as
+`packages/ui/src/gallery`, a StyleX component that renders every semantic token,
+elevation rung, control size, type step and Button state in both palettes and
+reads each sample's value back off the rendered node, hosted as a Storybook story
+in `@lody/components`. Building it exposed a real defect: component tokens that
+point at semantic colours are declared once at the document root, so a palette
+forced on a subtree left buttons carrying the root palette, which the board made
+visible as light secondary buttons inside the Vesper panel. The fix re-declares
+those tokens in a palette theme applied with each forced palette. Coverage of the
+board is asserted from the token objects themselves, so a token without a sample
+fails the package's tests; nothing asserts that a sample looks right.
+
+## Problem
+
+The token set landed with its Button, but the only picture of it lived at
+`https://claude.ai/code/artifact/8a512704-cd50-4b69-805b-c3277f9d6405`, linked
+from the PR description. That URL needs an authenticated Claude session, is not
+versioned with the tokens, and cannot be reviewed in a diff. The PR's own note
+listed "a token gallery" as a later step, and the takeover note closed with the
+observation that no story or screenshot asserts the rendered look.
+
+Without a board, a person choosing between `raisedBackground` and
+`secondaryBackground`, or between `tone="destructive"` and
+`variant="destructive"`, has to read `colors.stylex.ts` and `button.tsx` and
+imagine the result in two palettes.
+
+## Decision
+
+Rebuild the board in the repository rather than fetch the artifact. `@lody/ui`
+owns the gallery because it owns the tokens; `@lody/components` only hosts it,
+through a `Design System / UI Gallery` story on the existing Storybook, which
+already compiles this package's StyleX with the shared options. No new dev
+server, package or dependency was added.
+
+Two properties keep the board honest:
+
+- Samples are rendered from the tokens. A swatch's fill is `colors.<name>`, a
+  radius chip's corner is `radius.<name>`, a control bar's height is
+  `control.<name>`; nothing in the board restates a palette value.
+- The value printed under each sample is read back with `getComputedStyle` on the
+  rendered node, so the board reports what the token produced in that palette. A
+  token whose value changes needs no edit here. The read happens once per mount,
+  which is sufficient because every sample is mounted under a fixed palette.
+
+Each section renders its samples once per palette in labelled panels, side by
+side, so the two values of a token are compared in place rather than by toggling
+a theme. `palettes` selects `both`, one palette, or the ambient theme.
+
+Coverage is asserted structurally: the test walks the keys of the token objects
+and fails when a name has no entry on the board. That turns "the gallery is
+current" into a test rather than a habit, and is why the AGENTS.md rule asking
+for a board entry with each new token can be enforced.
+
+## Discovered defect: component tokens froze at the document root
+
+The first render of the board showed the Vesper panel with white secondary and
+icon buttons. The cause is CSS custom property resolution, not StyleX: the button
+token group is declared once at `:root` with values such as
+`--button-secondaryBackground: var(--colors-raisedBackground)`. A custom property
+is substituted at the element where it is declared, and the resolved value is
+what descendants inherit. A palette applied to a subtree redefines
+`--colors-raisedBackground` on that subtree, but `--button-secondaryBackground`
+had already resolved against the root palette.
+
+Production did not show this because `ThemeProvider` puts the forced classes on
+`<html>`, the same element the tokens are declared on. `ThemeRoot` — exported and
+documented as applying a theme to a subtree — was therefore broken for every
+component token that derives from a colour, and the gallery is its first
+consumer.
+
+The fix adds `buttonPaletteTheme`, a `createTheme` over the same group that
+re-declares only the colour-valued tokens as the same semantic references.
+`ThemeRoot` and `forcedThemeClassNames` apply it with each palette, so the
+declarations sit on the element that carries the palette and resolve against it.
+One theme serves both palettes because the overrides are references, not values.
+
+Alternatives considered:
+
+- Reference `colors.*` directly from `button.tsx` and keep only dimensions in the
+  component token file. Fewer moving parts, but it deletes the button's colour
+  token surface and contradicts the package rule that component tokens live
+  beside the component.
+- Write literal palette values into per-palette button themes. This duplicates
+  the palettes in a second place, which is the drift the token file exists to
+  prevent.
+- Leave the defect and render the board in one palette at a time. This gives up
+  the side-by-side comparison that motivates the board, and leaves a documented
+  guarantee of `ThemeRoot` broken.
+
+## Verification
+
+`pnpm --filter @lody/ui test` covers the board's token coverage, both palettes
+being rendered, every Button variant and size appearing, and a single-palette
+render carrying no classes of the other palette. `pnpm --filter @lody/ui
+typecheck` passes.
+
+The board was read in Chromium through Storybook at 1400px, in slices down the
+full scroll height, before and after the palette-theme fix; the Vesper panel's
+secondary, icon and pill buttons change from light to the dark palette between
+the two. Measured values render as expected (for example `rgb(255, 255, 255)`
+against `background` in Lody Light and `rgb(16, 16, 16)` in Vesper, `5px` for
+`radius.mini`, `28px` for `control.small`). The console reported no errors.
+
+Limits: no test asserts a rendered appearance, so a sample that renders in the
+wrong place or with the wrong emphasis is caught only by a person reading the
+board. The measured values are read once per mount, so a palette changed after
+mount without remounting would show stale values; `palettes="ambient"` is the
+only mode where that is reachable. Only Chromium was checked, which is also the
+only engine that draws `corner-shape: squircle`. `pnpm check` was not run to
+completion for the whole repository in this session.
+
+## Follow-ups
+
+Primitives that migrate into `@lody/ui` after the Button add their states to the
+board in the same change. If a second component token group with colour values
+appears, the palette theme it needs is part of that group, and `ThemeRoot`
+applies it the same way; a general mechanism is worth considering only once more
+than one exists.

--- a/packages/components/src/stories/UiGallery.stories.tsx
+++ b/packages/components/src/stories/UiGallery.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { UiGallery } from '@lody/ui/gallery';
+
+const meta = {
+  title: 'Design System/UI Gallery',
+  component: UiGallery,
+  parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof UiGallery>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The token board: every `@lody/ui` token and Button state, rendered twice so
+ * Lody Light and Vesper sit side by side regardless of the Storybook theme.
+ */
+export const TokenBoard: Story = {
+  args: { palettes: 'both' },
+};
+
+/** One palette at full width, for reading a surface the way the app renders it. */
+export const LodyLight: Story = {
+  args: { palettes: 'light' },
+};
+
+export const Vesper: Story = {
+  args: { palettes: 'dark' },
+};
+
+/**
+ * No forced theme: the board follows the Storybook theme toolbar, which is how
+ * a product surface sees the tokens.
+ */
+export const Ambient: Story = {
+  args: { palettes: 'ambient' },
+};

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -22,6 +22,14 @@ into one component at a time. Source-consumed; consumers compile it through
   `.stylex` (`@lody/ui/tokens/colors.stylex`), never through a barrel.
 - Component tokens live beside the component as
   `<name>/<name>.tokens.stylex.ts` and reference semantic tokens or literal px.
+  A component token that points at a semantic colour also belongs in that file's
+  `createTheme` palette theme, which `ThemeRoot` applies with every forced
+  palette; a custom property declared only at the document root keeps the root
+  palette inside a themed subtree.
+- `src/gallery` is the visual reference for the package. A new token, variant,
+  size, tone or shape lands with its board entry in the same change, and the
+  board reads sample values back off the rendered node instead of repeating a
+  literal. `test/gallery.test.tsx` fails when a token has no entry.
 - `corner.shape` is applied wherever a radius is applied. Round corners outside
   Chromium are the accepted fallback.
 - A Radix file in `packages/components/src/ui` is deleted when its in-repo

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -10,6 +10,7 @@ behavior.
 | `src/tokens`        | Semantic color, type, spacing, motion, radius, and elevation tokens |
 | `src/theme`         | Applies light or dark StyleX themes to a subtree                    |
 | `src/button`        | Base UI Button behavior and Lody variants, sizes, tones, and shapes |
+| `src/gallery`       | The token board: every token and primitive state, in both palettes  |
 | `stylex-options.ts` | Shared compiler configuration for source-consuming hosts            |
 
 Consumers compile this package's source with `@stylexjs/unplugin` and its exported
@@ -20,6 +21,12 @@ primitive's visual rules.
 The intended behavior is specified in [Shared UI primitives](../../specs/ui-primitives.md).
 The integration decision is recorded in the
 [UI Button migration takeover note](../../.agents/notes/implemented/architecture/2026-09-08-ui-button-migration-takeover.md).
+
+Open the gallery with `pnpm storybook` and pick _Design System / UI Gallery_.
+It renders each sample once per palette and reads its values back off the
+rendered nodes, so a token that changes shows its new value there without the
+board being edited. A new token or primitive state lands with its board entry;
+`test/gallery.test.tsx` fails when a token has no entry.
 
 Run `pnpm --filter @lody/ui typecheck` and `pnpm --filter @lody/ui test` after
 changing a primitive or token.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,8 @@
     "./tokens/colors.stylex": "./src/tokens/colors.stylex.ts",
     "./tokens/scales.stylex": "./src/tokens/scales.stylex.ts",
     "./theme": "./src/theme/theme.tsx",
-    "./button": "./src/button/button.tsx"
+    "./button": "./src/button/button.tsx",
+    "./gallery": "./src/gallery/gallery.tsx"
   },
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.json",

--- a/packages/ui/src/button/button.tokens.stylex.ts
+++ b/packages/ui/src/button/button.tokens.stylex.ts
@@ -26,3 +26,21 @@ export const button = stylex.defineVars({
   ghostLabel: colors.secondaryLabel,
   ghostHover: colors.hoverFill,
 });
+
+/**
+ * The colour-valued tokens above are declared once at the document root, so a
+ * custom property that points at a semantic token resolves against the palette
+ * in force there and inherits that resolved value. A theme applied to a subtree
+ * would leave a button carrying the root palette. This theme re-declares those
+ * tokens on the element that carries the palette, where they resolve again.
+ * `ThemeRoot` applies it with every forced palette.
+ */
+export const buttonPaletteTheme = stylex.createTheme(button, {
+  primaryBackground: colors.label,
+  primaryLabel: colors.background,
+  primaryEdge: shadow.inkEdge,
+  secondaryBackground: colors.raisedBackground,
+  secondaryShadow: shadow.raised,
+  ghostLabel: colors.secondaryLabel,
+  ghostHover: colors.hoverFill,
+});

--- a/packages/ui/src/gallery/gallery.tsx
+++ b/packages/ui/src/gallery/gallery.tsx
@@ -1,0 +1,770 @@
+import * as stylex from '@stylexjs/stylex';
+import { Fragment } from 'react';
+import { Button } from '../button/button';
+import { colors, shadow } from '../tokens/colors.stylex';
+import { control, corner, duration, ease, radius, space, text, z } from '../tokens/scales.stylex';
+import {
+  Board,
+  BoardHeader,
+  Cluster,
+  Field,
+  Grid,
+  LegendKey,
+  PaletteSplit,
+  Row,
+  Rows,
+  Section,
+  Swatch,
+  dyn,
+  useMeasured,
+  type GalleryPalettes,
+} from './parts';
+
+export type { GalleryPalettes };
+
+export interface UiGalleryProps {
+  /** Which palettes every sample is rendered in. Defaults to both. */
+  palettes?: GalleryPalettes;
+}
+
+const styles = stylex.create({
+  stage: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'flex-end',
+    gap: space[3],
+    boxSizing: 'border-box',
+    padding: space[4],
+    backgroundColor: colors.secondaryBackground,
+    borderRadius: radius.large,
+    cornerShape: corner.shape,
+  },
+  rung: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: space[1],
+    justifyContent: 'center',
+    boxSizing: 'border-box',
+    minWidth: '148px',
+    padding: space[3],
+    borderRadius: radius.medium,
+    cornerShape: corner.shape,
+  },
+  rungName: {
+    fontSize: text.footnoteSize,
+    lineHeight: text.footnoteLeading,
+    fontWeight: 500,
+  },
+  rungUse: {
+    fontSize: text.captionSize,
+    lineHeight: text.captionLeading,
+    color: colors.secondaryLabel,
+  },
+  well: { backgroundColor: colors.wellBackground, boxShadow: shadow.inset },
+  page: { backgroundColor: colors.background },
+  region: { backgroundColor: colors.secondaryBackground },
+  card: { backgroundColor: colors.elevatedBackground, boxShadow: shadow.card },
+  floating: { backgroundColor: colors.raisedBackground, boxShadow: shadow.popover },
+  modal: { backgroundColor: colors.elevatedBackground, boxShadow: shadow.large },
+  textSample: { display: 'flex', flexDirection: 'column', gap: space[1] },
+  separatorRow: { display: 'flex', flexDirection: 'column', gap: 0 },
+  separatorLine: { height: '1px', backgroundColor: colors.separator },
+  separatorText: {
+    paddingBlock: space[2],
+    fontSize: text.subheadlineSize,
+    lineHeight: text.subheadlineLeading,
+  },
+  hoverRow: {
+    paddingBlock: space[2],
+    paddingInline: space[3],
+    borderRadius: radius.medium,
+    cornerShape: corner.shape,
+    fontSize: text.subheadlineSize,
+    lineHeight: text.subheadlineLeading,
+  },
+  hoverFill: { backgroundColor: colors.hoverFill },
+  selectedFill: { backgroundColor: colors.selectedFill },
+  overlaySample: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '72px',
+    backgroundColor: colors.overlay,
+    borderRadius: radius.medium,
+    cornerShape: corner.shape,
+    // The scrim is dark in both palettes, so its own label is not a token.
+    color: 'hsl(0 0% 100% / 0.92)',
+    fontSize: text.captionSize,
+    lineHeight: text.captionLeading,
+  },
+  ring: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: control.medium,
+    paddingInline: space[3],
+    backgroundColor: colors.wellBackground,
+    boxShadow: shadow.inset,
+    borderRadius: radius.medium,
+    cornerShape: corner.shape,
+    outlineStyle: 'solid',
+    outlineWidth: '2px',
+    outlineOffset: 0,
+    fontSize: text.subheadlineSize,
+    lineHeight: 1,
+  },
+  ringAccent: { outlineColor: colors.accent },
+  ringDestructive: { outlineColor: colors.destructive },
+  shadowChip: {
+    height: '64px',
+    borderRadius: radius.medium,
+    cornerShape: corner.shape,
+  },
+  radiusChip: {
+    height: '64px',
+    backgroundColor: colors.wellBackground,
+    boxShadow: shadow.inset,
+  },
+  controlBar: {
+    display: 'flex',
+    alignItems: 'center',
+    boxSizing: 'border-box',
+    minWidth: '96px',
+    paddingInline: space[3],
+    backgroundColor: colors.wellBackground,
+    boxShadow: shadow.inset,
+    borderRadius: radius.medium,
+    cornerShape: corner.shape,
+    fontSize: text.footnoteSize,
+    color: colors.secondaryLabel,
+  },
+  spaceBar: {
+    height: '24px',
+    backgroundColor: colors.gray4,
+    borderRadius: radius.mini,
+    cornerShape: corner.shape,
+  },
+  typeSample: {
+    margin: 0,
+    letterSpacing: text.controlTracking,
+  },
+  motionChip: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '56px',
+    backgroundColor: colors.raisedBackground,
+    boxShadow: shadow.raised,
+    borderRadius: radius.medium,
+    cornerShape: corner.shape,
+    fontSize: text.captionSize,
+    color: colors.secondaryLabel,
+    transitionProperty: 'transform, background-color',
+    transitionTimingFunction: ease.standard,
+    transform: { default: 'none', ':hover': 'translateY(-4px)' },
+  },
+  constList: {
+    display: 'grid',
+    gap: space[2],
+    gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
+    margin: 0,
+  },
+  constRow: { display: 'flex', gap: space[2], alignItems: 'baseline' },
+  constName: {
+    fontSize: text.footnoteSize,
+    lineHeight: text.footnoteLeading,
+    fontWeight: 500,
+  },
+  constValue: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+    fontSize: text.captionSize,
+    lineHeight: text.captionLeading,
+    color: colors.tertiaryLabel,
+  },
+  matrix: {
+    display: 'grid',
+    gap: space[3],
+    gridTemplateColumns: 'auto 1fr',
+    alignItems: 'center',
+  },
+});
+
+const SURFACES = [
+  { name: 'background', value: colors.background, note: 'app ground' },
+  { name: 'elevatedBackground', value: colors.elevatedBackground, note: 'card, panel, dialog' },
+  { name: 'raisedBackground', value: colors.raisedBackground, note: 'secondary button, menu' },
+  { name: 'secondaryBackground', value: colors.secondaryBackground, note: 'sidebar, footer band' },
+  { name: 'wellBackground', value: colors.wellBackground, note: 'input, track, switch off' },
+];
+
+const CONTENT_COLORS = [
+  { name: 'label', value: colors.label, note: 'the thing' },
+  { name: 'secondaryLabel', value: colors.secondaryLabel, note: 'about the thing' },
+  { name: 'tertiaryLabel', value: colors.tertiaryLabel, note: 'placeholder, hint, icon at rest' },
+];
+
+const FILLS = [
+  { name: 'hoverFill', value: colors.hoverFill, note: 'pointer over a row' },
+  { name: 'selectedFill', value: colors.selectedFill, note: 'current row' },
+  { name: 'separator', value: colors.separator, note: 'between rows only' },
+  { name: 'overlay', value: colors.overlay, note: 'dialog and sheet backdrop' },
+];
+
+const ROLE_COLORS = [
+  { name: 'accent', value: colors.accent, note: 'focus, link, live state' },
+  { name: 'onAccent', value: colors.onAccent, note: 'content on accent' },
+  { name: 'destructive', value: colors.destructive, note: 'destructive fill, invalid ring' },
+  { name: 'onDestructive', value: colors.onDestructive, note: 'content on destructive' },
+];
+
+const GRAYS = [
+  { name: 'gray', value: colors.gray },
+  { name: 'gray2', value: colors.gray2 },
+  { name: 'gray3', value: colors.gray3 },
+  { name: 'gray4', value: colors.gray4 },
+  { name: 'gray5', value: colors.gray5 },
+  { name: 'gray6', value: colors.gray6 },
+];
+
+const RUNGS = [
+  { name: 'well', style: styles.well, use: 'input, track, selected item' },
+  { name: 'page', style: styles.page, use: 'app ground' },
+  { name: 'region', style: styles.region, use: 'sidebar, footer band' },
+  { name: 'card', style: styles.card, use: 'card, panel, composer' },
+  { name: 'floating', style: styles.floating, use: 'menu, popover, select list' },
+  { name: 'modal', style: styles.modal, use: 'dialog, sheet' },
+];
+
+const SHADOWS = [
+  {
+    name: 'shadow.inset',
+    box: shadow.inset,
+    fill: colors.wellBackground,
+    ink: false,
+    note: 'wells',
+  },
+  {
+    name: 'shadow.raised',
+    box: shadow.raised,
+    fill: colors.raisedBackground,
+    ink: false,
+    note: 'pressable',
+  },
+  {
+    name: 'shadow.inkEdge',
+    box: shadow.inkEdge,
+    fill: colors.label,
+    ink: true,
+    note: 'top highlight on ink fills',
+  },
+  {
+    name: 'shadow.card',
+    box: shadow.card,
+    fill: colors.elevatedBackground,
+    ink: false,
+    note: 'cards',
+  },
+  {
+    name: 'shadow.medium',
+    box: shadow.medium,
+    fill: colors.elevatedBackground,
+    ink: false,
+    note: 'tooltip',
+  },
+  {
+    name: 'shadow.popover',
+    box: shadow.popover,
+    fill: colors.raisedBackground,
+    ink: false,
+    note: 'menus and popovers',
+  },
+  {
+    name: 'shadow.large',
+    box: shadow.large,
+    fill: colors.elevatedBackground,
+    ink: false,
+    note: 'dialogs and sheets',
+  },
+];
+
+const RADII = [
+  { name: 'radius.mini', value: radius.mini, note: '16px things' },
+  { name: 'radius.small', value: radius.small, note: '28px controls, tooltips' },
+  { name: 'radius.medium', value: radius.medium, note: '32 and 36px controls' },
+  { name: 'radius.large', value: radius.large, note: 'surfaces' },
+  { name: 'radius.full', value: radius.full, note: 'pills' },
+];
+
+const CONTROL_SIZES = [
+  { name: 'control.small', value: control.small, size: 'small' as const },
+  { name: 'control.medium', value: control.medium, size: 'medium' as const },
+  { name: 'control.large', value: control.large, size: 'large' as const },
+];
+
+const TYPE_SCALE = [
+  { name: 'caption', size: text.captionSize, leading: text.captionLeading, note: 'measured value' },
+  { name: 'footnote', size: text.footnoteSize, leading: text.footnoteLeading, note: 'field label' },
+  {
+    name: 'subheadline',
+    size: text.subheadlineSize,
+    leading: text.subheadlineLeading,
+    note: 'controls, weight 500',
+  },
+  { name: 'body', size: text.bodySize, leading: text.bodyLeading, note: 'prose' },
+  {
+    name: 'headline',
+    size: text.headlineSize,
+    leading: text.headlineLeading,
+    note: 'dialog title',
+  },
+  { name: 'title', size: text.titleSize, leading: text.titleLeading, note: 'sheet, full page' },
+];
+
+const SPACES = [
+  { name: 'space.1', value: space[1] },
+  { name: 'space.1.5', value: space[1.5] },
+  { name: 'space.2', value: space[2] },
+  { name: 'space.3', value: space[3] },
+  { name: 'space.4', value: space[4] },
+  { name: 'space.6', value: space[6] },
+  { name: 'space.8', value: space[8] },
+];
+
+const CONSTS = [
+  { name: 'corner.shape', value: corner.shape },
+  { name: 'ease.standard', value: ease.standard },
+  { name: 'z.dialogBackdrop', value: z.dialogBackdrop },
+  { name: 'z.dialog', value: z.dialog },
+  { name: 'z.popover', value: z.popover },
+  { name: 'z.tooltip', value: z.tooltip },
+  { name: 'z.toast', value: z.toast },
+];
+
+const BUTTON_VARIANTS = ['primary', 'secondary', 'ghost', 'destructive', 'link'] as const;
+const BUTTON_SIZES = ['mini', 'small', 'medium', 'large'] as const;
+
+function PlusGlyph() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <path d="M8 3.5v9M3.5 8h9" />
+    </svg>
+  );
+}
+
+function ShadowChip({
+  name,
+  box,
+  fill,
+  ink,
+  note,
+}: {
+  name: string;
+  box: string;
+  fill: string;
+  ink: boolean;
+  note: string;
+}) {
+  const { ref, value } = useMeasured<HTMLDivElement>('box-shadow');
+  return (
+    <Field name={name} note={note} measured={value}>
+      <div
+        ref={ref}
+        {...stylex.props(
+          styles.shadowChip,
+          dyn.raised(fill, box),
+          ink && dyn.ink(fill, colors.background)
+        )}
+      />
+    </Field>
+  );
+}
+
+function RadiusChip({ name, value, note }: { name: string; value: string; note: string }) {
+  const { ref, value: measured } = useMeasured<HTMLDivElement>('border-radius');
+  return (
+    <Field name={name} note={note} measured={measured}>
+      <div ref={ref} {...stylex.props(styles.radiusChip, dyn.radius(value))} />
+    </Field>
+  );
+}
+
+function ControlRow({
+  name,
+  value,
+  size,
+}: {
+  name: string;
+  value: string;
+  size: 'small' | 'medium' | 'large';
+}) {
+  const { ref, value: measured } = useMeasured<HTMLDivElement>('height');
+  return (
+    <Row>
+      <LegendKey>{name}</LegendKey>
+      <div ref={ref} {...stylex.props(styles.controlBar, dyn.height(value))}>
+        {measured}
+      </div>
+      <Button size={size} variant="secondary">
+        Secondary
+      </Button>
+      <Button size={size} icon aria-label={`Add at ${size}`}>
+        <PlusGlyph />
+      </Button>
+    </Row>
+  );
+}
+
+function TypeRow({
+  name,
+  size,
+  leading,
+  note,
+}: {
+  name: string;
+  size: string;
+  leading: string;
+  note: string;
+}) {
+  const { ref, value } = useMeasured<HTMLParagraphElement>('font-size');
+  return (
+    <Row>
+      <LegendKey>
+        {name} · {note}
+      </LegendKey>
+      <p ref={ref} {...stylex.props(styles.typeSample, dyn.type(size, leading))}>
+        Ship the visual system {value ? `· ${value}` : ''}
+      </p>
+    </Row>
+  );
+}
+
+function SpaceRow({ name, value }: { name: string; value: string }) {
+  const { ref, value: measured } = useMeasured<HTMLDivElement>('width');
+  return (
+    <Row>
+      <LegendKey>{name}</LegendKey>
+      <div ref={ref} {...stylex.props(styles.spaceBar, dyn.width(value))} />
+      <span {...stylex.props(styles.rungUse)}>{measured}</span>
+    </Row>
+  );
+}
+
+/**
+ * The `@lody/ui` token board: every semantic token and every Button state,
+ * rendered from the tokens themselves so the board cannot drift from them.
+ */
+export function UiGallery({ palettes = 'both' }: UiGalleryProps) {
+  return (
+    <Board>
+      <BoardHeader
+        title="Lody UI"
+        lead="Token board and primitive gallery for @lody/ui. Every colour, elevation rung, shadow, radius, control size, type step and Button state, rendered from the tokens in both palettes. Values under each sample are read back from the rendered node, so this board reports what the tokens produce rather than a copy of them."
+      />
+
+      <Section
+        title="Surfaces"
+        rule="Depth without lines. No border token exists: surfaces separate by luminance step and shadow."
+      >
+        <PaletteSplit palettes={palettes}>
+          <Grid>
+            {SURFACES.map((token) => (
+              <Swatch key={token.name} {...token} />
+            ))}
+          </Grid>
+        </PaletteSplit>
+      </Section>
+
+      <Section
+        title="Elevation ladder"
+        rule="One rung per component. The rung fixes background and shadow together."
+      >
+        <PaletteSplit palettes={palettes}>
+          <div {...stylex.props(styles.stage)}>
+            {RUNGS.map((rung) => (
+              <div key={rung.name} {...stylex.props(styles.rung, rung.style)}>
+                <span {...stylex.props(styles.rungName)}>{rung.name}</span>
+                <span {...stylex.props(styles.rungUse)}>{rung.use}</span>
+              </div>
+            ))}
+          </div>
+        </PaletteSplit>
+      </Section>
+
+      <Section
+        title="Content"
+        rule="label is the thing, secondaryLabel is about the thing, tertiaryLabel is a hint."
+      >
+        <PaletteSplit palettes={palettes}>
+          <div {...stylex.props(styles.textSample)}>
+            <span {...stylex.props(dyn.text(colors.label))}>label — Session started</span>
+            <span {...stylex.props(dyn.text(colors.secondaryLabel))}>
+              secondaryLabel — 4 files changed
+            </span>
+            <span {...stylex.props(dyn.text(colors.tertiaryLabel))}>
+              tertiaryLabel — Describe the task
+            </span>
+          </div>
+          <Grid>
+            {CONTENT_COLORS.map((token) => (
+              <Swatch key={token.name} {...token} />
+            ))}
+          </Grid>
+        </PaletteSplit>
+      </Section>
+
+      <Section
+        title="Fills and edges"
+        rule="separator divides list and table rows only, never around a surface. The ring is 2px, tight to the control, no glow."
+      >
+        <PaletteSplit palettes={palettes}>
+          <Rows>
+            <div {...stylex.props(styles.hoverRow, styles.hoverFill)}>hoverFill</div>
+            <div {...stylex.props(styles.hoverRow, styles.selectedFill)}>selectedFill</div>
+            <div {...stylex.props(styles.separatorRow)}>
+              <span {...stylex.props(styles.separatorText)}>separator — first row</span>
+              <div {...stylex.props(styles.separatorLine)} />
+              <span {...stylex.props(styles.separatorText)}>separator — next row</span>
+            </div>
+            <div {...stylex.props(styles.overlaySample)}>overlay</div>
+            <Cluster>
+              <div {...stylex.props(styles.ring, styles.ringAccent)}>focus ring · accent</div>
+              <div {...stylex.props(styles.ring, styles.ringDestructive)}>
+                invalid · destructive
+              </div>
+            </Cluster>
+          </Rows>
+          <Grid>
+            {FILLS.map((token) => (
+              <Swatch key={token.name} {...token} />
+            ))}
+          </Grid>
+        </PaletteSplit>
+      </Section>
+
+      <Section
+        title="Roles"
+        rule="accent marks live state only — focus, link, running — and is never a button fill. Ink carries stored state instead."
+      >
+        <PaletteSplit palettes={palettes}>
+          <Grid>
+            {ROLE_COLORS.map((token) => (
+              <Swatch key={token.name} {...token} />
+            ))}
+          </Grid>
+        </PaletteSplit>
+      </Section>
+
+      <Section
+        title="Gray ramp"
+        rule="Semantic first, gray second. These are for things with no role: scrollbar, track, kbd, skeleton."
+      >
+        <PaletteSplit palettes={palettes}>
+          <Grid>
+            {GRAYS.map((token) => (
+              <Swatch key={token.name} {...token} note="no role" />
+            ))}
+          </Grid>
+        </PaletteSplit>
+      </Section>
+
+      <Section title="Shadows" rule="Strength by rung. Dark palettes add an inset top highlight.">
+        <PaletteSplit palettes={palettes}>
+          <Grid>
+            {SHADOWS.map((token) => (
+              <ShadowChip key={token.name} {...token} />
+            ))}
+          </Grid>
+        </PaletteSplit>
+      </Section>
+
+      <Section
+        title="Corners"
+        rule="corner.shape (squircle) rides along with every radius; round corners outside Chromium are the accepted fallback. Nested radius is outer minus inset."
+      >
+        <PaletteSplit palettes={palettes}>
+          <Grid>
+            {RADII.map((token) => (
+              <RadiusChip key={token.name} {...token} />
+            ))}
+          </Grid>
+        </PaletteSplit>
+      </Section>
+
+      <Section
+        title="Control sizes"
+        rule="28 / 32 / 36. Default 32; 36 only for empty states and onboarding. Icon-only buttons are square at the size's height."
+      >
+        <PaletteSplit palettes={palettes}>
+          <Rows>
+            {CONTROL_SIZES.map((token) => (
+              <ControlRow key={token.name} {...token} />
+            ))}
+          </Rows>
+        </PaletteSplit>
+      </Section>
+
+      <Section
+        title="Type"
+        rule="Controls at 13 with weight 500 and controlTracking. Prose at 14. Field labels and help at 12."
+      >
+        <PaletteSplit palettes={palettes}>
+          <Rows>
+            {TYPE_SCALE.map((token) => (
+              <TypeRow key={token.name} {...token} />
+            ))}
+          </Rows>
+        </PaletteSplit>
+      </Section>
+
+      <Section title="Space" rule="The spacing step used for gaps, padding and stack rhythm.">
+        <PaletteSplit palettes={palettes}>
+          <Rows>
+            {SPACES.map((token) => (
+              <SpaceRow key={token.name} {...token} />
+            ))}
+          </Rows>
+        </PaletteSplit>
+      </Section>
+
+      <Section
+        title="Motion"
+        rule="Press translates 1px and drops the ink edge at duration.fast. Popups rise from 4px below at duration.regular. One easing. Hover a chip to see its duration."
+      >
+        <PaletteSplit palettes={palettes}>
+          <Cluster>
+            <div {...stylex.props(styles.motionChip, dyn.transition(duration.fast))}>
+              duration.fast · press, cross-fade
+            </div>
+            <div {...stylex.props(styles.motionChip, dyn.transition(duration.regular))}>
+              duration.regular · rise
+            </div>
+          </Cluster>
+        </PaletteSplit>
+      </Section>
+
+      <Section title="Constants" rule="Compile-time values; they are the same in both palettes.">
+        <PaletteSplit palettes={palettes}>
+          <dl {...stylex.props(styles.constList)}>
+            {CONSTS.map((entry) => (
+              <div key={entry.name} {...stylex.props(styles.constRow)}>
+                <dt {...stylex.props(styles.constName)}>{entry.name}</dt>
+                <dd {...stylex.props(styles.constValue)}>{entry.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </PaletteSplit>
+      </Section>
+
+      <Section
+        title="Button · variants and sizes"
+        rule="Variant carries the role, size carries the density. Visual choices are props; callers never restyle a button."
+      >
+        <PaletteSplit palettes={palettes}>
+          <div {...stylex.props(styles.matrix)}>
+            {BUTTON_VARIANTS.map((variant) => (
+              <Fragment key={variant}>
+                <LegendKey>{variant}</LegendKey>
+                <Cluster>
+                  {BUTTON_SIZES.map((size) => (
+                    <Button key={size} variant={variant} size={size}>
+                      {size}
+                    </Button>
+                  ))}
+                </Cluster>
+              </Fragment>
+            ))}
+          </div>
+        </PaletteSplit>
+      </Section>
+
+      <Section
+        title="Button · states, tone, shape, icons"
+        rule="Disabled is 45% opacity on the whole control, not a colour. Destructive tone tints a quiet variant; the destructive variant fills."
+      >
+        <PaletteSplit palettes={palettes}>
+          <Rows>
+            <Row>
+              <LegendKey>disabled</LegendKey>
+              <Cluster>
+                <Button disabled>Primary</Button>
+                <Button variant="secondary" disabled>
+                  Secondary
+                </Button>
+                <Button variant="ghost" disabled>
+                  Ghost
+                </Button>
+                <Button variant="destructive" disabled>
+                  Delete
+                </Button>
+              </Cluster>
+            </Row>
+            <Row>
+              <LegendKey>tone=&quot;destructive&quot;</LegendKey>
+              <Cluster>
+                <Button variant="secondary" tone="destructive">
+                  Remove
+                </Button>
+                <Button variant="ghost" tone="destructive">
+                  Remove
+                </Button>
+                <Button variant="link" tone="destructive">
+                  Remove
+                </Button>
+                <Button variant="destructive">Delete session</Button>
+              </Cluster>
+            </Row>
+            <Row>
+              <LegendKey>shape=&quot;pill&quot;</LegendKey>
+              <Cluster>
+                <Button shape="pill">Send</Button>
+                <Button variant="secondary" shape="pill">
+                  Draft
+                </Button>
+                <Button shape="pill" icon aria-label="Add attachment">
+                  <PlusGlyph />
+                </Button>
+              </Cluster>
+            </Row>
+            <Row>
+              <LegendKey>icon</LegendKey>
+              <Cluster>
+                {BUTTON_SIZES.map((size) => (
+                  <Button
+                    key={size}
+                    size={size}
+                    variant="secondary"
+                    icon
+                    aria-label={`Add ${size}`}
+                  >
+                    <PlusGlyph />
+                  </Button>
+                ))}
+                <Button>
+                  <PlusGlyph />
+                  With label
+                </Button>
+              </Cluster>
+            </Row>
+            <Row>
+              <LegendKey>render</LegendKey>
+              <Cluster>
+                <Button variant="link" render={<a href="#gallery" />}>
+                  Anchor as a button
+                </Button>
+              </Cluster>
+            </Row>
+          </Rows>
+        </PaletteSplit>
+      </Section>
+    </Board>
+  );
+}

--- a/packages/ui/src/gallery/parts.tsx
+++ b/packages/ui/src/gallery/parts.tsx
@@ -1,0 +1,290 @@
+import * as stylex from '@stylexjs/stylex';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { colors, shadow } from '../tokens/colors.stylex';
+import { corner, radius, space, text } from '../tokens/scales.stylex';
+import { ThemeRoot, type ThemeMode } from '../theme/theme';
+
+/** Which palettes a board renders each sample in. */
+export type GalleryPalettes = 'both' | 'light' | 'dark' | 'ambient';
+
+const PALETTE_NAMES: Record<Exclude<ThemeMode, 'system'> | 'system', string> = {
+  light: 'Lody Light',
+  dark: 'Vesper',
+  system: 'Ambient',
+};
+
+const MONO = 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace';
+
+/**
+ * Reads a resolved value off a rendered node so the board reports what the
+ * token actually produces in this palette instead of a copied literal. The
+ * read happens once per mount; every sample is mounted under a fixed theme.
+ */
+export function useMeasured<T extends HTMLElement>(property: string) {
+  const ref = useRef<T>(null);
+  const [value, setValue] = useState('');
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    setValue(window.getComputedStyle(node).getPropertyValue(property).trim());
+  }, [property]);
+  return { ref, value };
+}
+
+const styles = stylex.create({
+  board: {
+    boxSizing: 'border-box',
+    maxHeight: '100%',
+    overflowY: 'auto',
+    backgroundColor: colors.background,
+    color: colors.label,
+    fontSize: text.bodySize,
+    lineHeight: text.bodyLeading,
+    paddingBlock: space[8],
+    paddingInline: space[6],
+  },
+  page: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: space[8],
+    marginInline: 'auto',
+    maxWidth: '1120px',
+  },
+  header: { display: 'flex', flexDirection: 'column', gap: space[2] },
+  headerTitle: {
+    margin: 0,
+    fontSize: text.titleSize,
+    lineHeight: text.titleLeading,
+    fontWeight: 600,
+    letterSpacing: text.controlTracking,
+  },
+  headerLead: {
+    margin: 0,
+    maxWidth: '68ch',
+    color: colors.secondaryLabel,
+  },
+  section: { display: 'flex', flexDirection: 'column', gap: space[3] },
+  sectionHead: { display: 'flex', flexDirection: 'column', gap: space[1] },
+  sectionTitle: {
+    margin: 0,
+    fontSize: text.headlineSize,
+    lineHeight: text.headlineLeading,
+    fontWeight: 600,
+    letterSpacing: text.controlTracking,
+  },
+  sectionRule: {
+    margin: 0,
+    maxWidth: '72ch',
+    fontSize: text.footnoteSize,
+    lineHeight: text.footnoteLeading,
+    color: colors.secondaryLabel,
+  },
+  split: {
+    display: 'grid',
+    gap: space[3],
+    gridTemplateColumns: 'repeat(auto-fit, minmax(340px, 1fr))',
+  },
+  panel: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: space[3],
+    boxSizing: 'border-box',
+    padding: space[4],
+    backgroundColor: colors.elevatedBackground,
+    color: colors.label,
+    borderRadius: radius.large,
+    cornerShape: corner.shape,
+    boxShadow: shadow.card,
+    fontSize: text.bodySize,
+    lineHeight: text.bodyLeading,
+  },
+  panelName: {
+    margin: 0,
+    fontSize: text.captionSize,
+    lineHeight: text.captionLeading,
+    fontWeight: 500,
+    letterSpacing: '0.06em',
+    textTransform: 'uppercase',
+    color: colors.tertiaryLabel,
+  },
+  grid: {
+    display: 'grid',
+    gap: space[3],
+    gridTemplateColumns: 'repeat(auto-fill, minmax(148px, 1fr))',
+  },
+  rows: { display: 'flex', flexDirection: 'column', gap: space[3] },
+  row: { display: 'flex', alignItems: 'center', gap: space[3], flexWrap: 'wrap' },
+  cluster: { display: 'flex', alignItems: 'center', gap: space[2], flexWrap: 'wrap' },
+  field: { display: 'flex', flexDirection: 'column', gap: space[1.5], minWidth: 0 },
+  fieldName: {
+    fontSize: text.footnoteSize,
+    lineHeight: text.footnoteLeading,
+    fontWeight: 500,
+    letterSpacing: text.controlTracking,
+    overflowWrap: 'anywhere',
+  },
+  fieldNote: {
+    fontSize: text.captionSize,
+    lineHeight: text.captionLeading,
+    color: colors.secondaryLabel,
+  },
+  measured: {
+    fontFamily: MONO,
+    fontSize: text.captionSize,
+    lineHeight: text.captionLeading,
+    color: colors.tertiaryLabel,
+    overflowWrap: 'anywhere',
+  },
+  legendKey: {
+    flexBasis: '168px',
+    flexGrow: 0,
+    flexShrink: 0,
+    fontSize: text.footnoteSize,
+    lineHeight: text.footnoteLeading,
+    fontWeight: 500,
+    color: colors.secondaryLabel,
+  },
+  swatchChip: {
+    height: '46px',
+    borderRadius: radius.small,
+    cornerShape: corner.shape,
+    boxShadow: shadow.raised,
+  },
+});
+
+export function Board({ children }: { children: ReactNode }) {
+  return (
+    <div {...stylex.props(styles.board)}>
+      <div {...stylex.props(styles.page)}>{children}</div>
+    </div>
+  );
+}
+
+export function BoardHeader({ title, lead }: { title: string; lead: string }) {
+  return (
+    <header {...stylex.props(styles.header)}>
+      <h1 {...stylex.props(styles.headerTitle)}>{title}</h1>
+      <p {...stylex.props(styles.headerLead)}>{lead}</p>
+    </header>
+  );
+}
+
+export function Section({
+  title,
+  rule,
+  children,
+}: {
+  title: string;
+  rule: string;
+  children: ReactNode;
+}) {
+  return (
+    <section {...stylex.props(styles.section)}>
+      <div {...stylex.props(styles.sectionHead)}>
+        <h2 {...stylex.props(styles.sectionTitle)}>{title}</h2>
+        <p {...stylex.props(styles.sectionRule)}>{rule}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function modesFor(palettes: GalleryPalettes): ThemeMode[] {
+  if (palettes === 'both') return ['light', 'dark'];
+  if (palettes === 'ambient') return ['system'];
+  return [palettes];
+}
+
+/**
+ * Renders the same sample once per selected palette, each under its own forced
+ * theme, so a token's two values sit next to each other.
+ */
+export function PaletteSplit({
+  palettes,
+  children,
+}: {
+  palettes: GalleryPalettes;
+  children: ReactNode;
+}) {
+  return (
+    <div {...stylex.props(styles.split)}>
+      {modesFor(palettes).map((mode) => (
+        <ThemeRoot key={mode} mode={mode}>
+          <div {...stylex.props(styles.panel)}>
+            <p {...stylex.props(styles.panelName)}>{PALETTE_NAMES[mode]}</p>
+            {children}
+          </div>
+        </ThemeRoot>
+      ))}
+    </div>
+  );
+}
+
+export function Grid({ children }: { children: ReactNode }) {
+  return <div {...stylex.props(styles.grid)}>{children}</div>;
+}
+
+export function Rows({ children }: { children: ReactNode }) {
+  return <div {...stylex.props(styles.rows)}>{children}</div>;
+}
+
+export function Row({ children }: { children: ReactNode }) {
+  return <div {...stylex.props(styles.row)}>{children}</div>;
+}
+
+export function Cluster({ children }: { children: ReactNode }) {
+  return <div {...stylex.props(styles.cluster)}>{children}</div>;
+}
+
+export function LegendKey({ children }: { children: ReactNode }) {
+  return <span {...stylex.props(styles.legendKey)}>{children}</span>;
+}
+
+export function Field({
+  name,
+  note,
+  measured,
+  children,
+}: {
+  name: string;
+  note?: string;
+  measured?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div {...stylex.props(styles.field)}>
+      {children}
+      <span {...stylex.props(styles.fieldName)}>{name}</span>
+      {measured ? <span {...stylex.props(styles.measured)}>{measured}</span> : null}
+      {note ? <span {...stylex.props(styles.fieldNote)}>{note}</span> : null}
+    </div>
+  );
+}
+
+export const dyn = stylex.create({
+  fill: (value: string) => ({ backgroundColor: value }),
+  ink: (background: string, foreground: string) => ({
+    backgroundColor: background,
+    color: foreground,
+  }),
+  raised: (background: string, box: string) => ({
+    backgroundColor: background,
+    boxShadow: box,
+  }),
+  text: (value: string) => ({ color: value }),
+  radius: (value: string) => ({ borderRadius: value, cornerShape: corner.shape }),
+  height: (value: string) => ({ height: value }),
+  width: (value: string) => ({ width: value }),
+  type: (size: string, leading: string) => ({ fontSize: size, lineHeight: leading }),
+  transition: (value: string) => ({ transitionDuration: value }),
+});
+
+/** A colour chip that reports the value the palette resolved it to. */
+export function Swatch({ name, value, note }: { name: string; value: string; note: string }) {
+  const { ref, value: measured } = useMeasured<HTMLDivElement>('background-color');
+  return (
+    <Field name={name} note={note} measured={measured}>
+      <div ref={ref} {...stylex.props(styles.swatchChip, dyn.fill(value))} />
+    </Field>
+  );
+}

--- a/packages/ui/src/theme/theme.tsx
+++ b/packages/ui/src/theme/theme.tsx
@@ -1,5 +1,6 @@
 import * as stylex from '@stylexjs/stylex';
 import type { ReactNode } from 'react';
+import { buttonPaletteTheme } from '../button/button.tokens.stylex';
 import { darkShadowTheme, darkTheme, lightShadowTheme, lightTheme } from '../tokens/colors.stylex';
 
 export type ThemeMode = 'system' | 'light' | 'dark';
@@ -12,8 +13,8 @@ const styles = stylex.create({
 
 export function forcedThemeClassNames(mode: ThemeMode): string[] {
   if (mode === 'system') return [];
-  const themes = mode === 'dark' ? [darkTheme, darkShadowTheme] : [lightTheme, lightShadowTheme];
-  return (stylex.props(...themes).className ?? '').split(' ').filter(Boolean);
+  const palette = mode === 'dark' ? [darkTheme, darkShadowTheme] : [lightTheme, lightShadowTheme];
+  return (stylex.props(...palette, buttonPaletteTheme).className ?? '').split(' ').filter(Boolean);
 }
 
 export function ThemeRoot({ mode, children }: { mode: ThemeMode; children: ReactNode }) {
@@ -24,6 +25,7 @@ export function ThemeRoot({ mode, children }: { mode: ThemeMode; children: React
         mode === 'dark' && darkShadowTheme,
         mode === 'light' && lightTheme,
         mode === 'light' && lightShadowTheme,
+        mode !== 'system' && buttonPaletteTheme,
         styles[mode]
       )}
     >

--- a/packages/ui/test/gallery.test.tsx
+++ b/packages/ui/test/gallery.test.tsx
@@ -1,0 +1,76 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, test } from 'vitest';
+import { UiGallery } from '../src/gallery/gallery';
+import { forcedThemeClassNames } from '../src/theme/theme';
+import { colors, shadow } from '../src/tokens/colors.stylex';
+import { control, duration, radius, space, text, z } from '../src/tokens/scales.stylex';
+
+/** StyleX adds bookkeeping keys to the runtime token objects. */
+function tokenNames(tokens: object): string[] {
+  return Object.keys(tokens).filter((key) => !key.startsWith('__'));
+}
+
+const board = renderToStaticMarkup(<UiGallery />);
+
+describe('UiGallery', () => {
+  test('names every colour and shadow token', () => {
+    for (const name of tokenNames(colors)) {
+      expect(board, `colour token ${name} is missing from the board`).toContain(`>${name}<`);
+    }
+    for (const name of tokenNames(shadow)) {
+      expect(board, `shadow token ${name} is missing from the board`).toContain(`>shadow.${name}<`);
+    }
+  });
+
+  test('names every scale token', () => {
+    const scales: [string, object][] = [
+      ['radius', radius],
+      ['control', control],
+      ['space', space],
+      ['duration', duration],
+      ['z', z],
+    ];
+    for (const [group, tokens] of scales) {
+      for (const name of tokenNames(tokens)) {
+        expect(board, `${group}.${name} is missing from the board`).toContain(`${group}.${name}`);
+      }
+    }
+    const typeSteps = new Set(tokenNames(text).map((name) => name.replace(/(Size|Leading)$/, '')));
+    for (const step of typeSteps) {
+      expect(board, `type step ${step} is missing from the board`).toContain(step);
+    }
+  });
+
+  test('renders each sample under both forced palettes', () => {
+    for (const className of [...forcedThemeClassNames('light'), ...forcedThemeClassNames('dark')]) {
+      expect(board).toContain(className);
+    }
+    expect(board).toContain('Lody Light');
+    expect(board).toContain('Vesper');
+  });
+
+  test('shows every Button variant and size', () => {
+    for (const variant of ['primary', 'secondary', 'ghost', 'destructive', 'link']) {
+      expect(board).toContain(`data-variant="${variant}"`);
+    }
+    for (const size of ['mini', 'small', 'medium', 'large']) {
+      expect(board).toContain(`data-size="${size}"`);
+    }
+    expect(board).toContain('disabled=""');
+  });
+
+  test('renders one palette when asked for one', () => {
+    const light = renderToStaticMarkup(<UiGallery palettes="light" />);
+    expect(light).toContain('Lody Light');
+    expect(light).not.toContain('Vesper');
+    // createTheme also emits a marker class shared by both themes of a variable
+    // group; only the palette-specific classes tell the two renders apart.
+    const darkOnly = forcedThemeClassNames('dark').filter(
+      (className) => !forcedThemeClassNames('light').includes(className)
+    );
+    expect(darkOnly.length).toBeGreaterThan(0);
+    for (const className of darkOnly) {
+      expect(light).not.toContain(className);
+    }
+  });
+});

--- a/specs/ui-primitives.md
+++ b/specs/ui-primitives.md
@@ -32,6 +32,20 @@ so a primitive responds without product code selecting raw palette values. Token
 names describe meaning and interaction role; component tokens derive from those
 semantic values or documented fixed dimensions.
 
+A forced theme applies to the subtree it is placed on, including the primitives
+inside it. A component token that derives from a semantic colour resolves against
+the palette in force on that subtree, not the palette of the document root, so two
+palettes can be shown at once on one page.
+
+## Gallery
+
+`@lody/ui` carries a gallery of its own tokens and primitives. It presents each
+semantic token, each elevation rung, and each state a primitive exposes through
+its props, rendered in both palettes from the tokens themselves rather than from
+copied values. The gallery is the reference a person reads when choosing a token
+or a prop, and the place a new token or primitive state becomes visible; a token
+that no sample presents is a gap the package reports.
+
 ## Migration
 
 Primitives move from `@lody/components` one at a time. A legacy primitive is
@@ -49,3 +63,6 @@ migrated Button consumers in `packages/components`, Electron, and site docs.
 
 Executed validation is recorded in the linked PR and its
 [Agent Note](../.agents/notes/implemented/architecture/2026-09-08-ui-button-migration-takeover.md).
+
+The gallery and the subtree palette behavior are recorded in the
+[UI token gallery note](../.agents/notes/implemented/feature/2026-09-09-ui-token-gallery.md).


### PR DESCRIPTION
## Related issue

None. Same-repository branch; a follow-up to the `@lody/ui` bootstrap landed in PR 305, which listed a token gallery as a later step.

## Problem / pressure

`@lody/ui` shipped a token set and a Button, but the only picture of them lives at `https://claude.ai/code/artifact/8a512704-cd50-4b69-805b-c3277f9d6405`, linked from the PR 305 description. That URL needs an authenticated Claude session, is not versioned with the tokens, and cannot be reviewed in a diff, so the visual system has no authority inside the repository. Choosing between `raisedBackground` and `secondaryBackground`, or between `tone="destructive"` and `variant="destructive"`, currently means reading `colors.stylex.ts` and `button.tsx` and imagining the result in two palettes. PR 305's own note closed with the same gap: no story or screenshot asserts the rendered look.

## Summary

- New `packages/ui/src/gallery` (`@lody/ui/gallery`): a StyleX-only token board with fourteen sections covering every semantic colour, the six-rung elevation ladder, every shadow, radius, control size, type step, space step, motion duration and compile-time constant, plus the Button's five variants across four sizes and its disabled, tone, pill, icon and `render` states.
- Every sample is rendered *from* the tokens, and the value printed under it is read back off the rendered node with `getComputedStyle`. The board restates no palette value, and a token that changes its value shows the new one without the board being edited.
- Each section renders its samples once per palette in labelled side-by-side panels, so Lody Light and Vesper are compared in place. `palettes` selects `both`, one palette, or the ambient theme.
- `packages/components` hosts it as the **Design System / UI Gallery** story on the existing Storybook (`pnpm storybook`). No new dependency, package or dev server; Storybook already compiles this package's StyleX with the shared options.
- Bug fix in `ThemeRoot`: the Button's colour tokens are declared once at the document root, and a custom property is substituted where it is declared, so a palette forced on a subtree left buttons carrying the root palette. `buttonPaletteTheme` re-declares those tokens on the element that carries the palette; `ThemeRoot` and `forcedThemeClassNames` apply it with each forced palette.
- `test/gallery.test.tsx` walks the keys of the token objects, so a token with no sample fails the package's tests. `packages/ui/AGENTS.md` records both new rules; the Spec gains a Gallery section and the subtree-palette guarantee; the decision is recorded in an Agent Note.

## Visual explanation

Ownership and hosting — the gallery lives with the tokens it documents, Storybook only renders it:

```text
packages/ui/src/
  tokens/colors.stylex.ts      defineVars + light/dark themes ─┐
  tokens/scales.stylex.ts      defineVars + defineConsts ──────┤
  button/button.tokens.stylex.ts  component tokens ────────────┤ read by
  button/button.tsx            the primitive ──────────────────┤
  theme/theme.tsx              ThemeRoot / forcedThemeClassNames
  gallery/
    parts.tsx                  Board, Section, PaletteSplit, Swatch, useMeasured
    gallery.tsx                UiGallery: the fourteen sections ◄┘
packages/components/src/stories/UiGallery.stories.tsx   Design System / UI Gallery
```

Each section is rendered once per palette, and every sample reports its own resolved value:

```text
Section "Surfaces"
├─ ThemeRoot mode="light"  panel "LODY LIGHT"
│   └─ Swatch background        chip fill = colors.background
│                               caption   = getComputedStyle(chip).background-color
│                                         → rgb(255, 255, 255)
└─ ThemeRoot mode="dark"   panel "VESPER"
    └─ Swatch background        same element, same token
                                → rgb(16, 16, 16)
```

Why the Vesper panel rendered light buttons, and what the fix changes:

```mermaid
flowchart TB
  subgraph before["Before: tokens declared only at :root"]
    R1[":root<br/>--colors-raised: light<br/>--button-secondaryBg: var(--colors-raised)<br/>resolves here → light"]
    T1[".darkTheme subtree<br/>--colors-raised: dark<br/>--button-secondaryBg inherited already resolved"]
    B1["Button<br/>background: var(--button-secondaryBg)<br/>→ light fill in Vesper"]
    R1 --> T1 --> B1
  end
  subgraph after["After: buttonPaletteTheme re-declares on the themed element"]
    R2[":root<br/>same declarations"]
    T2[".darkTheme .buttonPaletteTheme subtree<br/>--colors-raised: dark<br/>--button-secondaryBg: var(--colors-raised)<br/>resolves here → dark"]
    B2["Button<br/>→ dark fill in Vesper"]
    R2 --> T2 --> B2
  end
```

To see the board: `pnpm storybook`, then **Design System / UI Gallery** (`TokenBoard`, `LodyLight`, `Vesper`, `Ambient`).

## Before / after

| Before | After |
| ------ | ----- |
| The design reference is an authenticated `claude.ai` artifact URL in a PR description | The reference is `packages/ui/src/gallery`, rendered from the tokens and reviewable in a diff |
| A token's value is read from `colors.stylex.ts`, and its two palettes are imagined | Both palettes are rendered side by side with the value measured off each rendered node |
| Adding a token changes nothing visible; nothing notices it has no picture | `test/gallery.test.tsx` fails until the token has a board entry |
| `ThemeRoot` leaves a Button on the document root's palette; Vesper renders light secondary and icon buttons | A forced palette applies to the primitives inside the subtree it is placed on |
| No place shows `tone="destructive"` next to `variant="destructive"`, or the four icon-only sizes | Both, plus disabled, pill and `render`, in both palettes |

## Test plan

- `pnpm --filter @lody/ui test`: 13 tests pass (5 new — board covers every key of `colors`, `shadow`, `radius`, `control`, `space`, `duration`, `z` and every type step; both forced palettes render; every Button variant and size appears; a single-palette render carries none of the other palette's classes).
- `pnpm --filter @lody/ui typecheck` and `pnpm --filter @lody/components typecheck` pass.
- `oxlint` reports no findings on the new files; `pnpm run docs check` reports no errors.
- Read the board in Chromium through Storybook at 1400px, in slices down its full scroll height, before and after the palette fix: the Vesper panel's secondary, icon and pill buttons change from light to the dark palette, and measured values render as expected (`rgb(255, 255, 255)` vs `rgb(16, 16, 16)` for `background`, `5px` for `radius.mini`, `28px` for `control.small`). No console errors.
- Skipped: no screenshot regression suite exists, so no test asserts a rendered appearance; only Chromium was exercised, which is also the only engine that draws `corner-shape: squircle`; the full repository `pnpm check` was not run to completion.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `packages/ui/src/button/button.tokens.stylex.ts` and `packages/ui/src/theme/theme.tsx` are the only files that change existing behavior — everything else is additive; `packages/ui/src/gallery/gallery.tsx` is the board's content and `parts.tsx` its layout primitives and the `getComputedStyle` read.
- **Decisions to challenge:** the gallery ships inside `@lody/ui` (tree-shaken, not imported by product code) rather than in a separate package or dev app; one `buttonPaletteTheme` serves both palettes because its overrides are references, not values; `ThemeRoot` importing a component token group couples theme to component.
- **Plausible failures / evidence gaps:** nothing asserts the board *looks* right, so a mis-scoped sample is caught only by reading it; measured values are read once per mount and would go stale under `palettes="ambient"` if the ambient theme changes without a remount; a second component token group with colour values will need its own palette theme or it will reproduce the fixed bug silently.

### Authoring context

- **User goal / directives:** retrieve the Claude artifact linked from PR 305 or reproduce it in the repository, as a UI gallery, because the team is establishing a visual system.
- **Constraints / non-goals:** the artifact URL is not fetchable without an authenticated session, so it was rebuilt from its description rather than copied; `@lody/ui` keeps its no-Tailwind, no-`cn`, no-`cva` rule and gains no dependency; no product surface is changed and no other primitive is migrated.
- **Risk-bearing decisions:** adding `buttonPaletteTheme` to `forcedThemeClassNames` changes the class list `ThemeProvider` writes to `<html>`; the class set is still removed and re-added as a unit, and root-level resolution was already correct, so the app's rendering is unchanged.
- **Destructive or irreversible behavior:** none; the change is source-only, touches no data, settings or migration path, and reverting the commit restores the previous state.
- **Deliberately not done or tested:** screenshot regression tests, non-Chromium engines, a general mechanism for registering component token palette themes (worth adding once a second group exists), and re-reading measured values after a theme change.
- **Unknowns / confidence:** high confidence in the fix, its cause and the board's token coverage, which are covered by tests and by before/after rendering; medium confidence that every section is laid out the way a designer would want, since that is a taste judgment no test makes.

<!-- context-handoff:end -->
