### PR TITLE
fix: pin Codex compact-kill waiter rejection

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-09-codex-compact-kill-waiters.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-codex-compact-kill-waiters.md
@@ -7,14 +7,14 @@ Translation: current
 
 ## Abstract
 
-`/compact` waits on a `thread/compacted` notification. Turn waiters already reject when the Codex process exits; compaction waiters were resolve-only, so a death after `thread/compact/start` left the ACP prompt occupied and the next message `already active`. This host change pins `acp-extension-codex` to `a67f231` (adapter #38 rebased onto current adapter main) so close/dispose rejects those waiters. Healthy compact and mid-turn process death are unchanged. Adapter #38 is not merged yet; this pin must not ship until that merge.
+`/compact` waits on a `thread/compacted` notification. Turn waiters already reject when the Codex process exits; compaction waiters were resolve-only, so a death after `thread/compact/start` left the ACP prompt occupied and the next message `already active`. This host change pins `acp-extension-codex` to `31c5ecc` (adapter #38 rebased onto current adapter main, which already includes #30) so close/dispose rejects those waiters. Healthy compact and mid-turn process death are unchanged. Adapter #38 is not merged yet; this pin must not ship until that merge.
 
 ## Decision
 
-- Host gitlink `packages/acp-extension-codex` moves from main's `5f0aab0f` (#554 / adapter #40) to `a67f231` (open adapter PR #38, rebased onto that main).
+- Host gitlink `packages/acp-extension-codex` moves from main's `314b3823` (host #275 / adapter cancel-compaction) to `31c5ecc` (open adapter PR #38, rebased onto adapter main after #30).
 - Core and other submodules stay on current main. This PR does not touch them.
 - `runCompact` keeps registering the waiter first, then `Promise.all`s start + completion, so a vscode-jsonrpc `close` (which does not reject in-flight start RPCs) still finishes the prompt.
-- This is not adapter #37 / Lody #544 (fork unsubscribe). It is not open adapter #30 (cancel during compact).
+- This is not adapter #37 / Lody #544 (fork unsubscribe). Adapter #30 (cancel during compact) is already on adapter main and is not this change.
 
 ## Evidence and limits
 

--- a/.agents/notes/implemented/bug-fix/2026-09-09-codex-compact-kill-waiters.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-codex-compact-kill-waiters.md
@@ -1,0 +1,25 @@
+# Reject Codex compaction waiters when the process exits
+
+Status: implemented
+Translation: current
+
+[中文](./2026-09-09-codex-compact-kill-waiters.zh.md)
+
+## Abstract
+
+`/compact` waits on a `thread/compacted` notification. Turn waiters already reject when the Codex process exits; compaction waiters were resolve-only, so a death after `thread/compact/start` left the ACP prompt occupied and the next message `already active`. This host change pins `acp-extension-codex` to `a67f231` (adapter #38 rebased onto current adapter main) so close/dispose rejects those waiters. Healthy compact and mid-turn process death are unchanged. Adapter #38 is not merged yet; this pin must not ship until that merge.
+
+## Decision
+
+- Host gitlink `packages/acp-extension-codex` moves from main's `5f0aab0f` (#554 / adapter #40) to `a67f231` (open adapter PR #38, rebased onto that main).
+- Core and other submodules stay on current main. This PR does not touch them.
+- `runCompact` keeps registering the waiter first, then `Promise.all`s start + completion, so a vscode-jsonrpc `close` (which does not reject in-flight start RPCs) still finishes the prompt.
+- This is not adapter #37 / Lody #544 (fork unsubscribe). It is not open adapter #30 (cancel during compact).
+
+## Evidence and limits
+
+Independent review of adapter #38 used real Codex 0.153.4 and a synthetic model HTTP endpoint: compact-kill returned ACP `-32603` in 10ms with no `already active`; restart + `loadSession` then history, a normal prompt, and another compact all completed. Lifecycle 8/8 included a real vscode-jsonrpc close while start was still pending. Healthy compact and mid-turn kill still completed. Related adapter regression 130 passed; the known `/review` slash-command timeout exists on unpatched `400384e` and is not this pin's regression.
+
+This does not publish the adapter. Desktop users stay on the hang until adapter #38 merges and a release includes this gitlink. No in-window Electron compact-kill was re-run on this host pin; acceptance was adapter protocol plus host error classification (`-32603` should terminate the adapter).
+
+Related: [adapter #38](https://github.com/LodyAI/acp-extension-codex/pull/38), [adapter #37](https://github.com/LodyAI/acp-extension-codex/pull/37) / [Lody #544](https://github.com/LodyAI/Lody/pull/544) (already merged, not this change).

--- a/.agents/notes/implemented/bug-fix/2026-09-09-codex-compact-kill-waiters.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-codex-compact-kill-waiters.zh.md
@@ -7,14 +7,14 @@ Translation: current
 
 ## 摘要
 
-`/compact` 会等待 `thread/compacted` 通知。回合 waiter 在 Codex 进程退出时已经会 reject；压缩 waiter 只有 resolve，所以 `thread/compact/start` 之后进程一死，ACP prompt 一直占着，下一句变成 `already active`。这次宿主改动把 `acp-extension-codex` 钉到 `a67f231`（adapter #38，已 rebase 到当前 adapter main），让 close/dispose 拒绝这些 waiter。健康压缩和回合中途杀进程的行为不变。adapter #38 尚未合入，在它合并前这个 pin 不能随桌面发布。
+`/compact` 会等待 `thread/compacted` 通知。回合 waiter 在 Codex 进程退出时已经会 reject；压缩 waiter 只有 resolve，所以 `thread/compact/start` 之后进程一死，ACP prompt 一直占着，下一句变成 `already active`。这次宿主改动把 `acp-extension-codex` 钉到 `31c5ecc`（adapter #38，已 rebase 到包含 #30 的当前 adapter main），让 close/dispose 拒绝这些 waiter。健康压缩和回合中途杀进程的行为不变。adapter #38 尚未合入，在它合并前这个 pin 不能随桌面发布。
 
 ## 决策
 
-- 宿主 gitlink `packages/acp-extension-codex` 从 main 的 `5f0aab0f`（#554 / adapter #40）移到 `a67f231`（未合的 adapter PR #38，基线就是那条当前 main）。
+- 宿主 gitlink `packages/acp-extension-codex` 从 main 的 `314b3823`（宿主 #275 / adapter 取消压缩）移到 `31c5ecc`（未合的 adapter PR #38，已 rebase 到含 #30 的 adapter main）。
 - Core 和其它 submodule 保持当前 main。本 PR 不改它们。
 - `runCompact` 仍然先登记 waiter，再用 `Promise.all` 同时等 start 和 completion，这样 vscode-jsonrpc 的 `close`（不会 reject 进行中的 start RPC）也能结束 prompt。
-- 这不是 adapter #37 / Lody #544（fork 退订），也不是还开着的 adapter #30（压缩过程中点停止）。
+- 这不是 adapter #37 / Lody #544（fork 退订）。adapter #30（压缩过程中点停止）已在 adapter main，不是这次改动。
 
 ## 证据与限制
 

--- a/.agents/notes/implemented/bug-fix/2026-09-09-codex-compact-kill-waiters.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-codex-compact-kill-waiters.zh.md
@@ -1,0 +1,25 @@
+# Codex 进程退出时拒绝压缩完成等待
+
+Status: implemented
+Translation: current
+
+[English](./2026-09-09-codex-compact-kill-waiters.md)
+
+## 摘要
+
+`/compact` 会等待 `thread/compacted` 通知。回合 waiter 在 Codex 进程退出时已经会 reject；压缩 waiter 只有 resolve，所以 `thread/compact/start` 之后进程一死，ACP prompt 一直占着，下一句变成 `already active`。这次宿主改动把 `acp-extension-codex` 钉到 `a67f231`（adapter #38，已 rebase 到当前 adapter main），让 close/dispose 拒绝这些 waiter。健康压缩和回合中途杀进程的行为不变。adapter #38 尚未合入，在它合并前这个 pin 不能随桌面发布。
+
+## 决策
+
+- 宿主 gitlink `packages/acp-extension-codex` 从 main 的 `5f0aab0f`（#554 / adapter #40）移到 `a67f231`（未合的 adapter PR #38，基线就是那条当前 main）。
+- Core 和其它 submodule 保持当前 main。本 PR 不改它们。
+- `runCompact` 仍然先登记 waiter，再用 `Promise.all` 同时等 start 和 completion，这样 vscode-jsonrpc 的 `close`（不会 reject 进行中的 start RPC）也能结束 prompt。
+- 这不是 adapter #37 / Lody #544（fork 退订），也不是还开着的 adapter #30（压缩过程中点停止）。
+
+## 证据与限制
+
+adapter #38 的独立审核使用真实 Codex 0.153.4 和合成模型 HTTP：compact-kill 在 10ms 内返回 ACP `-32603`，没有 `already active`；重启并 `loadSession` 后，历史回放、普通 prompt、再次 compact 均完成。生命周期 8/8 包含 start 仍 pending 时的真实 vscode-jsonrpc close。健康压缩和回合中途杀进程仍然完成。相关 adapter 回归 130 通过；已知 `/review` 斜杠命令超时在未改的 `400384e` 上就有，不当作这个 pin 的回归。
+
+这不会发布 adapter。在 adapter #38 合入并且发行包含这个 gitlink 之前，桌面用户仍然会遇到该缺陷。这次宿主 pin 没有重新跑窗口内 Electron 的 compact-kill；验收是 adapter 协议加上宿主错误分类（`-32603` 应终止 adapter）。
+
+相关：[adapter #38](https://github.com/LodyAI/acp-extension-codex/pull/38)、[adapter #37](https://github.com/LodyAI/acp-extension-codex/pull/37) / [Lody #544](https://github.com/LodyAI/Lody/pull/544)（已合，不是这次改动）。


### PR DESCRIPTION
## Related issue

Closes #550

Depends on [LodyAI/acp-extension-codex#38](https://github.com/LodyAI/acp-extension-codex/pull/38). Review this host PR, then merge the adapter first and this pin second. Do not ship a desktop release until that adapter merge exists.

## Problem / pressure

`/compact` waits on a `thread/compacted` notification. Turn waiters already reject when the Codex process exits; compaction waiters were resolve-only. If app-server dies after `thread/compact/start`, the ACP prompt never finishes. Host Stop does not clear it. The next prompt is `already active`. Healthy compact still works. Mid-turn process death already returns `-32603`. This is the compact waiter hole, not the fork hang (#543 / #544) and not adapter #30 (stop during compact).

## Summary

Pin `acp-extension-codex` to `31c5ecc` (adapter #38, rebased onto current adapter main / `314b3823`) so close/dispose rejects compaction waiters. Other submodules stay on current main.

## Visual explanation

```mermaid
sequenceDiagram
  participant Host
  participant Adapter
  participant Codex
  Host->>Adapter: prompt /compact
  Adapter->>Codex: thread/compact/start
  Codex-->>Adapter: start ok
  Note over Codex: process exits
  Note over Adapter: before: wait forever for thread/compacted
  Host->>Adapter: session/prompt
  Adapter-->>Host: already active
  Note over Adapter: after: close rejects waiter, prompt returns -32603
```

## Before / after

| Before | After |
| ------ | ----- |
| `/compact` + process death stays compacting; Stop then `already active` | Prompt returns `-32603`; next prompt is not `already active` |
| Healthy `/compact` | Unchanged |
| Main pins Codex `314b3823` (host #275 / adapter cancel-compaction) | Codex `31c5ecc` (#38 on top of that main) |

## Test plan

- Adapter unit: `vitest run src/__tests__/CodexAppServerClient.test.ts --no-file-parallelism --retry=0` — 7 passed, including close while start is still in flight.
- Independent adapter check (Codex 0.153.4, synthetic model, rebuilt bundle of this patch): compact-kill returned `-32603` in 10ms with no `already active`; restart + `loadSession` then history, a normal prompt, and another compact all completed. Lifecycle 8/8 included real vscode-jsonrpc close while start was pending. Related adapter regression 130 passed; the known `/review` slash-command timeout is a pre-existing baseline skip.
- Host change is the gitlink plus Agent Notes. `pnpm run docs check` reported no errors on the new note pair; the command still fails on pre-existing broken links in unrelated notes/specs. Full `pnpm check` was not re-run on this pin-only host worktree.
- Not claimed: in-window Electron compact-kill on this host pin. Acceptance was adapter protocol plus host `-32603` classification.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** The Codex gitlink `314b3823` → `31c5ecc` and that Core / other submodules are unchanged.
- **Decisions to challenge:** Pinning unmerged adapter #38 (rebased onto adapter main after #30) versus waiting for that merge; whether this overlaps adapter #30 cancel-during-compact.
- **Plausible failures / evidence gaps:** CI submodule fetch of `31c5ecc` before #38 merges; no in-window desktop compact-kill on this pin.

### Authoring context

- **User goal / directives:** Land the host pin for the Codex compact-kill hang so desktop builds pick up adapter #38 after that adapter merges, same two-PR shape as #37 / #544.
- **Constraints / non-goals:** No other submodule refresh; no adapter publish; no desktop release from this PR; do not mix #536.
- **Risk-bearing decisions:** Host points at an open adapter PR SHA (`31c5ecc` / #38).
- **Destructive or irreversible behavior:** Gitlink move only. No data migration, no history rewrite.
- **Deliberately not done or tested:** In-window Electron compact-kill on this host pin; full host `pnpm check` on this worktree.
- **Unknowns / confidence:** High on the adapter path from independent real Codex evidence; merge order must keep adapter #38 first.

### Original user prompt

````text
Codex compact-kill should reject waiters instead of hanging.
````

<!-- context-handoff:end -->



