### PR TITLE
fix: lazily join machine monitor stream

### DIFF
--- a/.agents/notes/implemented/simplification/2026-09-10-lazy-machine-monitor-stream.md
+++ b/.agents/notes/implemented/simplification/2026-09-10-lazy-machine-monitor-stream.md
@@ -1,0 +1,21 @@
+# Join the machine-monitor stream only while it has observers
+
+Status: implemented
+Translation: pending
+
+## Abstract
+
+Each cloud workspace renderer previously joined the machine-monitor Ephemeral Stream at runtime startup, although no UI might be displaying a machine resource snapshot. The renderer now retains the authenticated connection inputs but joins only after the first machine-monitor subscriber appears, then closes the room after the final subscriber leaves. Presence remains a workspace-lifetime subscription because it supports independent online and session-viewing state. Rapid observer changes may briefly overlap teardown and a new join, but generation-gated transport cleanup prevents an old subscription from surviving.
+
+## Decision and ownership
+
+`WorkspaceMachineMonitorTransport` owns the observer-count lifecycle because it alone owns both the snapshot listeners and the Ephemeral Stream subscription. `createWorkspaceRuntime` continues to supply current connection inputs on cloud attach and to stop the transport on detach, token loss, and runtime disposal.
+
+An observer immediately receives its local empty snapshot, then starts the remote room and publishes its observer lease. The last observer clears its lease and tears down the remote room. The CLI continues sampling only for active observer leases.
+
+## Evidence and validation
+
+- `packages/components/src/providers/workspace-machine-monitor-transport.ts`
+- `packages/components/tests/workspace-machine-monitor-transport.test.ts`
+
+The regression test proves that workspace attachment alone creates no machine-monitor transport, the first observer creates one, the final observer closes it, and a later observer creates a fresh transport.

--- a/packages/components/src/providers/workspace-machine-monitor-transport.ts
+++ b/packages/components/src/providers/workspace-machine-monitor-transport.ts
@@ -14,6 +14,7 @@ import {
 } from '@lody/shared';
 import {
   EphemeralRoomTransport,
+  type EphemeralRoomStartArgs,
   type EphemeralRoomBaseOptions,
   type EphemeralRoomStoreLike,
 } from './ephemeral-room-transport';
@@ -35,6 +36,21 @@ export class WorkspaceMachineMonitorTransport extends EphemeralRoomTransport<
   private readonly listeners = new Map<MachineId, Set<SnapshotListener>>();
   private readonly renewalTimers = new Map<MachineId, ReturnType<typeof setInterval>>();
   private readonly forceSampleAtByMachine = new Map<MachineId, number>();
+  private startArgs: EphemeralRoomStartArgs | null = null;
+
+  /**
+   * Retain connection credentials while the workspace is attached, but do not
+   * join the ephemeral room until a consumer needs a machine snapshot.
+   */
+  override start(args: EphemeralRoomStartArgs): void {
+    this.startArgs = args;
+    if (this.listeners.size > 0) super.start(args);
+  }
+
+  override async stop(): Promise<void> {
+    this.startArgs = null;
+    await super.stop();
+  }
 
   shouldRestartOnExternalWake(nowMs: number = getServerNow()): boolean {
     const syncState = this.getSyncState();
@@ -53,10 +69,11 @@ export class WorkspaceMachineMonitorTransport extends EphemeralRoomTransport<
     if (!machineListeners) {
       machineListeners = new Set();
       this.listeners.set(machineId, machineListeners);
-      this.startRenewal(machineId);
     }
     machineListeners.add(listener);
     listener(this.getSnapshot(machineId));
+    this.startRenewal(machineId);
+    this.startIfObserved();
     this.publishObserver(machineId, null);
     return () => {
       const current = this.listeners.get(machineId);
@@ -68,6 +85,7 @@ export class WorkspaceMachineMonitorTransport extends EphemeralRoomTransport<
       this.renewalTimers.delete(machineId);
       this.forceSampleAtByMachine.delete(machineId);
       this.store?.delete(getMachineMonitorObserverKey(machineId, this.observerId));
+      if (this.listeners.size === 0) void super.stop();
     };
   }
 
@@ -109,11 +127,17 @@ export class WorkspaceMachineMonitorTransport extends EphemeralRoomTransport<
   }
 
   private startRenewal(machineId: MachineId): void {
+    if (this.renewalTimers.has(machineId)) return;
     const timer = setInterval(
       () => this.publishObserver(machineId, null),
       LODY_MACHINE_MONITOR_OBSERVER_RENEW_MS
     );
     this.renewalTimers.set(machineId, timer);
+  }
+
+  private startIfObserved(): void {
+    if (this.getSyncState() !== 'idle' || !this.startArgs) return;
+    super.start(this.startArgs);
   }
 
   private publishObserver(machineId: MachineId, forceSampleAtMs: number | null): void {

--- a/packages/components/tests/workspace-machine-monitor-transport.test.ts
+++ b/packages/components/tests/workspace-machine-monitor-transport.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MachineId, WorkspaceId } from '@lody/shared';
+import {
+  type EphemeralRoomStartArgs,
+  type EphemeralRoomTransportLike,
+} from '../src/providers/ephemeral-room-transport';
+import { WorkspaceMachineMonitorTransport } from '../src/providers/workspace-machine-monitor-transport';
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const MACHINE_ID = 'machine-1' as MachineId;
+
+class TestWorkspaceMachineMonitorTransport extends WorkspaceMachineMonitorTransport {
+  readonly transports: Array<{ close: ReturnType<typeof vi.fn> }> = [];
+
+  protected override createTransport(): EphemeralRoomTransportLike {
+    const close = vi.fn(async () => {});
+    this.transports.push({ close });
+    return {
+      join: () =>
+        Promise.resolve({
+          ok: true,
+          value: { unsubscribe: () => {} },
+        } as Awaited<ReturnType<EphemeralRoomTransportLike['join']>>),
+      close,
+    };
+  }
+}
+
+const START_ARGS: EphemeralRoomStartArgs = {
+  baseUrl: 'https://streams.example.test',
+  auth: async () => 'token',
+};
+
+describe('WorkspaceMachineMonitorTransport', () => {
+  it('joins only while at least one machine snapshot is observed', async () => {
+    const transport = new TestWorkspaceMachineMonitorTransport({ workspaceId: WORKSPACE_ID });
+
+    transport.start(START_ARGS);
+    expect(transport.transports).toHaveLength(0);
+
+    const unsubscribe = transport.subscribeMachine(MACHINE_ID, vi.fn());
+    expect(transport.transports).toHaveLength(1);
+
+    const secondListenerUnsubscribe = transport.subscribeMachine(MACHINE_ID, vi.fn());
+    expect(transport.transports).toHaveLength(1);
+    unsubscribe();
+    await Promise.resolve();
+    expect(transport.transports[0]?.close).not.toHaveBeenCalled();
+
+    secondListenerUnsubscribe();
+    await Promise.resolve();
+    expect(transport.transports[0]?.close).toHaveBeenCalledOnce();
+
+    const secondUnsubscribe = transport.subscribeMachine(MACHINE_ID, vi.fn());
+    expect(transport.transports).toHaveLength(2);
+    secondUnsubscribe();
+    await transport.stop();
+  });
+});


### PR DESCRIPTION
## Summary

- Join the cloud machine-monitor Ephemeral Stream only after the first resource-monitor subscriber appears.
- Close the subscription after the final subscriber leaves; concurrent listeners still share one room.
- Keep workspace presence unchanged and document the lifecycle decision.

## Validation

- `git diff --check`
- Scoped Prettier check for the source, regression test, and Agent Note

The current checkout has no `node_modules`, so its scoped Vitest command could not start. Running the available runner from another worktree was blocked before tests by its read-only Vite temporary-directory boundary. `pnpm run docs check` remains blocked by pre-existing broken links to unavailable ACP submodules.

## Review focus

Please verify that a remote machine resource monitor subscription always has current connection inputs before its first observer, and that the final observer teardown cannot leave an Ephemeral Stream subscription alive.
