### PR TITLE
fix(components): recover lost GitHub token action

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-10-github-operation-token-reconnect.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-10-github-operation-token-reconnect.zh.md
@@ -1,0 +1,19 @@
+# 静默恢复 GitHub 操作令牌的 Convex 断线
+
+Status: implemented
+Translation: pending
+PR: not created
+
+## 摘要
+
+用户点击合并 Pull Request 时，客户端可能在取得 GitHub 操作令牌的 Convex Action 期间断线。此时尚未向 GitHub 发出合并请求，但界面会把底层连接错误显示为“合并失败”。令牌请求现在会静默重试一次；若重试仍收到同一断线错误，合并按钮恢复可用且不显示该技术错误。GitHub 已返回的真实合并失败仍会照常提示，重试次数保持为一次以免在网络持续不可用时隐藏无限等待。
+
+## 决定与范围
+
+- 仅重试 `Connection lost while action was in flight`，并且仅作用于获取操作令牌；它发生在 GitHub 写操作之前，重复请求不会重复合并。
+- 重试耗尽后只抑制这条 Convex 传输错误的合并 toast；请求仍被分析事件记录，其他令牌、权限和 GitHub 合并错误仍显示给用户。
+- 不查询 GitHub 的合并状态：该错误点在 GitHub 合并请求之前，因此不存在“已合并但客户端未知”的状态。
+
+## 证据与限制
+
+令牌单测覆盖断线后重试成功，PR 容器测试覆盖耗尽后不显示 toast。此变更不证明特定用户的网络、代理或 Convex 服务端为何断开；持续断线时用户可再次点击合并。

--- a/packages/components/src/components/sessions/pr-tab-container.tsx
+++ b/packages/components/src/components/sessions/pr-tab-container.tsx
@@ -10,7 +10,10 @@ import type { GitHubMergeMethod, PrStatus } from '@lody/shared';
 import { currentWorkspaceIdAtom } from '@/atoms';
 import { derivePrStatusFromDetails } from '@/lib/github-pr-details-state';
 import { getDurationSinceMs, getPerformanceNowMs } from '@/lib/posthog-analytics';
-import { isGitHubUnauthorizedTokenError } from '@/lib/github-token';
+import {
+  isGitHubOperationTokenConnectionLostError,
+  isGitHubUnauthorizedTokenError,
+} from '@/lib/github-token';
 import { ReadyForReviewStillDraftError, useGitHubPrDetails } from '@/hooks/use-github-pr-details';
 import { PrTabView, type PrTabViewData, type PrTabViewState } from './pr-tab-view';
 import { resolveConflictsActionAtomFamily } from './session-pr-agent-action';
@@ -159,6 +162,12 @@ export function PrTabContainer({
           errorKind: classifyMergeError(err, pr),
           durationMs: getDurationSinceMs(startedAt),
         });
+        // The request only obtains the credential used for the subsequent
+        // GitHub merge. If Convex disconnects here, the merge was never sent;
+        // the retry above has already had a chance to recover, so leave the
+        // action ready to try again instead of exposing a backend transport
+        // detail as a merge failure.
+        if (isGitHubOperationTokenConnectionLostError(err)) return;
         const message = err instanceof Error ? err.message : String(err);
         toast.error(t('sessions.prTab.mergeError', 'Failed to merge'), { description: message });
       }

--- a/packages/components/src/lib/github-token.ts
+++ b/packages/components/src/lib/github-token.ts
@@ -80,6 +80,14 @@ export function isGitHubUnauthorizedTokenError(error: unknown): boolean {
   return error instanceof GitHubClientTokenError && error.code === 'unauthorized';
 }
 
+/**
+ * A Convex action was sent but its result was lost during a reconnect. This is
+ * safe to retry for token minting because no GitHub operation has started yet.
+ */
+export function isGitHubOperationTokenConnectionLostError(error: unknown): boolean {
+  return error instanceof Error && error.message === 'Connection lost while action was in flight';
+}
+
 function normalizeExpiresAt(expiresAt: string | undefined, tokenSource: GitHubTokenSource) {
   if (expiresAt) {
     const parsed = Date.parse(expiresAt);
@@ -205,7 +213,8 @@ export async function getGitHubOperationToken(
 
   const requestGeneration = tokenCacheGeneration;
   const request = (async (): Promise<TokenEntry> => {
-    const result = await requireGitHubTokenPort().getOperationToken({
+    const fetchToken = async (): Promise<TokenEntry> => {
+      const result = await requireGitHubTokenPort().getOperationToken({
         workspaceId,
         repoFullName,
         operation,
@@ -214,16 +223,26 @@ export async function getGitHubOperationToken(
           : {}),
       });
 
-    if (!result.success) {
-      throw new GitHubClientTokenError(result.errorCode, result.errorMessage);
-    }
+      if (!result.success) {
+        throw new GitHubClientTokenError(result.errorCode, result.errorMessage);
+      }
 
-    const tokenSource: GitHubTokenSource = result.tokenSource === 'personal' ? 'personal' : 'app';
-    const entry: TokenEntry = {
-      token: result.token,
-      expiresAt: normalizeExpiresAt(result.expiresAt, tokenSource),
-      tokenSource,
+      const tokenSource: GitHubTokenSource = result.tokenSource === 'personal' ? 'personal' : 'app';
+      const entry: TokenEntry = {
+        token: result.token,
+        expiresAt: normalizeExpiresAt(result.expiresAt, tokenSource),
+        tokenSource,
+      };
+      return entry;
     };
+
+    let entry: TokenEntry;
+    try {
+      entry = await fetchToken();
+    } catch (error) {
+      if (!isGitHubOperationTokenConnectionLostError(error)) throw error;
+      entry = await fetchToken();
+    }
     if (requestGeneration === tokenCacheGeneration) {
       tokenCache.set(key, entry);
     }

--- a/packages/components/tests/github-token.test.ts
+++ b/packages/components/tests/github-token.test.ts
@@ -235,6 +235,30 @@ describe('withGitHubOperationTokenRetry', () => {
     expect(mockAction).toHaveBeenCalledTimes(1);
   });
 
+  it('retries token minting once when Convex reconnects before returning the action result', async () => {
+    mockAction
+      .mockRejectedValueOnce(new Error('Connection lost while action was in flight'))
+      .mockResolvedValueOnce({
+        success: true,
+        token: 'ghu_reconnected',
+        tokenSource: 'personal',
+        expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      });
+
+    await expect(getGitHubOperationToken('ws-1', 'owner/repo', 'write')).resolves.toMatchObject({
+      token: 'ghu_reconnected',
+    });
+    expect(mockAction).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops after one reconnect retry when the token action keeps disconnecting', async () => {
+    const error = new Error('Connection lost while action was in flight');
+    mockAction.mockRejectedValue(error);
+
+    await expect(getGitHubOperationToken('ws-1', 'owner/repo', 'write')).rejects.toBe(error);
+    expect(mockAction).toHaveBeenCalledTimes(2);
+  });
+
   it('invalidates all cached tokens for a workspace after personal identity changes', async () => {
     mockAction
       .mockResolvedValueOnce({

--- a/packages/components/tests/pr-tab-container.test.tsx
+++ b/packages/components/tests/pr-tab-container.test.tsx
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => {
 
   return {
     markReadyForReview: vi.fn(),
+    mergePullRequest: vi.fn(),
     refresh: vi.fn(),
     toastError: vi.fn(),
     useGitHubPrDetails: vi.fn(),
@@ -40,6 +41,8 @@ vi.mock('sonner', () => ({
 }));
 
 vi.mock('@/lib/github-token', () => ({
+  isGitHubOperationTokenConnectionLostError: (error: unknown) =>
+    error instanceof Error && error.message === 'Connection lost while action was in flight',
   isGitHubUnauthorizedTokenError: (error: unknown) =>
     Boolean(
       error &&
@@ -50,6 +53,8 @@ vi.mock('@/lib/github-token', () => ({
 }));
 
 vi.mock('../src/lib/github-token', () => ({
+  isGitHubOperationTokenConnectionLostError: (error: unknown) =>
+    error instanceof Error && error.message === 'Connection lost while action was in flight',
   isGitHubUnauthorizedTokenError: (error: unknown) =>
     Boolean(
       error &&
@@ -108,8 +113,44 @@ const checkRuns: GitHubCheckRunsSummary = {
   runs: [],
 };
 
+const mergeablePullRequest: GitHubPullRequestDetails = {
+  ...pullRequest,
+  draft: false,
+  mergeable: true,
+  mergeableState: 'clean',
+};
+
 function createAuthError(): Error {
   return new Error('Not authenticated. Please sign in.');
+}
+
+function createPrDetailsResult(pr: GitHubPullRequestDetails = pullRequest) {
+  return {
+    state: 'ready' as const,
+    data: {
+      pullRequest: pr,
+      reviewThreads: [],
+      reviews: [],
+      issueComments: [],
+      checkRuns,
+    },
+    error: null,
+    checksPermissionError: false,
+    isRevalidating: false,
+    refresh: mocks.refresh,
+    refreshCheckRuns: vi.fn().mockResolvedValue(null),
+    postComment: vi.fn(),
+    isPostingComment: false,
+    mergePullRequest: mocks.mergePullRequest,
+    isMerging: false,
+    setPullRequestState: vi.fn(),
+    isUpdatingState: false,
+    markReadyForReview: mocks.markReadyForReview,
+    isMarkingReady: false,
+    deleteBranch: vi.fn(),
+    isDeletingBranch: false,
+    branchExists: null,
+  };
 }
 
 async function flushPromises(): Promise<void> {
@@ -126,6 +167,7 @@ describe('PrTabContainer ready-for-review auth recovery', () => {
 
   beforeEach(() => {
     mocks.markReadyForReview.mockReset();
+    mocks.mergePullRequest.mockReset();
     mocks.refresh.mockReset();
     mocks.toastError.mockReset();
     mocks.useGitHubPrDetails.mockReset();
@@ -133,32 +175,7 @@ describe('PrTabContainer ready-for-review auth recovery', () => {
     store = createStore();
     store.set(currentWorkspaceIdAtom, 'workspace-1' as WorkspaceId);
     mocks.refresh.mockResolvedValue(null);
-    mocks.useGitHubPrDetails.mockReturnValue({
-      state: 'ready',
-      data: {
-        pullRequest,
-        reviewThreads: [],
-        reviews: [],
-        issueComments: [],
-        checkRuns,
-      },
-      error: null,
-      checksPermissionError: false,
-      isRevalidating: false,
-      refresh: mocks.refresh,
-      refreshCheckRuns: vi.fn().mockResolvedValue(null),
-      postComment: vi.fn(),
-      isPostingComment: false,
-      mergePullRequest: vi.fn(),
-      isMerging: false,
-      setPullRequestState: vi.fn(),
-      isUpdatingState: false,
-      markReadyForReview: mocks.markReadyForReview,
-      isMarkingReady: false,
-      deleteBranch: vi.fn(),
-      isDeletingBranch: false,
-      branchExists: null,
-    });
+    mocks.useGitHubPrDetails.mockReturnValue(createPrDetailsResult());
 
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -197,6 +214,16 @@ describe('PrTabContainer ready-for-review auth recovery', () => {
     return button;
   }
 
+  function getMergeButton(): HTMLButtonElement {
+    const button = Array.from(container?.querySelectorAll<HTMLButtonElement>('button') ?? []).find(
+      (node) => node.textContent?.includes('Merge')
+    );
+    if (!button) {
+      throw new Error('Expected merge button');
+    }
+    return button;
+  }
+
   it('refreshes once and retries without showing a toast on the first auth failure', async () => {
     mocks.markReadyForReview
       .mockRejectedValueOnce(createAuthError())
@@ -229,5 +256,21 @@ describe('PrTabContainer ready-for-review auth recovery', () => {
     expect(mocks.toastError).toHaveBeenCalledWith('Failed to mark as ready for review', {
       description: 'still unauthorized',
     });
+  });
+
+  it('silently restores the merge action when Convex loses the token action result', async () => {
+    mocks.useGitHubPrDetails.mockReturnValue(createPrDetailsResult(mergeablePullRequest));
+    mocks.mergePullRequest.mockRejectedValueOnce(
+      new Error('Connection lost while action was in flight')
+    );
+    await renderContainer();
+
+    await act(async () => {
+      getMergeButton().click();
+    });
+    await flushPromises();
+
+    expect(mocks.mergePullRequest).toHaveBeenCalledWith('merge');
+    expect(mocks.toastError).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Related issue

No related issue; this is a focused same-repository repair.

## Problem / pressure

Convex can lose the result of the action that mints a GitHub operation token. The GitHub merge request has not started at that point, but the PR UI presents the raw transport error as a merge failure.

## Summary

Retry that token action once, then suppress only its exhausted connection-loss toast. Other GitHub and token failures continue to surface normally. Add regression coverage for bounded retry and the silent PR action state.

## Visual explanation

```mermaid
sequenceDiagram
  participant UI as PR merge button
  participant Token as token action
  participant GH as GitHub merge API
  UI->>Token: request write token
  Token-->>UI: connection lost
  UI->>Token: retry once
  alt token returned
    UI->>GH: merge PR
  else connection lost again
    UI-->>UI: restore button; no toast
  end
```

## Before / after

| Before | After |
| ------ | ----- |
| A lost token-action result displayed a raw Convex error as “Failed to merge”. | The token action retries once; an exhausted disconnect quietly restores the merge action. |

## Test plan

- `git diff --check` passed.
- Added unit coverage for successful and exhausted bounded token retries, plus the PR-container no-toast case.
- `pnpm --filter @lody/components test -- github-token.test.ts pr-tab-container.test.tsx` and `typecheck` could not start because this nested checkout has no `node_modules` (`vitest` and `tsgo` absent).
- `pnpm run docs check` still reports pre-existing broken links to absent ACP submodules; this change adds no documentation-check error.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Confirm the retry wraps only operation-token minting and that the UI suppression matches only the exact Convex disconnect message.
- **Decisions to challenge:** The bounded retry is intentionally one attempt because it precedes the GitHub write and must not create an indefinite busy state.
- **Plausible failures / evidence gaps:** Tests were added but could not run in this dependency-free nested checkout; verify them in CI or a checkout with dependencies.

### Authoring context

- **User goal / directives:** Remove the confusing raw transport-error experience when merging a GitHub PR, then open a ready-for-review PR.
- **Constraints / non-goals:** Do not suppress GitHub merge, authorization, or other definite failures; do not change GitHub merge behavior.
- **Risk-bearing decisions:** The retry occurs before any GitHub merge request, so retrying it cannot repeat a merge.
- **Destructive or irreversible behavior:** None; the change only changes local retry and presentation behavior.
- **Deliberately not done or tested:** No end-to-end network-disconnect test was run because this checkout has no installed dependencies.
- **Unknowns / confidence:** The exact Convex error string is the classification boundary; confidence is high for the reported path, pending CI execution.

<!-- context-handoff:end -->
