### PR TITLE
fix: keep fork actions visible while loading

### DIFF
--- a/packages/components/src/components/ai-gui/view.tsx
+++ b/packages/components/src/components/ai-gui/view.tsx
@@ -3629,7 +3629,7 @@ const AssistantForkButton = ({
   );
 };
 
-const AssistantTurnFooter = ({
+export const AssistantTurnFooter = ({
   message,
   sessionId,
   fileDiffOverride,
@@ -3737,7 +3737,7 @@ const AssistantTurnFooter = ({
             'flex flex-wrap items-center justify-start text-[11px] text-muted-foreground',
             isMobile ? 'min-h-6 gap-1' : 'min-h-7 gap-2',
             !isMobile && 'opacity-0 transition-opacity duration-150 focus-within:opacity-100',
-            !isMobile && isTurnHovered && 'opacity-100'
+            !isMobile && (isTurnHovered || isForking) && 'opacity-100'
           )}
           data-assistant-turn-actions
         >

--- a/packages/components/src/stories/AssistantTurnAlignment.stories.tsx
+++ b/packages/components/src/stories/AssistantTurnAlignment.stories.tsx
@@ -177,6 +177,24 @@ export const DesktopFinishedTurn: Story = {
   ),
 };
 
+export const DesktopForkingTurn: Story = {
+  args: { sessionId, items: finishedItems, renderMessageRow },
+  globals: { theme: 'dark' },
+  render: () => (
+    <div className="h-[520px] w-full bg-background">
+      <SessionChatStreamView
+        items={finishedItems}
+        sessionId={sessionId}
+        renderMessageRow={renderMessageRow}
+        lastAssistantMessageId={finishedTurn.id}
+        lastCompletedAssistantMessageId={finishedTurn.id}
+        onForkLastAssistant={() => undefined}
+        forkingAssistantMessageId={finishedTurn.id}
+      />
+    </div>
+  ),
+};
+
 /**
  * PLAN-MODE TURN — the widest set of top-level row shells in one column.
  *

--- a/packages/components/tests/assistant-turn-action-inset.test.ts
+++ b/packages/components/tests/assistant-turn-action-inset.test.ts
@@ -1,7 +1,21 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { SessionHistoryParsed, SessionId } from '@lody/shared';
 import { describe, expect, it } from 'vitest';
 
-import { MOBILE_TURN_ACTION_LEADING_INSET_PX } from '../src/components/ai-gui/view';
+import {
+  AssistantTurnFooter,
+  MOBILE_TURN_ACTION_LEADING_INSET_PX,
+} from '../src/components/ai-gui/view';
 import { EDGE_ZONE_PX } from '../src/components/mobile/mobile-edge-back-swipe';
+import { ForceDesktopLayoutProvider } from '../src/hooks/use-mobile';
+import { initI18n } from '../src/i18n';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 /*
  * The mobile assistant-turn action bar puts the turn duration in front of the
@@ -27,5 +41,47 @@ describe('mobile assistant-turn action bar inset', () => {
        the gutter changed. */
     expect(MOBILE_TURN_ACTION_LEADING_INSET_PX).toBeGreaterThan(0);
     expect(EDGE_ZONE_PX).toBeGreaterThan(0);
+  });
+});
+
+describe('desktop assistant-turn action bar visibility', () => {
+  it('keeps the whole action group visible while a fork is pending', async () => {
+    await initI18n('en');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root: Root = createRoot(container);
+    const message = {
+      id: 'assistant-turn-forking',
+      role: 'assistant',
+      timestamp: '2026-09-10T03:00:00.000Z',
+      endedAt: '2026-09-10T03:00:01.000Z',
+      finished: true,
+      items: [{ type: 'text', text: 'A completed response.' }],
+    } as unknown as SessionHistoryParsed;
+
+    await act(async () => {
+      root.render(
+        createElement(
+          ForceDesktopLayoutProvider,
+          null,
+          createElement(AssistantTurnFooter, {
+            message,
+            sessionId: 'session-forking' as SessionId,
+            showDuration: true,
+            isTurnHovered: false,
+            onFork: () => undefined,
+            isForking: true,
+          })
+        )
+      );
+    });
+
+    const actions = container.querySelector('[data-assistant-turn-actions]');
+    expect(actions?.classList.contains('opacity-100')).toBe(true);
+    expect(container.querySelector('[aria-label="Copy response"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Fork session"] .animate-spin')).not.toBeNull();
+
+    await act(async () => root.unmount());
+    container.remove();
   });
 });


### PR DESCRIPTION
## Related issue

Internal same-repository contribution; no Issue created solely for intake.

## Problem / pressure

On desktop, assistant-turn actions are normally revealed by hover or keyboard focus. Starting a conversation fork replaces the Fork icon with a loading spinner, but moving the pointer away hid the entire action row and removed the visible progress signal.

## Summary

- Keep the existing assistant-turn action row visible while its fork is pending.
- Cover the non-hover loading state with a DOM regression test.
- Add a focused Storybook state for the pending fork UI.

## Visual explanation

Simple change: one existing visibility condition now also accepts the already-propagated fork loading flag; a diagram would not add review value.

## Before / after

| Before | After |
| ------ | ----- |
| Moving the pointer away during a fork hid the action row. | The full action row remains visible until the fork leaves its loading state, then returns to normal hover and focus behavior. |

## Test plan

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm check` (all component and CLI suites passed; the Electron suite passed after restoring its locally missing binary)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @lody/electron test`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec vitest run tests/assistant-turn-action-inset.test.ts` from `packages/components`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm --filter @lody/components typecheck`
- `pnpm run docs check`

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check `AssistantTurnFooter` visibility classes and the desktop pending-fork regression test.
- **Decisions to challenge:** Confirm that the entire action row, rather than only the spinner, should remain visible while forking.
- **Plausible failures / evidence gaps:** Automated coverage verifies rendered classes and controls; direct pointer interaction was not captured because browser-control tooling was unavailable.

### Authoring context

- **User goal / directives:** Keep the conversation Fork loading state visible after the pointer leaves and open this same-repository change as a ready-for-review PR.
- **Constraints / non-goals:** Preserve normal desktop hover and focus behavior outside the loading state and leave mobile behavior unchanged.
- **Risk-bearing decisions:** Reuse the existing per-message `isForking` state at the footer visibility boundary without changing fork lifecycle or protocol code.
- **Destructive or irreversible behavior:** None; the change only affects presentation and adds deterministic test and story coverage.
- **Deliberately not done or tested:** No live fork was created against user data; behavior is covered with DOM state and the focused Storybook fixture.
- **Unknowns / confidence:** Low residual risk; the state is already propagated to the exact footer and the regression asserts the non-hover pending case.

<!-- context-handoff:end -->