### PR TITLE
feat(pr): preserve original user prompt in context handoff

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -90,4 +90,26 @@ characters. Include only the highest-value files, decisions, risks, and gaps.
 - **Deliberately not done or tested:** <!-- Intentional omissions and why they are acceptable. -->
 - **Unknowns / confidence:** <!-- Residual risk and confidence in the change. -->
 
+### Original user prompt
+
+<!--
+Required only for fork-based/external pull requests. Same-repository maintainer
+branches do not need to provide an original user prompt.
+
+For external PRs, preserve the triggering user's prompt as source evidence for
+review. Paste it verbatim: do not summarize, rewrite, clean up, or translate it.
+If the prompt contains secrets or private material that cannot be published,
+redact only those spans and leave an explicit marker in their place. Do not append
+unrelated transcript turns, tool logs, or attachment bytes.
+-->
+
+<details>
+<summary>Show original prompt</summary>
+
+````text
+<!-- Paste the triggering user's original prompt here, verbatim. -->
+````
+
+</details>
+
 <!-- context-handoff:end -->

--- a/.github/scripts/check-pr-body.mjs
+++ b/.github/scripts/check-pr-body.mjs
@@ -80,22 +80,72 @@ function parseArgs(argv) {
   return options;
 }
 
+/**
+ * Return line indexes that match `predicate` while ignoring fenced code payloads.
+ *
+ * Markdown headings inside the original-prompt fence are source text, not PR
+ * structure. Track CommonMark-style backtick/tilde fences so section discovery
+ * and duplicate-heading checks agree on the same structural lines.
+ */
+function lineIndexesOutsideFences(lines, predicate) {
+  const indexes = [];
+  let fence = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+
+    if (fence) {
+      const closing = line.match(/^ {0,3}(`+|~+)[ \t]*$/);
+      if (
+        closing &&
+        closing[1][0] === fence.marker &&
+        closing[1].length >= fence.length
+      ) {
+        fence = null;
+      }
+      continue;
+    }
+
+    const opening = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
+    if (opening) {
+      const marker = opening[1];
+      const info = opening[2] ?? '';
+      // CommonMark does not allow a backtick in a backtick fence's info string.
+      if (marker[0] !== '`' || !info.includes('`')) {
+        fence = { marker: marker[0], length: marker.length };
+        continue;
+      }
+    }
+
+    if (predicate(line, index)) {
+      indexes.push(index);
+    }
+  }
+
+  return indexes;
+}
+
 function headingCount(markdown, heading) {
-  return markdown.split('\n').filter((line) => line.trimEnd() === heading).length;
+  const lines = markdown.split('\n');
+  return lineIndexesOutsideFences(lines, (line) => line.trimEnd() === heading).length;
 }
 
 function sectionBody(markdown, heading) {
   const lines = markdown.split('\n');
-  const start = lines.findIndex((line) => line.trimEnd() === heading);
+  const starts = lineIndexesOutsideFences(lines, (line) => line.trimEnd() === heading);
+  const start = starts[0] ?? -1;
   if (start === -1) {
     return null;
   }
 
   const level = heading.startsWith('### ') ? 3 : 2;
   const nextHeading = level === 3 ? /^#{2,3}(?:\s|$)/ : /^##(?:\s|$)/;
-  const next = lines.findIndex((line, index) => index > start && nextHeading.test(line));
+  const next = lineIndexesOutsideFences(
+    lines,
+    (line, index) => index > start && nextHeading.test(line)
+  )[0];
   return lines
-    .slice(start + 1, next === -1 ? undefined : next)
+    .slice(start + 1, next === undefined ? undefined : next)
     .join('\n')
     .trim();
 }

--- a/.github/scripts/check-pr-body.mjs
+++ b/.github/scripts/check-pr-body.mjs
@@ -29,6 +29,7 @@ const CONTEXT_HANDOFF_END = '<!-- context-handoff:end -->';
 const REQUIRED_CONTEXT_HEADINGS = [
   '### Instructions for reviewing agents',
   '### Authoring context',
+  '### Original user prompt',
 ];
 const REVIEW_INSTRUCTION_FIELDS = [
   'Review focus',
@@ -125,6 +126,20 @@ function markdownField(section, field) {
 function isCompleteContext(value) {
   const normalized = value?.replaceAll('`', '').trim() ?? '';
   return isFilledSection(normalized) && !WITHHELD_CONTEXT.test(normalized);
+}
+
+function extractOriginalUserPrompt(section) {
+  if (!section) {
+    return '';
+  }
+
+  for (const match of section.matchAll(/(`{3,}|~{3,})(?:text)?[^\n]*\n([\s\S]*?)\n\1/g)) {
+    const prompt = match[2].replace(/<!--[\s\S]*?-->/g, '').trim();
+    if (prompt) {
+      return prompt;
+    }
+  }
+  return '';
 }
 
 function hasStructuralView(section) {
@@ -226,6 +241,15 @@ export function checkPullRequestBody(body, { changedLines = null } = {}) {
           `Authoring context must fill **${field}** with a meaningful public summary; N/A and redacted values are not accepted.`
         );
       }
+    }
+  }
+
+  if (contextHeadingCounts.get('### Original user prompt') === 1) {
+    const originalPrompt = extractOriginalUserPrompt(sectionBody(text, '### Original user prompt'));
+    if (!originalPrompt) {
+      findings.push(
+        'Original user prompt must contain the triggering prompt inside a fenced code block; the template placeholder does not count.'
+      );
     }
   }
 

--- a/.github/scripts/check-pr-template.test.mjs
+++ b/.github/scripts/check-pr-template.test.mjs
@@ -5,6 +5,8 @@ import { checkPullRequestBody } from './check-pr-body.mjs';
 
 const templateUrl = new URL('../PULL_REQUEST_TEMPLATE.md', import.meta.url);
 const template = readFileSync(templateUrl, 'utf8');
+const originalPromptPlaceholder = '<!-- Paste the triggering user\'s original prompt here, verbatim. -->';
+const originalPrompt = 'Keep the original user prompt in the PR body so reviewers can verify intent.';
 
 function completedTemplate(visualExplanation) {
   return template
@@ -19,7 +21,8 @@ function completedTemplate(visualExplanation) {
     .replace(
       /(- \*\*[^\n]+?:\*\*)\s*<!--[^\n]*-->/g,
       '$1 Reviewed local routing only; no runtime behavior changes.'
-    );
+    )
+    .replace(originalPromptPlaceholder, originalPrompt);
 }
 
 void test('the unedited template is not a valid PR body', () => {
@@ -43,8 +46,27 @@ void test('every repository path the template names resolves', () => {
   }
 });
 
-void test('an author who fills every required field passes', () => {
+void test('an external author who fills every required field passes', () => {
   const body = completedTemplate('Simple change: one documentation sentence changed.');
+  const result = checkPullRequestBody(body);
+  assert.equal(result.ok, true, result.findings.join('\n'));
+});
+
+void test('the original user prompt cannot be left as the template placeholder', () => {
+  const body = completedTemplate('Simple change: one documentation sentence changed.').replace(
+    originalPrompt,
+    originalPromptPlaceholder
+  );
+  const result = checkPullRequestBody(body);
+  assert.equal(result.ok, false);
+  assert.ok(result.findings.some((finding) => finding.startsWith('Original user prompt must')));
+});
+
+void test('the original prompt may itself contain a triple-backtick code fence', () => {
+  const body = completedTemplate('Simple change: one documentation sentence changed.').replace(
+    originalPrompt,
+    'Please preserve this snippet exactly:\n```ts\nconst answer = 42;\n```'
+  );
   const result = checkPullRequestBody(body);
   assert.equal(result.ok, true, result.findings.join('\n'));
 });

--- a/.github/scripts/check-pr-template.test.mjs
+++ b/.github/scripts/check-pr-template.test.mjs
@@ -71,6 +71,27 @@ void test('the original prompt may itself contain a triple-backtick code fence',
   assert.equal(result.ok, true, result.findings.join('\n'));
 });
 
+void test('headings inside the original prompt fence do not affect PR section parsing', () => {
+  const promptWithHeadings = [
+    'Preserve these lines exactly:',
+    '## Related issue',
+    '## Problem / pressure',
+    '## Summary',
+    '## Visual explanation',
+    '## Test plan',
+    '## Context handoff',
+    '### Instructions for reviewing agents',
+    '### Authoring context',
+    '### Original user prompt',
+  ].join('\n');
+  const body = completedTemplate('Simple change: one documentation sentence changed.').replace(
+    originalPrompt,
+    promptWithHeadings
+  );
+  const result = checkPullRequestBody(body);
+  assert.equal(result.ok, true, result.findings.join('\n'));
+});
+
 void test('a large change requires a structural visual', () => {
   const body = completedTemplate('Simple change: one documentation sentence changed.');
   const boundary = checkPullRequestBody(body, { changedLines: 200 });


### PR DESCRIPTION
## Related issue

Same-repository branch; no intake Issue required.

## Problem / pressure

Lody's PR context handoff currently preserves an agent-authored summary of the user's goal, but external contributors can still omit the source wording that produced the change. A reviewer can therefore verify the implementation only against the agent's interpretation, not against the original request.

## Summary

Require fork-based/external pull requests to include an `Original user prompt` section containing the triggering prompt in a fenced code block. Same-repository maintainer branches are explicitly exempt and do not need to include the original prompt.

The PR body checker rejects a missing heading or the untouched template placeholder for external contribution bodies. The template uses a four-backtick fence so an ordinary triple-backtick code block inside the user's prompt remains intact.

Sensitive spans may still be explicitly redacted before publication; unrelated transcript turns, tool logs, and attachment bytes stay out of the PR body.

## Visual explanation

Simple change: this extends the external-contribution PR template contract and its validator with one provenance field; there is no new runtime or multi-step control flow.

## Before / after

| Before | After |
| ------ | ----- |
| External reviewers receive an agent-authored `User goal / directives` summary | External reviewers receive that summary plus the source user prompt |
| External PRs can pass without preserving the user's wording | External PR validation requires a non-placeholder fenced original prompt |
| Same-repository maintainer branches have no explicit rule here | Maintainer branches are explicitly exempt from the original-prompt requirement |
| A prompt containing ``` can be awkward to embed | The template's outer fence uses four backticks |

## Test plan

- Added a passing fixture that fills the original prompt for an external contribution body.
- Added a regression test proving the untouched prompt placeholder is rejected.
- Added a regression test proving a prompt containing a triple-backtick code fence is accepted inside the four-backtick outer fence.
- Clarified the template text and test naming so the requirement is scoped to external/fork-based PRs rather than maintainer branches.
- Local execution was not available in this environment; rely on repository CI for the Node test run.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check `.github/PULL_REQUEST_TEMPLATE.md` and `check-pr-body.mjs` agree that original prompt provenance is an external-contribution requirement, not a maintainer-branch requirement.
- **Decisions to challenge:** Confirm the external/internal boundary matches the repository's existing contribution-policy boundary and that explicit sensitive-span redaction is the right exception.
- **Plausible failures / evidence gaps:** The checker can require presence for external bodies but cannot mechanically prove the pasted text is truly verbatim; that remains an authoring-agent responsibility.

### Authoring context

- **User goal / directives:** Preserve the user's original prompt for external Lody PRs, while exempting same-repository maintainer branches.
- **Constraints / non-goals:** Keep the existing structured authoring context; do not require maintainers to publish their original prompt; do not add full transcripts, tool logs, or attachment bytes.
- **Risk-bearing decisions:** External original prompt is public PR provenance, so sensitive spans may be explicitly redacted rather than silently copied.
- **Destructive or irreversible behavior:** None; this only changes PR template/validation requirements for future external bodies.
- **Deliberately not done or tested:** No runtime session or review-engine behavior changed; local Node tests were not executed in this environment.
- **Unknowns / confidence:** High confidence because the repository already distinguishes same-repository maintainer branches from external contributions before applying contribution-policy validation.

<!-- context-handoff:end -->