### PR TITLE
feat(shared): version turn hashes and store new metadata primitive

### DIFF
--- a/.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md
+++ b/.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md
@@ -132,5 +132,10 @@ Superseded intermediate claims and detailed run logs remain recoverable in Git h
 through 123e9132. Remove source-string-only tests; retain real behavior and compile-failure
 contracts. Future refinements update the owning note rather than adding a note per fix.
 
+Later turns changed two of this record's statements without changing its decision: new writes
+now insert ordinary metadata as primitives and reserve `LoroText` for streaming fields, and
+canonical turn hashes gained a version. See
+[versioned turn hashes and primitive metadata insertion](2026-09-10-versioned-history-hashes-and-primitive-metadata.md).
+
 Intent: [draft Spec](../../../../specs/session-history-writes.md).
 PR: [#460](https://github.com/LodyAI/Lody/pull/460).

--- a/.agents/notes/implemented/architecture/2026-09-10-versioned-history-hashes-and-primitive-metadata.md
+++ b/.agents/notes/implemented/architecture/2026-09-10-versioned-history-hashes-and-primitive-metadata.md
@@ -40,10 +40,16 @@ stored as a primitive. Streaming fields are declared explicitly in `schema.ts` a
 - tool-call `content` via a `storageSchema` hint;
 - worktree-script `steps` via a `storageSchema` hint.
 
-Nested tool content keeps its current shape with a `defaultLoroText: true` child catchall, so
-`content[].output`/`command`/`text` and `locations[].path` remain Text exactly as before. This is
-the smallest change that removes the metadata containers without also changing the nested
-container count that existing docs and the full-Mirror reader already depend on.
+The nested tool/worktree payload follows the same rule: its catchall is
+`defaultLoroText: false` and only the payload fields that stream are declared — tool `text`,
+tool `output`, the ACP `content` block's nested `content.text`, and the worktree step
+`output`. Everything else at that level (`terminal_command.command`, `args`, `cwd`, diff
+`path`/`newText`, `terminalId`, `input` values, `steps[].command`/`status`) is metadata and
+is stored primitive. A first version of this change defaulted the whole nested subtree to
+`defaultLoroText: true`, which still built Text for every one of those metadata strings and
+made the storage goal unfulfilled; the audit caught it. New values are primitive while a
+legacy stored `LoroText` keeps its container id on a same-type edit, because the writer
+diffs against the stored kind rather than the new schema.
 
 The policy is insertion-only, and the writer enforces that independently of the schema:
 
@@ -81,7 +87,12 @@ version mismatch occurs and no replay history is available to recompute, the dec
 rather than guessing.
 
 The stored-content baseline records the hash version it was computed with, so an old baseline
-cannot be read as v2, and existing v1 canonicalization is unchanged.
+cannot be read as v2, and existing v1 canonicalization is unchanged. A baseline written before
+the field existed has no `hashVersion`: it is v1 when compared with its cursor
+(`(baseline.hashVersion ?? 1) === cursorVersion`). Comparing the raw optional value rejected
+every genuine old baseline (`undefined !== 1`), which discarded the projected stored history and
+reported a normal append as `local_history_has_untracked_suffix`. The version binding still
+rejects a real v1/v2 mismatch in either direction (covered directly in the service suite).
 
 ## Alternatives and limits
 
@@ -89,9 +100,10 @@ cannot be read as v2, and existing v1 canonicalization is unchanged.
   rejected: it hides malformed new input instead of versioning hashes.
 - Dropping the stored version or reinterpreting a v1 cursor as v2 was rejected: it trades a
   false conflict for silent hash corruption.
-- Making every nested tool-content field an explicit primitive was rejected for this change: it
-  would alter storage for existing docs without a migration and is not needed to remove the
-  metadata containers. It remains a candidate for a separate, measured change.
+- Keeping the nested tool/worktree catchall at `defaultLoroText: true` (the first attempt) was
+  rejected: it moved the container growth one level down and left `command`/`path`/`args` as
+  Text, so the storage goal was unmet. Nested metadata defaults primitive; only declared
+  streaming payloads are Text.
 - The sealed-skeleton contract — a reader-side `ref` payload fetch, a `useToolCallPayload`
   hook, and the UI that consumes it — is **not** implemented here. The v2 canonical form is
   forward-compatible with it but is verified only against synthetic fixtures.

--- a/.agents/notes/implemented/architecture/2026-09-10-versioned-history-hashes-and-primitive-metadata.md
+++ b/.agents/notes/implemented/architecture/2026-09-10-versioned-history-hashes-and-primitive-metadata.md
@@ -1,0 +1,112 @@
+# Versioned turn hashes and primitive metadata insertion
+
+Status: implemented
+Translation: pending
+
+## Abstract
+
+The shared HistoryWriter now inserts new plain metadata as primitives and creates `LoroText`
+only for fields that genuinely stream, so a long session stops paying for thousands of
+unnecessary text containers. Alongside it, canonical turn hashes became versioned: a stored
+cursor without a version is v1, v2 hashes a canonical item form so a sealed tool_call skeleton
+and the full call it came from agree, and the session-doc cursor versions its own
+`importedTurnHashes` independently of the sync metadata's `replayDigest`. Both changes are
+insertion/comparison policies: opening stored history performs no writes, legacy Text and
+primitive values keep their representation, and no old payload is reparsed. The sealed-skeleton
+feature itself is not implemented here; only the hash and cursor compatibility it needs.
+
+## Problem
+
+Two pressures met in one storage change.
+
+First, the history item catchall used `schema.Any({ defaultLoroText: true })`. Every new string
+in a tool call — `toolCallId`, `status`, `title`, `kind`, a `locations[].path` — became a
+`LoroText` container. A single tool call could create a dozen containers that never stream, and
+their count is what makes a 3000-round session expensive to open and sync. The schema comment
+already argued against deep Text inference, but the code did the opposite.
+
+Second, the session-history sync compared per-turn hashes that were produced by different
+canonical forms. A legacy document cursor stored v1 hashes while newer sync metadata advanced to
+v2, and `markConflict` updates only the metadata. Comparing a v1 cursor against v2 hashes
+manufactured a `prefix_mismatch` on an unchanged transcript.
+
+## Storage insertion policy
+
+`historyItemAnySchema` is now `schema.Any({ defaultLoroText: false })`. Ordinary metadata is
+stored as a primitive. Streaming fields are declared explicitly in `schema.ts` and keep their
+`LoroText`:
+
+- outer `text` (shared by `text` and `thought`) and `markdown`;
+- tool-call `content` via a `storageSchema` hint;
+- worktree-script `steps` via a `storageSchema` hint.
+
+Nested tool content keeps its current shape with a `defaultLoroText: true` child catchall, so
+`content[].output`/`command`/`text` and `locations[].path` remain Text exactly as before. This is
+the smallest change that removes the metadata containers without also changing the nested
+container count that existing docs and the full-Mirror reader already depend on.
+
+The policy is insertion-only, and the writer enforces that independently of the schema:
+
+- `diffMap` preserves an existing stored representation for a same-type string edit, so a
+  legacy `LoroText` keeps its container id and a legacy primitive stays primitive;
+- unknown stored keys and untouched opaque items are never rewritten;
+- a malformed legacy value (for example `locations` stored as a Map) does not block an
+  unrelated field edit, because only authored changes are parsed.
+
+`schema.ts` and `history-materializer.ts` no longer describe the change as waiting on a
+`loro-mirror` patch. The pinned 2.3.2 reader carries the text-event optimization upstream; the
+`storageSchema` hint is read only by the shared materializer, and history writes go through the
+shared HistoryWriter, not `Mirror.setState`.
+
+## Hash versions
+
+`apps/cli/src/lib/local-project-history-sync-service.ts` defines `HASH_VERSION_V1 = 1` and
+`HASH_VERSION_V2 = 2`, with new imports materialized at v2. v1 hashed `{ role, items, plan }`
+verbatim. v2 canonicalizes each item:
+
+- `tool_call` keeps exactly `type`, an optional string `title`, `kind`, `status`, and
+  `locations` — the fields a sealed skeleton keeps — so dropping `toolCallId`, `content`,
+  `rawInput`/`rawOutput`, `ref`, runtime annotations, and permission prompts does not change
+  the hash. `title: null` hashes like an absent title.
+- `text`/`thought` keep only `type` and `text`, dropping derived `spans`.
+- every other item drops the same set of volatile keys.
+
+`resolveStoredHashVersion` treats a missing version as v1. The session doc cursor's
+`hashVersion` field versions its own `importedTurnHashes`, and `ExternalAcpHistorySyncMeta.hashVersion`
+versions the metadata `replayDigest`. They are independent because `markConflict` may advance
+only the metadata. When the two differ, the decision recomputes the replay hashes from the
+materialized history in the stored version instead of comparing across versions; recomputation
+preserves the turn count, so `appendFromIndex` still indexes the materialized history. If a
+version mismatch occurs and no replay history is available to recompute, the decision throws
+rather than guessing.
+
+The stored-content baseline records the hash version it was computed with, so an old baseline
+cannot be read as v2, and existing v1 canonicalization is unchanged.
+
+## Alternatives and limits
+
+- Relaxing `MessageContentSchema`/turning off write validation to avoid the mismatch was
+  rejected: it hides malformed new input instead of versioning hashes.
+- Dropping the stored version or reinterpreting a v1 cursor as v2 was rejected: it trades a
+  false conflict for silent hash corruption.
+- Making every nested tool-content field an explicit primitive was rejected for this change: it
+  would alter storage for existing docs without a migration and is not needed to remove the
+  metadata containers. It remains a candidate for a separate, measured change.
+- The sealed-skeleton contract — a reader-side `ref` payload fetch, a `useToolCallPayload`
+  hook, and the UI that consumes it — is **not** implemented here. The v2 canonical form is
+  forward-compatible with it but is verified only against synthetic fixtures.
+
+No 3000-round acceptance is claimed. This is a storage-insertion and hash-comparison change,
+not a windowed-reader or attachment-externalization rollout.
+
+## Evidence
+
+- `packages/shared/src/{schema,history-materializer}.ts`
+- `packages/shared/tests/history-storage-policy.test.ts` (new), `history-writer.test.ts`
+- `apps/cli/src/lib/local-project-history-sync-service.ts`
+- `apps/cli/tests/local-project-history-sync-service.test.ts`,
+  `local-project-history-sync-writer.test.ts`
+- [Single history writer](2026-09-07-single-history-writer.md) (the owner before this change;
+  its "no #359 hash-v2 rollout" line describes the earlier PR's scope, not current behavior)
+- Spec: [session history writes](../../../../specs/session-history-writes.md)
+- Supersedes the storage-policy portion of PR #443; see the PR body for the exact base/head.

--- a/apps/cli/src/lib/local-project-history-sync-service.ts
+++ b/apps/cli/src/lib/local-project-history-sync-service.ts
@@ -91,6 +91,8 @@ export type MaterializedReplay = {
   turnHashes: string[];
   replayDigest: string;
   droppedNotifications: number;
+  /** Canonical-hash version `turnHashes`/`replayDigest` were computed with. */
+  hashVersion: number;
 };
 
 type HistoryCatalogSnapshot = {
@@ -148,9 +150,21 @@ function stableJson(value: unknown): string {
   return `{${entries.join(',')}}`;
 }
 
-function hashText(value: string): string {
+export function hashText(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
+
+/**
+ * Canonical-hash versions. v1 hashed `{ role, items, plan }` verbatim; v2 hashes a
+ * canonical item form so a sealed tool_call skeleton
+ * (`{ type, kind, status, title?, locations?, ref }`) and the full tool_call shape it
+ * was sealed from produce the same hash. A stored cursor without a `hashVersion` is v1,
+ * written by a CLI that predates skeletons.
+ */
+export const HASH_VERSION_V1 = 1;
+export const HASH_VERSION_V2 = 2;
+/** Version new imports write. */
+export const HASH_VERSION = HASH_VERSION_V2;
 
 // Both stored legacy items and parsed new items are hashed as opaque content.
 type HistoryHashInput = {
@@ -159,6 +173,7 @@ type HistoryHashInput = {
   plan?: readonly unknown[];
 };
 
+/** v1 (legacy) hash input: only the parts of an entry that come from the source transcript. */
 function normalizeHistoryEntryForHash(entry: HistoryHashInput): unknown {
   return {
     role: entry.role,
@@ -167,11 +182,95 @@ function normalizeHistoryEntryForHash(entry: HistoryHashInput): unknown {
   };
 }
 
-function hashHistoryEntry(entry: HistoryHashInput): string {
+export function hashHistoryEntry(entry: HistoryHashInput): string {
   return hashText(stableJson(normalizeHistoryEntryForHash(entry)));
 }
 
-function materializeReplay(args: {
+/**
+ * Keys stripped from every item in the v2 canonical form. These are either
+ * import-time/runtime-only annotations or fields a sealed tool_call skeleton omits, so
+ * hashing them would make the same transcript hash differently once its turns are sealed.
+ */
+const VOLATILE_ITEM_KEYS_V2: ReadonlySet<string> = new Set([
+  'toolCallId',
+  'content',
+  'rawInput',
+  'rawOutput',
+  'ref',
+  'activityKind',
+  'permissionRequest',
+  'toolName',
+  'schedulingTimeZone',
+  'turnId',
+  'isLatest',
+  'startedAt',
+  'endedAt',
+  'startedAtEpochSeconds',
+  'endedAtEpochSeconds',
+]);
+
+const isHashRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+/**
+ * v2 canonical form of a tool_call item: exactly the fields a sealed skeleton keeps,
+ * minus `ref`. `title: null` (ACP "no title") is treated as absent so null, undefined and
+ * missing hash identically.
+ */
+function canonicalizeToolCallItemForHashV2(item: Record<string, unknown>): Record<string, unknown> {
+  const canonical: Record<string, unknown> = { type: 'tool_call' };
+  if (typeof item.title === 'string') canonical.title = item.title;
+  if (item.kind !== undefined) canonical.kind = item.kind;
+  if (item.status !== undefined) canonical.status = item.status;
+  if (item.locations !== undefined) canonical.locations = item.locations;
+  return canonical;
+}
+
+function canonicalizeItemForHashV2(item: unknown): unknown {
+  if (!isHashRecord(item)) return item;
+  if (item.type === 'text' || item.type === 'thought') {
+    // `spans` are mention regions derived from `text`; they add no transcript content.
+    return { type: item.type, text: item.text };
+  }
+  if (item.type === 'tool_call') return canonicalizeToolCallItemForHashV2(item);
+  const canonical: Record<string, unknown> = {};
+  for (const key of Object.keys(item)) {
+    if (VOLATILE_ITEM_KEYS_V2.has(key) || item[key] === undefined) continue;
+    canonical[key] = item[key];
+  }
+  return canonical;
+}
+
+/** v2 counterpart of the v1 normalizer: same entry shape, each item canonicalized. */
+function normalizeHistoryEntryForHashV2(entry: HistoryHashInput): unknown {
+  return {
+    role: entry.role,
+    items: (entry.items ?? []).map(canonicalizeItemForHashV2),
+    plan: entry.plan ?? [],
+  };
+}
+
+export function hashHistoryEntryV2(entry: HistoryHashInput): string {
+  return hashText(stableJson(normalizeHistoryEntryForHashV2(entry)));
+}
+
+/**
+ * Hash one entry with an explicit canonical version. Used when comparing a new replay
+ * against a stored cursor written by an older CLI, so an upgrade never looks like a
+ * conflict.
+ */
+export function hashHistoryEntryForVersion(entry: HistoryHashInput, version: number): string {
+  if (version === HASH_VERSION_V1) return hashHistoryEntry(entry);
+  if (version === HASH_VERSION_V2) return hashHistoryEntryV2(entry);
+  throw new Error(`Unsupported history hash version: ${version}`);
+}
+
+/** Cursors written before the field existed are v1. */
+export function resolveStoredHashVersion(source: { hashVersion?: number } | undefined): number {
+  return source?.hashVersion ?? HASH_VERSION_V1;
+}
+
+export function materializeReplay(args: {
   provider: LocalProjectHistoryProvider;
   acpSessionId: ACPSessionId;
   replayNotifications: Parameters<typeof buildHistoryReplayImport>[0];
@@ -188,7 +287,7 @@ function materializeReplay(args: {
     createId: () => `${providerKey}:${args.acpSessionId}:tmp:${tempId++}`,
     mode: 'imported_snapshot',
   });
-  const turnHashes = replay.history.map(hashHistoryEntry);
+  const turnHashes = replay.history.map(hashHistoryEntryV2);
   const history = replay.history.map((entry, index) => ({
     ...entry,
     id: `${providerKey}:${args.acpSessionId}:turn:${index}:${turnHashes[index]!.slice(0, 16)}`,
@@ -199,6 +298,7 @@ function materializeReplay(args: {
     turnHashes,
     replayDigest: hashText(turnHashes.join('\n')),
     droppedNotifications: replay.droppedNotifications,
+    hashVersion: HASH_VERSION,
   };
 }
 
@@ -223,6 +323,9 @@ function resolveImportedTurnHashes(
 
 const StoredHistoryBaselineSchema = z.object({
   version: z.literal(1),
+  // Absent on baselines written before hash versions; those are v1 and must not be
+  // interpreted against a v2 source.
+  hashVersion: z.number().optional(),
   sourceDigest: z.string(),
   turnHashes: z.array(z.string()),
 });
@@ -240,6 +343,7 @@ function storedBaselineHashes(
       );
       if (
         parsed.success &&
+        parsed.data.hashVersion === resolveStoredHashVersion(cursor) &&
         areStringArraysEqual(cursor.importedTurnHashes, sourceHashes) &&
         parsed.data.sourceDigest === hashText(sourceHashes.join('\n')) &&
         parsed.data.turnHashes.length === sourceHashes.length
@@ -254,28 +358,116 @@ function storedBaselineHashes(
 
 function createImportCursor(
   sourceHashes: readonly string[],
-  stored: readonly SessionHistoryInput[]
+  stored: readonly SessionHistoryInput[],
+  hashVersion: number
 ): SessionExternalHistoryCursorDocState {
   return {
     importedTurnHashes: [...sourceHashes],
+    hashVersion,
     storedHistoryBaseline: JSON.stringify({
       version: 1,
+      hashVersion,
       sourceDigest: hashText(sourceHashes.join('\n')),
-      turnHashes: stored.map(hashHistoryEntry),
+      turnHashes: stored.map((entry) => hashHistoryEntryForVersion(entry, hashVersion)),
     } satisfies z.infer<typeof StoredHistoryBaselineSchema>),
   };
 }
 
-export function decideHistoryRefresh(args: {
-  externalHistory: ExternalAcpHistorySyncMeta;
-  importedTurnHashes?: readonly string[];
+/**
+ * Subset of a materialized replay the decisions need to recompute hashes in the stored
+ * cursor's version. `hashVersion` may be absent in legacy fixtures; absent means "already
+ * in the stored version" (no recomputation).
+ */
+export type MaterializedReplayHashSource = Pick<MaterializedReplay, 'history'> & {
+  hashVersion?: number;
+};
+
+/**
+ * Express a replay's digest/turn hashes in an explicit canonical version. When the replay
+ * was materialized with a newer canonical form than the stored cursor (a v1 cursor from an
+ * older CLI versus a v2 replay), the stored-version hashes are recomputed from the replay
+ * history so an upgrade never produces a false conflict. Recomputation changes hashes but
+ * never the turn count, so `appendFromIndex` still indexes the materialized history.
+ */
+function resolveReplayHashesForStoredVersion(args: {
   replayDigest: string;
   turnHashes: readonly string[];
+  replayHashVersion: number;
+  storedHashVersion: number;
+  replayHistory?: readonly SessionHistoryInput[];
+}): { replayDigest: string; turnHashes: readonly string[] } {
+  if (args.replayHashVersion === args.storedHashVersion) {
+    return { replayDigest: args.replayDigest, turnHashes: args.turnHashes };
+  }
+  if (!args.replayHistory) {
+    throw new Error(
+      'History decisions need the materialized replay history to compare a ' +
+        `v${args.replayHashVersion} replay against a v${args.storedHashVersion} stored cursor.`
+    );
+  }
+  const turnHashes = args.replayHistory.map((entry) =>
+    hashHistoryEntryForVersion(entry, args.storedHashVersion)
+  );
+  return { replayDigest: hashText(turnHashes.join('\n')), turnHashes };
+}
+
+export function decideHistoryRefresh(args: {
+  externalHistory: ExternalAcpHistorySyncMeta;
+  /**
+   * Stored cursor hashes. Pass their own version alongside them when the hashes come from
+   * the session doc rather than the sync metadata.
+   */
+  importedTurnHashes?: readonly string[];
+  /** Version paired with the explicit cursor hashes; metadata may advance separately. */
+  importedTurnHashVersion?: number;
+  replayDigest: string;
+  turnHashes: readonly string[];
+  /**
+   * The materialized replay `replayDigest`/`turnHashes` came from. Pass it whenever the
+   * replay's `hashVersion` may differ from the stored cursor's version.
+   */
+  materialized?: MaterializedReplayHashSource;
+  /**
+   * Version of `replayDigest`/`turnHashes`. Defaults to `materialized.hashVersion`, or to
+   * the stored version when no materialized replay is passed (legacy callers compared
+   * same-version hashes).
+   */
+  replayHashVersion?: number;
+  /**
+   * Hashes of the locally stored turns. Callers must compute these with the STORED hash
+   * version, since they are compared against stored-version replay hashes here.
+   */
   currentHistoryHashes?: readonly string[];
   storedHistoryHashes?: readonly string[];
   projectedTurnHashes?: readonly string[];
 }): HistoryRefreshDecision {
-  if (!args.currentHistoryHashes && args.replayDigest === args.externalHistory.replayDigest) {
+  const metadataHashVersion = resolveStoredHashVersion(args.externalHistory);
+  const storedHashVersion = args.importedTurnHashVersion ?? metadataHashVersion;
+  const replay = resolveReplayHashesForStoredVersion({
+    replayDigest: args.replayDigest,
+    turnHashes: args.turnHashes,
+    replayHashVersion:
+      args.replayHashVersion ?? args.materialized?.hashVersion ?? storedHashVersion,
+    storedHashVersion,
+    replayHistory: args.materialized?.history,
+  });
+  // The metadata digest is paired with the metadata's own version, which may have advanced
+  // independently of the doc cursor.
+  const metadataReplay =
+    metadataHashVersion === storedHashVersion
+      ? replay
+      : resolveReplayHashesForStoredVersion({
+          replayDigest: args.replayDigest,
+          turnHashes: args.turnHashes,
+          replayHashVersion:
+            args.replayHashVersion ?? args.materialized?.hashVersion ?? metadataHashVersion,
+          storedHashVersion: metadataHashVersion,
+          replayHistory: args.materialized?.history,
+        });
+  if (
+    !args.currentHistoryHashes &&
+    metadataReplay.replayDigest === args.externalHistory.replayDigest
+  ) {
     return { status: 'skipped', reason: 'digest_match' };
   }
 
@@ -283,31 +475,31 @@ export function decideHistoryRefresh(args: {
     args.externalHistory,
     args.importedTurnHashes
   );
-  if (!isPrefix(importedTurnHashes, args.turnHashes)) {
+  if (!isPrefix(importedTurnHashes, replay.turnHashes)) {
     return { status: 'conflicted', reason: 'prefix_mismatch' };
   }
 
   if (args.currentHistoryHashes) {
+    const appendFromIndex = args.currentHistoryHashes.length;
+    // A caller-supplied projection is already expressed in the stored version. Default to
+    // the same-version replay hashes (identity when versions match).
+    const projectedTurnHashes = args.projectedTurnHashes ?? replay.turnHashes;
     const expected = args.storedHistoryHashes
-      ? [
-          ...args.storedHistoryHashes,
-          ...(args.projectedTurnHashes ?? args.turnHashes).slice(importedTurnHashes.length),
-        ]
-      : args.turnHashes;
+      ? [...args.storedHistoryHashes, ...projectedTurnHashes.slice(importedTurnHashes.length)]
+      : projectedTurnHashes;
     if (
       args.currentHistoryHashes.length < importedTurnHashes.length ||
       !isPrefix(args.currentHistoryHashes, expected)
     ) {
       return { status: 'conflicted', reason: 'local_history_has_untracked_suffix' };
     }
-    const appendFromIndex = args.currentHistoryHashes.length;
-    return args.turnHashes.length > appendFromIndex
+    return replay.turnHashes.length > appendFromIndex
       ? { status: 'refreshed', reason: 'prefix_append', appendFromIndex }
       : { status: 'skipped', reason: 'empty_suffix', appendFromIndex };
   }
 
   const appendFromIndex = args.externalHistory.importedTurnCount;
-  return args.turnHashes.length > appendFromIndex
+  return replay.turnHashes.length > appendFromIndex
     ? { status: 'refreshed', reason: 'prefix_append', appendFromIndex }
     : { status: 'skipped', reason: 'empty_suffix', appendFromIndex };
 }
@@ -319,9 +511,22 @@ function areStringArraysEqual(left: readonly string[], right: readonly string[])
 async function readSessionImportedTurnHashes(
   sessionDoc: SessionDocument,
   externalHistory: ExternalAcpHistorySyncMeta
-): Promise<readonly string[]> {
+): Promise<{ importedTurnHashes: readonly string[]; importedTurnHashVersion: number }> {
   const cursor = await sessionDoc.getExternalHistoryCursor();
-  return resolveImportedTurnHashes(externalHistory, cursor?.importedTurnHashes);
+  return {
+    importedTurnHashes: resolveImportedTurnHashes(externalHistory, cursor?.importedTurnHashes),
+    importedTurnHashVersion: resolveStoredHashVersion(
+      cursor?.importedTurnHashes !== undefined ? cursor : externalHistory
+    ),
+  };
+}
+
+/** Hash locally stored turns in the version of the stored sync cursor. */
+function hashHistoryForStoredVersion(
+  history: readonly SessionHistoryInput[],
+  hashVersion: number
+): string[] {
+  return history.map((entry) => hashHistoryEntryForVersion(entry, hashVersion));
 }
 
 function hasPendingDispatchHistory(history: readonly SessionHistoryInput[]): boolean {
@@ -330,11 +535,20 @@ function hasPendingDispatchHistory(history: readonly SessionHistoryInput[]): boo
 
 export function decideHistoryConflictResolution(args: {
   externalHistory: ExternalAcpHistorySyncMeta;
+  /** Stored cursor hashes, paired with importedTurnHashVersion when supplied. */
   importedTurnHashes?: readonly string[];
+  /** Version paired with the explicit cursor hashes; metadata may advance separately. */
+  importedTurnHashVersion?: number;
   materialized: Pick<
     MaterializedReplay,
     'history' | 'turnHashes' | 'replayDigest' | 'droppedNotifications'
-  >;
+  > & {
+    /**
+     * Version of `turnHashes`/`replayDigest`. Absent means "already in the stored
+     * version" (legacy callers); a real `MaterializedReplay` always carries it.
+     */
+    hashVersion?: number;
+  };
   currentHistoryHashes: readonly string[];
   storedHistoryHashes?: readonly string[];
   currentHistoryHasPendingDispatch: boolean;
@@ -342,6 +556,28 @@ export function decideHistoryConflictResolution(args: {
   if (args.currentHistoryHasPendingDispatch) {
     return { status: 'blocked', reason: 'session_has_pending_local_turn' };
   }
+
+  const metadataHashVersion = resolveStoredHashVersion(args.externalHistory);
+  const storedHashVersion = args.importedTurnHashVersion ?? metadataHashVersion;
+  const replay = resolveReplayHashesForStoredVersion({
+    replayDigest: args.materialized.replayDigest,
+    turnHashes: args.materialized.turnHashes,
+    replayHashVersion: args.materialized.hashVersion ?? storedHashVersion,
+    storedHashVersion,
+    replayHistory: args.materialized.history,
+  });
+  // `markConflict` advances only the metadata; compare its digest in its own version so a
+  // v1 doc cursor is not misread as v2.
+  const metadataReplay =
+    metadataHashVersion === storedHashVersion
+      ? replay
+      : resolveReplayHashesForStoredVersion({
+          replayDigest: args.materialized.replayDigest,
+          turnHashes: args.materialized.turnHashes,
+          replayHashVersion: args.materialized.hashVersion ?? metadataHashVersion,
+          storedHashVersion: metadataHashVersion,
+          replayHistory: args.materialized.history,
+        });
 
   const importedTurnHashes = resolveImportedTurnHashes(
     args.externalHistory,
@@ -354,8 +590,8 @@ export function decideHistoryConflictResolution(args: {
       args.storedHistoryHashes ?? importedTurnHashes
     ) ||
       (!args.storedHistoryHashes &&
-        args.externalHistory.replayDigest === args.materialized.replayDigest &&
-        areStringArraysEqual(args.currentHistoryHashes, args.materialized.turnHashes)));
+        args.externalHistory.replayDigest === metadataReplay.replayDigest &&
+        areStringArraysEqual(args.currentHistoryHashes, replay.turnHashes)));
   if (alreadyResolved) {
     return { status: 'already_resolved' };
   }
@@ -372,7 +608,7 @@ export function decideHistoryConflictResolution(args: {
     return { status: 'blocked', reason: 'source_replay_empty' };
   }
 
-  if (args.materialized.turnHashes.length < importedTurnHashes.length) {
+  if (replay.turnHashes.length < importedTurnHashes.length) {
     return { status: 'blocked', reason: 'source_replay_behind_import_cursor' };
   }
 
@@ -596,6 +832,8 @@ function buildExternalHistoryMeta(args: {
     sourceAcpSessionId: args.sourceAcpSessionId,
     sourceUpdatedAt: args.sourceUpdatedAt ?? undefined,
     replayDigest: args.materialized.replayDigest,
+    // Versions the digest only. The doc cursor versions its own importedTurnHashes.
+    hashVersion: args.materialized.hashVersion,
     importedTurnCount: args.materialized.turnHashes.length,
     lastSyncAt: getServerNow(),
     status: args.status ?? 'synced',
@@ -854,13 +1092,13 @@ export class LocalProjectHistorySyncService {
     }
     if (existingExternalHistory.status !== 'sync_conflict') {
       const cursor = await sessionDoc.getExternalHistoryCursor();
-      const importedTurnHashes = await readSessionImportedTurnHashes(
+      const { importedTurnHashes, importedTurnHashVersion } = await readSessionImportedTurnHashes(
         sessionDoc,
         existingExternalHistory
       );
       if (
         areStringArraysEqual(
-          currentHistoryBeforeReplay.map(hashHistoryEntry),
+          hashHistoryForStoredVersion(currentHistoryBeforeReplay, importedTurnHashVersion),
           storedBaselineHashes(cursor, importedTurnHashes)
         )
       ) {
@@ -904,17 +1142,21 @@ export class LocalProjectHistorySyncService {
       throw new Error('Imported session metadata no longer matches the selected ACP history.');
     }
 
-    const latestImportedTurnHashes = await readSessionImportedTurnHashes(
-      sessionDoc,
-      latestExternalHistory
-    );
+    const {
+      importedTurnHashes: latestImportedTurnHashes,
+      importedTurnHashVersion: latestImportedTurnHashVersion,
+    } = await readSessionImportedTurnHashes(sessionDoc, latestExternalHistory);
     const latestCursor = await sessionDoc.getExternalHistoryCursor();
     const latestHistory = await sessionDoc.getHistory();
     const decision = decideHistoryConflictResolution({
       externalHistory: latestExternalHistory,
       importedTurnHashes: latestImportedTurnHashes,
+      importedTurnHashVersion: latestImportedTurnHashVersion,
       materialized,
-      currentHistoryHashes: latestHistory.map(hashHistoryEntry),
+      currentHistoryHashes: hashHistoryForStoredVersion(
+        latestHistory,
+        latestImportedTurnHashVersion
+      ),
       storedHistoryHashes: storedBaselineHashes(latestCursor, latestImportedTurnHashes),
       currentHistoryHasPendingDispatch: hasPendingDispatchHistory(latestHistory),
     });
@@ -939,12 +1181,17 @@ export class LocalProjectHistorySyncService {
           latestExternalHistory,
           cursor?.importedTurnHashes
         );
+        // The cursor's own version governs the comparison; metadata may have advanced.
+        const storedHashVersion = resolveStoredHashVersion(
+          cursor?.importedTurnHashes !== undefined ? cursor : latestExternalHistory
+        );
         const writeTimeDecision = decideHistoryConflictResolution({
           externalHistory: latestExternalHistory,
           importedTurnHashes: sourceHashes,
+          importedTurnHashVersion: storedHashVersion,
           storedHistoryHashes: storedBaselineHashes(cursor, sourceHashes),
           materialized,
-          currentHistoryHashes: history.map(hashHistoryEntry),
+          currentHistoryHashes: hashHistoryForStoredVersion(history, storedHashVersion),
           currentHistoryHasPendingDispatch: hasPendingDispatchHistory(history),
         });
         if (writeTimeDecision.status !== 'replace') {
@@ -956,7 +1203,7 @@ export class LocalProjectHistorySyncService {
         }
         return materialized.history;
       },
-      (stored) => createImportCursor(materialized.turnHashes, stored)
+      (stored) => createImportCursor(materialized.turnHashes, stored, materialized.hashVersion)
     );
     await this.manager.repo.upsertDocMeta(roomId, {
       origin: 'external-acp',
@@ -1143,7 +1390,8 @@ export class LocalProjectHistorySyncService {
       const sessionDoc = await this.manager.getOrCreateSessionDoc(sessionId);
       await sessionDoc.updateHistoryAndCursor(
         () => args.materialized.history,
-        (stored) => createImportCursor(args.materialized.turnHashes, stored)
+        (stored) =>
+          createImportCursor(args.materialized.turnHashes, stored, args.materialized.hashVersion)
       );
       await this.manager.repo.upsertDocMeta(roomId, meta);
       const synced = await sessionDoc.waitUntilSynced();
@@ -1219,14 +1467,20 @@ export class LocalProjectHistorySyncService {
             externalHistory,
             cursor?.importedTurnHashes
           );
+          // Pair the comparison with the cursor's own version: metadata may have advanced.
+          const storedHashVersion = resolveStoredHashVersion(
+            cursor?.importedTurnHashes !== undefined ? cursor : externalHistory
+          );
           // Check the actual state inside the synchronous write boundary. A matching
           // metadata digest must not bless local edits or an independently stale cursor.
           const decision = decideHistoryRefresh({
             externalHistory,
             importedTurnHashes,
+            importedTurnHashVersion: storedHashVersion,
             replayDigest: materialized.replayDigest,
             turnHashes: materialized.turnHashes,
-            currentHistoryHashes: history.map(hashHistoryEntry),
+            materialized,
+            currentHistoryHashes: hashHistoryForStoredVersion(history, storedHashVersion),
             storedHistoryHashes: storedBaselineHashes(cursor, importedTurnHashes),
             // Only project the new source suffix, never existing storage or the
             // already imported source prefix. A peer's body may arrive before
@@ -1236,7 +1490,10 @@ export class LocalProjectHistorySyncService {
               ...materialized.history
                 .slice(importedTurnHashes.length)
                 .map((entry) =>
-                  hashHistoryEntry(parseHistoryWrite(HistoryEntryWriteSchema, entry))
+                  hashHistoryEntryForVersion(
+                    parseHistoryWrite(HistoryEntryWriteSchema, entry),
+                    storedHashVersion
+                  )
                 ),
             ],
           });
@@ -1245,7 +1502,7 @@ export class LocalProjectHistorySyncService {
           appended = suffix.length;
           return [...history, ...suffix];
         },
-        (stored) => createImportCursor(materialized.turnHashes, stored)
+        (stored) => createImportCursor(materialized.turnHashes, stored, materialized.hashVersion)
       );
     } catch (error) {
       if (!(error instanceof HistoryRefreshConflict)) throw error;

--- a/apps/cli/src/lib/local-project-history-sync-service.ts
+++ b/apps/cli/src/lib/local-project-history-sync-service.ts
@@ -330,7 +330,7 @@ const StoredHistoryBaselineSchema = z.object({
   turnHashes: z.array(z.string()),
 });
 
-function storedBaselineHashes(
+export function storedBaselineHashes(
   cursor: SessionExternalHistoryCursorDocState | undefined,
   sourceHashes: readonly string[]
 ): readonly string[] {
@@ -343,7 +343,13 @@ function storedBaselineHashes(
       );
       if (
         parsed.success &&
-        parsed.data.hashVersion === resolveStoredHashVersion(cursor) &&
+        // A baseline written before hash versions existed has no `hashVersion` field
+        // and is v1. Comparing it directly against the cursor version rejected every
+        // genuine old baseline (`undefined !== 1`), which discarded the projected
+        // stored history and turned a normal append into a conflict. The baseline is
+        // still bound to its own version, so a v1 baseline against a v2 cursor (or
+        // vice versa) is correctly ignored.
+        (parsed.data.hashVersion ?? HASH_VERSION_V1) === resolveStoredHashVersion(cursor) &&
         areStringArraysEqual(cursor.importedTurnHashes, sourceHashes) &&
         parsed.data.sourceDigest === hashText(sourceHashes.join('\n')) &&
         parsed.data.turnHashes.length === sourceHashes.length

--- a/apps/cli/tests/local-project-history-sync-service.test.ts
+++ b/apps/cli/tests/local-project-history-sync-service.test.ts
@@ -28,6 +28,7 @@ import {
   LocalProjectHistorySyncService,
   materializeReplay,
   selectLatestCatalogItems,
+  storedBaselineHashes,
 } from '../src/lib/local-project-history-sync-service';
 
 const machineId = 'machine-1' as MachineId;
@@ -595,6 +596,88 @@ describe('canonical hash versions', () => {
         materialized: second,
       })
     ).toEqual({ status: 'skipped', reason: 'digest_match' });
+  });
+});
+
+describe('stored baseline hash-version binding', () => {
+  const sourceHashes = ['source-1', 'source-2'];
+  const storedHashes = ['stored-1', 'stored-2'];
+  const baseline = (hashVersion?: number) =>
+    JSON.stringify({
+      version: 1,
+      ...(hashVersion === undefined ? {} : { hashVersion }),
+      sourceDigest: hashText(sourceHashes.join('\n')),
+      turnHashes: storedHashes,
+    });
+
+  it('accepts a genuine unversioned baseline as v1', () => {
+    expect(
+      storedBaselineHashes(
+        { importedTurnHashes: [...sourceHashes], storedHistoryBaseline: baseline() },
+        sourceHashes
+      )
+    ).toEqual(storedHashes);
+  });
+
+  it('accepts a baseline whose version matches the cursor', () => {
+    expect(
+      storedBaselineHashes(
+        {
+          importedTurnHashes: [...sourceHashes],
+          hashVersion: HASH_VERSION_V1,
+          storedHistoryBaseline: baseline(HASH_VERSION_V1),
+        },
+        sourceHashes
+      )
+    ).toEqual(storedHashes);
+    expect(
+      storedBaselineHashes(
+        {
+          importedTurnHashes: [...sourceHashes],
+          hashVersion: HASH_VERSION_V2,
+          storedHistoryBaseline: baseline(HASH_VERSION_V2),
+        },
+        sourceHashes
+      )
+    ).toEqual(storedHashes);
+  });
+
+  it('rejects a v1 baseline against a v2 cursor', () => {
+    expect(
+      storedBaselineHashes(
+        {
+          importedTurnHashes: [...sourceHashes],
+          hashVersion: HASH_VERSION_V2,
+          storedHistoryBaseline: baseline(HASH_VERSION_V1),
+        },
+        sourceHashes
+      )
+    ).toEqual(sourceHashes);
+  });
+
+  it('rejects a v2 baseline against a v1 cursor', () => {
+    expect(
+      storedBaselineHashes(
+        {
+          importedTurnHashes: [...sourceHashes],
+          hashVersion: HASH_VERSION_V1,
+          storedHistoryBaseline: baseline(HASH_VERSION_V2),
+        },
+        sourceHashes
+      )
+    ).toEqual(sourceHashes);
+  });
+
+  it('rejects a versioned baseline against an unversioned (v1) cursor when versions differ', () => {
+    expect(
+      storedBaselineHashes(
+        {
+          importedTurnHashes: [...sourceHashes],
+          storedHistoryBaseline: baseline(HASH_VERSION_V2),
+        },
+        sourceHashes
+      )
+    ).toEqual(sourceHashes);
   });
 });
 

--- a/apps/cli/tests/local-project-history-sync-service.test.ts
+++ b/apps/cli/tests/local-project-history-sync-service.test.ts
@@ -11,13 +11,22 @@ import type {
   SessionMeta,
 } from '@lody/shared';
 
+import { parseSessionNotification, type AcpSessionNotification } from '@lody/shared';
+
 import {
   buildExistingHistorySessionIndex,
   compareCatalogItems,
   decideHistoryConflictResolution,
   decideHistoryRefresh,
   getHistoryCatalogStatus,
+  HASH_VERSION_V1,
+  HASH_VERSION_V2,
+  hashHistoryEntry,
+  hashHistoryEntryForVersion,
+  hashHistoryEntryV2,
+  hashText,
   LocalProjectHistorySyncService,
+  materializeReplay,
   selectLatestCatalogItems,
 } from '../src/lib/local-project-history-sync-service';
 
@@ -80,6 +89,7 @@ function materializedReplay(
     turnHashes: string[];
     replayDigest: string;
     droppedNotifications: number;
+    hashVersion: number;
   }> = {}
 ) {
   return {
@@ -87,6 +97,8 @@ function materializedReplay(
     turnHashes: ['hash-1'],
     replayDigest: 'digest-new',
     droppedNotifications: 0,
+    // The opaque placeholder hashes above are already in the stored v1 form.
+    hashVersion: 1,
     ...overrides,
   };
 }
@@ -330,6 +342,259 @@ describe('decideHistoryConflictResolution', () => {
       status: 'blocked',
       reason: 'session_has_pending_local_turn',
     });
+  });
+});
+
+describe('canonical hash versions', () => {
+  const acpSessionId = 'codex-session-1' as ACPSessionId;
+
+  const notification = (update: unknown): AcpSessionNotification =>
+    parseSessionNotification({ sessionId: acpSessionId, update });
+
+  /** Two turns: a user prompt and an assistant turn with one tool call. */
+  function replayNotifications(toolCall: Record<string, unknown>, turns = 1) {
+    const result: AcpSessionNotification[] = [];
+    for (let turn = 0; turn < turns; turn += 1) {
+      result.push(
+        notification({
+          sessionUpdate: 'user_message_chunk',
+          content: { type: 'text', text: `inspect repo ${turn}` },
+        }),
+        notification({
+          sessionUpdate: 'tool_call_update',
+          toolCallId: `tool-${turn}`,
+          ...toolCall,
+        }),
+        notification({
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: `done ${turn}` },
+        })
+      );
+    }
+    return result;
+  }
+
+  const fullToolCall = {
+    kind: 'read',
+    title: 'Read package.json',
+    status: 'completed',
+    content: [{ type: 'content', content: { type: 'text', text: '{}' } }],
+    locations: [{ path: 'package.json' }],
+    rawInput: { path: 'package.json' },
+    rawOutput: { output: '{}' },
+    toolName: 'Read',
+    schedulingTimeZone: 'America/Los_Angeles',
+    activityKind: 'context_compaction',
+    permissionRequest: { requestId: 'req-1', options: [] },
+  };
+
+  /** The same tool call as a sealed skeleton: payload replaced by a local ref. */
+  const skeletonToolCall = {
+    kind: 'read',
+    title: 'Read package.json',
+    status: 'completed',
+    locations: [{ path: 'package.json' }],
+    ref: { machineId: 'machine-1', turnId: 'turn-1', index: 0 },
+  };
+
+  const hashEntry = (items: unknown[]) =>
+    ({
+      role: 'assistant' as const,
+      items: items as SessionHistoryInput['items'],
+      plan: [],
+    }) as unknown as SessionHistoryInput;
+
+  const materialize = (toolCall: Record<string, unknown>, turns = 1) =>
+    materializeReplay({
+      provider,
+      acpSessionId,
+      replayNotifications: replayNotifications(toolCall, turns),
+      userId: 'user-1',
+    });
+
+  it('records the version with the materialized replay', () => {
+    const materialized = materialize(fullToolCall);
+    expect(materialized.hashVersion).toBe(HASH_VERSION_V2);
+    expect(materialized.turnHashes).toHaveLength(2);
+    expect(materialized.turnHashes).toEqual(
+      materialized.history.map((entry) => hashHistoryEntryForVersion(entry, HASH_VERSION_V2))
+    );
+    // Entry ids stay content-addressed, now from the v2 hashes.
+    materialized.history.forEach((entry, index) => {
+      expect(entry.id.endsWith(materialized.turnHashes[index]!.slice(0, 16))).toBe(true);
+    });
+  });
+
+  it('hashes a full tool_call and its sealed skeleton identically under v2', () => {
+    // Canonicalization is a pure function of transcript content; going through a replay
+    // would normalize the payload away before the hash ever sees it.
+    const full = hashEntry([
+      { type: 'tool_call', toolCallId: 'call-1', ...fullToolCall },
+    ]) as unknown as Parameters<typeof hashHistoryEntryV2>[0];
+    const skeleton = hashEntry([
+      { type: 'tool_call', ref: { machineId: 'm', turnId: 't', index: 0 }, ...skeletonToolCall },
+    ]) as unknown as Parameters<typeof hashHistoryEntryV2>[0];
+    expect(hashHistoryEntryV2(full)).toBe(hashHistoryEntryV2(skeleton));
+    expect(hashHistoryEntryForVersion(full, HASH_VERSION_V2)).toBe(
+      hashHistoryEntryForVersion(skeleton, HASH_VERSION_V2)
+    );
+    // v1 hashed the items verbatim, which is exactly why v2 exists.
+    expect(hashHistoryEntry(full)).not.toBe(hashHistoryEntry(skeleton));
+  });
+
+  it('treats tool_call title null, undefined, and missing identically under v2', () => {
+    const withNull = hashEntry([
+      { type: 'tool_call', title: null, status: 'completed', kind: 'read' },
+    ]) as unknown as Parameters<typeof hashHistoryEntryV2>[0];
+    const withUndefined = hashEntry([
+      { type: 'tool_call', title: undefined, status: 'completed', kind: 'read' },
+    ]) as unknown as Parameters<typeof hashHistoryEntryV2>[0];
+    const without = hashEntry([
+      { type: 'tool_call', status: 'completed', kind: 'read' },
+    ]) as unknown as Parameters<typeof hashHistoryEntryV2>[0];
+    expect(hashHistoryEntryV2(withNull)).toBe(hashHistoryEntryV2(without));
+    expect(hashHistoryEntryV2(withUndefined)).toBe(hashHistoryEntryV2(without));
+  });
+
+  it('rejects an unknown hash version instead of guessing', () => {
+    const [entry] = materialize(fullToolCall).history;
+    expect(() => hashHistoryEntryForVersion(entry!, 3)).toThrow(/Unsupported history hash version/);
+  });
+
+  it('appends a v2 replay against a v1 cursor instead of reporting prefix_mismatch', () => {
+    const replay = materialize(fullToolCall);
+    // A legacy cursor: v1 hashes with no version field anywhere on the cursor, while the
+    // metadata digest already advanced to v2. Without version pairing this manufactured a
+    // prefix_mismatch because the v1 cursor was compared against v2 replay hashes. The
+    // replay is longer than the cursor's own prefix, so the decision must not conflict.
+    const v1Hashes = replay.history.map((entry) =>
+      hashHistoryEntryForVersion(entry, HASH_VERSION_V1)
+    );
+    const decision = decideHistoryRefresh({
+      externalHistory: externalHistory({
+        hashVersion: HASH_VERSION_V2,
+        replayDigest: 'advanced-v2-digest',
+        importedTurnCount: v1Hashes.length,
+      }),
+      importedTurnHashes: v1Hashes,
+      importedTurnHashVersion: HASH_VERSION_V1,
+      replayDigest: replay.replayDigest,
+      turnHashes: replay.turnHashes,
+      materialized: replay,
+      currentHistoryHashes: v1Hashes,
+    });
+    expect(decision.status).not.toBe('conflicted');
+    expect(decision).toEqual({
+      status: 'skipped',
+      reason: 'empty_suffix',
+      appendFromIndex: v1Hashes.length,
+    });
+  });
+
+  it('recognizes a v2 replay suffix against a shorter v1 cursor', () => {
+    // The same transcript at two source lengths, so the v1 cursor is a real prefix.
+    const cursorReplay = materialize(fullToolCall, 1);
+    const replay = materialize(fullToolCall, 2);
+    const v1Hashes = cursorReplay.history.map((entry) =>
+      hashHistoryEntryForVersion(entry, HASH_VERSION_V1)
+    );
+    expect(
+      decideHistoryRefresh({
+        externalHistory: externalHistory({
+          hashVersion: HASH_VERSION_V2,
+          replayDigest: cursorReplay.replayDigest,
+          importedTurnCount: v1Hashes.length,
+        }),
+        importedTurnHashes: v1Hashes,
+        importedTurnHashVersion: HASH_VERSION_V1,
+        replayDigest: replay.replayDigest,
+        turnHashes: replay.turnHashes,
+        materialized: replay,
+      })
+    ).toEqual({
+      status: 'refreshed',
+      reason: 'prefix_append',
+      appendFromIndex: v1Hashes.length,
+    });
+  });
+
+  it('treats an already-synced v1 session as already_resolved against a v2 replay', () => {
+    const replay = materialize(fullToolCall);
+    const v1Hashes = replay.history.map((entry) =>
+      hashHistoryEntryForVersion(entry, HASH_VERSION_V1)
+    );
+    expect(
+      decideHistoryConflictResolution({
+        externalHistory: externalHistory({
+          status: 'synced',
+          hashVersion: HASH_VERSION_V2,
+          replayDigest: replay.replayDigest,
+          importedTurnCount: v1Hashes.length,
+        }),
+        importedTurnHashes: v1Hashes,
+        importedTurnHashVersion: HASH_VERSION_V1,
+        materialized: replay,
+        currentHistoryHashes: v1Hashes,
+        currentHistoryHasPendingDispatch: false,
+      })
+    ).toEqual({ status: 'already_resolved' });
+  });
+
+  it('recomputes a v2 replay in the cursor version when only the metadata advanced', () => {
+    const replay = materialize(fullToolCall);
+    const v1Hashes = replay.history.map((entry) =>
+      hashHistoryEntryForVersion(entry, HASH_VERSION_V1)
+    );
+    // markConflict writes only the meta: its digest is v2 while the doc cursor stays v1.
+    expect(
+      decideHistoryConflictResolution({
+        externalHistory: externalHistory({
+          status: 'sync_conflict',
+          hashVersion: HASH_VERSION_V2,
+          replayDigest: replay.replayDigest,
+          importedTurnCount: v1Hashes.length,
+        }),
+        importedTurnHashes: v1Hashes,
+        importedTurnHashVersion: HASH_VERSION_V1,
+        materialized: replay,
+        currentHistoryHashes: [...v1Hashes, 'local-only'],
+        currentHistoryHasPendingDispatch: false,
+      })
+    ).toEqual({ status: 'replace' });
+  });
+
+  it('refuses to compare mismatched versions without the replay history', () => {
+    const replay = materialize(fullToolCall);
+    expect(() =>
+      decideHistoryRefresh({
+        externalHistory: externalHistory({ hashVersion: HASH_VERSION_V2 }),
+        importedTurnHashes: ['v1-hash'],
+        importedTurnHashVersion: HASH_VERSION_V1,
+        replayDigest: hashText('v2'),
+        turnHashes: replay.turnHashes,
+        replayHashVersion: HASH_VERSION_V2,
+      })
+    ).toThrow(/materialized replay history/);
+  });
+
+  it('re-imports an unchanged transcript to identical v2 hashes and ids', () => {
+    const first = materialize(fullToolCall);
+    const second = materialize(fullToolCall);
+    expect(second.turnHashes).toEqual(first.turnHashes);
+    expect(second.replayDigest).toBe(first.replayDigest);
+    expect(second.history.map((entry) => entry.id)).toEqual(first.history.map((entry) => entry.id));
+    expect(
+      decideHistoryRefresh({
+        externalHistory: externalHistory({
+          hashVersion: HASH_VERSION_V2,
+          replayDigest: first.replayDigest,
+          importedTurnCount: first.turnHashes.length,
+        }),
+        replayDigest: second.replayDigest,
+        turnHashes: second.turnHashes,
+        materialized: second,
+      })
+    ).toEqual({ status: 'skipped', reason: 'digest_match' });
   });
 });
 

--- a/apps/cli/tests/local-project-history-sync-writer.test.ts
+++ b/apps/cli/tests/local-project-history-sync-writer.test.ts
@@ -15,7 +15,12 @@ import {
   type WorkspaceId,
 } from '@lody/shared';
 
-import { LocalProjectHistorySyncService } from '../src/lib/local-project-history-sync-service';
+import {
+  HASH_VERSION_V1,
+  hashHistoryEntryForVersion,
+  hashText,
+  LocalProjectHistorySyncService,
+} from '../src/lib/local-project-history-sync-service';
 import { SessionDocument, type LoroDocumentManager } from '../src/lib/loro/doc';
 import type { Logger } from '../src/utils/logger';
 
@@ -150,8 +155,22 @@ async function createHarness() {
     const loro = await rawDoc();
     location(loro).set('endColumn', 12);
     loro.commit();
-    const cursor = await doc.getExternalHistoryCursor();
-    await doc.setExternalHistoryCursor({ importedTurnHashes: cursor?.importedTurnHashes });
+    // Model a real v1 client: recompute the source hashes in v1 and write a cursor shape
+    // that predates `hashVersion`. Neither the hashes nor their version are v2, so the
+    // stored cursor is internally consistent instead of wearing a v2 array as v1.
+    const stored = loro.getList('history').toJSON() as SessionHistoryInput[];
+    const importedTurnHashes = stored.map((entry) =>
+      hashHistoryEntryForVersion(entry, HASH_VERSION_V1)
+    );
+    await doc.setExternalHistoryCursor({
+      importedTurnHashes,
+      storedHistoryBaseline: JSON.stringify({
+        version: 1,
+        hashVersion: HASH_VERSION_V1,
+        sourceDigest: hashText(importedTurnHashes.join('\n')),
+        turnHashes: stored.map((entry) => hashHistoryEntryForVersion(entry, HASH_VERSION_V1)),
+      }),
+    });
     return loro;
   }
   return { repo, service, importTurns, getOnlyDoc, getMeta, rawDoc, makeLegacy };

--- a/apps/cli/tests/local-project-history-sync-writer.test.ts
+++ b/apps/cli/tests/local-project-history-sync-writer.test.ts
@@ -155,9 +155,9 @@ async function createHarness() {
     const loro = await rawDoc();
     location(loro).set('endColumn', 12);
     loro.commit();
-    // Model a real v1 client: recompute the source hashes in v1 and write a cursor shape
-    // that predates `hashVersion`. Neither the hashes nor their version are v2, so the
-    // stored cursor is internally consistent instead of wearing a v2 array as v1.
+    // Model a real pre-version client: v1 hashes AND a cursor/baseline shape that has no
+    // `hashVersion` field anywhere. A baseline that carries `hashVersion: 1` is a shape
+    // only this build can write and would hide the "unversioned baseline is v1" rule.
     const stored = loro.getList('history').toJSON() as SessionHistoryInput[];
     const importedTurnHashes = stored.map((entry) =>
       hashHistoryEntryForVersion(entry, HASH_VERSION_V1)
@@ -166,7 +166,6 @@ async function createHarness() {
       importedTurnHashes,
       storedHistoryBaseline: JSON.stringify({
         version: 1,
-        hashVersion: HASH_VERSION_V1,
         sourceDigest: hashText(importedTurnHashes.join('\n')),
         turnHashes: stored.map((entry) => hashHistoryEntryForVersion(entry, HASH_VERSION_V1)),
       }),
@@ -397,4 +396,33 @@ describe('history import through the real SessionDocument writer', () => {
     );
     expect((await harness.getMeta(sessionId)).externalHistory?.status).toBe('synced');
   });
+});
+
+it('accepts a genuine unversioned v1 stored baseline after upgrade', async () => {
+  // Regression: the baseline guard compared `parsed.hashVersion` directly against the
+  // cursor version, so every real pre-version baseline (`undefined !== 1`) was ignored.
+  // That discarded the projected stored history and turned a normal append into
+  // `local_history_has_untracked_suffix`. The cursor and the baseline here are the exact
+  // shape an old client writes: no `hashVersion` field anywhere.
+  const h = await createHarness();
+  await h.importTurns(1);
+  const { doc } = h.getOnlyDoc();
+  const loro = await h.rawDoc();
+  const source = loro.getList('history').toJSON() as SessionHistoryInput[];
+  const hashes = source.map((entry) => hashHistoryEntryForVersion(entry, HASH_VERSION_V1));
+  // A prior importer projected away an extension; its saved baseline represents the
+  // actual stored turns independently of the source transcript hashes.
+  location(loro).delete('endColumn');
+  loro.commit();
+  const stored = loro.getList('history').toJSON() as SessionHistoryInput[];
+  await doc.setExternalHistoryCursor({
+    importedTurnHashes: hashes,
+    storedHistoryBaseline: JSON.stringify({
+      version: 1,
+      sourceDigest: hashText(hashes.join('\n')),
+      turnHashes: stored.map((entry) => hashHistoryEntryForVersion(entry, HASH_VERSION_V1)),
+    }),
+  });
+
+  expect((await h.importTurns(2)).summary).toMatchObject({ refreshed: 1, conflicted: 0 });
 });

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -17,9 +17,11 @@
 - New inputs use the shared message parsers. Known protocol extension dictionaries
   retain JSON data, not arbitrary JS objects. Storage layout stays separate and is an
   insertion policy, never a migration or a validation constraint: new writes store
-  ordinary metadata strings as primitives and create `LoroText` only for streaming
-  fields declared in `schema.ts`; stored values keep their representation, and opening a
-  document never rewraps them. Rationale:
+  ordinary metadata strings as primitives and create `LoroText` only for fields that
+  stream. That holds at every nesting level — a tool content or worktree-step `command`,
+  `path`, `args` or terminal id is metadata, so only payloads like tool `text`/`output`
+  and nested `content.text` are declared Text in `schema.ts`. Stored values keep their
+  representation, and opening a document never rewraps them. Rationale:
   [single writer](../../.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md).
 - Parser coverage must include nested discriminators (`system_notice.name`) and
   correlated metadata, not just item `type`. Fork regression tests must cross the

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -15,9 +15,12 @@
   diagnostics; they must not leave partial history writes. Keep stored unknown fields
   and unchanged opaque items; do not sanitize/rewrite a whole stored document.
 - New inputs use the shared message parsers. Known protocol extension dictionaries
-  retain JSON data, not arbitrary JS objects. Storage layout stays separate: coordinate
-  any `Any.storageSchema` adoption with its Mirror patch, including rollback.
-  Rationale: [single writer](../../.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md).
+  retain JSON data, not arbitrary JS objects. Storage layout stays separate and is an
+  insertion policy, never a migration or a validation constraint: new writes store
+  ordinary metadata strings as primitives and create `LoroText` only for streaming
+  fields declared in `schema.ts`; stored values keep their representation, and opening a
+  document never rewraps them. Rationale:
+  [single writer](../../.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md).
 - Parser coverage must include nested discriminators (`system_notice.name`) and
   correlated metadata, not just item `type`. Fork regression tests must cross the
   actual SessionDocument/HistoryWriter boundary; a mock updateHistory cannot prove it.
@@ -41,17 +44,19 @@
 - Steer provenance is a declared history input-config field, not an unknown extension.
   Both new writes and read normalization must retain it for edit-and-resend checks.
 - Scalar/fileDiff writes read and diff only the requested field, never the turn's items.
-  Writer input parsers derive from schema definitions with all refinements retained;
-  never mutate the original RPC schemas. Parsing filters and validates in one pass.
-  `readStored` returns detached JSON for hashing, not stored-copy provenance. Keep `capture`
-  protection for callers that can author copies from an old snapshot.
+  Parser schemas derive from schema definitions with refinements retained; never mutate the
+  original RPC schemas. Parsing filters and validates in one pass. `readStored` returns
+  detached JSON for hashing, not stored-copy provenance. Keep `capture` protection.
 - Target-local streaming uses `updateEntry`; it must not produce/plan the entire history.
   Resolve the live turn on each call, preserve immutable ids, and preflight before writing.
   Generic history updates remain for operations with cross-turn ownership or structural edits.
-- The pinned Mirror text-event patch copies only an existing single text leaf's path.
-  Preserve descriptors, old snapshots and subscriber delivery; structural/multi-event/tree
-  paths retain the general reader. Future Mirror patches must compose with this patch,
-  never silently replace it. No storage schema or write validation depends on this optimization.
+- Every canonical turn hash carries a version and is compared only against hashes of the
+  same version. A stored cursor without a version is v1. The session doc cursor versions its
+  own `importedTurnHashes`; the sync metadata versions its own `replayDigest` independently,
+  because a conflict marker may update only the metadata. Recompute a replay in the stored
+  cursor's version; never reinterpret the cursor. A mismatch with no replay history is an error.
+- Mirror's text-event optimization ships upstream in pinned `loro-mirror`; no local patch
+  exists and no storage schema or write validation depends on it.
 These contracts bind producers and consumers, including UI and CLI callers outside
 this package. Read them when changing daemon protocol negotiation, MCP/Role catalogs,
 per-turn MCP selection, or Role-based session creation and dispatch.

--- a/packages/shared/src/history-materializer.ts
+++ b/packages/shared/src/history-materializer.ts
@@ -79,7 +79,8 @@ export function getMapFieldSchema(
   if (!isMapSchema(schema)) return undefined;
   if (Object.prototype.hasOwnProperty.call(schema.definition, key)) {
     const field = schema.definition[key];
-    // #443's optional hints require coordinated adoption of its Mirror patch.
+    // `schema.ts` marks genuinely streaming fields with an explicit `storageSchema`
+    // insertion hint. It is a storage policy, never a validation constraint.
     const storage =
       field?.type === 'any'
         ? (field.options as InferContainerOptions & { storageSchema?: SchemaType }).storageSchema

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -204,19 +204,41 @@ const isWorktreeScriptHistoryStep = (value: unknown): boolean =>
   typeof value.output === 'string';
 
 /**
- * Insertion hints for the nested payloads that stream. Each block keeps its
- * current on-disk shape (strings as `LoroText`) without making the nested shape
- * a validation constraint, so a malformed legacy value cannot reject an
- * unrelated write. `history-materializer.ts` reads `storageSchema`; the hints are
- * inert for every reader.
+ * Insertion hints for the nested payloads of tool content and worktree steps.
+ *
+ * Nested metadata is ordinary data, so the catchall defaults to *primitive* and only
+ * the fields that genuinely stream are declared as `LoroText`. A blanket
+ * `defaultLoroText: true` here built Text for `terminal_command.command`, `args[]`,
+ * diff `path`, `steps[].command` and every other string — the container growth this
+ * change exists to remove. The catchall stays permissive so an anomalous legacy shape
+ * is never a validation failure or a rewrite trigger; `history-materializer.ts` reads
+ * `storageSchema`, and the hints are inert for every reader.
  */
-const historyStreamingChildren = schema.Any({ defaultLoroText: true });
+const historyNestedPayloadSchema = schema.Any({ defaultLoroText: false });
 const historyToolContentSchema = schema
-  .LoroMap({ type: schema.String({ required: false }) })
-  .catchall(historyStreamingChildren);
+  .LoroMap({
+    type: schema.String({ required: false }),
+    // Only streaming payload fields; everything else inherits the primitive catchall.
+    text: schema.LoroText({ required: false }),
+    output: schema.LoroText({ required: false }),
+    // The ACP `content` block nests its own text payload.
+    content: schema
+      .LoroMap(
+        {
+          type: schema.String({ required: false }),
+          text: schema.LoroText({ required: false }),
+        },
+        { required: false }
+      )
+      .catchall(historyNestedPayloadSchema),
+  })
+  .catchall(historyNestedPayloadSchema);
 const historyScriptStepSchema = schema
-  .LoroMap({ output: schema.LoroText({ required: false }) })
-  .catchall(historyStreamingChildren);
+  .LoroMap({
+    // Only the step output streams; `command`/`status`/timestamps are metadata.
+    output: schema.LoroText({ required: false }),
+  })
+  .catchall(historyNestedPayloadSchema);
 
 const historyMessageItemSchema = schema
   .LoroMap(

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -173,21 +173,27 @@ export type AgentConfigMeta = {
  * - TypeScript API: still treat `items` as `MessageContent[]` at the application boundary.
  *   All producers/consumers in CLI/Web should use `MessageContent` as the canonical type.
  *
- * Why not `schema.Any({ defaultLoroText: true })`:
- * - It enables deep Text inference for schema-less nested objects (catchalls), which can
- *   cause Mirror to generate `insert-container` for string values inside maps without a
- *   registered schema. After a restart, the per-container infer options are not persisted,
- *   so applying those diffs can fail with `Unknown schema type: undefined`.
+ * Insertion policy (NOT a migration or a new validation constraint):
+ * - The history item catchall is `schema.Any({ defaultLoroText: false })` so a brand-new
+ *   string field is stored as a plain primitive. An old turn's known metadata
+ *   (`toolCallId`/`status`/`title`/`kind`/`locations[].path`) is therefore not wrapped in
+ *   a `LoroText`, which removes thousands of unnecessary containers across a long session.
+ * - Text containers are reserved for fields that genuinely grow while streaming. They are
+ *   declared explicitly (outer `text`/`markdown`/`content`/`steps`) instead of leaning on
+ *   deep inference, which also avoids Mirror emitting `insert-container` for schema-less
+ *   nested strings and then failing to replay those diffs after a restart.
+ * - Editing an existing string neither migrates nor rewraps it: the shared
+ *   `HistoryWriter` diffs against the stored container kind, so a legacy `LoroText` keeps
+ *   its container id and a legacy primitive stays primitive (`history-materializer.ts`).
  *
- * Decision:
- * - Keep the schema forward-compatible via `.catchall(schema.Any())`.
- * - Model streaming fields explicitly as `schema.LoroText()` (e.g. `text`) to avoid relying
- *   on inference.
+ * Validation stays separate from this storage hint: the permissive `validate` guard below
+ * still accepts unknown/sealed item types from newer peers, and no schema here rejects an
+ * old payload (see the `storageSchema` hints).
  */
 export type SessionHistoryItem = MessageContent;
 export type SessionHistoryItems = MessageContent[];
 
-const historyItemAnySchema = schema.Any({ defaultLoroText: true });
+const historyItemAnySchema = schema.Any({ defaultLoroText: false });
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -197,11 +203,34 @@ const isWorktreeScriptHistoryStep = (value: unknown): boolean =>
   (value.status === 'in_progress' || value.status === 'completed' || value.status === 'failed') &&
   typeof value.output === 'string';
 
+/**
+ * Insertion hints for the nested payloads that stream. Each block keeps its
+ * current on-disk shape (strings as `LoroText`) without making the nested shape
+ * a validation constraint, so a malformed legacy value cannot reject an
+ * unrelated write. `history-materializer.ts` reads `storageSchema`; the hints are
+ * inert for every reader.
+ */
+const historyStreamingChildren = schema.Any({ defaultLoroText: true });
+const historyToolContentSchema = schema
+  .LoroMap({ type: schema.String({ required: false }) })
+  .catchall(historyStreamingChildren);
+const historyScriptStepSchema = schema
+  .LoroMap({ output: schema.LoroText({ required: false }) })
+  .catchall(historyStreamingChildren);
+
 const historyMessageItemSchema = schema
   .LoroMap(
     {
       type: schema.String<MessageContent['type']>(),
       text: schema.LoroText({ required: false }),
+      // Streaming fields: a hint, not a validation constraint on old/future payloads.
+      markdown: schema.Any({ storageSchema: schema.LoroText({ required: false }) }),
+      content: schema.Any({
+        storageSchema: schema.LoroList(historyToolContentSchema, undefined, { required: false }),
+      }),
+      steps: schema.Any({
+        storageSchema: schema.LoroList(historyScriptStepSchema, undefined, { required: false }),
+      }),
       // `file` item: the mutable lifecycle fields `transport`/`machineId` are
       // carried through the `.catchall(...)` below (like every other variant's
       // payload fields, e.g. image's `imageId`/`sizeBytes`). They are plain
@@ -510,6 +539,7 @@ export const sessionPreviewDocSchema = schema.LoroMap(
 export const sessionExternalHistoryCursorDocSchema = schema.LoroMap(
   {
     importedTurnHashes: schema.LoroList(schema.String(), undefined, { required: false }),
+    hashVersion: schema.Number({ required: false }),
     // One atomic value: concurrent clients must not merge half of two baselines.
     storedHistoryBaseline: schema.String({ required: false }),
   },
@@ -713,6 +743,12 @@ export type ExternalAcpHistorySyncMeta = {
   sourceAcpSessionId: ACPSessionId;
   sourceUpdatedAt?: string;
   replayDigest?: string;
+  /**
+   * Canonical-hash version `replayDigest` was computed with. Absent means v1
+   * (written before skeletons existed). It versions the digest only; the session
+   * doc cursor carries its own version for `importedTurnHashes`.
+   */
+  hashVersion?: number;
   importedTurnCount: number;
   /** @deprecated Legacy bulky cursor. New writes do not store per-turn hashes in meta. */
   importedTurnHashes?: string[];
@@ -739,6 +775,13 @@ export type SessionPreviewLegacyMetaFields = {
 
 export type SessionExternalHistoryCursorDocState = {
   importedTurnHashes?: string[];
+  /**
+   * Canonical-hash version `importedTurnHashes` were computed with. Absent means
+   * v1. It is deliberately independent of `ExternalAcpHistorySyncMeta.hashVersion`:
+   * `markConflict` may advance the metadata while this cursor stays v1, and a
+   * v1 cursor must never be read as v2 (that manufactures a false prefix_mismatch).
+   */
+  hashVersion?: number;
   /** Versioned JSON bound to this cursor's source hashes, not the metadata digest. */
   storedHistoryBaseline?: string;
 };

--- a/packages/shared/tests/history-storage-policy.test.ts
+++ b/packages/shared/tests/history-storage-policy.test.ts
@@ -71,9 +71,21 @@ const storedContainerKinds = (doc: Loro) => {
     'tool.locations[0].path': kindOf(
       ((tool.get('locations') as LoroList).get(0) as LoroMap).get('path')
     ),
+    // Tool-content metadata stays primitive; only genuinely streamed payloads are Text.
     'content[0].command': kindOf((content.get(0) as LoroMap).get('command')),
+    'content[0].args[0]': kindOf(((content.get(0) as LoroMap).get('args') as LoroList).get(0)),
+    'content[0].cwd': kindOf((content.get(0) as LoroMap).get('cwd')),
     'content[1].output': kindOf((content.get(1) as LoroMap).get('output')),
     'content[1].type': kindOf((content.get(1) as LoroMap).get('type')),
+    'content[2].content.text': kindOf(
+      ((content.get(2) as LoroMap).get('content') as LoroMap).get('text')
+    ),
+    'content[3].path': kindOf((content.get(3) as LoroMap).get('path')),
+    'content[3].newText': kindOf((content.get(3) as LoroMap).get('newText')),
+    'content[4].text': kindOf((content.get(4) as LoroMap).get('text')),
+    'content[5].input.nested': kindOf(
+      ((content.get(5) as LoroMap).get('input') as LoroMap).get('nested')
+    ),
     'steps[0].command': kindOf((steps.get(0) as LoroMap).get('command')),
     'steps[0].output': kindOf((steps.get(0) as LoroMap).get('output')),
   };
@@ -92,15 +104,31 @@ const richItems = (output = 'streaming output'): SessionHistory['items'] =>
     },
     toolCallItem({
       content: [
-        { type: 'terminal_command', command: 'pnpm test' },
+        {
+          type: 'terminal_command',
+          command: 'pnpm test',
+          args: ['run', 'test'],
+          cwd: '/repo',
+        },
         { type: 'terminal_output', output },
+        { type: 'content', content: { type: 'text', text: 'nested streamed text' } },
+        { type: 'diff', path: 'src/a.ts', newText: 'const a = 1;' },
+        { type: 'text', text: 'block text' },
+        { type: 'input', input: { nested: 'metadata value' } },
       ],
     }),
     {
       type: 'worktree_script',
       phase: 'setup',
       status: 'completed',
-      steps: [{ command: 'pnpm install', status: 'completed', output: 'ok' }],
+      steps: [
+        {
+          command: 'pnpm install',
+          status: 'completed',
+          output: 'ok',
+          exitStatus: { exitCode: 0 },
+        },
+      ],
     },
   ] as unknown as SessionHistory['items'];
 
@@ -124,10 +152,17 @@ describe('new history storage policy', () => {
         'tool.title': 'string',
         'tool.kind': 'string',
         'tool.locations[0].path': 'string',
-        'content[0].command': 'Text',
+        'content[0].command': 'string',
+        'content[0].args[0]': 'string',
+        'content[0].cwd': 'string',
         'content[1].output': 'Text',
         'content[1].type': 'string',
-        'steps[0].command': 'Text',
+        'content[2].content.text': 'Text',
+        'content[3].path': 'string',
+        'content[3].newText': 'string',
+        'content[4].text': 'Text',
+        'content[5].input.nested': 'string',
+        'steps[0].command': 'string',
         'steps[0].output': 'Text',
       });
     } finally {

--- a/packages/shared/tests/history-storage-policy.test.ts
+++ b/packages/shared/tests/history-storage-policy.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it } from 'vitest';
+import { Loro, LoroList, LoroMap, LoroText, isContainer } from 'loro-crdt';
+import { createSessionMirror } from '../src/session-mirror';
+import type { SessionId } from '../src/ids';
+import type { SessionHistory } from '../src/schema';
+
+/**
+ * Storage policy for newly written history items:
+ *
+ * - A plain metadata string (`toolCallId`/`status`/`title`/`kind`/`locations[].path`)
+ *   becomes a primitive, not a `LoroText`.
+ * - Only fields that stream (`text`/`thought`, `markdown`, `tool_call.content`,
+ *   `worktree_script.steps`) create Text containers.
+ *
+ * The second half proves the policy is insertion-only: opening old storage performs no
+ * writes, and same-type string edits keep whatever representation is already stored.
+ */
+
+const id = 'synthetic-session' as SessionId;
+const open = (doc: Loro) =>
+  createSessionMirror({ doc, initialState: { session: { id }, history: [] } });
+const kindOf = (value: unknown): string => (isContainer(value) ? value.kind() : typeof value);
+/** Read a stored map entry whether it is a primitive or a `LoroText`. */
+const readString = (value: unknown): string =>
+  isContainer(value) ? (value as LoroText).toJSON() : (value as string);
+
+const toolCallItem = (overrides: Record<string, unknown> = {}) =>
+  ({
+    type: 'tool_call',
+    toolCallId: 'tool-1',
+    status: 'in_progress',
+    title: 'Run tests',
+    kind: 'execute',
+    locations: [{ path: 'packages/shared/src/schema.ts' }],
+    content: [
+      { type: 'terminal_command', command: 'pnpm test' },
+      { type: 'terminal_output', output: 'streaming output' },
+    ],
+    ...overrides,
+  }) as unknown as SessionHistory['items'][number];
+
+const turn = (turnId: string, items: SessionHistory['items']): SessionHistory => ({
+  id: turnId,
+  role: 'assistant',
+  timestamp: '2026-01-01T00:00:00Z',
+  items,
+  fileDiff: [],
+});
+
+const storedContainerKinds = (doc: Loro) => {
+  const row = doc.getList('history').get(0) as LoroMap;
+  const items = row.get('items') as LoroList;
+  const text = items.get(0) as LoroMap;
+  const thought = items.get(1) as LoroMap;
+  const plan = items.get(2) as LoroMap;
+  const tool = items.get(3) as LoroMap;
+  const content = tool.get('content') as LoroList;
+  const script = items.get(4) as LoroMap;
+  const steps = script.get('steps') as LoroList;
+  return {
+    'row.id': kindOf(row.get('id')),
+    'row.role': kindOf(row.get('role')),
+    'text.text': kindOf(text.get('text')),
+    'thought.text': kindOf(thought.get('text')),
+    'plan.markdown': kindOf(plan.get('markdown')),
+    'tool.type': kindOf(tool.get('type')),
+    'tool.toolCallId': kindOf(tool.get('toolCallId')),
+    'tool.status': kindOf(tool.get('status')),
+    'tool.title': kindOf(tool.get('title')),
+    'tool.kind': kindOf(tool.get('kind')),
+    'tool.locations[0].path': kindOf(
+      ((tool.get('locations') as LoroList).get(0) as LoroMap).get('path')
+    ),
+    'content[0].command': kindOf((content.get(0) as LoroMap).get('command')),
+    'content[1].output': kindOf((content.get(1) as LoroMap).get('output')),
+    'content[1].type': kindOf((content.get(1) as LoroMap).get('type')),
+    'steps[0].command': kindOf((steps.get(0) as LoroMap).get('command')),
+    'steps[0].output': kindOf((steps.get(0) as LoroMap).get('output')),
+  };
+};
+
+const richItems = (output = 'streaming output'): SessionHistory['items'] =>
+  [
+    { type: 'text', text: 'hello' },
+    { type: 'thought', text: 'thinking' },
+    {
+      type: 'proposed_plan',
+      turnId: 'plan-1',
+      markdown: '# plan',
+      status: 'delta',
+      isLatest: true,
+    },
+    toolCallItem({
+      content: [
+        { type: 'terminal_command', command: 'pnpm test' },
+        { type: 'terminal_output', output },
+      ],
+    }),
+    {
+      type: 'worktree_script',
+      phase: 'setup',
+      status: 'completed',
+      steps: [{ command: 'pnpm install', status: 'completed', output: 'ok' }],
+    },
+  ] as unknown as SessionHistory['items'];
+
+const richTurn = (output = 'streaming output'): SessionHistory => turn('rich', richItems(output));
+
+describe('new history storage policy', () => {
+  it('stores metadata as primitives and only streaming fields as Text', () => {
+    const doc = new Loro();
+    const mirror = open(doc);
+    try {
+      mirror.historyWriter.append(richTurn());
+      expect(storedContainerKinds(doc)).toEqual({
+        'row.id': 'string',
+        'row.role': 'string',
+        'text.text': 'Text',
+        'thought.text': 'Text',
+        'plan.markdown': 'Text',
+        'tool.type': 'string',
+        'tool.toolCallId': 'string',
+        'tool.status': 'string',
+        'tool.title': 'string',
+        'tool.kind': 'string',
+        'tool.locations[0].path': 'string',
+        'content[0].command': 'Text',
+        'content[1].output': 'Text',
+        'content[1].type': 'string',
+        'steps[0].command': 'Text',
+        'steps[0].output': 'Text',
+      });
+    } finally {
+      mirror.dispose();
+    }
+  });
+
+  it('keeps a streamed tool output Text container across repeated updates', () => {
+    const doc = new Loro();
+    const mirror = open(doc);
+    try {
+      mirror.historyWriter.append(richTurn());
+      const tool = ((doc.getList('history').get(0) as LoroMap).get('items') as LoroList).get(
+        3
+      ) as LoroMap;
+      const content = tool.get('content') as LoroList;
+      const containerId = (content.get(1) as LoroMap).get('output') as LoroText;
+      for (const output of ['streaming output', 'streaming output + more']) {
+        mirror.historyWriter.replace('rich', richTurn(output));
+      }
+      expect(doc.getContainerById(containerId.id)?.toJSON()).toBe('streaming output + more');
+    } finally {
+      mirror.dispose();
+    }
+  });
+});
+
+describe('legacy storage is insertion-only', () => {
+  /** Build a stored turn by hand so we control the pre-existing container kind. */
+  function seedDoc(options: { pathAsText: boolean; unknownFields?: boolean }) {
+    const doc = new Loro();
+    const row = doc.getList('history').pushContainer(new LoroMap());
+    row.set('id', 'legacy');
+    row.set('role', 'assistant');
+    row.set('timestamp', '2026-01-01T00:00:00Z');
+    if (options.unknownFields) {
+      row.set('futureTurnField', 7);
+      row.set('sendStatus', 'timeout');
+    }
+    const items = row.setContainer('items', new LoroList());
+    const tool = items.pushContainer(new LoroMap());
+    tool.set('type', 'tool_call');
+    tool.set('toolCallId', 'tool-legacy');
+    tool.set('status', 'completed');
+    tool.set('title', 'Read file');
+    tool.set('kind', 'read');
+    if (options.unknownFields) tool.set('futureToolField', 'kept');
+    const locations = tool.setContainer('locations', new LoroList());
+    const location = locations.pushContainer(new LoroMap());
+    // The pre-#443 writer stored metadata strings as Text. A legacy peer may also have
+    // stored a primitive; both layouts must survive an unrelated edit.
+    if (options.pathAsText) {
+      (location.setContainer('path', new LoroText()) as LoroText).insert(
+        0,
+        'packages/shared/src/schema.ts'
+      );
+    } else {
+      location.set('path', 'packages/shared/src/schema.ts');
+    }
+    const content = tool.setContainer('content', new LoroList());
+    const output = content.pushContainer(new LoroMap());
+    output.set('type', 'terminal_output');
+    (output.setContainer('output', new LoroText()) as LoroText).insert(0, 'legacy output');
+    doc.commit();
+    return { doc, tool, location, output };
+  }
+
+  for (const pathAsText of [true, false]) {
+    it(`edits a legacy ${pathAsText ? 'Text' : 'primitive'} path in place without migrating it`, () => {
+      const { doc, location } = seedDoc({ pathAsText });
+      const pathBefore = location.get('path');
+      const versionBefore = doc.version().toJSON();
+      const mirror = open(doc);
+      try {
+        // Opening/reading must not write anything.
+        expect(doc.version().toJSON()).toEqual(versionBefore);
+        mirror.historyWriter.setField('legacy', 'finished', true);
+        expect(doc.toJSON().history[0].finished).toBe(true);
+        // The unrelated control-field write did not touch the stored path layout.
+        expect(kindOf(location.get('path'))).toBe(pathAsText ? 'Text' : 'string');
+        expect(readString(location.get('path'))).toBe('packages/shared/src/schema.ts');
+        // A Text path keeps its exact container identity; a primitive stays primitive.
+        const after = location.get('path');
+        if (pathAsText) expect((after as LoroText).id).toBe((pathBefore as LoroText).id);
+        else expect(readString(after)).toBe('packages/shared/src/schema.ts');
+      } finally {
+        mirror.dispose();
+      }
+    });
+  }
+
+  it('retains unknown stored fields and does not rewrite the legacy turn', () => {
+    const { doc, tool } = seedDoc({ pathAsText: true, unknownFields: true });
+    const before = doc.toJSON().history[0];
+    const toolJsonBefore = tool.toJSON();
+    const mirror = open(doc);
+    try {
+      mirror.historyWriter.append(turn('appended', [{ type: 'text', text: 'next' } as never]));
+      const rows = doc.toJSON().history as Array<Record<string, unknown>>;
+      expect(rows[0]).toEqual(before);
+      expect(rows[1].id).toBe('appended');
+      expect(tool.toJSON()).toEqual(toolJsonBefore);
+    } finally {
+      mirror.dispose();
+    }
+  });
+
+  it('updates one item while retaining an unchanged opaque item verbatim', () => {
+    const { doc } = seedDoc({ pathAsText: true, unknownFields: true });
+    const row = doc.getList('history').get(0) as LoroMap;
+    const items = row.get('items') as LoroList;
+    const appended = items.pushContainer(new LoroMap());
+    appended.set('type', 'future_item');
+    appended.set('payload', { nested: true });
+    doc.commit();
+    const opaqueBefore = appended.toJSON();
+    const mirror = open(doc);
+    try {
+      mirror.historyWriter.updateEntry('legacy', (entry) => ({
+        ...entry,
+        finished: true,
+      }));
+      expect(doc.toJSON().history[0].finished).toBe(true);
+      expect((items.get(1) as LoroMap).toJSON()).toEqual(opaqueBefore);
+    } finally {
+      mirror.dispose();
+    }
+  });
+});
+
+describe('malformed legacy values do not block unrelated writes', () => {
+  it('accepts an unrelated edit while an unparsed legacy list value stays stored', () => {
+    const doc = new Loro();
+    const row = doc.getList('history').pushContainer(new LoroMap());
+    row.set('id', 'odd');
+    row.set('role', 'assistant');
+    row.set('timestamp', 'old');
+    const items = row.setContainer('items', new LoroList());
+    const tool = items.pushContainer(new LoroMap());
+    tool.set('type', 'tool_call');
+    tool.set('toolCallId', 'tool-odd');
+    tool.set('status', 'completed');
+    // Homogeneous legacy key, heterogeneous shape: `locations` is a Map, not a list.
+    const locations = tool.setContainer('locations', new LoroMap());
+    locations.set('legacy', 'shape');
+    doc.commit();
+    const mirror = open(doc);
+    try {
+      // Editing an independent field must not reparse or reject the odd payload.
+      mirror.historyWriter.setField('odd', 'finished', true);
+      expect(doc.toJSON().history[0].finished).toBe(true);
+      expect(doc.toJSON().history[0].items[0].locations).toEqual({ legacy: 'shape' });
+    } finally {
+      mirror.dispose();
+    }
+  });
+});
+
+describe('two real peers exchange both representations', () => {
+  it('keeps the new primitive layout and a legacy Text layout consistent across peers', () => {
+    const a = new Loro();
+    const b = new Loro();
+    a.setPeerId('1');
+    b.setPeerId('2');
+    const mirrorA = open(a);
+    const mirrorB = open(b);
+    try {
+      // A writes a new turn with the primitive metadata policy.
+      mirrorA.historyWriter.append(richTurn());
+      b.import(a.export({ mode: 'snapshot' }));
+      const mirrorB2 = open(b);
+      const tool = ((b.getList('history').get(0) as LoroMap).get('items') as LoroList).get(
+        3
+      ) as LoroMap;
+      expect(tool.get('toolCallId')).toBe('tool-1');
+      expect(kindOf(tool.get('toolCallId'))).toBe('string');
+
+      // B concurrently updates the streamed output Text while A updates a scalar field.
+      const content = tool.get('content') as LoroList;
+      const output = (content.get(1) as LoroMap).get('output') as LoroText;
+      output.update('streaming output + peer');
+      b.commit();
+      mirrorA.historyWriter.setField('rich', 'finished', true);
+
+      a.import(b.export({ mode: 'update', from: a.version() }));
+      b.import(a.export({ mode: 'update', from: b.version() }));
+      expect(a.toJSON()).toEqual(b.toJSON());
+      expect(a.toJSON().history[0].finished).toBe(true);
+      expect(a.toJSON().history[0].items[3].content[1].output).toBe('streaming output + peer');
+      mirrorB2.dispose();
+    } finally {
+      mirrorA.dispose();
+      mirrorB.dispose();
+    }
+  });
+});
+
+describe('opening stored history is read-only', () => {
+  it('hydrates a legacy doc without changing its version or layout', () => {
+    const doc = new Loro();
+    const row = doc.getList('history').pushContainer(new LoroMap());
+    row.set('id', 'legacy');
+    row.set('role', 'user');
+    row.set('timestamp', 'old');
+    const items = row.setContainer('items', new LoroList());
+    const text = items.pushContainer(new LoroMap());
+    text.set('type', 'text');
+    (text.setContainer('text', new LoroText()) as LoroText).insert(0, 'old body');
+    doc.commit();
+    const version = doc.version().toJSON();
+    const history = doc.getList('history').toJSON();
+    const mirror = open(doc);
+    try {
+      // Mirror initializes empty control containers in memory; the durable version is
+      // unchanged, which is what proves opening performed no writes.
+      expect(doc.version().toJSON()).toEqual(version);
+      expect(doc.getList('history').toJSON()).toEqual(history);
+      expect(mirror.getState().history[0]!.items![0]).toEqual({ type: 'text', text: 'old body' });
+    } finally {
+      mirror.dispose();
+    }
+  });
+});

--- a/packages/shared/tests/history-writer.test.ts
+++ b/packages/shared/tests/history-writer.test.ts
@@ -857,7 +857,7 @@ describe('single history writer', () => {
     mirror.dispose();
   });
 
-  it('uses the same new storage shape as Mirror before #443', () => {
+  it('uses the same new storage shape as a Mirror write', () => {
     const oldDoc = new Loro();
     const newDoc = new Loro();
     oldDoc.setPeerId('1');

--- a/specs/session-history-writes.md
+++ b/specs/session-history-writes.md
@@ -24,7 +24,12 @@ That tolerance must not authorize creating new malformed items locally.
   dictionaries remain JSON-valued. Preserve unknown stored fields and untouched
   unknown/damaged items; reading is not a migration or permission to scrub data.
 - Existing primitive strings remain primitive; existing Text edits retain their
-  container identity. Storage-layout changes are separately reviewed.
+  container identity. New writes store an ordinary metadata string (tool `title`/`status`/
+  `kind`/`toolCallId`, a `locations[].path`) as a primitive, and create a Text container
+  only for fields that stream (`text`/`thought`, `markdown`, tool `content`, worktree
+  `steps`). This is an insertion policy: it is not a migration, does not rewrap stored
+  values, and adds no validation constraint on old or sealed payloads. Storage-layout
+  changes are separately reviewed.
 - Fork is a stored-history copy, not new-message authoring. Copy from a snapshot
   captured by the writer, retaining target initialization rows and unchanged unknown fields
   and opaque items. Explicit changes and new fork notices still require parsing.
@@ -55,6 +60,15 @@ That tolerance must not authorize creating new malformed items locally.
   A local deletion is a conflict, not permission to restore deleted turns automatically.
   Baselines are bound to their own cursor's source hashes, never an independently newer
   metadata digest. Explicit conflict replacement records a fresh baseline.
+- Canonical turn hashes are versioned. v1 hashed `{role, items, plan}` verbatim; v2 hashes
+  a canonical item form so a sealed tool_call skeleton and the full tool_call it was sealed
+  from produce the same hash. A missing version means v1. Every hash is compared only against
+  a hash of its own version, and each stored cursor records the version of its own
+  `importedTurnHashes` while the sync metadata versions its own `replayDigest`
+  independently. `markConflict` may advance only the metadata; a v1 document cursor must
+  never be read as v2, which would manufacture a false `prefix_mismatch`. A mismatch
+  without the replay history to recompute is an error, not a permissive guess. New writes
+  use v2; existing v1 canonicalization is unchanged.
 
 This adds optional cursor metadata, not a body migration. Old readers can ignore it;
 old importers do not understand the stored baseline and may still report conflicts
@@ -72,11 +86,17 @@ arbitrary reordering of existing turns in a plain LoroList.
 The current full-Mirror read path still materializes history; this change is not
 the 3000-round performance acceptance or the windowed ConversationView rollout.
 Non-history control-field validation remains outside this HistoryWriter contract.
+The v2 canonical form is defined for the shapes this repository writes. The full
+sealed-skeleton feature (a reader-side `ref` payload fetch, payload hooks, and the
+UI that consumes them) is not implemented here; this change only prevents a future
+sealed turn from looking like a hash conflict once such skeletons exist.
 
 ## Implementation evidence
 
-- `packages/shared/src/{history-writer,history-write-schema,session-mirror}.ts`
-- `packages/shared/tests/history-writer.test.ts` and `history-writer.contract.ts`
+- `packages/shared/src/{history-writer,history-write-schema,history-materializer,session-mirror,schema}.ts`
+- `apps/cli/src/lib/local-project-history-sync-service.ts`
+- `packages/shared/tests/{history-writer,history-storage-policy}.test.ts` and `history-writer.contract.ts`
+- `apps/cli/tests/local-project-history-sync-service.test.ts` and `local-project-history-sync-writer.test.ts`
 - [Decision](../.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md)
 - [Business-field repair and pending hash decision](../.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md)
 - [Imported-history baseline repair](../.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md)

--- a/specs/session-history-writes.md
+++ b/specs/session-history-writes.md
@@ -26,10 +26,12 @@ That tolerance must not authorize creating new malformed items locally.
 - Existing primitive strings remain primitive; existing Text edits retain their
   container identity. New writes store an ordinary metadata string (tool `title`/`status`/
   `kind`/`toolCallId`, a `locations[].path`) as a primitive, and create a Text container
-  only for fields that stream (`text`/`thought`, `markdown`, tool `content`, worktree
-  `steps`). This is an insertion policy: it is not a migration, does not rewrap stored
-  values, and adds no validation constraint on old or sealed payloads. Storage-layout
-  changes are separately reviewed.
+  only for fields that stream (`text`/`thought`, `markdown`, a tool block's `text`/`output`
+  and nested `content.text`, a worktree step's `output`). The rule holds at every nesting
+  level: nested tool/worktree metadata such as `command`, `path`, `args`, `cwd`, `terminalId`
+  and `input` values is primitive, never Text. This is an insertion policy: it is not a
+  migration, does not rewrap stored values, and adds no validation constraint on old or
+  sealed payloads. Storage-layout changes are separately reviewed.
 - Fork is a stored-history copy, not new-message authoring. Copy from a snapshot
   captured by the writer, retaining target initialization rows and unchanged unknown fields
   and opaque items. Explicit changes and new fork notices still require parsing.
@@ -59,7 +61,11 @@ That tolerance must not authorize creating new malformed items locally.
   content to make it match. Without a baseline, compare exact legacy source hashes.
   A local deletion is a conflict, not permission to restore deleted turns automatically.
   Baselines are bound to their own cursor's source hashes, never an independently newer
-  metadata digest. Explicit conflict replacement records a fresh baseline.
+  metadata digest. A baseline written before the baseline carried a hash version has no
+  version field and is v1, matching a v1 cursor; treating the absent field as "not v1"
+  discards a legitimate projected baseline and misreports a normal append as a conflict.
+  A genuine v1/v2 mismatch is still rejected. Explicit conflict replacement records a fresh
+  baseline.
 - Canonical turn hashes are versioned. v1 hashed `{role, items, plan}` verbatim; v2 hashes
   a canonical item form so a sealed tool_call skeleton and the full tool_call it was sealed
   from produce the same hash. A missing version means v1. Every hash is compared only against


### PR DESCRIPTION
## Related issue

Refs #443
Refs #359

Same-repository integration. This supersedes #443's unfocused candidate-whitelist/patch
approach with a focused storage policy in the shared writer; the original PR stays open.
It carries #359's hash-version and cursor-compatibility logic onto current `main` and its
shared writer; that PR keeps its own old base and stays open.

## Problem / pressure

Two compatibility problems currently collide in session history.

1. The history item catchall uses `schema.Any({ defaultLoroText: true })`, so every new
   ordinary metadata string (`toolCallId`, `status`, `title`, `kind`, `locations[].path`)
   becomes its own `LoroText`. A single tool call creates a dozen never-streaming
   containers; over 3000 rounds that is the dominant storage and sync cost. `schema.ts`
   already argued against deep Text inference while doing the opposite.
2. Sync compares per-turn hashes produced by different canonical forms. A legacy document
   cursor stores v1 hashes while the metadata advances to v2, and `markConflict` updates
   only the metadata. Comparing a v1 cursor against v2 hashes manufactures a
   `prefix_mismatch` on an unchanged transcript.

Reproduction: `/tmp/lody-main-storage-policy.test.ts` on `main` prints `toolCallId: "Text"`,
`status: "Text"`, `title: "Text"`, `kind: "Text"`, `path: "Text"` through a production
`createSessionMirror().historyWriter.append` with a synthetic tool call.

## Summary

- **Storage insertion policy.** `historyItemAnySchema` becomes `defaultLoroText: false`.
  Ordinary metadata is stored primitive. `text`/`thought`, `markdown`, tool `content`, and
  worktree `steps` stay `LoroText` (the last two via the `storageSchema` hint the shared
  materializer already reads). Nested tool-content children keep their current Text shape,
  so existing docs and the full-Mirror reader see no change there.
- **Insertion-only guarantee.** The shared writer preserves an existing representation on a
  same-type string edit: a legacy `LoroText` keeps its container id, a legacy primitive stays
  primitive. Opening/hydrating a document writes nothing. Unknown stored fields and untouched
  opaque items are retained, and a malformed legacy value cannot block an unrelated edit.
- **Versioned hashes.** New logic adds `HASH_VERSION_V1`/`HASH_VERSION_V2`, materializes new
  imports at v2 with a canonical item form (so a sealed `tool_call` skeleton and the full call
  it came from hash identically), and versions the session-doc cursor's own
  `importedTurnHashes` independently from `ExternalAcpHistorySyncMeta.hashVersion`. A version
  mismatch recomputes the replay in the stored version; with no replay history it throws
  instead of guessing. The stored baseline records its version.
- **No migration / no patch.** No legacy row is rewritten and the removed `loro-mirror@2.3.1`
  patch is not ported. `schema.ts`/`history-materializer.ts` comments now match the code.

## Visual explanation

```mermaid
flowchart TB
  A["new history input"] --> B["HistoryWriter.parse"]
  B --> C{"field kind in schema.ts"}
  C -->|"ordinary metadata string"| D["primitive value"]
  C -->|"text / thought / markdown / content / steps"| E["LoroText"]
  C -->|"existing stored string edit"| F{"stored kind"}
  F -->|"LoroText"| G["keep container id"]
  F -->|"primitive"| H["keep primitive"]
  D --> I["Loro history"]
  E --> I
  G --> I
  H --> I
  B -->|"apply"| I
```

```mermaid
flowchart LR
  subgraph META["sync metadata"]
    R["replayDigest<br/>(version = meta.hashVersion)"]
  end
  subgraph CURSOR["session doc cursor"]
    T["importedTurnHashes<br/>(version = cursor.hashVersion)"]
  end
  R -. "versioned independently" .- T
  T --> Q{"same version?"}
  Q -->|"yes"| X["compare directly"]
  Q -->|"no"| Y["recompute replay hashes<br/>from materialized history"]
  Y --> X
```

The structural diff is one policy flag plus explicit declarations:
`defaultLoroText: true` → `false` on the item catchall, and four previously-inferred
streaming fields declared by hand. The hash change adds a version to each of the two
independently persisted hash stores instead of trusting a shared one.

## Before / after

| Case | Before | After |
| --- | --- | --- |
| New tool metadata (`toolCallId`/`status`/`title`/`kind`/`path`) | `LoroText` per string | primitive |
| New streaming field (`text`/`thought`/`markdown`/tool content/steps) | inferred/declared `LoroText` | explicit `LoroText` |
| Edit of a stored string | representation could be replaced | existing kind and Text id retained |
| Opening/hydrating old history | read | same read; no write |
| Malformed legacy value | could block unrelated writes when re-parsed | untouched; unrelated edit proceeds |
| v1 cursor vs v2 replay | false `prefix_mismatch` | recomputed in the cursor version |

## Test plan

- `packages/shared`: `vitest run` → **97 files, 1128 tests pass**, including the new
  `history-storage-policy.test.ts` (container-kind matrix; legacy Text and primitive path
  preservation; unknown-field retention; malformed legacy value; two real Loro peers;
  read-only hydrate). `tsgo --noEmit` passes.
- `apps/cli`: `vitest run` → **259 files passed / 1 skipped, 2681 tests pass**, including new
  version tests (full vs skeleton canonicalization, unknown-version rejection, v1-cursor vs
  v2-replay append, metadata-only advance, already-resolved, mismatch without replay history)
  and the updated real-writer import suite. `tsgo --noEmit` passes.
- Recursive workspace typecheck (`pnpm -r typecheck`, minus the two vendored ACP adapters)
  exits 0. `oxlint` reports 0 errors. `docs check`, i18n, code-collab, platform-boundary and
  public-boundary checks pass.
- Environment failure recorded, not reported green: `acp-extension-dsh` (a submodule with its
  own isolated workspace) fails to build on pre-existing missing `@types/node`. It is not
  imported by the changed paths.
- Not run: full Electron app build, browser/mobile UI, and the 3000-round acceptance. This is
  a storage-insertion and hash-comparison change, not an end-to-end performance claim.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `packages/shared/src/schema.ts` (storage hints), `history-materializer.ts`
  `getMapFieldSchema`/`diffMap` (representation preservation), and
  `apps/cli/src/lib/local-project-history-sync-service.ts` (`resolveReplayHashesForStoredVersion`
  and both decision functions).
- **Decisions to challenge:** (a) nested tool-content children stay Text while top-level
  metadata becomes primitive — is that boundary right? (b) cursor version and metadata version
  are independent — does every call site pair each hash array with its own version?
- **Plausible failures / evidence gaps:** old docs with mixed representation are covered
  synthetically, not against a real user corpus. The sealed-skeleton feature itself is not
  implemented, so `ref`/payload fetching is untested.

### Authoring context

- **User goal / directives:** integrate #443 and #359 with main, push for independent
  parent-verification, use the dsh Agent Role, do not merge or change real user storage.
- **Constraints / non-goals:** no UI rebuild, no end-to-end 3000-round claim, no attachment
  externalization, no candidate-whitelist/image filtering, no new Mirror version bump, do not
  auto-close the source PRs.
- **Risk-bearing decisions:** storage representation is per-field and insertion-only; hash
  comparison is version-paired and recomputes rather than downgrades; a missing replay history
  on a version mismatch is a hard error.
- **Destructive or irreversible behavior:** none on existing data. There is no migration,
  compaction, or in-place rewrite; only newly written turns use the new insertion policy.
- **Deliberately not done or tested:** the full sealed-tool_call model (`ref`, machine fetch,
  `useToolCallPayload`), a real-corpus audit, and desktop/mobile acceptance.
- **Unknowns / confidence:** canonicalization is verified with synthetic fixtures; confidence
  in the storage and version logic is high, confidence that no real-corpus shape is missed is
  moderate.

### Original user prompt

This is a same-repository maintainer branch, so the template makes this optional; the
triggering request is preserved verbatim for reviewer context.

````text
请实施 Lody #443 和 #359 与最新 main 的整合并 push，由父对话 Codex 独立验收。用户指定你使用 dsh Agent Role；遵循角色实际配置，不替换模型。请先核实当前代码/PR，不能只复述以下历史摘要。读取适用 AGENTS.md、.github/AGENTS.md，使用独立工作区，保留用户工作树；不 merge、不发版、不改真实用户存储，不自动关闭 PR。

总目标：长会话支持 3000 用户轮，减少不必要容器与全量处理；这次限定 schema/写入存储与 reader/hash 兼容整合，不做 UI 大重构，不声称端到端已达标。用 show-me 的简短 Mermaid/diff 解释最终实现。

刚验证的坐标：
- main 63ae7ad594bb14d272e3a7e1de4ec7cc53e68b0a
- #443 OPEN，base main，head b07d123f0f82dc6d60e1e0a3311571017710d73b，分支 feat/history-content-schema-audit
- #359 OPEN，base session/8336142a（不是 main），head b387ec80c22074cf0d4a15e873404587302e8fc0，分支 feat/reader-side-session-history-shapes
必须刷新以上状态。#443 merge-tree 对 main 的冲突为 components/src/components/AGENTS.md、shared/AGENTS.md、pnpm-lock.yaml；#359 是根 AGENTS.md、CLI local-project-history-sync-service.ts 及其测试、shared/src/ai.ts、shared/src/schema.ts、pnpm-lock.yaml。#359 GitHub MERGEABLE 仅相对其旧 base。

关键新架构（直接核对源码）：
- main packages/shared/src/session-mirror.ts 的 createSessionMirror 是 facade：Mirror 读完整 history/写控制字段，history 写入已走共享 createHistoryWriter。
- packages/shared/src/history-writer.ts + history-materializer.ts 直接写 Loro。materializer 已实现同类型字符串编辑保留旧 Text CID / 旧 primitive；也能识别 storageSchema，但注释仍提旧 #443 patch。
- schema.ts 仍有 historyItemAnySchema = schema.Any({defaultLoroText:true})，并用于 historyMessageItemSchema.catchall。最新主分支的注释和实际策略不一致。
父对话用生产 createSessionMirror.historyWriter.append 合成 tool_call 实测：turn id/role 和 item type 为普通 string；toolCallId/status/title/kind/locations[].path 全为 Text；回复 text 与 content[].content.text 为 Text。这证明普通元数据优化尚未完成。复现文件 /tmp/lody-main-storage-policy.test.ts；/tmp/lody-376-analysis 当前工作区相关 shared 五个文件与上述 main 完全一致。无需真实语料即可复现。

#443 目标：
新写入普通元数据用 primitive，真正流式增长字段显式保留 Text；旧数据打开/读取零写入，同类型编辑保留既有表示与 Text CID。旧 PR 将 storageSchema 与宽松校验分离，避免 content/markdown/steps 的旧异形值导致整 doc 不可写。
旧方案绑定 loro-mirror@2.3.1 patch，而 main 是 2.3.2，共享 writer 已接管历史写入。请将必要策略/测试整合到当前共享 writer，核实全部 history 写入口后判断是否能移除过时 patch。不要盲目把旧 patch 移植到新版或关闭全量校验来掩盖问题。Mirror 的新 toContainerTree/LazyList 不是 storageSchema 替代品；我核对 mirror main 97fd2f0（package 2.3.3）没有 storageSchema。Mirror 正在发版，不必为这两个业务 PR 引入无必要的版本升级。schema 定义/类型、控制面和现有读取仍依赖 Mirror，不能删整个依赖。
必要时可用新的小 PR 替代 #443，但先保留原 PR，交付明确 supersedes 关系供父对话验收，勿仅关闭任务。候选白名单/剔图不要未经验证整套接生产，不以本次存储优化宣称附件闭环已完成。

#359 目标：
基于当前消息定义、Zod 写入校验、共享 writer 接入骨架 reader 兼容与 hash 版本逻辑。完整 tool_call 与仅 ref 骨架的 TS/运行时契约一致（旧头 toolCallId 仍必填的问题需检查）。
修复后的重要不变量：doc importedTurnHashes 必须配 doc cursor 自己 hashVersion（缺省 v1），meta replayDigest 配 meta 自己版本；markConflict 可能只更新 meta，不得因此把 v1 hashes 当 v2 导致假 prefix_mismatch。源持续增长及源安静自愈、反向版本错位、冲突解除追加、already_resolved 都要保留回归。
已有 v1/v2 canonicalization 不能因新输入过滤偷偷改变，变化需要显式版本设计；ref.index 不能因旧数据过滤重排失效。payload hook 仍 unavailable stub，不据此剥离实际 payload。
优先整合 #443 的小存储策略，再整合 #359；可以叠 PR，但 base/title/body 要准确，避免包含无关变更。

验收：
1. 新写入字段真实容器类型（Text/primitive），包括 tool metadata/path/command 与实际流式 text/thought/markdown/output；旧 Text 和 primitive 两种布局同类型编辑保持。
2. 不改旧存储：打开/hydrate/read 无新操作；追加/局部更新不重写旧 turn，不丢未知旧字段；schema 异形旧值不阻断无关更新。输入错误内部隔离/报告，不能凭关闭校验声称完成。
3. 两真实 Loro peers、新旧表示的交换和并发；使用合成 fixture。CLI、主读取路径与 #376 回退对共享 writer 的使用要追到入口。
4. #359 完整/骨架、v1/v2、doc/meta 版本错位与导出/replay 回归。
5. 运行必要 build/typecheck/tests/format/boundary 按仓库规范；如环境失败具体记录，不能报全绿。
6. push 后验证本地 HEAD = 远端 = PR head，报告 CI。不要直接 merge。
7. 最终给父对话 PR URL/base/head、实际 diff、修改文件、测试命令结果、合成复现路径、已知限制、show-me 导读。父对话会重新拉代码独立验收，不以你的通过摘要代替复验。

请现在开始，授权已包含实施、push 和必要新 PR，无需重复审批。
````

<!-- context-handoff:end -->
