### PR TITLE
feat(shared): read ref-only tool_call skeletons safely

### DIFF
--- a/.agents/notes/implemented/architecture/2026-09-10-ref-only-tool-call-skeleton-readers.md
+++ b/.agents/notes/implemented/architecture/2026-09-10-ref-only-tool-call-skeleton-readers.md
@@ -35,9 +35,12 @@ machine. Three layers disagreed about it.
 
 ## Decision
 
-`toolCallId` is optional and `ref?: ToolCallRef` exists on the `tool_call` variant. The
-identity requirement lives at each runtime boundary instead of in one place:
+The `tool_call` variant carries a `ToolCallIdentity` union, so the TypeScript type itself
+requires at least one of `toolCallId` (full call) or `ref` (sealed skeleton); a full call may
+also carry a `ref`. The runtime boundaries enforce the same rule:
 
+- `history-writer.contract.ts` pins the type half with `@ts-expect-error` compile-failure
+  checks for an identity-less tool_call and an explicit-undefined id.
 - `MessageContentSchema.superRefine` rejects a tool call with neither identity. It lives on
   the union rather than on `ToolCallMessageSchema` because `z.discriminatedUnion` needs that
   object to stay a `ZodObject` (it is used with `.omit` in the writer).
@@ -51,8 +54,12 @@ Reader paths treat a skeleton as a first-class item without inventing payload:
 - `acp/history-apply.ts` skips non-string ids when indexing, resolving and merging, so a
   skeleton is never a merge target and an id-less replay appends like any unknown id.
 - `tool-call-skeleton.ts` owns `isToolCallRef`, `isToolCallSkeleton` and
-  `getToolCallStableId`; activity summaries and React/virtual keys use them, so a skeleton
-  classifies from `kind`/`status`/`locations` and never renders the literal `undefined`.
+  `getToolCallStableId`. `isToolCallSkeleton` requires `ref` AND no
+  `content`/`rawInput`/`rawOutput` (an empty `content` array counts as absent); `ref` alone is
+  not the predicate, because a full call may also carry a `ref` and must keep rendering its
+  payload instead of the "stored on <machine>" placeholder. Activity summaries and
+  React/virtual keys use these guards, so a skeleton classifies from
+  `kind`/`status`/`locations` and never renders the literal `undefined`.
 - `use-tool-call-payload.ts` is an explicit `unavailable` stub; the card adds a
   "stored on <machine>" row. `session-export` writes `toolCallId: null` plus `ref`, and the
   transcript markdown renders the skeleton without an id line.

--- a/.agents/notes/implemented/architecture/2026-09-10-ref-only-tool-call-skeleton-readers.md
+++ b/.agents/notes/implemented/architecture/2026-09-10-ref-only-tool-call-skeleton-readers.md
@@ -1,0 +1,85 @@
+# Ref-only tool_call skeletons in every reader
+
+Status: implemented
+Translation: pending
+
+## Abstract
+
+The storage and hash layers already tolerated a sealed `tool_call` skeleton, but the
+TypeScript type, the Zod input parser, the ACP history applier, the UI and the CLI export
+still assumed `toolCallId` and `content` were always present, so a ref-only skeleton could
+not be expressed without a cast and could be corrupted by an unrelated update. This change
+makes `toolCallId` optional and adds `ref`, keeps the identity requirement at every
+validation boundary, and teaches each reader to classify a skeleton from
+`kind`/`status`/`locations`. Turning a full call into a skeleton (payload stripping, a
+sealing writer, a derived `summary`/`live`, and the Machine RPC that fetches a payload) is
+deliberately not implemented; `useToolCallPayload` stays an `unavailable` stub.
+
+## Problem
+
+A sealed turn stores a skeleton: `{ type: 'tool_call', kind, status, title?, locations?,
+ref }`, with the execution payload (`content`/`rawInput`/`rawOutput`) left on the origin
+machine. Three layers disagreed about it.
+
+- `MessageContent` declared `toolCallId: string` and had no `ref`, so a skeleton only
+  compiled through `as unknown as MessageContent`.
+- The Loro schema `validate` accepted a ref-only item, but the Zod `ToolCallMessageSchema`
+  still required `toolCallId`, and the `AllNestedMessageFieldsHaveAParser` compile-time
+  guard in `history-writer.contract.ts` failed as soon as `ref` was added to the type —
+  proof that the runtime parser and the type had drifted.
+- `upsertToolCall` matched tool calls with
+  `(m as ToolCallMessage).toolCallId === incoming.toolCallId`. When both sides omitted
+  `toolCallId`, `undefined === undefined` matched and a replayed skeleton overwrote a
+  stored skeleton — the exact "filtering/reordering breaks the position reference" failure,
+  and one TypeScript cannot catch because comparing two optional strings is legal.
+
+## Decision
+
+`toolCallId` is optional and `ref?: ToolCallRef` exists on the `tool_call` variant. The
+identity requirement lives at each runtime boundary instead of in one place:
+
+- `MessageContentSchema.superRefine` rejects a tool call with neither identity. It lives on
+  the union rather than on `ToolCallMessageSchema` because `z.discriminatedUnion` needs that
+  object to stay a `ZodObject` (it is used with `.omit` in the writer).
+- the Loro `validate` guard accepts `typeof toolCallId === 'string' || isToolCallRef(ref)`.
+- `message-content-guards.ts` mirrors both for raw values.
+- `history-writer.ts` omits `ref` from `ToolStateWriteSchema`, alongside `toolCallId`, so a
+  changed payload pointer is an identity change that requires the complete item parser.
+
+Reader paths treat a skeleton as a first-class item without inventing payload:
+
+- `acp/history-apply.ts` skips non-string ids when indexing, resolving and merging, so a
+  skeleton is never a merge target and an id-less replay appends like any unknown id.
+- `tool-call-skeleton.ts` owns `isToolCallRef`, `isToolCallSkeleton` and
+  `getToolCallStableId`; activity summaries and React/virtual keys use them, so a skeleton
+  classifies from `kind`/`status`/`locations` and never renders the literal `undefined`.
+- `use-tool-call-payload.ts` is an explicit `unavailable` stub; the card adds a
+  "stored on <machine>" row. `session-export` writes `toolCallId: null` plus `ref`, and the
+  transcript markdown renders the skeleton without an id line.
+
+## Alternatives and explicit scope
+
+- Declaring `summary`/`live` for sealed turns was rejected: they belong to the sealing
+  writer. A test proves an unknown turn-level key is ignored on read and does not block an
+  unrelated write, so readers stay safe without declaring a writer's private shape.
+- Casting at each call site (the previous approach) was rejected: it left the type lying
+  and hid the `undefined === undefined` merge bug.
+- A separate `ToolCallSkeleton` union member was rejected: both shapes share the
+  `tool_call` discriminant, so a second member would force every consumer to narrow twice.
+- Not implemented: payload stripping, a skeleton-emitting writer, remote payload fetch,
+  and any UI for a fetched payload.
+
+## Evidence
+
+- `packages/shared/src/{ai,message-schemas,schema,history-writer}.ts`,
+  `packages/shared/src/acp/history-apply.ts`
+- `packages/components/src/components/ai-gui/{tool-call-skeleton,use-tool-call-payload,message-content-guards,assistant-turn-render-blocks,view}.ts(x)`
+- `apps/cli/src/lib/session-export/{formatters,markdown,types}.ts`
+- Tests: `packages/shared/tests/{session-history-shapes,acp-history-apply}.test.ts`,
+  `packages/components/tests/tool-call-skeleton.test.ts`,
+  `apps/cli/src/lib/session-export/formatters.test.ts`, `apps/cli/src/commands/session.test.ts`
+- Spec: [session history writes](../../../../specs/session-history-writes.md)
+- Prior storage/hash decision:
+  [versioned turn hashes and primitive metadata insertion](2026-09-10-versioned-history-hashes-and-primitive-metadata.md)
+  (its "sealed-skeleton feature itself is not implemented" limit now applies only to the
+  writer and payload fetch, not the reader).

--- a/.agents/notes/implemented/architecture/2026-09-10-versioned-history-hashes-and-primitive-metadata.md
+++ b/.agents/notes/implemented/architecture/2026-09-10-versioned-history-hashes-and-primitive-metadata.md
@@ -122,3 +122,4 @@ not a windowed-reader or attachment-externalization rollout.
   its "no #359 hash-v2 rollout" line describes the earlier PR's scope, not current behavior)
 - Spec: [session history writes](../../../../specs/session-history-writes.md)
 - Supersedes the storage-policy portion of PR #443; see the PR body for the exact base/head.
+- Follow-up reader work: [ref-only tool_call skeletons in every reader](2026-09-10-ref-only-tool-call-skeleton-readers.md).

--- a/apps/cli/src/commands/session.test.ts
+++ b/apps/cli/src/commands/session.test.ts
@@ -11,6 +11,7 @@ import {
   type LocalProjectGitState,
   type MachineId,
   type MachineMeta,
+  type MessageContent,
   type SessionHistoryInput,
   type SessionId,
   type SessionMeta,
@@ -1414,6 +1415,16 @@ describe('session command helpers', () => {
   });
 
   it('builds transcript entries from visible user and assistant content only', () => {
+    // Sealed turns persist tool_call skeletons (no toolCallId/content); the
+    // transcript path shared by `session history` and MCP `lody_session_history`
+    // must skip them like any other tool call.
+    const skeleton: MessageContent = {
+      type: 'tool_call',
+      kind: 'execute',
+      status: 'completed',
+      title: 'Shell: ls',
+      ref: { machineId: 'machine-id' as MachineId, turnId: 'assistant-entry', index: 1 },
+    };
     expect(
       toSessionTranscriptEntries([
         createHistoryEntry({
@@ -1442,6 +1453,7 @@ describe('session command helpers', () => {
             { type: 'thought', text: 'internal reasoning' },
             { type: 'tool_call', toolCallId: 'tool-1', status: 'completed' },
             { type: 'text', text: 'Final answer' },
+            skeleton,
             { type: 'text', text: 'Second paragraph' },
             { type: 'tool_call', toolCallId: 'tool-2', status: 'completed' },
           ],
@@ -1526,6 +1538,17 @@ describe('session command helpers', () => {
     expect(renderAssistantTurnCompletion([{ type: 'tool_call', toolCallId: 'tool-1' }])).toBe(
       'No visible assistant reply found.'
     );
+    // A sealed tool_call skeleton (no toolCallId/content) is likewise invisible.
+    expect(
+      renderAssistantTurnCompletion([
+        {
+          type: 'tool_call',
+          kind: 'execute',
+          status: 'completed',
+          ref: { machineId: 'machine-id' as MachineId, turnId: 'turn-1', index: 0 },
+        },
+      ])
+    ).toBe('No visible assistant reply found.');
   });
 
   it('waits only when --wait is explicit, independently of JSON output', () => {

--- a/apps/cli/src/lib/session-export/formatters.test.ts
+++ b/apps/cli/src/lib/session-export/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { SessionHistoryInput, SessionMeta } from '@lody/shared';
+import type { MachineId, MessageContent, SessionHistoryInput, SessionMeta } from '@lody/shared';
 import { buildSessionArtifacts, toExportSessionSummary, toUserFacingAgentType } from './formatters';
 import { buildTranscriptMarkdown } from './markdown';
 
@@ -20,6 +20,13 @@ const createHistoryEntry = (overrides: Partial<SessionHistoryInput> = {}): Sessi
   items: [],
   fileDiff: [],
   ...overrides,
+});
+
+type ToolCallMessage = Extract<MessageContent, { type: 'tool_call' }>;
+const toolRef = (index: number, turnId = 'turn-2'): NonNullable<ToolCallMessage['ref']> => ({
+  machineId: 'machine-1' as MachineId,
+  turnId,
+  index,
 });
 
 describe('session export formatters', () => {
@@ -231,5 +238,151 @@ describe('session export formatters', () => {
     expect(markdown).toContain('#### Thought');
     expect(markdown).toContain('Need to keep this independent.');
     expect(markdown).toContain('![diagram.png](artifacts/attachments/files/img-1.png)');
+  });
+
+  it('tolerates sealed tool_call skeletons without execution payload', () => {
+    // A sealed skeleton stores only kind/status/title/locations/ref — no
+    // toolCallId, content, rawInput, or rawOutput. Built without a cast.
+    const skeleton: MessageContent = {
+      type: 'tool_call',
+      kind: 'execute',
+      status: 'completed',
+      title: 'Shell: ls',
+      locations: [{ path: '/tmp/work' }],
+      ref: toolRef(0),
+    };
+
+    const artifacts = buildSessionArtifacts([
+      createHistoryEntry({
+        id: 'turn-2',
+        role: 'assistant',
+        items: [skeleton],
+      }),
+    ]);
+
+    expect(artifacts.toolCalls).toEqual([
+      {
+        turnId: 'turn-2',
+        timestamp: '2026-03-23T10:01:00.000Z',
+        role: 'assistant',
+        toolCallId: null,
+        title: 'Shell: ls',
+        kind: 'execute',
+        status: 'completed',
+        locations: [{ path: '/tmp/work' }],
+        permissionRequest: undefined,
+        content: [],
+        rawInput: undefined,
+        rawOutput: undefined,
+        ref: { machineId: 'machine-1', turnId: 'turn-2', index: 0 },
+      },
+    ]);
+    // The transcript copy keeps the skeleton and serializes cleanly.
+    expect(artifacts.transcript[0]?.items).toEqual([{ ...skeleton, content: [] }]);
+    expect(() => JSON.stringify(artifacts)).not.toThrow();
+  });
+
+  it('keeps old-shape tool call records byte-identical in serialized output', () => {
+    const artifacts = buildSessionArtifacts([
+      createHistoryEntry({
+        id: 'turn-2',
+        role: 'assistant',
+        items: [
+          {
+            type: 'tool_call',
+            toolCallId: 'tool-1',
+            status: 'completed',
+            kind: 'read',
+            title: 'Read session schema',
+            rawInput: { path: 'schema.ts' },
+            rawOutput: { ok: true },
+          },
+        ],
+      }),
+    ]);
+
+    expect(JSON.stringify(artifacts.toolCalls[0])).toBe(
+      '{"turnId":"turn-2","timestamp":"2026-03-23T10:01:00.000Z","role":"assistant",' +
+        '"toolCallId":"tool-1","title":"Read session schema","kind":"read","status":"completed",' +
+        '"content":[],"rawInput":{"path":"schema.ts"},"rawOutput":{"ok":true}}'
+    );
+  });
+
+  it('renders old-shape tool calls unchanged in transcript markdown', () => {
+    const markdown = buildTranscriptMarkdown({
+      session: toExportSessionSummary(createSessionMeta({ title: 'Exporter' }), 'workspace-1'),
+      turns: [
+        {
+          turnId: 'turn-1',
+          role: 'assistant',
+          timestamp: '2026-03-23T10:01:00.000Z',
+          finished: true,
+          sendStatus: undefined,
+          startedAt: null,
+          endedAt: null,
+          modelInfo: undefined,
+          items: [
+            {
+              type: 'tool_call',
+              toolCallId: 'tool-1',
+              status: 'completed',
+              kind: 'read',
+              title: 'Read `schema.ts`',
+            },
+          ],
+        },
+      ],
+      attachments: [],
+    });
+
+    expect(markdown).toContain(
+      '#### Tool Call\n- id: `tool-1`\n- title: Read `schema.ts`\n- status: `completed`\n- kind: `read`'
+    );
+    expect(markdown).not.toContain('origin machine');
+  });
+
+  it('renders sealed tool_call skeletons in transcript markdown without an id', () => {
+    const skeleton: MessageContent = {
+      type: 'tool_call',
+      kind: 'execute',
+      status: 'completed',
+      title: 'Shell: ls',
+      ref: toolRef(0, 'turn-1'),
+    };
+    const titleless: MessageContent = {
+      type: 'tool_call',
+      kind: 'read',
+      status: 'completed',
+      ref: toolRef(1, 'turn-1'),
+    };
+
+    const markdown = buildTranscriptMarkdown({
+      session: toExportSessionSummary(createSessionMeta({ title: 'Exporter' }), 'workspace-1'),
+      turns: [
+        {
+          turnId: 'turn-1',
+          role: 'assistant',
+          timestamp: '2026-03-23T10:01:00.000Z',
+          finished: true,
+          sendStatus: undefined,
+          startedAt: null,
+          endedAt: null,
+          modelInfo: undefined,
+          items: [skeleton, titleless],
+        },
+      ],
+      attachments: [],
+    });
+
+    expect(markdown).toContain(
+      '#### Tool Call\n- title: Shell: ls\n- status: `completed`\n- kind: `execute`\n' +
+        '- note: execution details stored on the origin machine'
+    );
+    // Without a title the kind line still identifies the tool.
+    expect(markdown).toContain(
+      '#### Tool Call\n- status: `completed`\n- kind: `read`\n' +
+        '- note: execution details stored on the origin machine'
+    );
+    expect(markdown).not.toContain('- id:');
   });
 });

--- a/apps/cli/src/lib/session-export/formatters.ts
+++ b/apps/cli/src/lib/session-export/formatters.ts
@@ -43,9 +43,7 @@ function sanitizeTranscriptItem(item: MessageContent): MessageContent {
   return {
     ...item,
     content: (item.content ?? []).filter(
-      (
-        content
-      ): content is Exclude<NonNullable<typeof item.content>[number], { type: 'diff' }> =>
+      (content): content is Exclude<NonNullable<typeof item.content>[number], { type: 'diff' }> =>
         content.type !== 'diff'
     ),
   };
@@ -164,7 +162,9 @@ export function buildSessionArtifacts(history: SessionHistoryInput[]): ExportSes
           turnId: entry.id,
           timestamp: entry.timestamp,
           role: entry.role,
-          toolCallId: item.toolCallId,
+          // A sealed skeleton has no `toolCallId`; its `ref` points at the
+          // origin machine's payload instead.
+          toolCallId: typeof item.toolCallId === 'string' ? item.toolCallId : null,
           title: normalizeString(item.title),
           kind: normalizeString(item.kind),
           status: item.status,
@@ -178,6 +178,7 @@ export function buildSessionArtifacts(history: SessionHistoryInput[]): ExportSes
           ),
           rawInput: item.rawInput,
           rawOutput: item.rawOutput,
+          ...(item.ref ? { ref: item.ref } : {}),
         });
         continue;
       }

--- a/apps/cli/src/lib/session-export/markdown.ts
+++ b/apps/cli/src/lib/session-export/markdown.ts
@@ -33,15 +33,22 @@ function renderItem(item: MessageContent, attachmentLinks: Map<string, string>):
     case 'plan':
       return ['#### Plan', ...item.entries.map((entry) => `- [${entry.status}] ${entry.content}`)];
     case 'tool_call': {
-      const parts = [
-        `- id: \`${escapeInlineCode(item.toolCallId)}\``,
-        `- status: \`${escapeInlineCode(item.status)}\``,
-      ];
-      if (item.title?.trim()) {
-        parts.splice(1, 0, `- title: ${item.title.trim()}`);
+      // A sealed skeleton has no `toolCallId`/`content`; its execution payload
+      // stays on the origin machine (see `ref`), so name that instead of
+      // printing an empty id.
+      const parts: string[] = [];
+      if (typeof item.toolCallId === 'string' && item.toolCallId.trim()) {
+        parts.push(`- id: \`${escapeInlineCode(item.toolCallId)}\``);
       }
+      if (item.title?.trim()) {
+        parts.push(`- title: ${item.title.trim()}`);
+      }
+      parts.push(`- status: \`${escapeInlineCode(item.status)}\``);
       if (item.kind?.trim()) {
         parts.push(`- kind: \`${escapeInlineCode(item.kind)}\``);
+      }
+      if (item.ref) {
+        parts.push('- note: execution details stored on the origin machine');
       }
       return ['#### Tool Call', ...parts];
     }

--- a/apps/cli/src/lib/session-export/types.ts
+++ b/apps/cli/src/lib/session-export/types.ts
@@ -1,4 +1,9 @@
-import type { MessageContent, SessionHistoryInput, SessionMeta, SessionPlanEntry } from '@lody/shared';
+import type {
+  MessageContent,
+  SessionHistoryInput,
+  SessionMeta,
+  SessionPlanEntry,
+} from '@lody/shared';
 
 export type ExportSessionSummary = {
   sessionId: string;
@@ -38,7 +43,8 @@ export type ExportToolCallRecord = {
   turnId: string;
   timestamp: string;
   role: SessionHistoryInput['role'];
-  toolCallId: string;
+  /** Absent on sealed skeletons, whose payload stays on the origin machine. */
+  toolCallId: string | null;
   title: string | null;
   kind: string | null;
   status: string;
@@ -50,6 +56,8 @@ export type ExportToolCallRecord = {
   >[];
   rawInput: Extract<MessageContent, { type: 'tool_call' }>['rawInput'];
   rawOutput: Extract<MessageContent, { type: 'tool_call' }>['rawOutput'];
+  /** Payload pointer present only on sealed skeletons. */
+  ref?: Extract<MessageContent, { type: 'tool_call' }>['ref'];
 };
 
 export type ExportSystemNoticeRecord = {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1215,6 +1215,7 @@
   "sessions.activity.compactingContext": "Compacting context",
   "sessions.activity.contextCompacted": "Context compacted",
   "sessions.activity.contextCompactionFailed": "Context compaction failed",
+  "sessions.toolCall.executionDetailsStoredOnMachine": "Execution details are stored on {{machine}}",
   "sessions.askQuestion.answered": "Answered",
   "sessions.askQuestion.autoContinueIn": "Continues in {{seconds}}s",
   "sessions.askQuestion.continuing": "Continuing",

--- a/locales/zh_CN.json
+++ b/locales/zh_CN.json
@@ -1215,6 +1215,7 @@
   "sessions.activity.compactingContext": "正在压缩上下文",
   "sessions.activity.contextCompacted": "上下文已压缩",
   "sessions.activity.contextCompactionFailed": "上下文压缩失败",
+  "sessions.toolCall.executionDetailsStoredOnMachine": "执行详情保存在 {{machine}} 上",
   "sessions.askQuestion.answered": "已回答",
   "sessions.askQuestion.autoContinueIn": "{{seconds}} 秒后自动继续",
   "sessions.askQuestion.continuing": "正在继续",

--- a/packages/components/src/components/ai-gui/AGENTS.md
+++ b/packages/components/src/components/ai-gui/AGENTS.md
@@ -113,10 +113,11 @@ File-by-file ownership and coverage pointers: [README.md](README.md).
   without per-file pills.
 - Update `message-content-guards.ts` with every shared `MessageContent` variant.
   `isMessageContent` gates rendering; a missing case silently drops the item.
-- A sealed `tool_call` skeleton has no `toolCallId`/`content`; `ref` points at the
-  origin machine. `tool-call-skeleton.ts` owns the runtime guards, and each reader
-  classifies from `kind`/`status`/`locations` without reading `content`.
-  `use-tool-call-payload.ts` always reports `unavailable` (no Machine RPC yet).
+- A sealed `tool_call` skeleton has no payload and points at the origin machine with
+  `ref`. `isToolCallSkeleton` requires `ref` AND no payload — a full call may also carry
+  `ref`, so `ref` alone is not the predicate. Readers classify a skeleton from
+  `kind`/`status`/`locations`, never `content`; `use-tool-call-payload.ts` stays
+  `unavailable` (no Machine RPC yet).
 - A user entry marked by `SessionMeta.lastMissingHistoryUserMsgId` renders the
   terminal "Not delivered" label. That label is the only recovery entry: its
   dialog resends the same content as a new ordinary message, then marks the old

--- a/packages/components/src/components/ai-gui/AGENTS.md
+++ b/packages/components/src/components/ai-gui/AGENTS.md
@@ -113,6 +113,10 @@ File-by-file ownership and coverage pointers: [README.md](README.md).
   without per-file pills.
 - Update `message-content-guards.ts` with every shared `MessageContent` variant.
   `isMessageContent` gates rendering; a missing case silently drops the item.
+- A sealed `tool_call` skeleton has no `toolCallId`/`content`; `ref` points at the
+  origin machine. `tool-call-skeleton.ts` owns the runtime guards, and each reader
+  classifies from `kind`/`status`/`locations` without reading `content`.
+  `use-tool-call-payload.ts` always reports `unavailable` (no Machine RPC yet).
 - A user entry marked by `SessionMeta.lastMissingHistoryUserMsgId` renders the
   terminal "Not delivered" label. That label is the only recovery entry: its
   dialog resends the same content as a new ordinary message, then marks the old

--- a/packages/components/src/components/ai-gui/assistant-turn-render-blocks.ts
+++ b/packages/components/src/components/ai-gui/assistant-turn-render-blocks.ts
@@ -4,6 +4,7 @@ import {
   type AssistantMessageRenderItem,
 } from './assistant-message-render-items';
 import { shouldCollapseAssistantMessageItem } from './message-copy';
+import { getToolCallStableId, isToolCallSkeleton } from './tool-call-skeleton';
 
 type ToolCallMessage = Extract<MessageContent, { type: 'tool_call' }>;
 type ThoughtMessage = Extract<MessageContent, { type: 'thought' }>;
@@ -129,9 +130,13 @@ export const summarizeAssistantActivity = (
         fetchCount += 1;
         break;
       default: {
-        const hasTerminalContent = toolCall.content?.some(
-          (block) => block.type === 'terminal_command' || block.type === 'terminal_output'
-        );
+        // A sealed skeleton carries no payload; it must classify from
+        // `kind`/`status` alone, so only a full item consults its `content`.
+        const hasTerminalContent =
+          !isToolCallSkeleton(toolCall) &&
+          toolCall.content?.some(
+            (block) => block.type === 'terminal_command' || block.type === 'terminal_output'
+          );
         if (hasTerminalContent) {
           commandCount += 1;
         } else {
@@ -161,7 +166,9 @@ const isActivityGroupEntry = (
     entry.content.activityKind === undefined);
 
 const buildActivityGroupKey = (messageId: string, first: AssistantActivityRenderItem): string => {
-  const suffix = first.content.type === 'tool_call' ? first.content.toolCallId : first.itemIndex;
+  // A sealed skeleton has no `toolCallId`; its ref keeps the key stable.
+  const suffix =
+    first.content.type === 'tool_call' ? getToolCallStableId(first.content) : first.itemIndex;
   return `activity-group:${messageId}:${first.itemIndex}:${suffix}`;
 };
 

--- a/packages/components/src/components/ai-gui/message-content-guards.ts
+++ b/packages/components/src/components/ai-gui/message-content-guards.ts
@@ -1,5 +1,7 @@
 import { SESSION_IMAGE_MAX_COUNT, type MessageContent } from '@lody/shared';
 
+import { isToolCallRef } from './tool-call-skeleton';
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -137,7 +139,14 @@ export const isMessageContent = (value: unknown): value is MessageContent => {
         (value.updatedAt === undefined || typeof value.updatedAt === 'number')
       );
     case 'tool_call':
-      return typeof value.toolCallId === 'string' && typeof value.status === 'string';
+      // A full call carries `toolCallId`; a sealed skeleton omits it and points
+      // at the origin machine's payload with a valid `ref`. A skeleton has no
+      // `content`; a full call's `content`, when present, must be an array.
+      return (
+        typeof value.status === 'string' &&
+        (typeof value.toolCallId === 'string' || isToolCallRef(value.ref)) &&
+        (value.content === undefined || Array.isArray(value.content))
+      );
     case 'subagent_task':
       return typeof value.taskId === 'string' && typeof value.status === 'string';
     case 'available_commands':

--- a/packages/components/src/components/ai-gui/tool-call-skeleton.ts
+++ b/packages/components/src/components/ai-gui/tool-call-skeleton.ts
@@ -1,0 +1,34 @@
+import { isToolCallRef, type MessageContent, type ToolCallRef } from '@lody/shared';
+
+type ToolCallMessage = Extract<MessageContent, { type: 'tool_call' }>;
+
+export { isToolCallRef };
+
+/**
+ * A sealed tool_call skeleton: the turn stores only `kind`/`status`/`title`/
+ * `locations`/`ref`, and the execution payload (`content`/`rawInput`/
+ * `rawOutput`) stays on the origin machine. A full call and a skeleton share the
+ * `tool_call` discriminant, so callers narrow with this guard rather than
+ * casting around `toolCallId`.
+ */
+export const isToolCallSkeleton = (
+  content: ToolCallMessage
+): content is ToolCallMessage & { ref: ToolCallRef } => isToolCallRef(content.ref);
+
+/**
+ * Stable identity for rows and React keys. A full call uses its `toolCallId`; a
+ * skeleton falls back to its payload ref, which is unique within the turn and
+ * stable across renders. Never returns `undefined`, so keys cannot collide on
+ * the string "undefined".
+ */
+export const getToolCallStableId = (content: ToolCallMessage): string => {
+  if (typeof content.toolCallId === 'string') return content.toolCallId;
+  if (isToolCallRef(content.ref)) {
+    return `ref:${content.ref.machineId}:${content.ref.turnId}:${content.ref.index}`;
+  }
+  return '';
+};
+
+/** Display fallback for a machine whose meta has not loaded (or never will). */
+export const getShortMachineId = (machineId: string): string =>
+  machineId.length > 12 ? `${machineId.slice(0, 8)}…` : machineId;

--- a/packages/components/src/components/ai-gui/tool-call-skeleton.ts
+++ b/packages/components/src/components/ai-gui/tool-call-skeleton.ts
@@ -6,14 +6,21 @@ export { isToolCallRef };
 
 /**
  * A sealed tool_call skeleton: the turn stores only `kind`/`status`/`title`/
- * `locations`/`ref`, and the execution payload (`content`/`rawInput`/
- * `rawOutput`) stays on the origin machine. A full call and a skeleton share the
- * `tool_call` discriminant, so callers narrow with this guard rather than
- * casting around `toolCallId`.
+ * `locations`/`ref`, with no execution payload, because `content`/`rawInput`/
+ * `rawOutput` stay on the origin machine.
+ *
+ * `ref` alone is NOT enough: a full call may also carry a `ref`, and treating it
+ * as a skeleton would make the card render the "stored on <machine>" placeholder
+ * instead of the payload it actually has. A skeleton must therefore actually omit
+ * the payload (an empty `content` array counts as omitted).
  */
 export const isToolCallSkeleton = (
   content: ToolCallMessage
-): content is ToolCallMessage & { ref: ToolCallRef } => isToolCallRef(content.ref);
+): content is ToolCallMessage & { ref: ToolCallRef } =>
+  isToolCallRef(content.ref) &&
+  (content.content?.length ?? 0) === 0 &&
+  content.rawInput === undefined &&
+  content.rawOutput === undefined;
 
 /**
  * Stable identity for rows and React keys. A full call uses its `toolCallId`; a

--- a/packages/components/src/components/ai-gui/use-tool-call-payload.ts
+++ b/packages/components/src/components/ai-gui/use-tool-call-payload.ts
@@ -1,0 +1,25 @@
+import type { ToolCallPayload, ToolCallRef } from '@lody/shared';
+
+export type ToolCallPayloadState = 'idle' | 'loading' | 'ready' | 'unavailable';
+
+export type ToolCallPayloadResult = {
+  state: ToolCallPayloadState;
+  value?: ToolCallPayload;
+};
+
+const UNAVAILABLE: ToolCallPayloadResult = { state: 'unavailable' };
+
+/**
+ * Resolves the execution payload (`content`/`rawInput`/`rawOutput`) of a sealed
+ * tool_call skeleton from the origin machine named by `ref`.
+ *
+ * Scope: this round only makes a ref-only skeleton readable. The Machine RPC
+ * that fetches the payload is NOT implemented, so every lookup reports
+ * `unavailable` and readers render the skeleton (title, kind, status,
+ * locations) with a "stored on <machine>" row instead of the payload. When the
+ * fetch lands it wires in here without changing this signature or its callers.
+ */
+export const useToolCallPayload = (ref: ToolCallRef | undefined): ToolCallPayloadResult => {
+  void ref;
+  return UNAVAILABLE;
+};

--- a/packages/components/src/components/ai-gui/view.tsx
+++ b/packages/components/src/components/ai-gui/view.tsx
@@ -209,6 +209,7 @@ import type {
   MessageTextSpan,
   SessionFilePayload,
   TaskProposalMeta,
+  ToolCallRef,
 } from '@lody/shared';
 import { MessageTextWithChips } from '@/components/mentions/message-text-chips';
 import { isNativeIOSAppShell } from '@/lib/native-platform';
@@ -223,6 +224,8 @@ import { usePermissionResponse } from '@/hooks/use-permission-response';
 import { TaskProposalNotice } from '@/components/tasks/task-proposal-notice';
 import { tasksFeatureEnabledAtom } from '@/atoms/settings';
 import { shouldRenderSystemRowItem } from './message-content-guards';
+import { getShortMachineId, getToolCallStableId, isToolCallSkeleton } from './tool-call-skeleton';
+import { useToolCallPayload } from './use-tool-call-payload';
 import { getChatFailedDiagnosticCopy } from './chat-failed-diagnostic-copy';
 import { extractReadableChatFailedMessage } from './chat-failed-error-report';
 import { ChatFailedDetailDialog } from './chat-failed-detail-dialog';
@@ -976,7 +979,7 @@ export const buildChatVirtualRows = ({
       if (expanded) {
         for (const entry of block.entries) {
           const entrySuffix =
-            entry.content.type === 'tool_call' ? entry.content.toolCallId : 'thought';
+            entry.content.type === 'tool_call' ? getToolCallStableId(entry.content) : 'thought';
           target.push({
             type: 'assistant',
             key: `assistant:${message.id}:${block.key}:item:${entry.itemIndex}:${entrySuffix}`,
@@ -5733,6 +5736,14 @@ const ToolCallCard = memo(function ToolCallCard({
   inlineOutput?: boolean;
 }) {
   const { t } = useTranslation();
+  // A sealed skeleton carries only `kind`/`status`/`title`/`locations`/`ref`;
+  // its payload arrives via `useToolCallPayload`. The Machine RPC is not
+  // implemented yet, so every lookup is `unavailable` and the placeholder row
+  // below names the origin machine instead.
+  const payload = useToolCallPayload(toolCall.ref);
+  const payloadValue = payload.state === 'ready' ? payload.value : undefined;
+  const effectiveContent = payloadValue?.content ?? toolCall.content;
+  const effectiveRawOutput = payloadValue?.rawOutput ?? toolCall.rawOutput;
   if (toolCall.activityKind === 'codex_retry') {
     if (toolCall.status !== 'pending' && toolCall.status !== 'in_progress') return null;
     return (
@@ -5770,18 +5781,18 @@ const ToolCallCard = memo(function ToolCallCard({
     ? ACTIVITY_STEP_ICON_CLASS
     : 'h-3.5 w-3.5 flex-none shrink-0 text-current';
 
-  const hasDiffContent = Boolean(toolCall.content?.some((block) => block.type === 'diff'));
+  const hasDiffContent = Boolean(effectiveContent?.some((block) => block.type === 'diff'));
   const hasTerminalContent = Boolean(
-    toolCall.content?.some(
+    effectiveContent?.some(
       (block) => block.type === 'terminal_command' || block.type === 'terminal_output'
     )
   );
-  const contentBlocks = toolCall.content?.filter((block) => {
+  const contentBlocks = effectiveContent?.filter((block) => {
     if (!hasDiffContent) return true;
     return block.type !== 'terminal' && block.type !== 'terminal_output';
   });
 
-  const hasOutput = Boolean(toolCall.rawOutput);
+  const hasOutput = Boolean(effectiveRawOutput);
   const hasContent = Boolean(contentBlocks?.length);
   /* A cancelled request records nothing, so it must not count towards the body:
      otherwise the card stays collapsible and opens onto empty padding. */
@@ -5966,7 +5977,7 @@ const ToolCallCard = memo(function ToolCallCard({
     return nodes;
   };
 
-  return (
+  const card = (
     <CollapsibleCard
       isCollapsible={hasDetails && !isReadOnly}
       defaultExpanded={isRunning || hasTerminalContent || isFailed || hasPermission}
@@ -6080,10 +6091,10 @@ const ToolCallCard = memo(function ToolCallCard({
     >
       {hasDetails && !isReadOnly ? (
         <Fragment>
-          {hasOutput && isRecord(toolCall.rawOutput) ? (
+          {hasOutput && isRecord(effectiveRawOutput) ? (
             <StructuredObject
               label="Output"
-              value={toolCall.rawOutput}
+              value={effectiveRawOutput}
               dense
               unbounded={inlineOutput}
               fontSize={fontSize}
@@ -6105,7 +6116,7 @@ const ToolCallCard = memo(function ToolCallCard({
                 )}
                 style={conversationMonoFontSizeStyle(fontSize)}
               >
-                {formatJsonValue(toolCall.rawOutput)}
+                {formatJsonValue(effectiveRawOutput)}
               </pre>
             </div>
           ) : null}
@@ -6117,7 +6128,36 @@ const ToolCallCard = memo(function ToolCallCard({
       ) : null}
     </CollapsibleCard>
   );
+
+  // A skeleton whose payload has not arrived says where the execution details
+  // live instead of opening onto nothing.
+  if (!isToolCallSkeleton(toolCall) || payload.state === 'ready') return card;
+  return (
+    <Fragment>
+      {card}
+      <ToolCallPayloadStoredRow toolCallRef={toolCall.ref} />
+    </Fragment>
+  );
 });
+
+/**
+ * One small line under a sealed skeleton tool call naming the machine its
+ * execution payload is stored on. The meta lookup falls back to a short id
+ * when the machine's meta has not loaded (or the machine is unknown).
+ */
+const ToolCallPayloadStoredRow = ({ toolCallRef }: { toolCallRef: ToolCallRef }) => {
+  const { t } = useTranslation();
+  const machineMeta = useAtomValue(getMachineMetaByIdAtomFamily(toolCallRef.machineId));
+  const machineName = machineMeta?.name ?? getShortMachineId(toolCallRef.machineId);
+  return (
+    <div className={cn('flex items-center gap-1.5 py-0.5', ACTIVITY_PROCESS_TEXT_CLASS)}>
+      {t('sessions.toolCall.executionDetailsStoredOnMachine', {
+        machine: machineName,
+        defaultValue: 'Execution details are stored on {{machine}}',
+      })}
+    </div>
+  );
+};
 
 const TOOL_KIND_META: Record<
   NonNullable<ToolCallMessage['kind']>,

--- a/packages/components/tests/tool-call-skeleton.test.ts
+++ b/packages/components/tests/tool-call-skeleton.test.ts
@@ -156,6 +156,8 @@ describe('tool-call skeleton helpers', () => {
     expect(isToolCallRef(null)).toBe(false);
 
     expect(isToolCallSkeleton(skeletonTool('execute'))).toBe(true);
+    // An empty content array from a normalizing reader is still "no payload".
+    expect(isToolCallSkeleton(skeletonTool('execute', { content: [] }))).toBe(true);
     expect(
       isToolCallSkeleton({
         type: 'tool_call',
@@ -163,6 +165,55 @@ describe('tool-call skeleton helpers', () => {
         status: 'completed',
       })
     ).toBe(false);
+  });
+
+  it('does not treat a full call that also carries a ref as a skeleton', () => {
+    // `ref` alone is not the predicate: a full call with payload + ref must keep
+    // rendering its real payload, not the "stored on <machine>" placeholder.
+    expect(
+      isToolCallSkeleton({
+        type: 'tool_call',
+        toolCallId: 'call-1',
+        status: 'completed',
+        ref: ref(),
+        content: [{ type: 'terminal_output', output: 'real output' }],
+      })
+    ).toBe(false);
+    expect(
+      isToolCallSkeleton({
+        type: 'tool_call',
+        toolCallId: 'call-1',
+        status: 'completed',
+        ref: ref(),
+        rawOutput: { ok: true },
+      })
+    ).toBe(false);
+    expect(
+      isToolCallSkeleton({
+        type: 'tool_call',
+        toolCallId: 'call-1',
+        status: 'completed',
+        ref: ref(),
+        rawInput: { command: 'ls' },
+      })
+    ).toBe(false);
+  });
+
+  it('classifies a full call with a ref from its content, not its ref', () => {
+    // With the loose predicate this was counted as `other`; a full call must
+    // consult `content` for terminal detection even when a ref is present.
+    const blocks = buildAssistantTurnRenderBlocks('assistant-1', [
+      {
+        type: 'tool_call',
+        toolCallId: 'call-1',
+        status: 'completed',
+        ref: ref(),
+        content: [{ type: 'terminal_output', output: 'real output' }],
+      },
+    ]);
+    const block = blocks[0];
+    if (block?.kind !== 'activity_group') throw new Error('Expected activity group');
+    expect(block.summary).toMatchObject({ commandCount: 1, otherCount: 0 });
   });
 
   it('falls back to the ref when a skeleton has no toolCallId', () => {

--- a/packages/components/tests/tool-call-skeleton.test.ts
+++ b/packages/components/tests/tool-call-skeleton.test.ts
@@ -1,0 +1,176 @@
+import type { MachineId, MessageContent, ToolCallRef } from '@lody/shared';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAssistantTurnRenderBlocks,
+  buildAssistantTurnRenderLayout,
+} from '../src/components/ai-gui/assistant-turn-render-blocks';
+import {
+  getCopyTextFromMessageItems,
+  getVisibleAssistantTextContent,
+  hasTextContentFromMessageItems,
+} from '../src/components/ai-gui/message-copy';
+import {
+  isMessageContent,
+  normalizeMessageContent,
+} from '../src/components/ai-gui/message-content-guards';
+import {
+  getToolCallStableId,
+  isToolCallRef,
+  isToolCallSkeleton,
+} from '../src/components/ai-gui/tool-call-skeleton';
+
+const ref = (overrides: Partial<ToolCallRef> = {}): ToolCallRef => ({
+  machineId: 'machine-1' as MachineId,
+  turnId: 'turn-1',
+  index: 0,
+  ...overrides,
+});
+
+type ToolCallMessage = Extract<MessageContent, { type: 'tool_call' }>;
+
+/**
+ * A sealed skeleton as a writer persists it: no `toolCallId`, no `content`, no
+ * `rawInput`/`rawOutput`. Built without a cast — the shared type must express it.
+ */
+const skeletonTool = (
+  kind: ToolCallMessage['kind'],
+  overrides: Partial<ToolCallMessage> = {}
+): ToolCallMessage => ({
+  type: 'tool_call',
+  kind,
+  status: 'completed',
+  ref: ref(),
+  ...overrides,
+});
+
+describe('sealed tool_call skeletons in message content guards', () => {
+  it('accepts a skeleton with a valid ref and no toolCallId or content', () => {
+    expect(isMessageContent(skeletonTool('execute', { title: 'pnpm test' }))).toBe(true);
+    expect(normalizeMessageContent(skeletonTool('read'))).not.toBeNull();
+  });
+
+  it('still accepts a full tool_call with toolCallId and content', () => {
+    expect(
+      isMessageContent({
+        type: 'tool_call',
+        toolCallId: 'call-1',
+        kind: 'edit',
+        status: 'completed',
+        content: [{ type: 'diff', path: 'src/view.tsx', newText: 'next' }],
+      })
+    ).toBe(true);
+  });
+
+  it('accepts a full tool_call that also carries a ref', () => {
+    expect(
+      isMessageContent({
+        type: 'tool_call',
+        toolCallId: 'call-1',
+        status: 'completed',
+        ref: ref(),
+      })
+    ).toBe(true);
+  });
+
+  it('rejects tool_call garbage: no identity, no status, or a malformed ref', () => {
+    expect(isMessageContent({ type: 'tool_call', status: 'completed' })).toBe(false);
+    expect(isMessageContent({ type: 'tool_call', ref: ref() })).toBe(false);
+    expect(
+      isMessageContent({
+        type: 'tool_call',
+        status: 'completed',
+        ref: { machineId: 'machine-1', turnId: 'turn-1' },
+      })
+    ).toBe(false);
+    expect(isMessageContent({ type: 'tool_call', status: 'completed', toolCallId: 42 })).toBe(
+      false
+    );
+  });
+});
+
+describe('sealed tool_call skeletons in activity counting', () => {
+  it('counts activity from kind/status and locations without reading content', () => {
+    const blocks = buildAssistantTurnRenderBlocks('assistant-1', [
+      skeletonTool('execute'),
+      skeletonTool('read', { ref: ref({ index: 1 }), locations: [{ path: 'src/view.tsx' }] }),
+      skeletonTool('edit', { ref: ref({ index: 2 }), locations: [{ path: 'src/view.tsx' }] }),
+      skeletonTool('search', { ref: ref({ index: 3 }), status: 'failed' }),
+    ]);
+
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    expect(block?.kind).toBe('activity_group');
+    if (block?.kind !== 'activity_group') throw new Error('Expected activity group');
+    expect(block.summary).toMatchObject({
+      commandCount: 1,
+      readFileCount: 1,
+      editFileCount: 1,
+      searchCount: 1,
+      otherCount: 0,
+    });
+  });
+
+  it('keeps group keys stable for skeletons that have no toolCallId', () => {
+    const initial = buildAssistantTurnRenderBlocks('assistant-1', [skeletonTool('execute')]);
+    const updated = buildAssistantTurnRenderBlocks('assistant-1', [
+      skeletonTool('execute'),
+      skeletonTool('read', { ref: ref({ index: 1 }) }),
+    ]);
+
+    expect(initial[0]?.key).toBe(updated[0]?.key);
+    expect(initial[0]?.key).not.toContain('undefined');
+  });
+
+  it('derives edited paths from locations when content is absent', () => {
+    const layout = buildAssistantTurnRenderLayout(
+      'assistant-1',
+      [
+        skeletonTool('edit', { locations: [{ path: 'src/a.ts' }, { path: 'src/b.ts' }] }),
+        { type: 'text', text: 'Done.' },
+      ],
+      true
+    );
+
+    const group = layout.blocks.find((block) => block.kind === 'activity_group');
+    if (group?.kind !== 'activity_group') throw new Error('Expected activity group');
+    expect(group.summary.editFileCount).toBe(2);
+  });
+});
+
+describe('sealed tool_call skeletons in message copy', () => {
+  it('copies only the text items of a turn that contains skeletons', () => {
+    const items: MessageContent[] = [skeletonTool('execute'), { type: 'text', text: 'All done.' }];
+
+    expect(getCopyTextFromMessageItems(items)).toBe('All done.');
+    expect(getVisibleAssistantTextContent(items, true)).toBe('All done.');
+    expect(hasTextContentFromMessageItems([skeletonTool('execute')])).toBe(false);
+  });
+});
+
+describe('tool-call skeleton helpers', () => {
+  it('recognizes refs and skeletons at runtime', () => {
+    expect(isToolCallRef(ref())).toBe(true);
+    expect(isToolCallRef({ machineId: 'm', turnId: 't' })).toBe(false);
+    expect(isToolCallRef({ ...ref(), index: Number.NaN })).toBe(false);
+    expect(isToolCallRef(null)).toBe(false);
+
+    expect(isToolCallSkeleton(skeletonTool('execute'))).toBe(true);
+    expect(
+      isToolCallSkeleton({
+        type: 'tool_call',
+        toolCallId: 'call-1',
+        status: 'completed',
+      })
+    ).toBe(false);
+  });
+
+  it('falls back to the ref when a skeleton has no toolCallId', () => {
+    expect(getToolCallStableId(skeletonTool('execute', { ref: ref({ index: 2 }) }))).toBe(
+      'ref:machine-1:turn-1:2'
+    );
+    expect(
+      getToolCallStableId({ type: 'tool_call', toolCallId: 'call-1', status: 'completed' })
+    ).toBe('call-1');
+  });
+});

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -18,10 +18,9 @@
   retain JSON data, not arbitrary JS objects. Storage layout stays separate and is an
   insertion policy, never a migration or a validation constraint: new writes store
   ordinary metadata strings as primitives and create `LoroText` only for fields that
-  stream. That holds at every nesting level — a tool content or worktree-step `command`,
-  `path`, `args` or terminal id is metadata, so only payloads like tool `text`/`output`
-  and nested `content.text` are declared Text in `schema.ts`. Stored values keep their
-  representation, and opening a document never rewraps them. Rationale:
+  stream, at every nesting level — nested tool/worktree `command`/`path`/`args` are
+  metadata, only payloads like `text`/`output`/nested `content.text` are Text. Stored
+  values keep their representation, and opening a document never rewraps them. Rationale:
   [single writer](../../.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md).
 - Parser coverage must include nested discriminators (`system_notice.name`) and
   correlated metadata, not just item `type`. Fork regression tests must cross the
@@ -33,15 +32,15 @@
   of untouched rows and later appended rows. Reject changes to existing row identity/order and edits inside that range,
   except pending-to-seen read acknowledgement on newly inserted user rows.
   External ACP imports remain new input.
-- A `tool_call` is identified by `toolCallId` (full call) or a valid `ref` (sealed
-  skeleton); the TS type, Zod parser and Loro `validate` accept both and reject
-  neither-identity. A skeleton has no payload (`content`/`rawInput`/`rawOutput`), is
-  never a merge target matched by id, and its `ref.index` must survive filtering,
-  hashing and unrelated edits. The payload fetch is not implemented.
-- Tool fields other than type/toolCallId/ref are independent
-  edits: derive their parsers from the tool message schema and validate changed fields,
-  not untouched stored payloads. Content-list edits retain unchanged blocks and parse
-  authored blocks; tool identity changes still use the complete item parser.
+- A `tool_call` carries `toolCallId` (full call) or `ref` (sealed skeleton) in one
+  `ToolCallIdentity` union; the TS type, Zod parser and Loro `validate` all reject
+  neither-identity (`history-writer.contract.ts` compiles that guard). A skeleton is a
+  *no-payload* item, not merely any item carrying `ref` (a full call may carry one too);
+  it is never a merge target and its `ref.index` must survive filtering, hashing and
+  unrelated edits. The payload fetch is not implemented.
+- Tool fields other than type/toolCallId/ref parse only authored changes, derived from
+  the tool message schema, not untouched stored payloads. Content-list edits retain
+  unchanged blocks and parse authored blocks; identity changes use the complete item parser.
 - Normalize legacy built-in CLI selectors on new history input only. Independent stored
   input-config and task-proposal metadata edits validate changed fields, not untouched
   historical values; proposal identity changes still require complete parsing.

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -33,7 +33,12 @@
   of untouched rows and later appended rows. Reject changes to existing row identity/order and edits inside that range,
   except pending-to-seen read acknowledgement on newly inserted user rows.
   External ACP imports remain new input.
-- Tool fields other than type/toolCallId are independent
+- A `tool_call` is identified by `toolCallId` (full call) or a valid `ref` (sealed
+  skeleton); the TS type, Zod parser and Loro `validate` accept both and reject
+  neither-identity. A skeleton has no payload (`content`/`rawInput`/`rawOutput`), is
+  never a merge target matched by id, and its `ref.index` must survive filtering,
+  hashing and unrelated edits. The payload fetch is not implemented.
+- Tool fields other than type/toolCallId/ref are independent
   edits: derive their parsers from the tool message schema and validate changed fields,
   not untouched stored payloads. Content-list edits retain unchanged blocks and parse
   authored blocks; tool identity changes still use the complete item parser.

--- a/packages/shared/src/acp/history-apply.ts
+++ b/packages/shared/src/acp/history-apply.ts
@@ -1404,6 +1404,8 @@ class NotificationOnHistoryApplier {
 
       for (const content of items) {
         if (content.type !== 'tool_call') continue;
+        // A sealed skeleton may omit `toolCallId`; it is never a merge target.
+        if (typeof content.toolCallId !== 'string') continue;
         if (!unresolved.has(content.toolCallId)) continue;
         this.toolCallEntryIndexById.set(content.toolCallId, i);
         unresolved.delete(content.toolCallId);
@@ -1563,14 +1565,21 @@ class NotificationOnHistoryApplier {
         return;
       }
       case 'tool_call': {
-        const existingEntryIndex = this.resolveToolCallEntryIndex(message.toolCallId);
+        // A message without a `toolCallId` (e.g. a replayed sealed skeleton) can
+        // never match a live item; append it like any unknown id, but do not index it.
+        const existingEntryIndex =
+          typeof message.toolCallId === 'string'
+            ? this.resolveToolCallEntryIndex(message.toolCallId)
+            : undefined;
         if (existingEntryIndex !== undefined) {
           this.upsertToolCall(existingEntryIndex, message);
           return;
         }
         const entryIndex = this.ensureActiveAssistantEntry();
         this.upsertToolCall(entryIndex, this.stampSchedulingToolCall(message));
-        this.toolCallEntryIndexById.set(message.toolCallId, entryIndex);
+        if (typeof message.toolCallId === 'string') {
+          this.toolCallEntryIndexById.set(message.toolCallId, entryIndex);
+        }
         return;
       }
       case 'subagent_task': {
@@ -1706,8 +1715,13 @@ class NotificationOnHistoryApplier {
     if (!entry) return;
 
     const items = this.ensureEntryItems(entryIndex);
+    // A sealed skeleton may omit `toolCallId`; an id-less incoming item must
+    // never match it on an `undefined === undefined` key and overwrite it.
     const toolIndex = items.findIndex(
-      (m) => m.type === 'tool_call' && (m as ToolCallMessage).toolCallId === incoming.toolCallId
+      (m) =>
+        m.type === 'tool_call' &&
+        typeof (m as ToolCallMessage).toolCallId === 'string' &&
+        (m as ToolCallMessage).toolCallId === incoming.toolCallId
     );
     if (toolIndex >= 0) {
       const prevTool = items[toolIndex] as ToolCallMessage;
@@ -2010,8 +2024,13 @@ export const applyMessageContentsBatch = (
 
     // Tool calls are keyed by `toolCallId` (not by position).
     // We merge updates into the original entry whenever possible.
+    // A sealed skeleton may omit `toolCallId`; an id-less incoming item must
+    // never match it on an `undefined === undefined` key and overwrite it.
     const toolIndex = state.items.findIndex(
-      (m) => m.type === 'tool_call' && (m as ToolCallMessage).toolCallId === incoming.toolCallId
+      (m) =>
+        m.type === 'tool_call' &&
+        typeof (m as ToolCallMessage).toolCallId === 'string' &&
+        (m as ToolCallMessage).toolCallId === incoming.toolCallId
     );
     if (toolIndex >= 0) {
       const prevTool = state.items[toolIndex] as ToolCallMessage;
@@ -2039,12 +2058,14 @@ export const applyMessageContentsBatch = (
 
   // Build an index of existing tool calls so updates can be applied to the entry where the
   // tool call originally appeared (instead of always appending to the latest assistant entry).
+  // Sealed skeleton items may omit `toolCallId`; skip them so they never collide on an
+  // `undefined` key or become merge targets.
   const toolCallEntryIndexById = new Map<string, number>();
   for (let i = 0; i < entryStates.length; i++) {
     const state = entryStates[i];
     if (!state) continue;
     for (const content of state.items) {
-      if (content.type === 'tool_call') {
+      if (content.type === 'tool_call' && typeof content.toolCallId === 'string') {
         toolCallEntryIndexById.set(content.toolCallId, i);
       }
     }
@@ -2090,13 +2111,20 @@ export const applyMessageContentsBatch = (
       case 'tool_call': {
         // Unlike other message types, tool calls can receive future updates that should
         // modify the original tool call entry (by `toolCallId`), not the "current" entry.
-        const existingEntryIndex = toolCallEntryIndexById.get(message.toolCallId);
+        // A message without a `toolCallId` (e.g. a replayed sealed skeleton) can never
+        // match a live item; append it like any unknown id, but do not index it.
+        const existingEntryIndex =
+          typeof message.toolCallId === 'string'
+            ? toolCallEntryIndexById.get(message.toolCallId)
+            : undefined;
         if (existingEntryIndex !== undefined) {
           upsertToolCall(existingEntryIndex, message);
         } else {
           const entryIndex = ensureActiveAssistantEntry();
           upsertToolCall(entryIndex, message);
-          toolCallEntryIndexById.set(message.toolCallId, entryIndex);
+          if (typeof message.toolCallId === 'string') {
+            toolCallEntryIndexById.set(message.toolCallId, entryIndex);
+          }
         }
         break;
       }

--- a/packages/shared/src/acp/history-apply.ts
+++ b/packages/shared/src/acp/history-apply.ts
@@ -1,4 +1,4 @@
-import type { MessageContent, ModelInfo } from '../ai';
+import type { MessageContent, ModelInfo, ToolCallIdentity } from '../ai';
 import type { SessionHistoryInput, SessionPlanEntry } from '../schema';
 import { sanitizeLodyInternalInstructions } from '../goal';
 
@@ -909,9 +909,18 @@ const mergeToolCallMessage = (
   const nextStatus =
     statusRank[incoming.status] < statusRank[prev.status] ? prev.status : incoming.status;
 
+  // This merge path is keyed by `toolCallId`, so a live update carries one; a `ref`-only
+  // replay never reaches here because skeletons are not merge targets. Rebuild the
+  // identity explicitly so the TS union stays satisfied, but never clear `ref` with an
+  // `undefined` from an update that predates the pointer.
+  const identity: ToolCallIdentity =
+    typeof incoming.toolCallId === 'string'
+      ? { toolCallId: incoming.toolCallId, ...(incoming.ref ? { ref: incoming.ref } : {}) }
+      : { ref: incoming.ref };
+
   return {
     ...prev,
-    toolCallId: incoming.toolCallId,
+    ...identity,
     // `null` title/kind means "no information" on the wire (zod allows explicit null);
     // it must keep the previously persisted value, not wipe it.
     title: incoming.title ?? prev.title,

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -1534,15 +1534,9 @@ export type MessageContent =
       isLatest: boolean;
     }
   | SessionGoalContent
-  | {
+  | ({
       type: 'tool_call';
       _meta?: { [k: string]: unknown } | null;
-      /**
-       * ACP-assigned id. Present on every live/full tool call. A sealed skeleton
-       * omits it and identifies itself with `ref` instead, so this is optional in
-       * the type to match the runtime contract exactly.
-       */
-      toolCallId?: string;
       title?: string | null;
       status: ToolCallStatus;
       kind?: ToolKind;
@@ -1550,13 +1544,6 @@ export type MessageContent =
       locations?: ToolCallLocation[];
       rawInput?: { [k: string]: unknown };
       rawOutput?: { [k: string]: unknown };
-      /**
-       * Payload pointer of a sealed skeleton. The execution payload
-       * (`content`/`rawInput`/`rawOutput`) stays on the origin machine; readers
-       * must tolerate its absence whenever `ref` is present and never treat a
-       * skeleton as a merge target for a live tool call.
-       */
-      ref?: ToolCallRef;
       /** Small provider-neutral marker for tool-like status rows rendered in the transcript. */
       activityKind?: 'context_compaction' | 'codex_retry';
       /**
@@ -1588,7 +1575,7 @@ export type MessageContent =
         _meta?: Record<string, unknown>;
         outcome?: PermissionOutcome;
       };
-    }
+    } & ToolCallIdentity)
   | ({
       type: 'subagent_task';
     } & SubagentTaskPayload)
@@ -1632,6 +1619,16 @@ export type ToolCallRef = {
   turnId: string;
   index: number;
 };
+
+/**
+ * A `tool_call` carries at least one identity: `toolCallId` for a live/full call or
+ * `ref` for a sealed skeleton. Expressing it as a union makes the TypeScript type
+ * reject an identity-less tool_call exactly like the Zod parser and the Loro
+ * `validate` guard do. A full call may additionally carry a `ref`.
+ */
+export type ToolCallIdentity =
+  | { toolCallId: string; ref?: ToolCallRef }
+  | { toolCallId?: undefined; ref: ToolCallRef };
 
 /**
  * The execution payload a sealed skeleton omits. Fetched on demand from the

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -8,7 +8,7 @@ import {
 import type { ToolCallContent as AcpToolCallContent, SessionMode } from '@agentclientprotocol/sdk';
 import type { PermissionOutcome } from './message';
 import { createPlanModeConfigOption } from 'acp-extension-core';
-import type { AgentConfigId, AgentRoleId, McpServerId, SessionId } from './ids';
+import type { AgentConfigId, AgentRoleId, MachineId, McpServerId, SessionId } from './ids';
 import type { MessageTextSpan } from './message-text-spans';
 import type { MinimalVisualAnnotationAnchor } from './visual-annotation-types';
 import type { WorktreeScriptPhase } from './project';
@@ -1537,7 +1537,12 @@ export type MessageContent =
   | {
       type: 'tool_call';
       _meta?: { [k: string]: unknown } | null;
-      toolCallId: string;
+      /**
+       * ACP-assigned id. Present on every live/full tool call. A sealed skeleton
+       * omits it and identifies itself with `ref` instead, so this is optional in
+       * the type to match the runtime contract exactly.
+       */
+      toolCallId?: string;
       title?: string | null;
       status: ToolCallStatus;
       kind?: ToolKind;
@@ -1545,6 +1550,13 @@ export type MessageContent =
       locations?: ToolCallLocation[];
       rawInput?: { [k: string]: unknown };
       rawOutput?: { [k: string]: unknown };
+      /**
+       * Payload pointer of a sealed skeleton. The execution payload
+       * (`content`/`rawInput`/`rawOutput`) stays on the origin machine; readers
+       * must tolerate its absence whenever `ref` is present and never treat a
+       * skeleton as a merge target for a live tool call.
+       */
+      ref?: ToolCallRef;
       /** Small provider-neutral marker for tool-like status rows rendered in the transcript. */
       activityKind?: 'context_compaction' | 'codex_retry';
       /**
@@ -1607,6 +1619,40 @@ export type MessageContent =
   | ({
       type: 'visual_annotation_reference';
     } & VisualAnnotationReferencePayload);
+
+/**
+ * Pointer from a sealed tool_call skeleton to its full execution payload. The
+ * payload lives in the origin machine's local store, keyed by the owning turn
+ * and the item's index inside that turn's `items` list. The index is the
+ * skeleton's anchor: reader paths must preserve item positions and must never
+ * renumber a skeleton when they filter or edit unrelated items.
+ */
+export type ToolCallRef = {
+  machineId: MachineId;
+  turnId: string;
+  index: number;
+};
+
+/**
+ * The execution payload a sealed skeleton omits. Fetched on demand from the
+ * origin machine; until that transport exists, readers resolve it to an
+ * `unavailable` state and render the skeleton itself.
+ */
+export type ToolCallPayload = {
+  content?: ToolCallContent[];
+  rawInput?: { [k: string]: unknown };
+  rawOutput?: { [k: string]: unknown };
+};
+
+/** Runtime guard for a skeleton's payload pointer; shared by every reader. */
+export const isToolCallRef = (value: unknown): value is ToolCallRef =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  typeof (value as ToolCallRef).machineId === 'string' &&
+  typeof (value as ToolCallRef).turnId === 'string' &&
+  typeof (value as ToolCallRef).index === 'number' &&
+  Number.isFinite((value as ToolCallRef).index);
 
 export type TerminalExitStatus = {
   exitCode?: number | null;

--- a/packages/shared/src/history-writer.ts
+++ b/packages/shared/src/history-writer.ts
@@ -118,10 +118,13 @@ const cleanNew = (schema: z.ZodType, input: unknown, old?: unknown): unknown => 
 };
 
 // One independently editable group, derived from the message definition rather
-// than a second set of validators. Tool identity stays outside this group.
+// than a second set of validators. Tool identity stays outside this group:
+// `toolCallId` for a full call and `ref` for a sealed skeleton, so changing
+// either uses the complete item parser.
 const ToolStateWriteSchema = ToolCallMessageSchema.omit({
   type: true,
   toolCallId: true,
+  ref: true,
 });
 
 function prepareObjectFields(

--- a/packages/shared/src/message-schemas.ts
+++ b/packages/shared/src/message-schemas.ts
@@ -3173,10 +3173,22 @@ export const ChatFailedMetaSchema = z.object({
   message: z.string().optional(),
 });
 
+/**
+ * Payload pointer of a sealed tool_call skeleton. Mirrors `ToolCallRef` in
+ * `ai.ts`; the `index` is the item's position in the owning turn's `items`, so
+ * reader paths must never renumber items around a skeleton.
+ */
+export const ToolCallRefSchema = z.object({
+  machineId: z.string(),
+  turnId: z.string(),
+  index: z.number(),
+});
+
 export const ToolCallMessageSchema = z.object({
   type: z.literal('tool_call'),
   _meta: PermissionMetaSchema.optional(),
-  toolCallId: z.string(),
+  /** Absent on a sealed skeleton, which identifies itself with `ref` instead. */
+  toolCallId: z.string().optional(),
   title: z.string().nullable().optional(),
   status: ToolCallStatusSchema,
   kind: ToolKindSchema.optional(),
@@ -3184,6 +3196,8 @@ export const ToolCallMessageSchema = z.object({
   locations: z.array(ToolCallLocationSchema).optional(),
   rawInput: z.record(z.string(), z.unknown()).optional(),
   rawOutput: z.record(z.string(), z.unknown()).optional(),
+  /** Present only on a sealed skeleton; it never carries the execution payload. */
+  ref: ToolCallRefSchema.optional(),
   activityKind: z.enum(['context_compaction', 'codex_retry']).optional(),
   // Canonical tool name, when the agent published one (ACP `title` is human-facing).
   toolName: z.string().optional(),
@@ -3357,6 +3371,17 @@ export const MessageContentSchema = z
   .union([NonSystemNoticeMessageContentSchema, SystemNoticeSchema, WorktreeScriptContentSchema])
   .superRefine((item, ctx) => {
     if (item.type === 'file') refineSessionFileBlock(item, ctx);
+    // A tool_call is identified by `toolCallId` (full/live) or `ref` (sealed
+    // skeleton). The discriminated union above keeps `ToolCallMessageSchema` an
+    // object so it stays usable with `.omit`; the identity requirement lives
+    // here so no writer can persist an unaddressable tool call.
+    if (item.type === 'tool_call' && typeof item.toolCallId !== 'string' && !item.ref) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'tool_call requires toolCallId or ref',
+        path: ['toolCallId'],
+      });
+    }
   });
 
 export const MessageContentArraySchema = z.array(MessageContentSchema);

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -31,7 +31,7 @@ import {
   WorktreeSetupScriptConfig,
 } from '.';
 import type { PlanEntry } from '@agentclientprotocol/sdk';
-import type { ModelInfo } from './ai';
+import { isToolCallRef, type ModelInfo } from './ai';
 import type { MachineProtocolCapabilities } from './machine-protocol-capabilities';
 export * from 'loro-mirror';
 import type { RateLimit } from 'acp-extension-core';
@@ -322,7 +322,10 @@ const historyMessageItemSchema = schema
               ? true
               : 'Missing goal metadata';
           case 'tool_call':
-            return typeof v.toolCallId === 'string' && typeof v.status === 'string'
+            // A full tool call carries `toolCallId`; a sealed skeleton omits it
+            // and points at the origin machine's payload with a valid `ref`.
+            return typeof v.status === 'string' &&
+              (typeof v.toolCallId === 'string' || isToolCallRef(v.ref))
               ? true
               : 'Missing toolCallId/status';
           case 'subagent_task':

--- a/packages/shared/tests/acp-history-apply.test.ts
+++ b/packages/shared/tests/acp-history-apply.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import { describe, expect, it } from 'vitest';
 
 import type { MessageContent } from '../src/ai';
+import type { MachineId } from '../src/ids';
 import {
   MAX_STORED_TERMINAL_OUTPUT_BYTES,
   applyMessageContentsBatch,
@@ -945,4 +946,218 @@ describe('acp history apply', () => {
       }
     }
   );
+});
+
+describe('sealed skeleton tool_call items', () => {
+  type HistoryInput = Parameters<typeof applyNotificationOnHistory>[0];
+
+  // A sealed turn's skeleton: no `toolCallId`, no `content`, no rawInput/rawOutput —
+  // only the ref pointer to the origin machine's payload store. Typed without a cast.
+  const skeletonItem: MessageContent = {
+    type: 'tool_call',
+    kind: 'execute',
+    status: 'completed',
+    title: 'Shell',
+    ref: { machineId: 'machine-1' as MachineId, turnId: 'sealed-turn', index: 1 },
+  };
+
+  const makeSealedHistory = (items: unknown[]): HistoryInput =>
+    [
+      {
+        id: 'sealed-turn',
+        role: 'assistant',
+        finished: true,
+        timestamp: '2026-05-13T00:00:00.000Z',
+        items,
+      },
+    ] as unknown as HistoryInput;
+
+  const readItems = (entry: unknown): MessageContent[] => {
+    const items = (entry as { items?: unknown }).items;
+    return Array.isArray(items) ? (items as unknown as MessageContent[]) : [];
+  };
+
+  const findToolCall = (entry: unknown) =>
+    readItems(entry).find((item) => item.type === 'tool_call') as
+      | Extract<MessageContent, { type: 'tool_call' }>
+      | undefined;
+
+  it('still merges tool_call_update into a live item when earlier sealed entries hold skeletons', () => {
+    const history = applyNotificationOnHistory(
+      makeSealedHistory([{ type: 'text', text: 'done' }, skeletonItem]),
+      [
+        makeNotification({
+          sessionUpdate: 'tool_call',
+          toolCallId: 'live-1',
+          title: 'Shell',
+          status: 'in_progress',
+          rawInput: { command: 'echo hi' },
+        }),
+        makeNotification({
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'live-1',
+          status: 'completed',
+          rawOutput: { stdout: 'hi\n', exit_code: 0 },
+        }),
+      ],
+      undefined,
+      { createId: () => 'live-entry', now: () => '2026-05-14T00:00:00.000Z' }
+    );
+
+    expect(history).toHaveLength(2);
+    // The sealed entry (including its skeleton) is untouched.
+    expect(readItems(history[0])).toEqual([{ type: 'text', text: 'done' }, skeletonItem]);
+
+    const toolCall = findToolCall(history[1]);
+    expect(toolCall).toMatchObject({ toolCallId: 'live-1', status: 'completed' });
+    const output = toolCall?.content?.find((block) => block.type === 'terminal_output');
+    expect(output).toMatchObject({ output: 'hi\n' });
+  });
+
+  it('merges an update into the live entry holding the id when a sealed skeleton entry precedes it', () => {
+    const history = [
+      {
+        id: 'sealed-turn',
+        role: 'assistant',
+        finished: true,
+        timestamp: '2026-05-13T00:00:00.000Z',
+        items: [skeletonItem],
+      },
+      {
+        id: 'live-turn',
+        role: 'assistant',
+        timestamp: '2026-05-14T00:00:00.000Z',
+        items: [
+          {
+            type: 'tool_call',
+            toolCallId: 'live-9',
+            title: 'Shell',
+            status: 'in_progress',
+            content: [{ type: 'terminal_command', command: 'echo hi' }],
+          },
+        ],
+      },
+    ] as unknown as HistoryInput;
+
+    const next = applyNotificationOnHistory(history, [
+      makeNotification({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'live-9',
+        status: 'completed',
+        rawOutput: { stdout: 'hi\n', exit_code: 0 },
+      }),
+    ]);
+
+    expect(next).toHaveLength(2);
+    expect(readItems(next[0])).toEqual([skeletonItem]);
+    const merged = findToolCall(next[1]);
+    expect(merged).toMatchObject({ toolCallId: 'live-9', status: 'completed' });
+    expect(merged?.content?.some((block) => block.type === 'terminal_output')).toBe(true);
+  });
+
+  it('appends a tool_call_update whose id matches no live item (unknown-id semantics unchanged)', () => {
+    const history = applyNotificationOnHistory(
+      makeSealedHistory([skeletonItem]),
+      [
+        makeNotification({
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'missing-id',
+          status: 'completed',
+          rawOutput: { stdout: 'orphan\n', exit_code: 0 },
+        }),
+      ],
+      undefined,
+      { createId: () => 'live-entry', now: () => '2026-05-14T00:00:00.000Z' }
+    );
+
+    expect(history).toHaveLength(2);
+    expect(readItems(history[0])).toEqual([skeletonItem]);
+    expect(findToolCall(history[1])).toMatchObject({
+      toolCallId: 'missing-id',
+      status: 'completed',
+    });
+  });
+
+  it('hydrates a skeleton that carries a toolCallId instead of crashing on its missing content', () => {
+    const skeletonWithId: MessageContent = {
+      type: 'tool_call',
+      toolCallId: 'sealed-1',
+      kind: 'execute',
+      status: 'in_progress',
+      title: 'Shell',
+      ref: { machineId: 'machine-1' as MachineId, turnId: 'sealed-turn', index: 0 },
+    };
+
+    const next = applyNotificationOnHistory(makeSealedHistory([skeletonWithId]), [
+      makeNotification({
+        sessionUpdate: 'tool_call_update',
+        toolCallId: 'sealed-1',
+        status: 'completed',
+        rawOutput: { stdout: 'late\n', exit_code: 0 },
+      }),
+    ]);
+
+    // Merged in place inside the sealed entry; the ref pointer survives.
+    expect(next).toHaveLength(1);
+    const merged = findToolCall(next[0]);
+    expect(merged).toMatchObject({
+      toolCallId: 'sealed-1',
+      status: 'completed',
+      ref: skeletonWithId.ref,
+    });
+    expect(merged?.content?.some((block) => block.type === 'terminal_output')).toBe(true);
+  });
+
+  it('applyMessageContentsBatch ignores skeletons when indexing and never merges into them', () => {
+    const history = [
+      {
+        id: 'live-turn',
+        role: 'assistant',
+        timestamp: '2026-05-14T00:00:00.000Z',
+        items: [
+          // Sealed skeleton sitting inside an unfinished entry.
+          skeletonItem,
+          {
+            type: 'tool_call',
+            toolCallId: 'live-9',
+            title: 'Shell',
+            status: 'in_progress',
+            content: [{ type: 'terminal_command', command: 'echo hi' }],
+          },
+        ],
+      },
+    ] as unknown as Parameters<typeof applyMessageContentsBatch>[0];
+
+    const replayedSkeleton: MessageContent = {
+      type: 'tool_call',
+      kind: 'read',
+      status: 'completed',
+      title: 'ReadFile',
+      ref: { machineId: 'machine-1' as MachineId, turnId: 'other-turn', index: 0 },
+    };
+
+    const next = applyMessageContentsBatch(
+      history,
+      [
+        {
+          type: 'tool_call',
+          toolCallId: 'live-9',
+          status: 'completed',
+          content: [{ type: 'terminal_output', output: 'hi\n', stream: 'combined' }],
+        },
+        replayedSkeleton,
+      ] as unknown as MessageContent[],
+      { createId: () => 'entry-x', now: () => '2026-05-14T01:00:00.000Z' }
+    );
+
+    expect(next).toHaveLength(1);
+    const toolCalls = readItems(next[0]).filter((item) => item.type === 'tool_call');
+    expect(toolCalls).toHaveLength(3);
+    // The original skeleton is untouched and was not a merge target.
+    expect(toolCalls[0]).toEqual(skeletonItem);
+    // The live item merged in place by id.
+    expect(toolCalls[1]).toMatchObject({ toolCallId: 'live-9', status: 'completed' });
+    // The id-less replayed skeleton appended as its own item (unknown-id semantics).
+    expect(toolCalls[2]).toEqual(replayedSkeleton);
+  });
 });

--- a/packages/shared/tests/history-writer.contract.ts
+++ b/packages/shared/tests/history-writer.contract.ts
@@ -2,6 +2,7 @@ import type { HistoryWriter } from '../src/history-writer';
 import type { SessionHistory } from '../src/schema';
 import type { HistoryEntryWrite, HistoryEntryWriteSchema } from '../src/history-write-schema';
 import type { MessageContent } from '../src/ai';
+import type { MachineId } from '../src/ids';
 import type { MessageContentValidated } from '../src/message-schemas';
 
 type AssertNever<T extends never> = T;
@@ -76,6 +77,33 @@ export type MissingNestedFieldIsDetected = AssertNever<
   // @ts-expect-error a newly declared nested field must fail the coverage guard
   MissingFields<{ content: { newField: string }[] }, { content: { text: string }[] }>
 >;
+
+// The TS type must express the same identity requirement as the Zod parser and the
+// Loro `validate` guard: a tool_call carries `toolCallId` (full call) or `ref` (sealed
+// skeleton). If the type ever becomes permissive again, these `@ts-expect-error`
+// lines fail the build.
+const toolCallWithId: MessageContent = {
+  type: 'tool_call',
+  toolCallId: 'call-1',
+  status: 'completed',
+};
+const toolCallWithRef: MessageContent = {
+  type: 'tool_call',
+  status: 'completed',
+  ref: { machineId: 'machine-1' as MachineId, turnId: 'turn-1', index: 0 },
+};
+// @ts-expect-error a tool_call needs toolCallId or ref, not only status
+const toolCallWithoutIdentity: MessageContent = { type: 'tool_call', status: 'completed' };
+// @ts-expect-error an explicit undefined id is not an identity
+const toolCallWithUndefinedId: MessageContent = {
+  type: 'tool_call',
+  toolCallId: undefined,
+  status: 'completed',
+};
+void toolCallWithId;
+void toolCallWithRef;
+void toolCallWithoutIdentity;
+void toolCallWithUndefinedId;
 
 // Included by the normal shared typecheck, not executed by the test runner.
 export function historyWriterTypeContract(writer: HistoryWriter, entry: SessionHistory) {

--- a/packages/shared/tests/session-history-shapes.test.ts
+++ b/packages/shared/tests/session-history-shapes.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+import { Loro, LoroList, LoroMap, LoroText } from 'loro-crdt';
+import { Mirror } from 'loro-mirror';
+import type { MachineId, MessageContent } from '../src/ai';
+import type { SessionId } from '../src/ids';
+import { MessageContentSchema } from '../src/message-schemas';
+import { sessionDocSchema } from '../src/schema';
+import { createSessionMirror } from '../src/session-mirror';
+
+/**
+ * Reader compatibility for sealed tool_call skeletons.
+ *
+ * The writer that seals turns is NOT part of this change. These tests prove the
+ * current readers express and safely read BOTH shapes: a full tool_call (with
+ * `toolCallId` + payload) and a ref-only skeleton (no `toolCallId`, no
+ * `content`, payload pointer `ref`). The TS type (`MessageContent`) and the
+ * runtime validators (Zod + Loro schema) must agree, and a skeleton's
+ * `ref.index` must survive unrelated edits without renumbering.
+ */
+
+const sessionId = 'session-history-shapes' as SessionId;
+const skeletonRef = {
+  machineId: 'machine-1' as MachineId,
+  turnId: 'turn-1',
+  index: 2,
+};
+
+const fullToolCall: MessageContent = {
+  type: 'tool_call',
+  toolCallId: 'call-1',
+  title: 'ls -la',
+  status: 'completed',
+  kind: 'execute',
+  content: [
+    { type: 'terminal_command', command: 'ls', args: ['-la'], cwd: '/tmp' },
+    { type: 'terminal_output', output: 'total 0' },
+  ],
+  rawInput: { command: 'ls -la' },
+  rawOutput: { exitCode: 0 },
+};
+
+// No cast: the shared type must express a ref-only skeleton directly.
+const skeletonToolCall: MessageContent = {
+  type: 'tool_call',
+  kind: 'execute',
+  status: 'completed',
+  title: 'ls -la',
+  locations: [{ path: '/tmp' }],
+  ref: skeletonRef,
+};
+
+function openMirror(doc: Loro) {
+  return createSessionMirror({ doc, initialState: { session: { id: sessionId }, history: [] } });
+}
+
+function readMirror(doc: Loro) {
+  return new Mirror({
+    doc,
+    schema: sessionDocSchema,
+    ignoreUnknownProperties: true,
+  });
+}
+
+function turn(id: string, items: MessageContent[]) {
+  return {
+    id,
+    role: 'assistant' as const,
+    timestamp: '2026-09-01T00:00:00.000Z',
+    finished: true,
+    items,
+  };
+}
+
+describe('tool_call shape contract', () => {
+  it('accepts a full tool_call, a ref-only skeleton, and a full call carrying a ref', () => {
+    expect(MessageContentSchema.safeParse(fullToolCall).success).toBe(true);
+    expect(MessageContentSchema.safeParse(skeletonToolCall).success).toBe(true);
+    expect(MessageContentSchema.safeParse({ ...fullToolCall, ref: skeletonRef }).success).toBe(
+      true
+    );
+  });
+
+  it('rejects a tool_call with neither toolCallId nor ref, and a malformed ref', () => {
+    expect(MessageContentSchema.safeParse({ type: 'tool_call', status: 'completed' }).success).toBe(
+      false
+    );
+    expect(
+      MessageContentSchema.safeParse({
+        type: 'tool_call',
+        status: 'completed',
+        ref: { machineId: 'machine-1', turnId: 'turn-1' },
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('reading a stored skeleton', () => {
+  it('writes and re-reads a ref-only skeleton with its ref intact', () => {
+    const doc = new Loro();
+    const mirror = openMirror(doc);
+    try {
+      mirror.historyWriter.append(turn('turn-1', [skeletonToolCall]) as never);
+      // The shared writer must accept it...
+      expect(doc.getList('history').toJSON()[0].items[0]).toEqual(skeletonToolCall);
+
+      // ...and a fresh Mirror read must not reject the stored document.
+      const reader = readMirror(doc);
+      try {
+        const entry = reader.getState().history[0]!;
+        expect(entry.items?.[0]).toEqual(skeletonToolCall);
+      } finally {
+        reader.dispose();
+      }
+    } finally {
+      mirror.dispose();
+    }
+  });
+
+  it('keeps a skeleton and its ref.index through an unrelated turn edit', () => {
+    const doc = new Loro();
+    const mirror = openMirror(doc);
+    try {
+      mirror.historyWriter.append(turn('turn-1', [skeletonToolCall]) as never);
+      const row = doc.getList('history').get(0) as LoroMap;
+      const items = row.get('items') as LoroList;
+      const skeleton = items.get(0) as LoroMap;
+      const refBefore = (skeleton.get('ref') as LoroMap).toJSON();
+
+      mirror.historyWriter.setField('turn-1', 'finished', true);
+
+      expect(row.get('finished')).toBe(true);
+      expect((items.get(0) as LoroMap).toJSON()).toEqual(skeletonToolCall);
+      expect(((items.get(0) as LoroMap).get('ref') as LoroMap).toJSON()).toEqual(refBefore);
+    } finally {
+      mirror.dispose();
+    }
+  });
+
+  it('appends a new turn without rewriting the stored skeleton, preserving item order', () => {
+    const doc = new Loro();
+    const mirror = openMirror(doc);
+    try {
+      mirror.historyWriter.append(turn('turn-1', [skeletonToolCall]) as never);
+      const before = doc.getList('history').toJSON()[0];
+      mirror.historyWriter.append(turn('turn-2', [{ type: 'text', text: 'next' }]) as never);
+      const rows = doc.getList('history').toJSON() as Array<{ id: string }>;
+      expect(rows[0]).toEqual(before);
+      expect(rows.map((r) => r.id)).toEqual(['turn-1', 'turn-2']);
+    } finally {
+      mirror.dispose();
+    }
+  });
+
+  it('rejects a new identity-less tool_call before writing anything', () => {
+    const doc = new Loro();
+    const mirror = openMirror(doc);
+    try {
+      expect(() =>
+        mirror.historyWriter.append(
+          turn('bad', [
+            { type: 'tool_call', status: 'completed' } as unknown as MessageContent,
+          ]) as never
+        )
+      ).toThrow('Invalid history write');
+      expect(doc.getList('history').length).toBe(0);
+    } finally {
+      mirror.dispose();
+    }
+  });
+});
+
+describe('old-shape round-trip is unchanged', () => {
+  it('round-trips a full tool_call payload without materializing new keys', () => {
+    const doc = new Loro();
+    const mirror = openMirror(doc);
+    try {
+      mirror.historyWriter.append(turn('turn-1', [fullToolCall]) as never);
+      const snapshot = doc.export({ mode: 'snapshot' });
+      const reopened = new Loro();
+      reopened.import(snapshot);
+      const reader = readMirror(reopened);
+      try {
+        expect(reader.getState().history[0]!.items?.[0]).toEqual(fullToolCall);
+        expect(reader.getState().history[0]).not.toHaveProperty('summary');
+        expect(reader.getState().history[0]).not.toHaveProperty('live');
+      } finally {
+        reader.dispose();
+      }
+    } finally {
+      mirror.dispose();
+    }
+  });
+});
+
+describe('unrelated sealed turn-level keys do not break reading', () => {
+  it('loads a turn carrying unknown derived keys and still accepts an unrelated write', () => {
+    const doc = new Loro();
+    const row = doc.getList('history').pushContainer(new LoroMap());
+    row.set('id', 'turn-legacy');
+    row.set('role', 'assistant');
+    row.set('timestamp', 'old');
+    // A future sealed writer may add these; readers must ignore them safely.
+    const summary = row.setContainer('summary', new LoroMap());
+    summary.set('itemCount', 3);
+    const live = row.setContainer('live', new LoroMap());
+    live.set('kind', 'text');
+    (live.setContainer('text', new LoroText()) as LoroText).insert(0, 'streamed');
+    const items = row.setContainer('items', new LoroList());
+    const skeleton = items.pushContainer(new LoroMap());
+    skeleton.set('type', 'tool_call');
+    skeleton.set('status', 'completed');
+    skeleton.set('kind', 'execute');
+    const ref = skeleton.setContainer('ref', new LoroMap());
+    ref.set('machineId', 'machine-1');
+    ref.set('turnId', 'turn-1');
+    ref.set('index', 2);
+    doc.commit();
+    const version = doc.version().toJSON();
+
+    const mirror = openMirror(doc);
+    try {
+      // Opening is read-only even with the unknown keys present.
+      expect(doc.version().toJSON()).toEqual(version);
+      // An unrelated append must still succeed and leave the stored turn untouched.
+      const before = doc.getList('history').toJSON()[0];
+      mirror.historyWriter.append(turn('turn-2', [{ type: 'text', text: 'ok' }]) as never);
+      expect(doc.getList('history').toJSON()[0]).toEqual(before);
+    } finally {
+      mirror.dispose();
+    }
+  });
+});

--- a/specs/session-history-writes.md
+++ b/specs/session-history-writes.md
@@ -46,10 +46,18 @@ That tolerance must not authorize creating new malformed items locally.
   External provider imports remain new inputs, not privileged stored-history copies.
 - Acceptance here means a local CRDT write. Existing repo persistence and transport
   still own durability, permissions, and remote synchronization.
-- Tool fields other than type/toolCallId
+- Tool fields other than type/toolCallId/ref
   parse only changed fields without reparsing untouched tool payloads; outcome-only
   edits retain existing request information. Identity changes require complete item parsing;
   changed content blocks are parsed separately. Invalid new fields reject the command before any write.
+- A `tool_call` item is identified by `toolCallId` (full call) or a valid `ref` (sealed
+  skeleton); the TypeScript type, the Zod input parser and the Loro schema accept both and
+  reject an item with neither identity. A skeleton carries no execution payload, so readers
+  classify it from `kind`/`status`/`locations` and never from `content`; it is never a merge
+  target keyed by `toolCallId`, and reader paths preserve its `ref.index` without renumbering
+  items around it. Fetching the payload from the origin machine is explicitly out of scope:
+  the reader-side resolver reports `unavailable` and the skeleton renders with a
+  "stored on <machine>" note.
 - New history accepts existing legacy built-in CLI selector normalization without rewriting
   stored history. Steer config and same-identity task-proposal edits parse only changed fields.
 - Queue promotion removes its queued row only after history acceptance; failed writes retain it.
@@ -92,17 +100,24 @@ arbitrary reordering of existing turns in a plain LoroList.
 The current full-Mirror read path still materializes history; this change is not
 the 3000-round performance acceptance or the windowed ConversationView rollout.
 Non-history control-field validation remains outside this HistoryWriter contract.
-The v2 canonical form is defined for the shapes this repository writes. The full
-sealed-skeleton feature (a reader-side `ref` payload fetch, payload hooks, and the
-UI that consumes them) is not implemented here; this change only prevents a future
-sealed turn from looking like a hash conflict once such skeletons exist.
+The v2 canonical form is defined for the shapes this repository writes. Reader-side
+skeleton compatibility is implemented (type, Zod/Loro validation, ACP apply, UI render,
+CLI export/transcript), but turning a full call into a skeleton is NOT: there is no
+payload stripping, no writer that seals turns, no derived `summary`/`live` fields, and
+no Machine RPC to fetch a skeleton's payload. `useToolCallPayload` therefore always
+resolves to `unavailable`, and an unknown turn-level `summary`/`live` key is ignored on
+read rather than surfaced.
 
 ## Implementation evidence
 
-- `packages/shared/src/{history-writer,history-write-schema,history-materializer,session-mirror,schema}.ts`
+- `packages/shared/src/{history-writer,history-write-schema,history-materializer,session-mirror,schema,message-schemas,ai}.ts`
+- `packages/shared/src/acp/history-apply.ts`
 - `apps/cli/src/lib/local-project-history-sync-service.ts`
-- `packages/shared/tests/{history-writer,history-storage-policy}.test.ts` and `history-writer.contract.ts`
+- `apps/cli/src/lib/session-export/{formatters,markdown,types}.ts`
+- `packages/components/src/components/ai-gui/{tool-call-skeleton,use-tool-call-payload,message-content-guards,assistant-turn-render-blocks,view}.ts(x)`
+- `packages/shared/tests/{history-writer,history-storage-policy,session-history-shapes,acp-history-apply}.test.ts`
 - `apps/cli/tests/local-project-history-sync-service.test.ts` and `local-project-history-sync-writer.test.ts`
+- `packages/components/tests/tool-call-skeleton.test.ts`
 - [Decision](../.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md)
 - [Business-field repair and pending hash decision](../.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md)
 - [Imported-history baseline repair](../.agents/notes/implemented/architecture/2026-09-07-single-history-writer.md)


### PR DESCRIPTION
## Related issue

Refs #584
Refs #359

Stacked on #584 (`feat/history-schema-writer-integration`); its head is unchanged. This
completes the reader half of #359 that the first round explicitly left out; the original
#359 stays open and this does not close it.

## Problem / pressure

A sealed turn stores a `tool_call` **skeleton** — `kind`/`status`/`title`/`locations`/`ref`,
with `content`/`rawInput`/`rawOutput` left on the origin machine. The type and every runtime
layer still required `toolCallId` and `content`:

- `MessageContent` declared `toolCallId: string` and had no `ref`, so a skeleton only
  compiled through `as unknown as MessageContent`. Adding `ref` immediately failed the
  `AllNestedMessageFieldsHaveAParser` compile-time guard because the Zod parser had no `ref`.
- `message-content-guards`, ACP `history-apply`, the transcript and the CLI export all
  assumed an id.
- `upsertToolCall` matched with `toolCallId === incoming.toolCallId`; when both were
  `undefined` this matched and a replayed skeleton **overwrote a stored skeleton** — the
  "filtering/reordering breaks the position reference" failure, invisible to TypeScript.

## Summary

- The `tool_call` variant intersects a `ToolCallIdentity` union, so the TypeScript type
  itself requires `toolCallId` (full call) or `ref` (sealed skeleton); a full call may also
  carry a `ref`. `ToolCallRef`/`ToolCallPayload`/`isToolCallRef` are exported from `@lody/shared`.
- The same identity rule is enforced at runtime: the Loro `validate` guard accepts
  `toolCallId || isToolCallRef(ref)`; `MessageContentSchema.superRefine` rejects an item with
  neither (on the union, so `ToolCallMessageSchema` stays a `ZodObject` for `.omit`).
  `history-writer.contract.ts` adds `@ts-expect-error` compile-failure checks for an
  identity-less tool_call and an explicit-undefined id.
- `history-writer` omits `ref` from `ToolStateWriteSchema`, so changing the payload pointer
  needs the complete item parser.
- `history-apply` skips non-string ids when indexing, resolving and merging (fixes the
  overwrite bug); `tool-call-skeleton.ts` owns `isToolCallRef`/`isToolCallSkeleton`/
  `getToolCallStableId`. `isToolCallSkeleton` requires `ref` AND no payload — a full call may
  also carry a `ref`, so `ref` alone is not the predicate; activity summaries and
  virtual/React keys use these guards.
- `use-tool-call-payload.ts` is an **unavailable** stub (no Machine RPC); the card renders a
  "stored on <machine>" row. `session-export` emits `toolCallId: null` + `ref`, and the
  transcript markdown renders a skeleton without an id line.
- **Explicitly not implemented:** payload stripping, a skeleton-emitting writer, remote
  payload fetch, and the derived `summary`/`live` turn fields. A test proves an unknown
  turn-level key is ignored on read and does not block an unrelated write.

## Visual explanation

```mermaid
flowchart TB
  subgraph validator["identity boundary"]
    L["Loro validate: status && (toolCallId || isToolCallRef(ref))"]
    Z["Zod superRefine: toolCallId || ref"]
    G["isMessageContent: status && (toolCallId || ref) && content?[]"]
  end
  subgraph readers["readers"]
    H["history-apply: index/resolve/merge only string ids"]
    C["components: isToolCallSkeleton -> stable key, kind/status/locations"]
    P["useToolCallPayload -> unavailable"]
    E["session-export: toolCallId null + ref; markdown note"]
  end
  full["full tool_call (toolCallId + payload)"] --> validator
  skel["ref-only skeleton (ref, no payload)"] --> validator
  validator --> readers
```

The structural diff: `toolCallId` becomes optional and `ref` is added on one union variant;
the merge key in `upsertToolCall` gains a `typeof === 'string'` guard; each reader gains one
skeleton branch. No payload is stripped, fetched, or invented.

## Before / after

| Case | Before | After |
| --- | --- | --- |
| Express a ref-only skeleton in TS | `as unknown as MessageContent` | direct; identity union requires `toolCallId` or `ref` |
| Zod parse a skeleton | rejected (toolCallId required) | accepted; neither-identity rejected |
| Replayed id-less skeleton vs stored skeleton | `undefined === undefined` → overwrite | appended separately; stored one intact |
| Skeleton in activity/key/transcript/export | `undefined` id, could drop/merge | stable ref id, classified by kind/status |
| Skeleton payload | n/a | `unavailable` + "stored on <machine>" |

## Test plan

- `packages/shared`: `vitest run` → **98 files, 1141 tests pass**, including new
  `session-history-shapes.test.ts` (both shapes parse; reopen; unrelated edit preserves
  `ref.index` and order; identity-less rejected; unknown sealed turn keys tolerated) and
  five new `acp-history-apply` cases (the overwrite regression).
- `packages/components`: `NODE_ENV=test vitest run` → **450 files, 3411 tests pass**,
  including new `tool-call-skeleton.test.ts` (strict no-payload predicate).
- `apps/cli`: `vitest run` → **259 passed / 1 skipped, 2691 tests pass**, including new
  export/markdown and transcript skeleton cases. These require `HOME=/tmp/...` and
  `TMPDIR=/tmp`: this session's sandbox denies writes to `~/.lody` (locks, credential
  broker) and to the default temp dir, which fails 9 unrelated tests; with the redirects all
  pass. Recorded, not reported green.
- Recursive `pnpm -r typecheck` (minus two vendored ACP adapters) exits 0; `oxlint` 0 errors;
  prettier clean; i18n, docs check, code-collab, platform and public-boundary checks pass.
- Not run: desktop E2E and any UI screenshot of the "stored on <machine>" row.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** the `ToolCallIdentity` union in `packages/shared/src/ai.ts` and its
  compile-failure checks in `history-writer.contract.ts`, `MessageContentSchema.superRefine`,
  `upsertToolCall`'s string guard in both `history-apply` paths, and the strict
  `isToolCallSkeleton` predicate the card uses.
- **Decisions to challenge:** the identity union changes a previously permissive type —
  confirm every construction site carries an identity, that the merge path never clears an
  existing `ref`, and that the strict predicate does not hide a payload-bearing call.
  `summary`/`live` are intentionally NOT declared.
- **Plausible failures / evidence gaps:** payload fetch is a stub, so the "stored on
  \u003cmachine\u003e" row is the only rendering path; no real sealed document exists yet.

### Authoring context

- **User goal / directives:** complete the missing #359 reader half on a separate branch,
  now rebased onto the fixed #584 head `33177fda`; do not merge or close #443/#359.
- **Constraints / non-goals:** no payload stripping, no remote fetch, no skeleton writer, no
  full sealed feature; no rewrite of #584.
- **Risk-bearing decisions:** identity accepted as `toolCallId` OR `ref`, rejected when
  neither; a skeleton is never a merge target; `ref.index` is preserved, never renumbered.
- **Destructive or irreversible behavior:** none; readers only, no migration or rewrite.
- **Deliberately not done or tested:** payload resolution, sealed-turn derivation, browser
  E2E for the placeholder row.
- **Unknowns / confidence:** high confidence in the reader contract; the sealing writer's
  exact output remains unverified because it does not exist yet.

### Original user prompt

````text
收到 #584 @42f41400。我正在独立验收这个固定 SHA，请不要改写它或关闭 #443/#359。你交付明确遗漏原任务中 #359 的骨架 reader 兼容（ref-only 类型/校验/渲染/导出/replay），因此整体任务尚未完成。请继续完成这部分，单独分支/PR 叠在 #584 上（或按实际依赖独立），保持 #584 当前 head 便于验收。先核对旧 #359 真正的 reader 改动与当前 main 的 Zod 类型/写入边界；不实现 payload 剥离、远程 payload 获取或骨架 writer 上线，不扩大到完整sealed功能。目标只是旧完整消息与 ref-only 骨架均可被类型/运行时reader正确表达和安全读取，hash v1/v2契约一致，位置引用不被过滤重排破坏。原 #359 的 unavailable stub 和相关读取/导出兼容应明确范围。将首轮未完成部分补齐，运行类型与相关回归后 push，返回 PR/SHA/测试。不要merge。若发现这部分已不适合当前产品契约，先提供具体源码依据和建议，不能直接省略后称两个PR整合完成。
````

<!-- context-handoff:end -->

