### PR TITLE
fix(cli): list remote machine projects without daemon

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-10-daemon-free-remote-project-list.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-10-daemon-free-remote-project-list.md
@@ -1,0 +1,43 @@
+# List remote projects without a client daemon
+
+Status: implemented
+Translation: current
+
+[中文](2026-09-10-daemon-free-remote-project-list.zh.md)
+
+## Abstract
+
+`lody project list` previously required the current machine's daemon even when a user only needed
+the synchronized project catalog of another workspace machine. Explicit workspace or machine
+selectors now use a one-shot cloud-backed read, while the selector-free command preserves the local
+daemon behavior. The remote result is synchronized before use and filtered through the same
+requester access checks as Session creation; the local platform rejects this path before cloud I/O.
+
+## Decision
+
+An explicit `--workspace` or `--machine` selects the remote catalog path. This includes naming the
+machine associated with the current CLI login: selector intent, rather than machine-id equality,
+determines the transport. With no selector, existing local IPC behavior remains unchanged.
+
+The remote path resolves an accessible workspace, synchronizes its machine metadata, and filters
+machines with the non-delegated `canRequestMachineForCliToken` capability used by CLI Session
+creation. Machine selection accepts an exact id or a unique name among authorized machines. It then
+awaits synchronization of the exact target Machine Flock document, merges its project rows over
+legacy Machine metadata, and applies a project-scoped access check before returning any name or
+path. A metadata, Flock, or authorization transport failure fails the command instead of presenting
+a stale or unfiltered catalog.
+
+Open-source local platform mode rejects remote selectors before authentication or workspace
+transport setup. It continues to support the selector-free daemon-backed list.
+
+## Scope and verification
+
+This implements the project-catalog behavior requested by
+[issue #582](https://github.com/LodyAI/Lody/issues/582). It does not change project registration,
+deletion, Session creation, or remote project mutation.
+
+Synthetic behavior coverage models a daemon-free client and a distinct target machine. It verifies
+that synchronized Flock rows override legacy rows, denied project paths never enter the response,
+explicit selectors choose the remote path, exact ids and unique names resolve deterministically,
+and a rejected Flock sync fails before cached projects are read. The test uses injected transports;
+it is not a live cloud or device test.

--- a/.agents/notes/implemented/bug-fix/2026-09-10-daemon-free-remote-project-list.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-10-daemon-free-remote-project-list.zh.md
@@ -1,0 +1,38 @@
+# 无需客户端 daemon 列出远程项目
+
+Status: implemented
+Translation: current
+
+[English](2026-09-10-daemon-free-remote-project-list.md)
+
+## 摘要
+
+过去，即使用户只想读取 workspace 内另一台机器已同步的项目目录，`lody project list` 也要求
+当前机器的 daemon 正在运行。现在，显式 workspace 或 machine selector 会使用一次性的云端读取，
+而不带 selector 的命令继续保留本地 daemon 行为。远程结果会先完成同步，并使用与 Session 创建
+相同的 requester 权限检查进行过滤；local platform 则会在发生 cloud I/O 前拒绝这条路径。
+
+## 决策
+
+显式传入 `--workspace` 或 `--machine` 会选择远程目录路径。即使指定的是当前 CLI 登录所关联的
+machine 也同样如此：传输方式由 selector 意图决定，而不是由 machine id 是否相同决定。不带
+selector 时，现有的本地 IPC 行为保持不变。
+
+远程路径先解析用户可访问的 workspace，同步其中的 machine metadata，再用 CLI Session 创建所用
+的非委托 `canRequestMachineForCliToken` 能力过滤机器。机器 selector 支持精确 id，或在已授权机器中
+唯一匹配的名称。随后，命令会等待目标 Machine Flock 文档完成同步，将其中的项目行覆盖到旧版
+Machine metadata 上，并在返回任何名称或路径前执行 project scope 权限检查。Metadata、Flock 或
+授权传输失败都会使命令失败，而不会展示陈旧或未经筛选的目录。
+
+开源 local platform 会在认证或 workspace transport 建立前拒绝远程 selector，同时继续支持不带
+selector 的 daemon-backed list。
+
+## 范围与验证
+
+本次实现处理 [issue #582](https://github.com/LodyAI/Lody/issues/582) 请求的项目目录行为，不修改项目
+注册、删除、Session 创建或远程项目内容。
+
+合成行为测试模拟了无 daemon 的客户端和另一台目标机器。测试验证：同步后的 Flock 行会覆盖旧版
+数据；被拒绝项目的路径不会进入响应；显式 selector 会选择远程路径；精确 id 与唯一名称可以确定性
+解析；Flock 同步被拒绝时，会在读取缓存项目之前失败。该测试使用注入的 transport，并非真实云端或
+设备测试。

--- a/apps/cli/src/commands/project.ts
+++ b/apps/cli/src/commands/project.ts
@@ -19,6 +19,14 @@ import {
 import { renderTerminalTable } from '@/lib/terminal-table';
 import { getLogger, rootLogger } from '@/utils/logger';
 import { formatErrorMessage } from '@/utils/format-error';
+import {
+  getAuthContextOrThrow,
+  resolveWorkspaceOrThrow,
+  runOneShotCommand,
+  withWorkspaceManager,
+} from '@/lib/command-runtime';
+import { getCliPlatformKind } from '@/lib/cli-platform';
+import { listRemoteLocalProjects } from '@/lib/remote-local-project-list';
 
 type CommonOptions = {
   json?: boolean;
@@ -30,6 +38,11 @@ type AddProjectOptions = CommonOptions & {
   allWorkspaces?: boolean;
 };
 
+type ListProjectOptions = CommonOptions & {
+  workspace?: string;
+  machine?: string;
+};
+
 type SelectableProject = {
   workspaceId: WorkspaceId;
   workspaceName: string;
@@ -37,6 +50,13 @@ type SelectableProject = {
   name: string;
   rootPath: string;
 };
+
+export function shouldUseRemoteProjectCatalog(options: {
+  workspace?: string;
+  machine?: string;
+}): boolean {
+  return Boolean(options.workspace?.trim() || options.machine?.trim());
+}
 
 function setDebugIfEnabled(options: CommonOptions): void {
   if (options.debug) {
@@ -348,67 +368,101 @@ const projectDeleteCommand = new Command('delete')
 
 const projectListCommand = new Command('list')
   .description('List local projects')
+  .option('--workspace <selector>', 'Remote workspace id, slug, or name')
+  .option('--machine <selector>', 'Remote machine id or name')
   .option('--json', 'Output machine-readable JSON')
   .option('-d, --debug', 'enable debug output')
-  .action(async (options: CommonOptions) => {
+  .action(async (options: ListProjectOptions) => {
     setDebugIfEnabled(options);
+
+    const useRemoteCatalog = shouldUseRemoteProjectCatalog(options);
+    if (useRemoteCatalog && getCliPlatformKind() === 'local') {
+      const message = 'Remote project listing is not available on the local platform.';
+      if (options.json) {
+        process.stdout.write(`${JSON.stringify({ ok: false, error: message })}\n`);
+      } else {
+        getLogger('project').error(message);
+      }
+      process.exit(1);
+      return;
+    }
+
+    if (useRemoteCatalog) {
+      await runOneShotCommand('project', options, async () => {
+        const auth = getAuthContextOrThrow('project');
+        const workspace = await resolveWorkspaceOrThrow(auth, options.workspace);
+        const response = await withWorkspaceManager(
+          auth,
+          workspace,
+          'project',
+          async (manager) =>
+            await listRemoteLocalProjects({
+              manager,
+              auth,
+              workspace,
+              machineSelector: options.machine,
+            })
+        );
+        renderProjectListResponse(response, options);
+      });
+      return;
+    }
 
     const machineId = resolveMachineIdOrExit();
     const response = await sendLocalProjectControl({
       type: 'local-project/list',
       machineId,
     });
-
-    if (options.json) {
-      process.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
-      if (!response.ok) {
-        process.exit(1);
-      }
-      return;
-    }
-
-    const logger = getLogger('project');
-    if (!response.ok) {
-      printProjectControlError('list projects', response);
-      process.exit(1);
-    }
-    if (response.type !== 'local-project/list') {
-      logger.error(`Unexpected response type: ${response.type}`);
-      process.exit(1);
-    }
-
-    const rows = response.result.workspaces
-      .flatMap((workspace) =>
-        workspace.projects.map((project) => [
-          workspace.workspaceName,
-          project.name,
-          project.rootPath,
-        ])
-      )
-      .sort((left, right) => {
-        const workspaceCompare = String(left[0]).localeCompare(String(right[0]));
-        if (workspaceCompare !== 0) {
-          return workspaceCompare;
-        }
-        const projectCompare = String(left[1]).localeCompare(String(right[1]));
-        if (projectCompare !== 0) {
-          return projectCompare;
-        }
-        return String(left[2]).localeCompare(String(right[2]));
-      });
-
-    if (rows.length === 0) {
-      logger.info('No local projects found.');
-      return;
-    }
-
-    console.log(
-      renderTerminalTable(
-        [{ header: 'Workspace' }, { header: 'Project' }, { header: 'Path' }],
-        rows
-      )
-    );
+    renderProjectListResponse(response, options);
   });
+
+function renderProjectListResponse(
+  response: LocalProjectControlResponse,
+  options: CommonOptions
+): void {
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
+    if (!response.ok) {
+      process.exit(1);
+    }
+    return;
+  }
+
+  const logger = getLogger('project');
+  if (!response.ok) {
+    printProjectControlError('list projects', response);
+    process.exit(1);
+  }
+  if (response.type !== 'local-project/list') {
+    logger.error(`Unexpected response type: ${response.type}`);
+    process.exit(1);
+  }
+
+  const rows = response.result.workspaces
+    .flatMap((workspace) =>
+      workspace.projects.map((project) => [workspace.workspaceName, project.name, project.rootPath])
+    )
+    .sort((left, right) => {
+      const workspaceCompare = String(left[0]).localeCompare(String(right[0]));
+      if (workspaceCompare !== 0) {
+        return workspaceCompare;
+      }
+      const projectCompare = String(left[1]).localeCompare(String(right[1]));
+      if (projectCompare !== 0) {
+        return projectCompare;
+      }
+      return String(left[2]).localeCompare(String(right[2]));
+    });
+
+  if (rows.length === 0) {
+    logger.info('No local projects found.');
+    return;
+  }
+
+  console.log(
+    renderTerminalTable([{ header: 'Workspace' }, { header: 'Project' }, { header: 'Path' }], rows)
+  );
+}
 
 export const projectCommand = new Command('project')
   .description('Manage local projects')

--- a/apps/cli/src/lib/remote-local-project-list.test.ts
+++ b/apps/cli/src/lib/remote-local-project-list.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  machineFlockKeys,
+  writeMachineFlockRowToFlock,
+  type LocalProjectId,
+  type LocalProjectMeta,
+  type MachineFlockKey,
+  type MachineFlockWritableFlock,
+  type MachineId,
+  type MachineMeta,
+  type WorkspaceId,
+} from '@lody/shared';
+import type { LoroRepo } from 'loro-repo';
+
+import type { AuthContext } from '@/lib/command-runtime';
+import type { LoroDocumentManager } from '@/lib/loro/doc';
+import type { WorkspaceSummary } from '@/lib/workspace';
+import { shouldUseRemoteProjectCatalog } from '@/commands/project';
+
+import { listRemoteLocalProjects, selectRemoteProjectMachine } from './remote-local-project-list';
+
+class FakeMachineFlock implements MachineFlockWritableFlock {
+  readonly rows = new Map<string, { key: MachineFlockKey; value: unknown }>();
+
+  scan(options?: { prefix?: readonly unknown[] }) {
+    return [...this.rows.values()].filter((row) =>
+      options?.prefix ? options.prefix.every((part, index) => row.key[index] === part) : true
+    );
+  }
+
+  set(key: MachineFlockKey, value: unknown): void {
+    this.rows.set(JSON.stringify(key), { key: [...key] as MachineFlockKey, value });
+  }
+
+  delete(key: MachineFlockKey): void {
+    this.rows.delete(JSON.stringify(key));
+  }
+
+  commit(): void {}
+}
+
+const workspaceId = 'workspace-fixture' as WorkspaceId;
+const authMachineId = '11111111-1111-4111-8111-111111111111' as MachineId;
+const targetMachineId = '22222222-2222-4222-8222-222222222222' as MachineId;
+const targetMachine: MachineMeta = {
+  id: targetMachineId,
+  name: 'developer-host',
+  cliVersion: '0.92.1',
+  os: 'linux',
+  sessions: [],
+};
+const auth: AuthContext = {
+  token: 'synthetic-token-do-not-send',
+  userId: 'synthetic-user',
+  userName: 'Fixture User',
+  userEmail: 'fixture@example.invalid',
+  machineId: authMachineId,
+  machineName: 'headless-client',
+};
+const workspace: WorkspaceSummary = {
+  id: workspaceId,
+  slug: 'fixture',
+  name: 'Fixture workspace',
+  role: 'member',
+};
+
+function project(
+  id: string,
+  name: string,
+  rootPath: string,
+  createdAtMs: number
+): LocalProjectMeta {
+  return { id: id as LocalProjectId, name, rootPath, createdAtMs };
+}
+
+function createFixtureManager(options: { syncError?: Error } = {}) {
+  const flock = new FakeMachineFlock();
+  const legacy = {
+    'local-project-legacy': project('local-project-legacy', 'legacy', '/synthetic/legacy', 100),
+    'local-project-shared': project('local-project-shared', 'stale-name', '/synthetic/stale', 100),
+  } as Record<LocalProjectId, LocalProjectMeta>;
+  const repo = {
+    getDocMeta: vi.fn(async () => ({ meta: { localProjects: legacy } })),
+    openFlockDoc: vi.fn(async () => ({ flock })),
+  } as unknown as LoroRepo;
+  const manager = {
+    repo,
+    syncMetaOrThrow: vi.fn(async () => undefined),
+    syncFlockDocOrThrow: vi.fn(async () => {
+      if (options.syncError) throw options.syncError;
+      writeMachineFlockRowToFlock(
+        flock,
+        {
+          key: machineFlockKeys.localProject('local-project-shared' as LocalProjectId),
+          value: project('local-project-shared', 'fresh-name', '/synthetic/fresh', 200),
+        },
+        200
+      );
+      writeMachineFlockRowToFlock(
+        flock,
+        {
+          key: machineFlockKeys.localProject('local-project-denied' as LocalProjectId),
+          value: project('local-project-denied', 'denied', '/synthetic/denied', 200),
+        },
+        200
+      );
+    }),
+  } as unknown as LoroDocumentManager;
+  return { manager, repo };
+}
+
+const fixtureDependencies = {
+  listMachines: async () => [targetMachine],
+  verifyAccess: async (input: { localProjectId?: LocalProjectId }) => ({
+    allowed: input.localProjectId !== ('local-project-denied' as LocalProjectId),
+    ...(input.localProjectId === ('local-project-denied' as LocalProjectId)
+      ? { reason: 'project_not_shared' as const }
+      : {}),
+  }),
+};
+
+describe('remote local project list', () => {
+  it('uses the remote path for any explicit selector, including the auth machine id', () => {
+    expect(shouldUseRemoteProjectCatalog({})).toBe(false);
+    expect(shouldUseRemoteProjectCatalog({ workspace: 'fixture' })).toBe(true);
+    expect(shouldUseRemoteProjectCatalog({ machine: authMachineId })).toBe(true);
+  });
+
+  it('awaits the target Flock sync, merges legacy rows, and hides denied paths', async () => {
+    const { manager } = createFixtureManager();
+
+    const response = await listRemoteLocalProjects({
+      manager,
+      auth,
+      workspace,
+      machineSelector: 'developer-host',
+      dependencies: fixtureDependencies,
+    });
+
+    expect(response).toEqual({
+      ok: true,
+      type: 'local-project/list',
+      result: {
+        workspaces: [
+          {
+            workspaceId,
+            workspaceName: 'Fixture workspace',
+            projects: [
+              {
+                localProjectId: 'local-project-shared',
+                name: 'fresh-name',
+                rootPath: '/synthetic/fresh',
+              },
+              {
+                localProjectId: 'local-project-legacy',
+                name: 'legacy',
+                rootPath: '/synthetic/legacy',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(JSON.stringify(response)).not.toContain('/synthetic/denied');
+  });
+
+  it('fails instead of returning a stale catalog when the target sync rejects', async () => {
+    const { manager, repo } = createFixtureManager({ syncError: new Error('offline') });
+
+    await expect(
+      listRemoteLocalProjects({
+        manager,
+        auth,
+        workspace,
+        machineSelector: targetMachineId,
+        dependencies: fixtureDependencies,
+      })
+    ).rejects.toThrow('offline');
+    expect(repo.openFlockDoc).not.toHaveBeenCalled();
+  });
+
+  it('requires a unique machine name while accepting an exact id', () => {
+    const duplicate = { ...targetMachine, id: authMachineId };
+    expect(selectRemoteProjectMachine([targetMachine, duplicate], targetMachineId)).toBe(
+      targetMachine
+    );
+    expect(() => selectRemoteProjectMachine([targetMachine, duplicate], 'developer-host')).toThrow(
+      'Machine selector is ambiguous'
+    );
+  });
+});

--- a/apps/cli/src/lib/remote-local-project-list.ts
+++ b/apps/cli/src/lib/remote-local-project-list.ts
@@ -1,0 +1,169 @@
+import {
+  getMachineFlockDocId,
+  isMachineDocRoomId,
+  type LocalProjectControlResponse,
+  type LocalProjectId,
+  type LocalProjectMeta,
+  type MachineId,
+  type MachineMeta,
+  type WorkspaceId,
+} from '@lody/shared';
+import type { LoroRepo } from 'loro-repo';
+
+import { listAliveDocMetas, normalizeCliValue, type AuthContext } from '@/lib/command-runtime';
+import type { LoroDocumentManager } from '@/lib/loro/doc';
+import { readMachineLocalProjects } from '@/lib/local-project-meta';
+import {
+  canRequestMachineForCliToken,
+  type MachineAccessCheckResult,
+  type WorkspaceSummary,
+} from '@/lib/workspace';
+import { readMachineAccessWithBoundedRetry } from '@/session/session-access-retry';
+import { getLogger } from '@/utils/logger';
+
+type ProjectListResponse = Extract<
+  LocalProjectControlResponse,
+  { ok: true; type: 'local-project/list' }
+>;
+
+export type RemoteProjectListDependencies = {
+  listMachines: (manager: LoroDocumentManager) => Promise<readonly MachineMeta[]>;
+  readProjects: (
+    repo: LoroRepo,
+    workspaceId: WorkspaceId,
+    machineId: MachineId
+  ) => Promise<Record<LocalProjectId, LocalProjectMeta>>;
+  verifyAccess: (input: {
+    auth: AuthContext;
+    workspaceId: WorkspaceId;
+    machineId: MachineId;
+    localProjectId?: LocalProjectId;
+  }) => Promise<MachineAccessCheckResult>;
+};
+
+const defaultDependencies: RemoteProjectListDependencies = {
+  listMachines: async (manager) =>
+    (await listAliveDocMetas<MachineMeta>(manager, isMachineDocRoomId)).map((entry) => entry.meta),
+  readProjects: readMachineLocalProjects,
+  verifyAccess: async ({ auth, workspaceId, machineId, localProjectId }) =>
+    await readMachineAccessWithBoundedRetry({
+      verify: async () =>
+        await canRequestMachineForCliToken({
+          token: auth.token,
+          workspaceId,
+          machineId,
+          requesterUserId: auth.userId,
+          ...(localProjectId ? { localProjectId } : {}),
+        }),
+      onRetry: ({ attempt, maxAttempts, delayMs, error }) => {
+        getLogger('project').warn(
+          `Machine access verification unavailable; retrying ` +
+            `(attempt=${attempt}/${maxAttempts} delayMs=${delayMs}): ${error}`
+        );
+      },
+    }),
+};
+
+function formatMachineCandidates(machines: readonly MachineMeta[]): string {
+  return machines
+    .map((machine) => `${machine.name} (${machine.id})`)
+    .sort((left, right) => left.localeCompare(right))
+    .join(', ');
+}
+
+export function selectRemoteProjectMachine(
+  machines: readonly MachineMeta[],
+  selector: string
+): MachineMeta {
+  const normalizedSelector = normalizeCliValue(selector);
+  if (!normalizedSelector) {
+    throw new Error('Missing machine selector.');
+  }
+  const idMatch = machines.find((machine) => machine.id === normalizedSelector);
+  if (idMatch) return idMatch;
+
+  const nameMatches = machines.filter(
+    (machine) => normalizeCliValue(machine.name) === normalizedSelector
+  );
+  if (nameMatches.length === 1) return nameMatches[0]!;
+  if (nameMatches.length > 1) {
+    throw new Error(
+      `Machine selector is ambiguous: ${normalizedSelector}. Use a machine id. Candidates: ${formatMachineCandidates(nameMatches)}`
+    );
+  }
+  throw new Error(
+    `Machine not found: ${normalizedSelector}. Candidates: ${formatMachineCandidates(machines)}`
+  );
+}
+
+export async function listRemoteLocalProjects(args: {
+  manager: LoroDocumentManager;
+  auth: AuthContext;
+  workspace: WorkspaceSummary;
+  machineSelector?: string;
+  dependencies?: Partial<RemoteProjectListDependencies>;
+}): Promise<ProjectListResponse> {
+  const dependencies = { ...defaultDependencies, ...args.dependencies };
+  const workspaceId = args.workspace.id as WorkspaceId;
+  await args.manager.syncMetaOrThrow({ reason: `project.list:${workspaceId}:meta` });
+
+  const machines = await dependencies.listMachines(args.manager);
+  const machineAccess = await Promise.all(
+    machines.map(async (machine) => ({
+      machine,
+      access: await dependencies.verifyAccess({
+        auth: args.auth,
+        workspaceId,
+        machineId: machine.id,
+      }),
+    }))
+  );
+  const authorizedMachines = machineAccess
+    .filter((entry) => entry.access.allowed)
+    .map((entry) => entry.machine);
+  if (authorizedMachines.length === 0) {
+    throw new Error('No authorized machines are available in this workspace.');
+  }
+
+  const machine = selectRemoteProjectMachine(
+    authorizedMachines,
+    normalizeCliValue(args.machineSelector) ?? args.auth.machineId
+  );
+  await args.manager.syncFlockDocOrThrow(getMachineFlockDocId(workspaceId, machine.id), {
+    reason: `project.list:${machine.id}`,
+  });
+
+  const localProjects = Object.values(
+    await dependencies.readProjects(args.manager.repo, workspaceId, machine.id)
+  );
+  const projectAccess = await Promise.all(
+    localProjects.map(async (project) => ({
+      project,
+      access: await dependencies.verifyAccess({
+        auth: args.auth,
+        workspaceId,
+        machineId: machine.id,
+        localProjectId: project.id,
+      }),
+    }))
+  );
+  const projects = projectAccess
+    .filter((entry) => entry.access.allowed)
+    .map(({ project }) => ({
+      localProjectId: project.id,
+      name: project.name,
+      rootPath: project.rootPath,
+    }))
+    .sort((left, right) => {
+      const nameCompare = left.name.localeCompare(right.name);
+      return nameCompare !== 0 ? nameCompare : left.rootPath.localeCompare(right.rootPath);
+    });
+
+  return {
+    ok: true,
+    type: 'local-project/list',
+    result: {
+      workspaces: [{ workspaceId, workspaceName: args.workspace.name, projects }],
+    },
+  };
+}

--- a/site-docs/content/docs/en/(core-concepts)/cli.mdx
+++ b/site-docs/content/docs/en/(core-concepts)/cli.mdx
@@ -186,6 +186,18 @@ Project commands manage local-project registrations that can later be selected i
 | `lody project list`       | List registered local projects     | `lody project list --help`   |
 | `lody project delete`     | Delete registered local projects   | `lody project delete --help` |
 
+Without selectors, `lody project list` reads the current machine through its local daemon. To
+inspect projects registered on a workspace machine without running a daemon on the client, use the
+cloud catalog path:
+
+```bash
+lody project list --workspace <id|slug|name> [--machine <id|name>] --json
+```
+
+If `--machine` is omitted, Lody selects the machine associated with the current CLI login. The
+result includes only machines and local projects the authenticated user may request. Remote listing
+is unavailable in the open-source local platform because that mode performs no cloud I/O.
+
 For the exact current flags, always check the built-in help:
 
 ```bash

--- a/site-docs/content/docs/zh/(core-concepts)/cli.mdx
+++ b/site-docs/content/docs/zh/(core-concepts)/cli.mdx
@@ -171,6 +171,16 @@ Project 命令用于管理本地项目注册。注册之后，session 创建时�
 | `lody project list`       | 列出已注册的本地项目 | `lody project list --help`   |
 | `lody project delete`     | 删除已注册的本地项目 | `lody project delete --help` |
 
+不带 selector 时，`lody project list` 会通过本机 daemon 读取当前机器。如果客户端没有运行
+daemon，但需要查看 workspace 内某台机器注册的项目，可以使用 cloud catalog 路径：
+
+```bash
+lody project list --workspace <id|slug|name> [--machine <id|name>] --json
+```
+
+省略 `--machine` 时，Lody 会选择当前 CLI 登录所关联的机器。结果只包含已认证用户有权请求的
+机器和本地项目。开源 local platform 不执行 cloud I/O，因此不支持远程列出项目。
+
 精确参数请直接查看：
 
 ```bash


### PR DESCRIPTION
## Related issue

Closes #582

## Problem / pressure

`lody project list` always uses local-daemon IPC, even though authenticated session creation can already synchronize and read a selected remote machine's local-project catalog. A headless client with credentials but no daemon can therefore dispatch work to a remote machine only if it already knows a project selector; it cannot list the available projects through a stable CLI contract.

## Summary

Add `--workspace` and `--machine` selectors to `lody project list`. Selector-free calls retain the existing local-daemon behavior, while an explicit selector uses the authenticated one-shot workspace path, resolves the selected machine, synchronizes its Flock document, and returns the same merged local-project catalog used by session creation.

The remote path verifies machine and per-project access before returning paths. It fails closed on authorization or synchronization errors, supports machine ids and unique names, and preserves JSON and terminal-table response behavior. The CLI reference and bilingual Agent Note document the resulting boundary.

## Visual explanation

```mermaid
flowchart TD
  A[lody project list] --> B{workspace or machine selector?}
  B -- no --> C[Existing local-daemon IPC]
  B -- yes --> D[Authenticated one-shot workspace manager]
  D --> E[Resolve authorized machine]
  E --> F[Sync target machine Flock]
  F --> G[Read merged local-project catalog]
  G --> H[Filter project access]
  H --> I[JSON or terminal table]
```

## Before / after

| Before | After |
| ------ | ----- |
| `project list` requires a daemon on the client machine. | Explicit workspace or machine selectors list the authorized remote machine catalog without local-daemon IPC. |
| Headless callers infer project choices from a failing `session create` error. | Headless callers receive a structured `local-project/list` response. |
| Remote catalog synchronization and access filtering exist only in session creation. | Project listing applies the same Flock-backed catalog and capability checks. |

## Test plan

- `corepack pnpm --filter lody exec vitest run src/lib/remote-local-project-list.test.ts` — 4 tests passed.
- `corepack pnpm --filter lody run typecheck` — passed.
- `corepack pnpm --filter lody run format:check` — passed.
- `node scripts/docs/main.mjs check` — passed with existing translation and Agent-instruction size warnings.
- `git diff --check upstream/main...HEAD` — passed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Inspect selector routing in `apps/cli/src/commands/project.ts` and the sync/access order in `remote-local-project-list.ts`.
- **Decisions to challenge:** Confirm that selector-free listing should preserve local IPC while every explicit workspace or machine selector opts into the remote catalog.
- **Plausible failures / evidence gaps:** The regression fixture exercises distinct synthetic client/target machines and Flock synchronization; it does not connect to a live hosted workspace.

### Authoring context

- **User goal / directives:** Issue #582 asks for a supported daemon-free remote project-list command; Dante-dan authorized the tracker to investigate eligible issues and publish validated fixes under each repository's current rules.
- **Constraints / non-goals:** Preserve the existing selector-free local workflow; do not change session creation, agent-config listing, daemon identity routing, or hosted backend contracts.
- **Risk-bearing decisions:** Machine and project capability checks run before paths are returned, and synchronization failure aborts rather than serving a stale catalog.
- **Destructive or irreversible behavior:** The command is read-only; it creates no session, changes no project registration, and performs no migration or cleanup.
- **Deliberately not done or tested:** No live hosted-workspace or installed-binary test was run; the remote transport, Flock merge, denial, ambiguity, and failure paths are covered with synthetic fixtures.
- **Unknowns / confidence:** Confidence is high in the CLI boundary and deterministic catalog behavior; live service availability remains outside the repository-local fixture.

### Original user prompt

<details>
<summary>Show original prompt</summary>

````text
#582 / PR #587：CLI 无本地 daemon 时，也能按 workspace/machine 列出远端项目，保持原有本机行为
````

</details>

<!-- context-handoff:end -->
