### PR TITLE
fix(cli): let acp-extension-core build itself during install

### DIFF
--- a/.agents/docs/cli-overview.md
+++ b/.agents/docs/cli-overview.md
@@ -97,3 +97,7 @@ after a submodule update, which is why `prepare:acp-adapters` runs before both
 `scripts/dev-build.mjs` in the CLI `dev` script and Vite in the CLI `build` chain. The
 `src/claude-acp-entry.ts` and `src/codex-acp-entry.ts` entries import the adapters' package roots,
 whose runtime exports point at adapter `dist/`.
+
+`packages/acp-extension-core` is the exception: it builds its own `dist/` through its `prepare`
+script on every install, because `packages/shared` (and every other workspace consumer) imports
+its runtime export directly. `prepare:acp-adapters` therefore only compiles the four adapters.

--- a/.agents/notes/implemented/process/2026-09-11-acp-core-install-build.md
+++ b/.agents/notes/implemented/process/2026-09-11-acp-core-install-build.md
@@ -1,0 +1,71 @@
+# Build `acp-extension-core` on install, not in each consumer
+
+Status: implemented
+Translation: pending
+PR: https://github.com/LodyAI/Lody/pull/596
+
+Upstream change: https://github.com/LodyAI/acp-extension-core/pull/8
+
+## Abstract
+
+`acp-extension-core` ships raw TypeScript plus a compiled `dist/`, and its runtime
+`exports.import` points at `dist/index.js`. Only `build` and `prepublishOnly` produced that
+directory, so a pnpm workspace install linked the package without compiling it: any consumer
+that bundles the runtime export failed with `Failed to resolve entry for package
+"acp-extension-core"` unless it ran its own `pnpm --filter acp-extension-core build` first. Five
+such workarounds accumulated across `loro-dev/lody` and this repository, and each new consumer
+rediscovered the failure. The package now declares `prepare`, which pnpm runs on install as well
+as on pack/publish, so workspace consumers get `dist/` from a plain install while the published
+tarball is unchanged; `prepare:acp-adapters` no longer compiles Core. Residual limit: an install
+that does not include the package in its filter scope still never builds it, so correctness now
+depends on the dependency graph rather than on per-job discipline.
+
+## Problem
+
+- `main` and `exports.import` are `./dist/index.js`; `dist/` is gitignored and absent from a
+  clean checkout.
+- `types` is `./src/index.ts`, so `pnpm typecheck` always passed and only bundlers
+  (Vite, esbuild, Wrangler) failed — late, in publish pipelines.
+- pnpm's `workspace:*` links the package; it does not run its build.
+- `packages/shared` imports runtime values from Core (`createPlanModeConfigOption`,
+  `LODY_PLAN_MODE_CONFIG_ID`), so Core's runtime entry reaches the browser bundle, the Convex
+  bundle, the Worker, Pages, the CLI, and mobile.
+
+## Decision
+
+Declare `prepare: npm run build` in `packages/acp-extension-core/package.json`, replacing
+`prepublishOnly`, which `prepare` supersedes for the pack/publish path. The producer builds its
+own runtime entry at install time; consumers stop carrying a build step for a dependency.
+
+Alternatives rejected:
+
+- **Pin every consumer to a published registry version.** It removes the local checkout from the
+  build input. `acp-extension-codex` inlines Core into its bundled `dist/`, and the CLI inlines
+  Core and all four adapters, so the products would ship whatever npm last published instead of
+  the pinned submodule; the adapters already declare three different Core versions
+  (0.1.0/0.1.1/0.1.4), which the root `overrides: acp-extension-core: workspace:*` deliberately
+  collapses to one copy.
+- **Point `exports.import` at `src/index.ts`.** Changes runtime semantics for Node consumers and
+  needs a `publishConfig` override plus two resolution conditions.
+- **Keep the per-job build steps.** They are correct but live at the wrong layer: every new
+  consumer has to rediscover the failure, and local development has no such job.
+
+## Evidence
+
+pnpm 10.20.0 workspace, verified in a scratch workspace and then in `loro-dev/lody`:
+
+- `pnpm install` and `pnpm install --frozen-lockfile` both run a workspace project's `prepare`.
+- A filtered install that reaches the package through the dependency closure
+  (`--filter '@lody/web...'`, the Cloudflare Pages install) also runs it; `--filter pkg` without
+  `...` does not, because the package is outside that install scope.
+- `onlyBuiltDependencies` / `ignoredBuiltDependencies` gate external dependency build scripts;
+  they do not gate workspace project lifecycle scripts.
+- After the change, `acp-extension-core/dist/index.js` appears from a plain root install and the
+  mobile production bundle that previously failed in the resolver completes.
+
+## Consequences
+
+`loro-dev/lody` can drop the four per-consumer Core builds (Convex deploy step, site-docs
+release step, Pages inputs, mobile publish jobs) and this repository can drop the Core stage from
+`prepare:acp-adapters`. An extra `tsc` now runs on every install of the workspace, including
+installs that never bundle Core.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -13,7 +13,7 @@
     "build": "pnpm run clean && pnpm run prepare:acp-adapters && pnpm run typecheck && pnpm run build:bundle && pnpm run copy:dsh-presets && pnpm run check:published-bundle-imports && pnpm run copy:wasm",
     "build:watch": "pnpm run prepare:review-assets && vite build --watch",
     "build:bundle": "pnpm run prepare:review-assets && vite build",
-    "prepare:acp-adapters": "corepack pnpm --dir ../.. --filter acp-extension-core build && corepack pnpm --dir ../.. --filter acp-extension-claude build && corepack pnpm --dir ../.. --filter acp-extension-codex build && corepack pnpm --dir ../.. --filter acp-extension-grok build && corepack pnpm --dir ../.. --filter acp-extension-dsh build",
+    "prepare:acp-adapters": "corepack pnpm --dir ../.. --filter acp-extension-claude build && corepack pnpm --dir ../.. --filter acp-extension-codex build && corepack pnpm --dir ../.. --filter acp-extension-grok build && corepack pnpm --dir ../.. --filter acp-extension-dsh build",
     "prepare:review-assets": "pnpm --dir ../.. --filter lody-code-review-viewer build",
     "check:published-bundle-imports": "node scripts/check-published-bundle-imports.js",
     "copy:dsh-presets": "node scripts/copy-deepseek-presets.js",


### PR DESCRIPTION
Risk: 🟡 medium | Confidence: high — verified by a real root install in `loro-dev/lody` and a full mobile production bundle; the only unverified path is the merge-commit re-pin.

Depends on LodyAI/acp-extension-core#8. The submodule pointer here is pinned to that PR's commit (`fde22a0`); re-point it at the merge commit before merging this.

## What

`packages/acp-extension-core` declares `main` / `exports.import` as `./dist/index.js`, but nothing compiled it during a workspace install — only `build` and `prepublishOnly` did. So every consumer that bundles the runtime export carried its own copy of `pnpm --filter acp-extension-core build`; `prepare:acp-adapters` had one more. LodyAI/acp-extension-core#8 adds `prepare` to the package itself, which pnpm runs on install as well as on pack/publish.

This change:

- drops the Core stage from `prepare:acp-adapters`, which now compiles only `acp-extension-claude`, `acp-extension-codex`, `acp-extension-grok`, `acp-extension-dsh`;
- advances the `packages/acp-extension-core` submodule pointer;
- records the split in `.agents/docs/cli-overview.md` and a new Agent Note.

Adapter `dist/` outputs still have no install-time build: `prepare:acp-adapters` stays the owner of those four, and `apps/cli/AGENTS.md` already requires it before `dev-build.mjs` and Vite.

## Verification

- Root `pnpm install` in `loro-dev/lody` now produces `lody-oss/packages/acp-extension-core/dist/index.js` with no dedicated build step.
- `pnpm --filter @lody/mobile build` (with `VITE_PREVIEW_PUBLIC_BASE_DOMAIN`) completes; before this it failed in the resolver.
- `--frozen-lockfile` installs and dependency-closure filtered installs (`--filter '@lody/web...'`, the Pages path) also run the new `prepare`.
- Not verified: the re-pin to the Core merge commit (blocked on the Core PR landing), and Cloudflare's out-of-band Worker/Pages installs, which this repo cannot exercise.

## Merge order

1. LodyAI/acp-extension-core#8
2. this PR (re-pinned to the Core merge commit)
3. the `loro-dev/lody` pointer bump, then the removal of the per-job workarounds there