### PR TITLE
fix: support mouse wheel scrolling in side-panel tabs

### DIFF
--- a/packages/components/src/components/sessions/session-side-panel-tab-bar.tsx
+++ b/packages/components/src/components/sessions/session-side-panel-tab-bar.tsx
@@ -218,6 +218,39 @@ export const SessionSidePanelTabBar = memo(function SessionSidePanelTabBar({
 }: SessionSidePanelTabBarProps) {
   const windowDragClass = useWindowDragRegionClass();
   const activeTabRef = useRef<HTMLDivElement>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      // Keep native horizontal gestures and browser zoom intact.
+      if (event.defaultPrevented || event.ctrlKey || event.deltaX !== 0 || event.deltaY === 0) return;
+
+      const maxScrollLeft = viewport.scrollWidth - viewport.clientWidth;
+      if (maxScrollLeft <= 0) return;
+
+      const unit =
+        event.deltaMode === WheelEvent.DOM_DELTA_LINE
+          ? 16
+          : event.deltaMode === WheelEvent.DOM_DELTA_PAGE
+            ? viewport.clientWidth
+            : 1;
+      const nextScrollLeft = Math.max(
+        0,
+        Math.min(maxScrollLeft, viewport.scrollLeft + event.deltaY * unit)
+      );
+      if (nextScrollLeft === viewport.scrollLeft) return;
+
+      event.preventDefault();
+      viewport.scrollLeft = nextScrollLeft;
+    };
+
+    // React's delegated wheel listener is passive, so bind to the viewport.
+    viewport.addEventListener('wheel', handleWheel, { passive: false });
+    return () => viewport.removeEventListener('wheel', handleWheel);
+  }, []);
 
   useEffect(() => {
     activeTabRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -228,6 +261,7 @@ export const SessionSidePanelTabBar = memo(function SessionSidePanelTabBar({
       <ScrollArea
         scrollableX
         horizontalOnly
+        viewportRef={viewportRef}
         className="min-w-0 flex-1"
         // Compact overlay bar: default horizontal track is too tall in this h-11 strip.
         horizontalScrollbarClassName="h-1 border-0 p-0"

--- a/packages/components/src/components/sessions/session-side-panel-tab-bar.tsx
+++ b/packages/components/src/components/sessions/session-side-panel-tab-bar.tsx
@@ -222,11 +222,12 @@ export const SessionSidePanelTabBar = memo(function SessionSidePanelTabBar({
 
   useEffect(() => {
     const viewport = viewportRef.current;
-    if (!viewport) return;
+    if (!viewport) return undefined;
 
     const handleWheel = (event: WheelEvent) => {
       // Keep native horizontal gestures and browser zoom intact.
-      if (event.defaultPrevented || event.ctrlKey || event.deltaX !== 0 || event.deltaY === 0) return;
+      if (event.defaultPrevented || event.ctrlKey || event.deltaX !== 0 || event.deltaY === 0)
+        return;
 
       const maxScrollLeft = viewport.scrollWidth - viewport.clientWidth;
       if (maxScrollLeft <= 0) return;


### PR DESCRIPTION
## Related issue

Closes #600

## Problem / pressure

Overflowing side-panel tabs are difficult to navigate with an ordinary mouse because the strip only scrolls horizontally.

## Summary

Map vertical mouse-wheel input over the side-panel tab viewport to horizontal scrolling. Normalize line/page deltas, preserve native horizontal gestures and Ctrl-wheel zoom, and allow default scrolling when no further horizontal movement is possible. Remove the native listener on unmount.

## Visual explanation

Simple change: one viewport-local wheel handler changes scrolling direction; a diagram would duplicate the before/after comparison.

## Before / after

| Before | After |
| ------ | ----- |
| A vertical mouse wheel does not reveal overflowing side-panel tabs. | Wheel down moves right; wheel up moves left. |
| Horizontal gestures scroll natively. | Horizontal gestures continue scrolling natively. |

## Test plan

- Passed: `git diff --check` and Prettier check for the changed component.
- Passed: the existing side-panel tab-bar suite (13 tests).
- Passed: full local desktop build, including CLI and Electron main/renderer type checks; launched the built app with isolated test data.
- Passed: component type-aware lint (zero errors; existing warnings remain). Fixed the CI `consistent-return` error by explicitly returning `undefined` before the effect cleanup branch.
- Passed: document checks after initializing ACP submodules.
- Verified vertical wheel input in the real component's Storybook example: scrolling up reveals leftmost tabs and scrolling down reveals rightmost tabs. The contributor also confirmed manual verification passed.
- Full repository checks were initially blocked by missing dependencies and were not rerun in full; the targeted checks above were completed after installation. Trackpad and Ctrl-wheel behavior were not separately exercised by the authoring agent.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Check wheel handling in `session-side-panel-tab-bar.tsx`, including viewport binding and cleanup.
- **Decisions to challenge:** Native horizontal deltas bypass conversion, line units use 16 pixels, and edges release default scrolling.
- **Plausible failures / evidence gaps:** Vertical scrolling was exercised in Chromium; trackpad and Ctrl-wheel behavior were not separately exercised by the authoring agent.

### Authoring context

- **User goal / directives:** Make horizontally overflowing side-panel tabs usable with an ordinary mouse wheel, based on upstream main.
- **Constraints / non-goals:** One UI component only; preserve tab lifecycle and native horizontal gestures.
- **Risk-bearing decisions:** A non-passive native listener cancels only vertical wheel events that move the viewport.
- **Destructive or irreversible behavior:** None; no persistence, migrations, or external product operations change.
- **Deliberately not done or tested:** No dependency changes or new test suite; full repository checks were not rerun in full after installing dependencies.
- **Unknowns / confidence:** Targeted tests, full desktop build, and vertical-wheel UI verification pass; additional device-specific gesture behavior remains unverified by the authoring agent.

### Original user prompt

<details>
<summary>Show original prompt</summary>

````text
拉一下上游的main，然后我希望做一个改进，现在侧边栏tab栏对于鼠标滚轮很不友好，他是横向滚动的，我希望能够用鼠标横向滚动
````

</details>

<!-- context-handoff:end -->
