### PR TITLE
fix: preserve ordinary POSIX mode when Code Collab saves text

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-11-save-text-file-mode-preservation.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-save-text-file-mode-preservation.md
@@ -1,0 +1,21 @@
+# Preserve ordinary POSIX mode when saving Code Collab text
+
+Status: implemented
+Translation: current
+
+[中文](./2026-09-11-save-text-file-mode-preservation.zh.md)
+
+## Abstract
+
+Code Collab v2 `saveText` replaced an existing file with a temp file created at mode 0666, so the process umask decided the new permissions. Saving an executable script reported success and then lost `+x`. The helper now copies the original file's ordinary permission bits onto the temp file with `chmod` before rename, which is not masked by umask.
+
+## Decision
+
+- Keep digest conflict detection and atomic replace-via-rename.
+- On non-Windows, `lstat` the existing file and `chmod` the temp path with `mode & 0o777` before it becomes visible.
+- Do not preserve setuid/setgid/sticky, ACLs, xattrs, or ownership; those were not independently verified as product requirements.
+- Skip the chmod on Windows; Node file modes there are not POSIX, and this change is untested on Windows.
+
+## Evidence and limits
+
+Linux tests in `code-collab-v2-service.test.ts` cover 0755 remaining executable after save under umask 0022, 0600 remaining 0600, 0644 remaining 0644 under umask 0022, a digest conflict leaving 0755 untouched, and a deleted-file save that returns `file_deleted` without recreating the path. Packaged Electron click-through was not completed. macOS and Windows were not tested.

--- a/.agents/notes/implemented/bug-fix/2026-09-11-save-text-file-mode-preservation.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-save-text-file-mode-preservation.zh.md
@@ -1,0 +1,21 @@
+# 保存 Code Collab 文本时保留普通 POSIX 权限
+
+Status: implemented
+Translation: current
+
+[English](./2026-09-11-save-text-file-mode-preservation.md)
+
+## 摘要
+
+Code Collab v2 的 `saveText` 用 mode 0666 的临时文件替换已有文件，新权限由进程 umask 决定。保存可执行脚本会报告成功，随后丢失执行位。现在在 rename 之前对临时文件 `chmod` 原文件的普通权限位（`mode & 0o777`），不受 umask 再削。
+
+## 决策
+
+- 保留 digest 冲突检测和 rename 原子替换。
+- 非 Windows 上 `lstat` 已有文件，在可见替换前 `chmod` 普通权限。
+- 不保留 setuid/setgid/sticky、ACL、xattr、所有者；这些没有作为产品要求独立验证。
+- Windows 跳过 chmod；该平台 Node 的 mode 不是 POSIX，本次未测。
+
+## 证据与限制
+
+`code-collab-v2-service.test.ts` 在 Linux 上覆盖 umask 0022 下 0755 仍可执行、0600 仍为 0600、0644 仍为 0644、冲突保存不改 0755，以及删除后保存返回 `file_deleted` 且不重建文件。未完成打包 Electron 点击验收。未测 macOS 与 Windows。

--- a/apps/cli/src/lib/code-collab/code-collab-v2-service.test.ts
+++ b/apps/cli/src/lib/code-collab/code-collab-v2-service.test.ts
@@ -1,6 +1,16 @@
 import { createHash } from 'node:crypto';
-import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, readdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { execFile, spawnSync } from 'node:child_process';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -211,6 +221,160 @@ describe('CodeCollabV2Service text RPC boundary', () => {
         rawBytes: Buffer.byteLength('new\n'),
       });
       expect(await readFile(filePath, 'utf8')).toBe('new\n');
+    });
+  });
+
+  it.runIf(process.platform !== 'win32')(
+    'keeps ordinary POSIX mode on an existing file after a successful save',
+    async () => {
+      const modeOf = async (filePath: string) => ((await stat(filePath)).mode & 0o777).toString(8);
+      const script = '#!/bin/sh\nprintf "saved\\n"\n';
+
+      await withWorkspace(async (workspaceRoot) => {
+        const previousMask = process.umask(0o022);
+        try {
+          const filePath = path.join(workspaceRoot, 'run.sh');
+          await writeFile(filePath, '#!/bin/sh\nprintf "old\\n"\n');
+          await chmod(filePath, 0o755);
+          const service = new CodeCollabV2Service({
+            resolveWorkspace: makeResolver(workspaceRoot),
+          });
+          const opened = await service.openText({ sessionId: SESSION_ID, path: 'run.sh' });
+          const saved = await service.saveText({
+            sessionId: SESSION_ID,
+            requestedByUserId: 'user-1',
+            path: 'run.sh',
+            baseDigest: opened.digest,
+            text: {
+              encoding: 'plain',
+              text: script,
+              rawBytes: Buffer.byteLength(script),
+            },
+          });
+          expect(saved.status).toBe('ok');
+          expect(await readFile(filePath, 'utf8')).toBe(script);
+          expect(await modeOf(filePath)).toBe('755');
+          const ran = spawnSync(filePath, [], { encoding: 'utf8' });
+          expect(ran.error).toBeUndefined();
+          expect(ran.status).toBe(0);
+          expect(ran.stdout).toBe('saved\n');
+        } finally {
+          process.umask(previousMask);
+        }
+      });
+
+      await withWorkspace(async (workspaceRoot) => {
+        const filePath = path.join(workspaceRoot, 'secret.txt');
+        await writeFile(filePath, 'old\n');
+        await chmod(filePath, 0o600);
+        const service = new CodeCollabV2Service({
+          resolveWorkspace: makeResolver(workspaceRoot),
+        });
+        const opened = await service.openText({ sessionId: SESSION_ID, path: 'secret.txt' });
+        const saved = await service.saveText({
+          sessionId: SESSION_ID,
+          requestedByUserId: 'user-1',
+          path: 'secret.txt',
+          baseDigest: opened.digest,
+          text: {
+            encoding: 'plain',
+            text: 'new\n',
+            rawBytes: Buffer.byteLength('new\n'),
+          },
+        });
+        expect(saved.status).toBe('ok');
+        expect(await readFile(filePath, 'utf8')).toBe('new\n');
+        expect(await modeOf(filePath)).toBe('600');
+      });
+
+      await withWorkspace(async (workspaceRoot) => {
+        const previousMask = process.umask(0o022);
+        try {
+          const filePath = path.join(workspaceRoot, 'plain.txt');
+          await writeFile(filePath, 'old\n');
+          await chmod(filePath, 0o644);
+          const service = new CodeCollabV2Service({
+            resolveWorkspace: makeResolver(workspaceRoot),
+          });
+          const opened = await service.openText({ sessionId: SESSION_ID, path: 'plain.txt' });
+          const saved = await service.saveText({
+            sessionId: SESSION_ID,
+            requestedByUserId: 'user-1',
+            path: 'plain.txt',
+            baseDigest: opened.digest,
+            text: {
+              encoding: 'plain',
+              text: 'new\n',
+              rawBytes: Buffer.byteLength('new\n'),
+            },
+          });
+          expect(saved.status).toBe('ok');
+          expect(await modeOf(filePath)).toBe('644');
+        } finally {
+          process.umask(previousMask);
+        }
+      });
+    }
+  );
+
+  it.runIf(process.platform !== 'win32')(
+    'does not change POSIX mode when a digest conflict skips the write',
+    async () => {
+      await withWorkspace(async (workspaceRoot) => {
+        const filePath = path.join(workspaceRoot, 'run.sh');
+        await writeFile(filePath, 'old\n');
+        await chmod(filePath, 0o755);
+        const service = new CodeCollabV2Service({
+          resolveWorkspace: makeResolver(workspaceRoot),
+        });
+        const opened = await service.openText({ sessionId: SESSION_ID, path: 'run.sh' });
+        await writeFile(filePath, 'external\n');
+        await chmod(filePath, 0o755);
+        const conflict = await service.saveText({
+          sessionId: SESSION_ID,
+          requestedByUserId: 'user-1',
+          path: 'run.sh',
+          baseDigest: opened.digest,
+          text: {
+            encoding: 'plain',
+            text: 'new\n',
+            rawBytes: Buffer.byteLength('new\n'),
+          },
+        });
+        expect(conflict.status).toBe('conflict');
+        expect(await readFile(filePath, 'utf8')).toBe('external\n');
+        expect(((await stat(filePath)).mode & 0o777).toString(8)).toBe('755');
+      });
+    }
+  );
+
+  it('does not recreate a deleted file when save reports file_deleted', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const filePath = path.join(workspaceRoot, 'gone.ts');
+      await writeFile(filePath, 'old\n');
+      const service = new CodeCollabV2Service({
+        resolveWorkspace: makeResolver(workspaceRoot),
+      });
+      const opened = await service.openText({ sessionId: SESSION_ID, path: 'gone.ts' });
+      await rm(filePath);
+      const deleted = await service.saveText({
+        sessionId: SESSION_ID,
+        requestedByUserId: 'user-1',
+        path: 'gone.ts',
+        baseDigest: opened.digest,
+        text: {
+          encoding: 'plain',
+          text: 'new\n',
+          rawBytes: Buffer.byteLength('new\n'),
+        },
+      });
+      expect(deleted).toEqual({
+        status: 'conflict',
+        reason: 'file_deleted',
+        path: 'gone.ts',
+        baseDigest: opened.digest,
+      });
+      await expect(stat(filePath)).rejects.toMatchObject({ code: 'ENOENT' });
     });
   });
 

--- a/apps/cli/src/lib/code-collab/code-collab-v2-service.ts
+++ b/apps/cli/src/lib/code-collab/code-collab-v2-service.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { execFile } from 'node:child_process';
 import {
+  chmod,
   lstat,
   opendir,
   open,
@@ -2288,8 +2289,19 @@ async function writeFileAtomically(
   workspacePath: string
 ): Promise<void> {
   const temporaryPath = `${absolutePath}.lody-save-${process.pid}-${randomUUID()}.tmp`;
+  // writeFile's mode is still masked by umask. chmod the temp file before rename
+  // so an existing 0755 script does not become 0644/0664 and lose +x.
+  const preserveMode =
+    process.platform === 'win32'
+      ? undefined
+      : await lstat(absolutePath)
+          .then((existing) => (existing.isFile() ? existing.mode & 0o777 : undefined))
+          .catch(() => undefined);
   try {
     await writeFile(temporaryPath, bytes, { mode: 0o666 });
+    if (preserveMode !== undefined) {
+      await chmod(temporaryPath, preserveMode);
+    }
     await rename(temporaryPath, absolutePath);
   } catch (error) {
     await unlink(temporaryPath).catch(() => undefined);


### PR DESCRIPTION
## Related issue

Closes #603

## Problem / pressure

Code Collab `saveText` reports success and then replaces the file with a new inode whose mode is `0666 & ~umask`. Saving a `0755` script drops `+x` (`EACCES` on the next run). A `0600` file is widened to `0664`/`0644`. Digest conflicts already skip the write; the successful path does not keep the ordinary mode.

## Summary

`writeFileAtomically` still writes a temp file and `rename`s it over the original path. On non-Windows it now `lstat`s an existing regular file, `chmod`s the temp path with `mode & 0o777` before rename, and leaves conflict / `file_deleted` returns on the existing no-write paths. Adapter/core gitlinks are unchanged.

## Visual explanation

```text
writeFileAtomically(path, bytes)
  mode = lstat(path).mode & 0o777   # skip win32 / missing / non-file
  writeFile(temp, bytes, mode 0666) # still masked by umask
  if mode known: chmod(temp, mode)  # not masked by umask
  rename(temp, path)                # atomic replace
```

Conflict and deleted-file checks still run in `saveText` before this helper. A digest mismatch or missing file returns without creating the temp file.

## Before / after

| Before | After |
| ------ | ----- |
| Save `0755` under umask 0022 → `0644`, next exec is `EACCES` | Save keeps `0755`; script still runs |
| Save `0600` → `0664`/`0644` | Save keeps `0600` |
| Digest conflict / deleted file | Unchanged: no write, no recreate |
| Windows | Unchanged: no chmod (untested) |

## Test plan

- `apps/cli` Vitest `src/lib/code-collab/code-collab-v2-service.test.ts`: 48 passed on Linux (Node 24.15.0). New coverage: umask 0022 + `0755` remains executable, `0600` stays `0600`, `0644` stays `0644`, digest conflict leaves `0755`, deleted file returns `file_deleted` and is not recreated. Existing save/conflict tests still pass.
- `oxlint` on the two changed TypeScript files: 0 warnings / 0 errors.
- `pnpm run docs check`: 0 new errors (pre-existing AGENTS.md size warnings only).
- `check:code-collab-imports`, `check:platform-boundaries`, `check:public-boundary`: passed.
- Not run: packaged Electron click-save, macOS, Windows, ACL/xattr/setuid. Isolated profile; the developer's existing Electron instance was not stopped or replaced.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `writeFileAtomically` in `apps/cli/src/lib/code-collab/code-collab-v2-service.ts` and the POSIX save tests; chmod must land on the temp path before rename, and conflict/deleted returns must still skip the write.
- **Decisions to challenge:** Copying only `mode & 0o777` (dropping setuid/setgid/sticky), skipping Windows chmod, and not restoring ACL/xattr on the new inode.
- **Plausible failures / evidence gaps:** Packaged Electron click-save was not run; macOS/Windows untested; a delete between the digest check and rename can still recreate the file (pre-existing TOCTOU).

### Authoring context

- **User goal / directives:** Fix Code Collab save dropping ordinary POSIX mode, then open a main-repo Issue and PR; do not change adapter/core or fold this into #38/#551.
- **Constraints / non-goals:** Keep atomic rename and digest/deleted conflict behavior; do not claim ACL, special bits, Windows, macOS, or GUI coverage.
- **Risk-bearing decisions:** chmod the temp file with the previous ordinary mode before it becomes visible, so umask cannot strip bits after writeFile.
- **Destructive or irreversible behavior:** A successful save still replaces the file inode via rename; failed writes still unlink the temp path. Conflict and deleted-file paths do not write.
- **Deliberately not done or tested:** No adapter/core changes; no Electron GUI click-through; no Windows/macOS/ACL/xattr/setuid tests.
- **Unknowns / confidence:** Linux service tests pass for 0755/0600/0644 plus conflict/deleted protection. Residual risk is untested desktop GUI and non-Linux permission models.

### Original user prompt

````text
Code Collab text save should keep the file's original ordinary POSIX permission bits.
````

<!-- context-handoff:end -->
