### PR TITLE
fix: skip unsupported builtin Grok default ACP mode

### DIFF
--- a/apps/cli/src/commands/session.test.ts
+++ b/apps/cli/src/commands/session.test.ts
@@ -213,6 +213,41 @@ describe('session command helpers', () => {
     expect(withBuiltinDefaultTurnMode({}, createSessionMeta({ cliType: 'registry' }))).toEqual({});
   });
 
+  it('skips a builtin default mode the adapter does not offer', () => {
+    const grok = createSessionMeta({ agentType: 'grok' });
+    expect(withBuiltinDefaultTurnMode({}, grok)).toEqual({ modeId: 'default' });
+    expect(
+      withBuiltinDefaultTurnMode({}, grok, {
+        ...createAcpCapability(),
+        agentType: 'grok',
+        modes: [],
+        configOptions: [
+          {
+            id: 'permission_mode',
+            name: 'Permission Mode',
+            category: '_permission',
+            type: 'select',
+            currentValue: 'ask',
+            options: [
+              { value: 'ask', name: 'Ask' },
+              { value: 'always-approve', name: 'Always Approve' },
+            ],
+          },
+        ],
+      })
+    ).toEqual({});
+    expect(
+      withBuiltinDefaultTurnMode({}, grok, {
+        ...createAcpCapability(),
+        agentType: 'grok',
+        modes: [
+          { id: 'default', name: 'Agent' },
+          { id: 'plan', name: 'Plan' },
+        ],
+      })
+    ).toEqual({ modeId: 'default' });
+  });
+
   it('picks prompt candidates by explicit precedence', () => {
     expect(
       resolvePromptCandidate({

--- a/apps/cli/src/commands/session.ts
+++ b/apps/cli/src/commands/session.ts
@@ -1435,13 +1435,23 @@ export function resolveTurnDispatchConfig(args: {
 
 export function withBuiltinDefaultTurnMode(
   config: ResolvedTurnDispatchConfig,
-  target: Pick<SessionMeta, 'cliType' | 'agentType'>
+  target: Pick<SessionMeta, 'cliType' | 'agentType'>,
+  capability?: AcpCapabilityCacheEntry
 ): ResolvedTurnDispatchConfig {
   if (config.modeId || typeof config.configOptionValues?.mode === 'string') {
     return config;
   }
   const modeId = getBuiltinDefaultModeId(target.cliType, target.agentType);
-  return modeId ? { ...config, modeId } : config;
+  if (!modeId) {
+    return config;
+  }
+  // Match the UI selector: only apply Lody's builtin default when the adapter
+  // actually offers that mode. Grok used to inherit Codex `agent` and Role/MCP
+  // creates then failed with "Unsupported ACP mode for the selected agent".
+  if (capability && !getSupportedTurnSelectorIds(capability, 'mode').has(modeId)) {
+    return config;
+  }
+  return { ...config, modeId };
 }
 
 function mergeTurnDispatchConfig(
@@ -1523,10 +1533,10 @@ export function filterCompatibleTurnConfigOptionValues(
   return Object.keys(compatible).length > 0 ? compatible : undefined;
 }
 
-const getSupportedTurnSelectorIds = (
+function getSupportedTurnSelectorIds(
   capability: AcpCapabilityCacheEntry | undefined,
   category: 'mode' | 'model'
-): Set<string> => {
+): Set<string> {
   const ids = new Set<string>(
     category === 'mode'
       ? (capability?.modes ?? []).map((mode) => mode.id)
@@ -1543,7 +1553,7 @@ const getSupportedTurnSelectorIds = (
     }
   }
   return ids;
-};
+}
 
 export function validateTurnModeAndModel(
   config: Pick<ResolvedTurnDispatchConfig, 'modeId' | 'modelId'>,
@@ -2847,7 +2857,8 @@ async function resolveEffectiveSessionCreateDispatchConfig(args: {
         requested.config,
         filterCompatibleInheritedTurnConfig(inheritedDispatchConfig, capability)
       ),
-      args.agentConfig
+      args.agentConfig,
+      capability
     ),
     inheritSessionDefaults: false,
   };
@@ -3232,17 +3243,27 @@ export async function sendSessionChatResult(
     sessionId,
     requester,
   });
+  const mayApplyBuiltinDefault =
+    Boolean(getBuiltinDefaultModeId(session.cliType, session.agentType)) &&
+    !dispatchConfig.modeId &&
+    typeof dispatchConfig.configOptionValues?.mode !== 'string';
+  const capability =
+    dispatchConfig.modeId ||
+    dispatchConfig.modelId ||
+    dispatchConfig.configOptionValues ||
+    mayApplyBuiltinDefault
+      ? await readAgentAcpCapability({
+          manager,
+          workspaceId: workspace.id as WorkspaceId,
+          machineId: session.machineId,
+          agentConfigId: session.agentConfigId,
+        })
+      : undefined;
   if (dispatchConfig.modeId || dispatchConfig.modelId || dispatchConfig.configOptionValues) {
-    const capability = await readAgentAcpCapability({
-      manager,
-      workspaceId: workspace.id as WorkspaceId,
-      machineId: session.machineId,
-      agentConfigId: session.agentConfigId,
-    });
     validateTurnModeAndModel(dispatchConfig, capability);
     validateTurnConfigOptionValues(dispatchConfig.configOptionValues, capability);
   }
-  const effectiveDispatchConfig = withBuiltinDefaultTurnMode(dispatchConfig, session);
+  const effectiveDispatchConfig = withBuiltinDefaultTurnMode(dispatchConfig, session, capability);
 
   await syncDocForRead(
     manager,

--- a/apps/cli/src/commands/session.ts
+++ b/apps/cli/src/commands/session.ts
@@ -2828,7 +2828,16 @@ async function resolveEffectiveSessionCreateDispatchConfig(args: {
             args.agentConfig
           )
         : undefined;
+  // Builtin Role/MCP creates often have no modeId. Read capabilities before
+  // accepting so withBuiltinDefaultTurnMode cannot freeze an unoffered mode.
+  const mayApplyBuiltinDefault =
+    Boolean(getBuiltinDefaultModeId(args.agentConfig.cliType, args.agentConfig.agentType)) &&
+    dispatchConfig.modeId === undefined &&
+    typeof dispatchConfig.configOptionValues?.mode !== 'string' &&
+    inheritedDispatchConfig?.modeId === undefined &&
+    typeof inheritedDispatchConfig?.configOptionValues?.mode !== 'string';
   const needsCapability =
+    mayApplyBuiltinDefault ||
     dispatchConfig.modeId !== undefined ||
     dispatchConfig.modelId !== undefined ||
     dispatchConfig.configOptionValues !== undefined ||

--- a/packages/shared/src/ai.ts
+++ b/packages/shared/src/ai.ts
@@ -514,7 +514,9 @@ export const CODEX_AUTO_REVIEW_MODE_ID = 'agent-auto-review';
 
 const BUILTIN_DEFAULT_MODE_IDS: Record<BuiltinAgentType, string> = {
   kimi: 'auto',
-  grok: 'agent',
+  // Grok advertises `default` / `plan`, not Codex `agent`. Injecting `agent`
+  // makes Role/MCP session create fail with "Unsupported ACP mode".
+  grok: 'default',
   claude: 'auto',
   codex: CODEX_AUTO_REVIEW_MODE_ID,
   deepseek: 'workspace-write',

--- a/packages/shared/tests/ai-grok.test.ts
+++ b/packages/shared/tests/ai-grok.test.ts
@@ -56,7 +56,7 @@ describe('builtin Grok shared contract', () => {
       'medium',
       'low',
     ]);
-    expect(getBuiltinDefaultModeId('builtin', 'grok')).toBe('agent');
+    expect(getBuiltinDefaultModeId('builtin', 'grok')).toBe('default');
     expect(classifyPermissionModeFace('always-approve')).toEqual({
       kind: 'full-access',
       tone: 'warning',


### PR DESCRIPTION
## Related issue

Closes #606

## Problem / pressure

MCP `lody_session_create` with an Agent Role bound to builtin Grok preallocated a session id, then failed materialization with `Unsupported ACP mode for the selected agent: agent`. The Role has no `modeId`, `inheritSessionDefaults` is false, and `withBuiltinDefaultTurnMode` injected Lody's builtin default. That default was Codex `agent`, which Grok does not advertise. UI new-session works because the selector only applies the builtin default when the adapter offers it.

## Summary

- Set `BUILTIN_DEFAULT_MODE_IDS.grok` to Grok's advertised `default` mode instead of Codex `agent`.
- Make `withBuiltinDefaultTurnMode` capability-aware: skip the builtin default when the adapter does not offer that mode.
- Pass ACP capability into session create and chat default-mode injection.
- Cover Grok with no advertised modes, and Grok that advertises `default`/`plan`.

## Visual explanation

```text
lody_session_create (Agent Role, builtin Grok, no modeId)
  resolveEffectiveSessionCreateDispatchConfig
    applyAgentRunConfigSelection
    validateTurnModeAndModel          // requested config has no modeId
    withBuiltinDefaultTurnMode
      getBuiltinDefaultModeId         // was "agent", now "default"
      getSupportedTurnSelectorIds     // skip inject if adapter does not offer it
  accept Operation                    // preallocates sessionId
  createSessionResult                 // previously threw; now persists
```

Simple change: the control-flow difference is one capability check that the UI already had.

## Before / after

| Before | After |
| ------ | ----- |
| Builtin Grok Role/MCP create injects `modeId=agent`, materialization throws, `inputDurable=false`, `SESSION_NOT_FOUND` | Inject `default` only if advertised; otherwise omit `modeId` so the session persists |
| UI selector already skipped an unoffered builtin default | CLI create/chat now match that selector |
| Custom Grok ACP worked (no builtin default) | Builtin Grok Role create should work the same way |

## Test plan

- `pnpm --filter @lody/shared exec vitest run tests/ai-grok.test.ts` — 3 passed
- `pnpm --filter lody exec vitest run src/commands/session.test.ts` — 67 passed, including the new Grok capability cases
- Skipped full `pnpm test` / desktop e2e (requires remaining ACP submodules and Electron). Did not re-run live MCP create against 0.93.2 after this patch; reproduction was on desktop 0.93.2 with builtin Grok Role create.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `packages/shared/src/ai.ts` grok default, `apps/cli/src/commands/session.ts` `withBuiltinDefaultTurnMode` plus the create/chat call sites that pass capability.
- **Decisions to challenge:** injecting `default` when Grok advertises it, versus always omitting modeId; extra capability read on builtin chat turns that have no mode.
- **Plausible failures / evidence gaps:** live Grok adapters that advertise neither `default` nor `agent` must omit modeId; chat path now fetches capability when a builtin default would apply.

### Authoring context

- **User goal / directives:** Open a Lody PR that stops builtin Grok Agent Role / MCP session create from producing ghost sessions.
- **Constraints / non-goals:** Do not change Codex/Claude/Kimi defaults when those adapters still advertise them. Do not change custom ACP launch. No desktop UI rewrite.
- **Risk-bearing decisions:** CLI create/chat now skip an unoffered builtin default instead of throwing later in ACP apply. Builtin Grok default string changes from `agent` to `default`.
- **Destructive or irreversible behavior:** None. Failed creates already left no durable session; this only avoids allocating ids that never persist.
- **Deliberately not done or tested:** Full workspace test suite and desktop e2e; live MCP retest after the patch (reproduced on 0.93.2 before the change).
- **Unknowns / confidence:** High that the injected `agent` mode is the failure. Medium that every live Grok adapter advertises `default`; the capability check covers adapters that advertise nothing.

### Original user prompt

<details>
<summary>Show original prompt</summary>

````text
那你能帮我给 lody 提一个 pr 来修复这个问题吗？
````

</details>

<!-- context-handoff:end -->
