### PR TITLE
fix(cli): route PR association to HTTP action endpoint [risk:medium]

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-11-pr-association-http-endpoint.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-pr-association-http-endpoint.md
@@ -1,0 +1,31 @@
+# Route PR association through the HTTP action endpoint
+
+Status: implemented
+Translation: pending
+
+## Abstract
+
+Cloud CLI PR association sent `/api/action` requests to the public Convex RPC
+endpoint, which cannot invoke the internal association function. This produces
+`Could not find public function for 'github:associatePullRequestForCli'`.
+The request now uses the existing `authSiteUrl`, reaching the HTTP action proxy
+and preserving explicitly configured site URLs as well as derived defaults.
+
+## Decision
+
+`cloud-cli-port.ts` owns endpoint selection. Use its existing site URL for PR
+association, consistent with other HTTP action consumers. The request payload,
+token checks, and response handling do not change. Making the backend function
+public is unnecessary; the intended HTTP proxy already supports this operation.
+
+## Verification limits
+
+An isolated runtime check executed the transpiled cloud port with unrelated
+services stubbed and intercepted fetch requests. Both the derived Convex site URL
+and an explicitly configured site URL received the expected POST and association
+payload. Changed-file formatting passed. Full checks are blocked in this checkout
+by missing nested ACP modules; document checks report links to those modules.
+
+This change does not include a live association against a hosted deployment.
+Review the endpoint selection separately from the unchanged association payload
+and backend authorization.

--- a/apps/cli/src/lib/AGENTS.md
+++ b/apps/cli/src/lib/AGENTS.md
@@ -22,6 +22,8 @@ end-to-end map. The WS/DO control-plane path is DEPRECATED; do not add to it.
   declarations and private workspace packages are forbidden. Prime the token provider
   before reading `getGatewayBaseUrl()`, and never let runtime transports or Machine RPC
   require `LODY_LORO_STREAMS_BASE_URL` as a parallel hidden composition path.
+- PR association uses the HTTP action proxy at `authSiteUrl`, not the public Convex
+  RPC endpoint at `authBaseUrl`; the association function is internal-only.
 - Local session control preserves every intermediate response: new clients negotiate
   NDJSON, legacy clients keep the buffered JSON envelope. `MachineRuntime` may collect
   responses for completion, but must also forward each to the streaming observer as it

--- a/apps/cli/src/lib/cloud-cli-port.ts
+++ b/apps/cli/src/lib/cloud-cli-port.ts
@@ -214,7 +214,7 @@ export function createCloudCliPort(options: CloudCliPortOptions): CloudPort {
     prAssociation: {
       associatePullRequest: async (input: CloudPrAssociationInput) => {
         const { ownerSessionId, ...association } = input;
-        const response = await fetch(new URL('/api/action', authBaseUrl), {
+        const response = await fetch(new URL('/api/action', authSiteUrl), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({


### PR DESCRIPTION
Risk: 🟡 medium | Confidence: medium — endpoint correction verified in isolation; full checks blocked by missing nested ACP modules.

## Problem / pressure

CLI PR association posts to the public Convex RPC endpoint, which rejects the internal function with `Could not find public function for 'github:associatePullRequestForCli'`.

## Summary

Use the existing `authSiteUrl` for the HTTP action proxy. Keep the association payload and response handling unchanged, and document the endpoint invariant.

## Visual explanation

Simple change: one endpoint variable changes; the before/after table captures the routing difference.

## Before / after

| Before | After |
| ------ | ----- |
| PR association posts to `authBaseUrl/api/action` (public RPC). | PR association posts to `authSiteUrl/api/action` (HTTP action proxy). |

## Test plan

- Passed: isolated execution of the actual transpiled cloud port, with unrelated services stubbed and fetch intercepted, for both derived and custom site URLs; checked POST URL and association payload.
- Passed: changed-file Prettier check, targeted oxlint, and `git diff --check`.
- Attempted `pnpm check:affected` and OSS `pnpm check`: blocked by missing nested ACP modules, including `acp-extension-core` and `acp-extension-dsh`.
- Attempted OSS `pnpm format`: nested workspace could not resolve Prettier; changed files passed the root-installed formatter check.
- Document check reports existing links into missing ACP submodules.
- No live hosted PR association or full build verified.

## Context handoff

### Instructions for reviewing agents

- **Review focus:** Confirm `cloud-cli-port.ts` routes PR association through the configured HTTP action site URL.
- **Decisions to challenge:** Reuse the existing site URL derivation instead of changing backend visibility.
- **Plausible failures / evidence gaps:** Full checks and a live hosted association remain unverified; ensure deployment site configuration points to the intended HTTP action service.
