### PR TITLE
fix: hide thinking indicator under a finished assistant reply

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.md
@@ -7,15 +7,16 @@ Translation: current
 
 ## Abstract
 
-After the assistant turn is stamped `finished`, the desktop footer already shows the completion time and duration. Session presence can still be `running` during host finalization, so the activity row kept saying "Thinking" under that finished bubble. The row is omitted when the last history entry is a finished assistant **and** live presence is leftover `running`. Goal resume has no user row; thinking presence is published only after `openAssistantEntry`, so the gap stays on `initializing` and the presence-driven label remains.
+After the assistant turn is stamped `finished`, the desktop footer already shows the completion time and duration. Session presence stays `running` until the turn scope releases, so the activity row kept saying "Thinking" under that finished bubble. Host and viewer deliver presence and history on separate planes, so a finished last bubble cannot prove the live turn has stopped. The execution owner now publishes an optional `running.phase = finalizing` at the shared prompt/autoPrompt exit; the UI hides Thinking from that phase only.
 
 ## Decision
 
-- Hide leftover Thinking under a finished last assistant while presence is `running` (same-turn finalize tail).
-- Do not hide for `initializing` or `requestPermission`. Goal resume stays on initializing until the assistant entry exists.
-- Publish `thinking` presence after `openAssistantEntry` on continueSession, not before prompt setup.
-- Do not clear presence on `history.finished`.
+- Add optional `phase: 'finalizing'` on `{ type: 'running' }`. Do not add `activity: 'finalizing'`; old `ActiveSessionStatusSchema` would reject the enum and drop the whole presence entry.
+- `markPromptWorkingEnded` reports `finalizing` without clearing presence. `markPromptWorkingStarted` already restores `thinking`, including autoPrompt restart.
+- UI hides the activity row only when live presence is `running` with `phase === 'finalizing'`. Do not hide from last-history `finished`.
+- Keep the original continueSession thinking order. An earlier `openAssistantEntry` already ran before initializing; moving thinking after the inner open cannot fence lagged viewer history.
+- Old clients strip unknown `phase` and keep `running`. Mixed old hosts without `phase` still show leftover Thinking.
 
 ## Evidence and limits
 
-A Windows 0.93.3 tester confirmed leftover Thinking under a finished first Codex reply, then it disappeared. Unit tests cover last-entry finished vs open vs later user turn, initializing/permission not hidden, and continueSession thinking-after-assistant-entry order. Packaged Electron and a live goal-resume GUI click were not retested here.
+A Windows 0.93.3 tester confirmed leftover Thinking under a finished first Codex reply, then it disappeared. Independent review reproduced a goal resume where presence was `running` and prompt was in flight while the viewer's history still ended on the previous finished assistant. Unit tests cover presence-only hide, old running parsers keeping the session, goal resume with lagged history, usage-flush finalization, autoPrompt start/end, and permission remaining a distinct status. Packaged Electron click-through of the fix was not retested here.

--- a/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.md
@@ -1,0 +1,20 @@
+# Hide thinking under a finished assistant reply
+
+Status: implemented
+Translation: current
+
+[中文](./2026-09-11-thinking-under-finished-reply.zh.md)
+
+## Abstract
+
+After the assistant turn is stamped `finished`, the desktop footer already shows the completion time and duration. Session presence can still be `running` during host finalization, so the activity row kept saying "Thinking" under that finished bubble. The row is now omitted when the last history entry is a finished assistant. Presence is unchanged.
+
+## Decision
+
+- Gate the activity row on the last history bubble, not on clearing session presence.
+- Keep showing permission and initializing labels. A later user turn in history restores the thinking row.
+- Do not clear presence on `history.finished`; that signal is session-scoped and still covers a new turn, permission wait, and autoPrompt.
+
+## Evidence and limits
+
+A Windows 0.93.3 tester confirmed the sequence on Codex, first conversation: the reply and completion time appear, then the extra "Thinking" under them disappears on its own. No exact overlap duration was recorded. Unit tests cover last-entry finished vs open vs later user turn. Packaged Electron was not retested here.

--- a/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.md
@@ -7,14 +7,15 @@ Translation: current
 
 ## Abstract
 
-After the assistant turn is stamped `finished`, the desktop footer already shows the completion time and duration. Session presence can still be `running` during host finalization, so the activity row kept saying "Thinking" under that finished bubble. The row is now omitted when the last history entry is a finished assistant. Presence is unchanged.
+After the assistant turn is stamped `finished`, the desktop footer already shows the completion time and duration. Session presence can still be `running` during host finalization, so the activity row kept saying "Thinking" under that finished bubble. The row is omitted when the last history entry is a finished assistant **and** live presence is leftover `running`. Goal resume has no user row; thinking presence is published only after `openAssistantEntry`, so the gap stays on `initializing` and the presence-driven label remains.
 
 ## Decision
 
-- Gate the activity row on the last history bubble, not on clearing session presence.
-- Keep showing permission and initializing labels. A later user turn in history restores the thinking row.
-- Do not clear presence on `history.finished`; that signal is session-scoped and still covers a new turn, permission wait, and autoPrompt.
+- Hide leftover Thinking under a finished last assistant while presence is `running` (same-turn finalize tail).
+- Do not hide for `initializing` or `requestPermission`. Goal resume stays on initializing until the assistant entry exists.
+- Publish `thinking` presence after `openAssistantEntry` on continueSession, not before prompt setup.
+- Do not clear presence on `history.finished`.
 
 ## Evidence and limits
 
-A Windows 0.93.3 tester confirmed the sequence on Codex, first conversation: the reply and completion time appear, then the extra "Thinking" under them disappears on its own. No exact overlap duration was recorded. Unit tests cover last-entry finished vs open vs later user turn. Packaged Electron was not retested here.
+A Windows 0.93.3 tester confirmed leftover Thinking under a finished first Codex reply, then it disappeared. Unit tests cover last-entry finished vs open vs later user turn, initializing/permission not hidden, and continueSession thinking-after-assistant-entry order. Packaged Electron and a live goal-resume GUI click were not retested here.

--- a/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.md
@@ -13,6 +13,7 @@ After the assistant turn is stamped `finished`, the desktop footer already shows
 
 - Add optional `phase: 'finalizing'` on `{ type: 'running' }`. Do not add `activity: 'finalizing'`; old `ActiveSessionStatusSchema` would reject the enum and drop the whole presence entry.
 - `markPromptWorkingEnded` reports `finalizing` without clearing presence. `markPromptWorkingStarted` already restores `thinking`, including autoPrompt restart.
+- Codex image begin/end update presence activity only (`thinking` ↔ `image_generation`). They do not write durable `SessionMeta.status`, so an in-flight `setStatus` cannot undo `finalizing` or idle.
 - UI hides the activity row only when live presence is `running` with `phase === 'finalizing'`. Do not hide from last-history `finished`.
 - Keep the original continueSession thinking order. An earlier `openAssistantEntry` already ran before initializing; moving thinking after the inner open cannot fence lagged viewer history.
 - Old clients strip unknown `phase` and keep `running`. Mixed old hosts without `phase` still show leftover Thinking.

--- a/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.zh.md
@@ -13,6 +13,7 @@ Translation: current
 
 - 在 `{ type: 'running' }` 上增加可选 `phase: 'finalizing'`。不新增 `activity: 'finalizing'`，旧 `ActiveSessionStatusSchema` 会拒收该枚举并丢掉整条 presence。
 - `markPromptWorkingEnded` 报告 `finalizing`，不清 presence。`markPromptWorkingStarted` 已会恢复 `thinking`，覆盖 autoPrompt 重启。
+- Codex image begin/end 只改 presence activity（`thinking` ↔ `image_generation`），不写 durable `SessionMeta.status`，避免在途 `setStatus` 把 `finalizing` / idle 写回 running。
 - UI 只在 live presence 为 `running` 且 `phase === 'finalizing'` 时藏活动条。不再按 last-history `finished` 藏灯。
 - 保持 continueSession 原 thinking 顺序。更早的 `openAssistantEntry` 已在 initializing 之前发生；把 thinking 挪到内层 open 之后挡不住 viewer 历史落后。
 - 旧端忽略未知 `phase` 并保留 `running`。没有 `phase` 的旧 host 仍会露出收尾残留的「思考中」。

--- a/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.zh.md
@@ -7,15 +7,16 @@ Translation: current
 
 ## 摘要
 
-助手 turn 盖上 `finished` 后，桌面 footer 已经画出完成时间和耗时。host 收尾期间 session presence 仍可能是 `running`，活动条就会在这条已完成气泡下面继续写「思考中」。最后一条是已完成 assistant 且 presence 为残留 `running` 时不再画「思考中」。Goal resume 没有 user 行；`thinking` 相位改到 `openAssistantEntry` 之后，空窗停在 `initializing`，presence 文案仍显示。
+助手 turn 盖上 `finished` 后，桌面 footer 已经画出完成时间和耗时。turn 作用域释放前 session presence 仍是 `running`，活动条就会在这条已完成气泡下面继续写「思考中」。host 与 viewer 的 presence 和 history 不在同一平面交付，最后一条已完成气泡不能证明当前 turn 已经停止思考。执行端在 prompt / autoPrompt 共有出口上报可选的 `running.phase = finalizing`；UI 只根据该相位隐藏「思考中」。
 
 ## 决策
 
-- 同一 turn 收尾：last finished + presence `running` 时藏 Thinking。
-- `initializing` / `requestPermission` 不藏。Goal 在 assistant 条目出现前保持 initializing。
-- continueSession 在 `openAssistantEntry` 之后才发 `thinking` presence。
-- 不在 `history.finished` 时清 presence。
+- 在 `{ type: 'running' }` 上增加可选 `phase: 'finalizing'`。不新增 `activity: 'finalizing'`，旧 `ActiveSessionStatusSchema` 会拒收该枚举并丢掉整条 presence。
+- `markPromptWorkingEnded` 报告 `finalizing`，不清 presence。`markPromptWorkingStarted` 已会恢复 `thinking`，覆盖 autoPrompt 重启。
+- UI 只在 live presence 为 `running` 且 `phase === 'finalizing'` 时藏活动条。不再按 last-history `finished` 藏灯。
+- 保持 continueSession 原 thinking 顺序。更早的 `openAssistantEntry` 已在 initializing 之前发生；把 thinking 挪到内层 open 之后挡不住 viewer 历史落后。
+- 旧端忽略未知 `phase` 并保留 `running`。没有 `phase` 的旧 host 仍会露出收尾残留的「思考中」。
 
 ## 证据与限制
 
-Windows 0.93.3 真人确认完成后残留 Thinking 随后消失。单元测试覆盖 last finished / 打开 / 后续 user turn、initializing 不藏、continueSession thinking 在 assistant entry 之后。未再跑打包 Electron，也未做 Goal 按钮真人点击。
+Windows 0.93.3 真人确认完成后残留 Thinking 随后消失。独立复核复现了 goal resume：presence 已是 `running` 且 prompt 已在执行，viewer 历史仍停在上一条已完成 assistant。单元测试覆盖 presence-only 隐藏、旧 running 解析器保会话、history 落后的 goal resume、usage flush 收尾、autoPrompt start/end，以及 permission 仍为独立状态。未再跑打包 Electron 点击验证。

--- a/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.zh.md
@@ -1,0 +1,20 @@
+# 已完成回复下方不再显示「思考中」
+
+Status: implemented
+Translation: current
+
+[English](./2026-09-11-thinking-under-finished-reply.md)
+
+## 摘要
+
+助手 turn 盖上 `finished` 后，桌面 footer 已经画出完成时间和耗时。host 收尾期间 session presence 仍可能是 `running`，活动条就会在这条已完成气泡下面继续写「思考中」。现在最后一条 history 是已完成 assistant 时不再画这行。presence 生命周期不改。
+
+## 决策
+
+- 用最后一条气泡决定要不要画活动条，而不是看到 `finished` 就清 presence。
+- 权限等待和初始化文案照旧。history 里已有下一条用户 turn 时，思考中会再出现。
+- 不在 `history.finished` 时清 presence；presence 是 session 级，还要罩住新 turn、权限等待和 autoPrompt。
+
+## 证据与限制
+
+Windows 0.93.3 真人在 Codex 首次对话确认顺序：回复和完成时间先出现，底部多余的「思考中」随后自行消失。没有精确重叠秒数。单元测试覆盖最后一条已完成 / 仍打开 / 后面又有用户 turn。此处未再跑打包 Electron。

--- a/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-11-thinking-under-finished-reply.zh.md
@@ -7,14 +7,15 @@ Translation: current
 
 ## 摘要
 
-助手 turn 盖上 `finished` 后，桌面 footer 已经画出完成时间和耗时。host 收尾期间 session presence 仍可能是 `running`，活动条就会在这条已完成气泡下面继续写「思考中」。现在最后一条 history 是已完成 assistant 时不再画这行。presence 生命周期不改。
+助手 turn 盖上 `finished` 后，桌面 footer 已经画出完成时间和耗时。host 收尾期间 session presence 仍可能是 `running`，活动条就会在这条已完成气泡下面继续写「思考中」。最后一条是已完成 assistant 且 presence 为残留 `running` 时不再画「思考中」。Goal resume 没有 user 行；`thinking` 相位改到 `openAssistantEntry` 之后，空窗停在 `initializing`，presence 文案仍显示。
 
 ## 决策
 
-- 用最后一条气泡决定要不要画活动条，而不是看到 `finished` 就清 presence。
-- 权限等待和初始化文案照旧。history 里已有下一条用户 turn 时，思考中会再出现。
-- 不在 `history.finished` 时清 presence；presence 是 session 级，还要罩住新 turn、权限等待和 autoPrompt。
+- 同一 turn 收尾：last finished + presence `running` 时藏 Thinking。
+- `initializing` / `requestPermission` 不藏。Goal 在 assistant 条目出现前保持 initializing。
+- continueSession 在 `openAssistantEntry` 之后才发 `thinking` presence。
+- 不在 `history.finished` 时清 presence。
 
 ## 证据与限制
 
-Windows 0.93.3 真人在 Codex 首次对话确认顺序：回复和完成时间先出现，底部多余的「思考中」随后自行消失。没有精确重叠秒数。单元测试覆盖最后一条已完成 / 仍打开 / 后面又有用户 turn。此处未再跑打包 Electron。
+Windows 0.93.3 真人确认完成后残留 Thinking 随后消失。单元测试覆盖 last finished / 打开 / 后续 user turn、initializing 不藏、continueSession thinking 在 assistant entry 之后。未再跑打包 Electron，也未做 Goal 按钮真人点击。

--- a/apps/cli/src/lib/loro/session-active-presence.test.ts
+++ b/apps/cli/src/lib/loro/session-active-presence.test.ts
@@ -83,6 +83,27 @@ describe('SessionActivePresenceController', () => {
     );
   });
 
+  it('retains active ownership through finalization and resumes prompt or permission activity', () => {
+    const controller = new SessionActivePresenceController(
+      createWorkspaceDocument() as LoroDocumentManager,
+      machineId,
+      createLogger(),
+      { intervalMs: 1_000 }
+    );
+    controller.start(sessionId, 'thinking');
+    controller.setPhase(sessionId, 'finalizing');
+    expect(controller.getStatus(sessionId)).toEqual({ type: 'running', phase: 'finalizing' });
+    vi.advanceTimersByTime(1_000);
+    expect(controller.has(sessionId)).toBe(true);
+    expect(controller.activeSessionCount()).toBe(1);
+    controller.setPhase(sessionId, 'thinking');
+    expect(controller.getStatus(sessionId)).toEqual({ type: 'running' });
+    controller.setPhase(sessionId, 'requestPermission');
+    expect(controller.getStatus(sessionId)).toEqual({ type: 'requestPermission' });
+    controller.clear(sessionId);
+    expect(controller.getStatus(sessionId)).toBeNull();
+  });
+
   it('publishes managed runtime progress as initializing presence detail', () => {
     const workspaceDocument = createWorkspaceDocument();
     const controller = new SessionActivePresenceController(

--- a/apps/cli/src/lib/loro/session-active-presence.ts
+++ b/apps/cli/src/lib/loro/session-active-presence.ts
@@ -20,6 +20,7 @@ const DEFAULT_SLOW_THRESHOLD_MS = 120_000;
 
 export type SessionActivePresencePhase =
   | 'thinking'
+  | 'finalizing'
   | 'initializing'
   | 'git-clone'
   | 'managed-runtime'
@@ -51,6 +52,8 @@ const phaseToStatus = (
   switch (phase ?? 'thinking') {
     case 'thinking':
       return SessionStatusFactory.running();
+    case 'finalizing':
+      return { type: 'running', phase: 'finalizing' };
     case 'initializing':
       return SessionStatusFactory.initializing(undefined, detail);
     case 'git-clone':

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -256,7 +256,7 @@ import {
   type SessionActivePresencePhase,
 } from './loro/session-active-presence';
 import {
-  resolveImageGenerationStatusWrite,
+  resolveImageGenerationPresencePhase,
   shouldRestoreRunningAfterPermission,
 } from './session-activity-status';
 import { markAssistantTurnFinished } from './assistant-turn-finalize';
@@ -1197,28 +1197,17 @@ export class MessageHandler {
     const state = this.store.get(sessionId);
     const task = state.imageGenerationActivityStatusChain
       .catch(() => undefined)
-      .then(async () => {
+      .then(() => {
         const currentState = this.store.get(sessionId);
-        const hasActiveImageGeneration = currentState.imageGenerationActiveCallIds.size > 0;
-        const sessionDoc = await this.workspaceDocument.getOrCreateSessionDoc(sessionId);
-        const status = (await sessionDoc.getMetaState())?.status;
-
-        // This chain rides on ACP events and can drain after the visible active
-        // scope ended; a working-status write is only sustainable while this
-        // session still has active presence.
-        const nextStatus = resolveImageGenerationStatusWrite({
-          hasActiveImageGeneration,
-          hasActivePresence: this.hasSessionActivePresence(sessionId),
-          status,
+        // Image activity is presence-only. Durable setStatus awaits
+        // getDocMeta/upsert and can land after prompt-end already published
+        // finalizing + idle.
+        const nextPhase = resolveImageGenerationPresencePhase({
+          hasActiveImageGeneration: currentState.imageGenerationActiveCallIds.size > 0,
+          current: this.sessionActivePresence.getStatus(sessionId),
         });
-        if (nextStatus) {
-          await sessionDoc.setStatus(nextStatus);
-          this.setSessionActivePresencePhase(
-            sessionId,
-            nextStatus.type === 'running' && nextStatus.activity === 'image_generation'
-              ? 'image_generation'
-              : 'thinking'
-          );
+        if (nextPhase) {
+          this.setSessionActivePresencePhase(sessionId, nextPhase);
         }
       });
 

--- a/apps/cli/src/lib/session-activity-status.test.ts
+++ b/apps/cli/src/lib/session-activity-status.test.ts
@@ -2,80 +2,67 @@ import { describe, expect, it } from 'vitest';
 import { SessionStatusFactory } from '@lody/shared';
 
 import {
-  resolveImageGenerationStatusWrite,
+  resolveImageGenerationPresencePhase,
   shouldRestoreRunningAfterPermission,
 } from './session-activity-status';
 
-describe('resolveImageGenerationStatusWrite', () => {
-  it('marks image generation while active presence is live', () => {
+describe('resolveImageGenerationPresencePhase', () => {
+  it('marks image generation while the turn is thinking', () => {
     expect(
-      resolveImageGenerationStatusWrite({
+      resolveImageGenerationPresencePhase({
         hasActiveImageGeneration: true,
-        hasActivePresence: true,
-        status: SessionStatusFactory.running(),
+        current: SessionStatusFactory.running(),
       })
-    ).toEqual(SessionStatusFactory.running('image_generation'));
+    ).toBe('image_generation');
   });
 
-  it('never writes a working status without active presence', () => {
-    // The status chain rides on ACP events and can drain after the turn scope
-    // released active presence; meta must not stay stuck non-idle.
+  it('does not retarget missing, initializing, or permission presence', () => {
     expect(
-      resolveImageGenerationStatusWrite({
+      resolveImageGenerationPresencePhase({
         hasActiveImageGeneration: true,
-        hasActivePresence: false,
-        status: SessionStatusFactory.running(),
+        current: null,
       })
     ).toBeNull();
     expect(
-      resolveImageGenerationStatusWrite({
-        hasActiveImageGeneration: false,
-        hasActivePresence: false,
-        status: SessionStatusFactory.running('image_generation'),
+      resolveImageGenerationPresencePhase({
+        hasActiveImageGeneration: true,
+        current: SessionStatusFactory.initializing(),
       })
     ).toBeNull();
-  });
-
-  it('does not override a permission request', () => {
     expect(
-      resolveImageGenerationStatusWrite({
+      resolveImageGenerationPresencePhase({
         hasActiveImageGeneration: true,
-        hasActivePresence: true,
-        status: SessionStatusFactory.requestPermission(),
+        current: SessionStatusFactory.requestPermission(),
       })
     ).toBeNull();
   });
 
-  it('does not resurrect an idle session while finalization still owns presence', () => {
+  it('does not retarget finalizing presence', () => {
     expect(
-      resolveImageGenerationStatusWrite({
+      resolveImageGenerationPresencePhase({
         hasActiveImageGeneration: true,
-        hasActivePresence: true,
-        status: SessionStatusFactory.idle(),
+        current: { type: 'running', phase: 'finalizing' },
+      })
+    ).toBeNull();
+    expect(
+      resolveImageGenerationPresencePhase({
+        hasActiveImageGeneration: false,
+        current: { type: 'running', phase: 'finalizing' },
       })
     ).toBeNull();
   });
 
-  it('restores plain running only from the image-generation activity', () => {
+  it('restores thinking only from the image-generation activity', () => {
     expect(
-      resolveImageGenerationStatusWrite({
+      resolveImageGenerationPresencePhase({
         hasActiveImageGeneration: false,
-        hasActivePresence: true,
-        status: SessionStatusFactory.running('image_generation'),
+        current: SessionStatusFactory.running('image_generation'),
       })
-    ).toEqual(SessionStatusFactory.running());
+    ).toBe('thinking');
     expect(
-      resolveImageGenerationStatusWrite({
+      resolveImageGenerationPresencePhase({
         hasActiveImageGeneration: false,
-        hasActivePresence: true,
-        status: SessionStatusFactory.running(),
-      })
-    ).toBeNull();
-    expect(
-      resolveImageGenerationStatusWrite({
-        hasActiveImageGeneration: false,
-        hasActivePresence: true,
-        status: SessionStatusFactory.idle(),
+        current: SessionStatusFactory.running(),
       })
     ).toBeNull();
   });

--- a/apps/cli/src/lib/session-activity-status.ts
+++ b/apps/cli/src/lib/session-activity-status.ts
@@ -1,41 +1,39 @@
-import { SessionStatusFactory, type SessionStatus } from '@lody/shared';
+import { type SessionStatus } from '@lody/shared';
+import type { SessionActivePresencePhase } from './loro/session-active-presence';
 
 /**
  * Decisions for async, post-hoc session status writes that run outside the
- * visible active scope (Codex image-generation activity sync, permission
- * resolution restore). These callbacks can fire after the turn ended and its
- * active presence was cleared; without active presence a working-status write
- * is a lie — the presence entry cannot be kept alive while meta status stays
- * stuck non-idle.
+ * visible active scope (permission resolution restore). Those callbacks can
+ * fire after the turn ended and its active presence was cleared; without
+ * active presence a working-status write is a lie — the presence entry cannot
+ * be kept alive while meta status stays stuck non-idle.
  *
  * Rule: never write a working status without active presence. Stuck statuses
  * left behind by crashes are the dispatch watcher's stale-status recovery job,
  * not these callbacks'.
+ *
+ * Codex image-generation activity is presence-only. Image begin/end must not
+ * write durable SessionMeta.status: that path awaits getDocMeta/upsert and can
+ * land after prompt-end has already published `finalizing` and idle.
  */
 
 /**
- * What (if anything) the Codex image-generation activity sync should write.
- * Returns the status to write, or null to leave the status untouched.
+ * Presence phase the Codex image-generation activity sync may apply.
+ * Only thinking ↔ image_generation. Finalizing, permission, initializing, and
+ * missing presence stay owned by the turn scope.
  */
-export const resolveImageGenerationStatusWrite = (input: {
+export const resolveImageGenerationPresencePhase = (input: {
   hasActiveImageGeneration: boolean;
-  hasActivePresence: boolean;
-  status: SessionStatus | undefined;
-}): SessionStatus | null => {
-  if (!input.hasActivePresence) {
-    return null;
-  }
-  if (input.status?.type === 'idle') {
+  current: SessionStatus | null | undefined;
+}): Extract<SessionActivePresencePhase, 'image_generation' | 'thinking'> | null => {
+  if (input.current?.type !== 'running' || input.current.phase === 'finalizing') {
     return null;
   }
   if (input.hasActiveImageGeneration) {
-    if (input.status?.type === 'requestPermission') {
-      return null;
-    }
-    return SessionStatusFactory.running('image_generation');
+    return 'image_generation';
   }
-  if (input.status?.type === 'running' && input.status.activity === 'image_generation') {
-    return SessionStatusFactory.running();
+  if (input.current.activity === 'image_generation') {
+    return 'thinking';
   }
   return null;
 };

--- a/apps/cli/src/session/session-execution-service.ts
+++ b/apps/cli/src/session/session-execution-service.ts
@@ -4455,7 +4455,6 @@ export class SessionExecutionService {
 
         bindReadySession(readySession);
         yield* acpReplaySuppression.release;
-        self.deps.setSessionActivePresencePhase(sessionId, 'thinking');
         yield* self.tryPromise(() => sessionDoc.setStatus(SessionStatusFactory.running()));
         self.captureStatusChanged(sessionId, 'running', undefined, 'chat_dispatch');
         self.scheduleLiveActivitySummarySync(userId, {
@@ -4482,6 +4481,9 @@ export class SessionExecutionService {
         yield* abortIfCancelled();
 
         yield* openAssistantEntry();
+        // Goal turns have no user row. Presence must stay `initializing` until
+        // the assistant entry exists, or the finished last bubble hides Thinking.
+        self.deps.setSessionActivePresencePhase(sessionId, 'thinking');
 
         yield* abortIfCancelled();
 

--- a/apps/cli/src/session/session-execution-service.ts
+++ b/apps/cli/src/session/session-execution-service.ts
@@ -901,6 +901,7 @@ export class SessionExecutionService {
     triggerReason: string
   ): Promise<void> {
     try {
+      this.deps.setSessionActivePresencePhase(sessionId, 'finalizing');
       await sessionDoc.setStatus(SessionStatusFactory.idle());
       this.captureStatusChanged(sessionId, 'idle', undefined, triggerReason);
     } catch (error) {
@@ -4455,6 +4456,7 @@ export class SessionExecutionService {
 
         bindReadySession(readySession);
         yield* acpReplaySuppression.release;
+        self.deps.setSessionActivePresencePhase(sessionId, 'thinking');
         yield* self.tryPromise(() => sessionDoc.setStatus(SessionStatusFactory.running()));
         self.captureStatusChanged(sessionId, 'running', undefined, 'chat_dispatch');
         self.scheduleLiveActivitySummarySync(userId, {
@@ -4481,9 +4483,6 @@ export class SessionExecutionService {
         yield* abortIfCancelled();
 
         yield* openAssistantEntry();
-        // Goal turns have no user row. Presence must stay `initializing` until
-        // the assistant entry exists, or the finished last bubble hides Thinking.
-        self.deps.setSessionActivePresencePhase(sessionId, 'thinking');
 
         yield* abortIfCancelled();
 

--- a/apps/cli/tests/message-handler-image-upload.test.ts
+++ b/apps/cli/tests/message-handler-image-upload.test.ts
@@ -28,16 +28,23 @@ const createSilentLogger = (): Logger => ({
 });
 
 /**
- * Mark a session as having active presence so async status callbacks are allowed
- * to write working statuses (see session-activity-status.ts).
+ * Mark a session as having active presence so image activity can retarget
+ * thinking ↔ image_generation (see session-activity-status.ts).
  */
 const injectActivePresence = (handler: MessageHandler, sessionId: SessionId): void => {
-  (
-    handler as unknown as {
-      startSessionActivePresence: (id: SessionId) => void;
-    }
-  ).startSessionActivePresence(sessionId);
+  internals(handler).startSessionActivePresence(sessionId);
 };
+
+const internals = (handler: MessageHandler) =>
+  handler as unknown as {
+    startSessionActivePresence: (id: SessionId) => void;
+    setSessionActivePresencePhase: (
+      id: SessionId,
+      phase: 'thinking' | 'image_generation' | 'finalizing'
+    ) => void;
+    sessionActivePresence: { getStatus: (id: SessionId) => SessionStatus | null };
+    store: { get: (id: SessionId) => { imageGenerationActivityStatusChain: Promise<void> } };
+  };
 
 type TestHarness = {
   handler: MessageHandler;
@@ -141,16 +148,13 @@ describe('MessageHandler image upload flow', () => {
     }
   });
 
-  it('publishes and clears Codex image generation activity status', async () => {
+  it('publishes and clears Codex image generation activity on presence only', async () => {
     const harness = createHarness();
     handlers.push(harness.handler);
 
     const sessionId = 'session-1' as SessionId;
     await harness.sessionDoc.setStatus({ type: 'running' } as SessionStatus);
     harness.sessionDoc.setStatus.mockClear();
-
-    // Image-generation status is only sustainable while active presence is live;
-    // simulate the in-flight turn that owns this activity.
     injectActivePresence(harness.handler, sessionId);
 
     (harness.host.handleImageGenerationBegin as (sessionId: SessionId, event: unknown) => void)(
@@ -160,13 +164,12 @@ describe('MessageHandler image upload flow', () => {
         callId: 'ig-1',
       }
     );
-
-    await vi.waitFor(() => {
-      expect(harness.sessionDoc.setStatus).toHaveBeenCalledWith({
-        type: 'running',
-        activity: 'image_generation',
-      });
+    await internals(harness.handler).store.get(sessionId).imageGenerationActivityStatusChain;
+    expect(internals(harness.handler).sessionActivePresence.getStatus(sessionId)).toEqual({
+      type: 'running',
+      activity: 'image_generation',
     });
+    expect(harness.sessionDoc.setStatus).not.toHaveBeenCalled();
 
     (harness.host.handleImageGenerationEnd as (sessionId: SessionId, event: unknown) => void)(
       sessionId,
@@ -176,18 +179,22 @@ describe('MessageHandler image upload flow', () => {
         status: 'completed',
       }
     );
-
-    await vi.waitFor(() => {
-      expect(harness.sessionDoc.setStatus).toHaveBeenLastCalledWith({ type: 'running' });
+    await internals(harness.handler).store.get(sessionId).imageGenerationActivityStatusChain;
+    expect(internals(harness.handler).sessionActivePresence.getStatus(sessionId)).toEqual({
+      type: 'running',
     });
+    expect(harness.sessionDoc.setStatus).not.toHaveBeenCalled();
   });
 
-  it('does not resurrect image generation activity after durable status is idle', async () => {
+  it('does not retarget image activity after the turn has started finalizing', async () => {
     const harness = createHarness();
     handlers.push(harness.handler);
 
     const sessionId = 'session-idle-image-generation' as SessionId;
     injectActivePresence(harness.handler, sessionId);
+    internals(harness.handler).setSessionActivePresencePhase(sessionId, 'finalizing');
+    await harness.sessionDoc.setStatus({ type: 'idle' });
+    harness.sessionDoc.setStatus.mockClear();
 
     (harness.host.handleImageGenerationBegin as (sessionId: SessionId, event: unknown) => void)(
       sessionId,
@@ -196,11 +203,46 @@ describe('MessageHandler image upload flow', () => {
         callId: 'ig-idle',
       }
     );
-
-    await vi.waitFor(() => {
-      expect(harness.sessionDoc.getMetaState).toHaveBeenCalled();
+    await internals(harness.handler).store.get(sessionId).imageGenerationActivityStatusChain;
+    expect(internals(harness.handler).sessionActivePresence.getStatus(sessionId)).toEqual({
+      type: 'running',
+      phase: 'finalizing',
     });
     expect(harness.sessionDoc.setStatus).not.toHaveBeenCalled();
+  });
+
+  it('does not let a queued image end undo finalizing or idle', async () => {
+    const harness = createHarness();
+    handlers.push(harness.handler);
+    const sessionId = 'session-image-finalization-race' as SessionId;
+    const host = internals(harness.handler);
+    await harness.sessionDoc.setStatus({ type: 'running' });
+    harness.sessionDoc.setStatus.mockClear();
+    injectActivePresence(harness.handler, sessionId);
+    harness.host.handleImageGenerationBegin(sessionId, {
+      acpSessionId: 'acp-1',
+      callId: 'ig-race',
+    });
+    await host.store.get(sessionId).imageGenerationActivityStatusChain;
+    expect(host.sessionActivePresence.getStatus(sessionId)).toEqual({
+      type: 'running',
+      activity: 'image_generation',
+    });
+    expect(harness.sessionDoc.setStatus).not.toHaveBeenCalled();
+
+    host.setSessionActivePresencePhase(sessionId, 'finalizing');
+    await harness.sessionDoc.setStatus({ type: 'idle' });
+    harness.host.handleImageGenerationEnd(sessionId, {
+      acpSessionId: 'acp-1',
+      callId: 'ig-race',
+      status: 'completed',
+    });
+    await host.store.get(sessionId).imageGenerationActivityStatusChain;
+    expect(host.sessionActivePresence.getStatus(sessionId)).toEqual({
+      type: 'running',
+      phase: 'finalizing',
+    });
+    expect((await harness.sessionDoc.getMetaState()).status).toEqual({ type: 'idle' });
   });
 
   it('attaches uploaded images as partial success when a later upload fails', async () => {

--- a/apps/cli/tests/session-execution-service.test.ts
+++ b/apps/cli/tests/session-execution-service.test.ts
@@ -37,6 +37,7 @@ import { GitExecutableNotFoundError } from '../src/session/worktree/git-process-
 import { LodyOperationStore } from '../src/orchestration/operation-store';
 import { markAssistantTurnFinished } from '../src/lib/assistant-turn-finalize';
 import { shouldWatchSession } from '../src/session/session-dispatch-logic';
+import { SessionActivePresenceController } from '../src/lib/loro/session-active-presence';
 
 const capabilityConfigId = 'config-1' as AgentConfigId;
 
@@ -2143,10 +2144,9 @@ describe('SessionExecutionService', () => {
     expect(idleAfterPromptAt).toBeGreaterThan(promptResolvedAt);
     expect(finalizeStartedAt).toBeGreaterThan(idleAfterPromptAt);
     expect(activeClearedAt).toBeGreaterThan(finalizeStartedAt);
-    const assistantEntryAt = events.indexOf('assistant-entry');
-    const thinkingAt = events.indexOf('phase:thinking');
-    expect(assistantEntryAt).toBeGreaterThanOrEqual(0);
-    expect(thinkingAt).toBeGreaterThan(assistantEntryAt);
+    const finalizingAt = events.indexOf('phase:finalizing');
+    expect(finalizingAt).toBeGreaterThan(promptResolvedAt);
+    expect(idleAfterPromptAt).toBeGreaterThan(finalizingAt);
   });
 
   it.each([undefined, 'delivery'] as const)(
@@ -7253,6 +7253,114 @@ describe('SessionExecutionService goal control', () => {
     completion.resolve();
     await released;
     expect(service.getExecutionSnapshot(goalSessionId).hasActiveTurn).toBe(false);
+  });
+
+  it('reports resumed goal activity while viewer history still shows the previous finished turn', async () => {
+    const { service, deps, sessionDoc, submitted, completion, failed, failures } =
+      createGoalService({
+        transport: 'promptMeta',
+      });
+    const history: SessionHistoryInput[] = [
+      {
+        id: 'earlier-user',
+        role: 'user',
+        status: 'handled',
+        items: [{ type: 'text', text: 'Work toward the goal.' }],
+      },
+      {
+        id: 'earlier-assistant',
+        role: 'assistant',
+        finished: true,
+        items: [{ type: 'text', text: 'The previous turn is complete.' }],
+      },
+    ];
+    const visibleHistory = history.slice();
+    const originalGetMetaState = sessionDoc.getMetaState;
+    Object.assign(sessionDoc, {
+      getHistory: async () => history,
+      getMetaState: async () => ({
+        ...(await originalGetMetaState()),
+        project: { kind: 'github', repoFullName: 'example/project' },
+      }),
+    });
+    Object.assign(deps.sessionManager, { refreshGhTokenForSession: async () => {} });
+    const presence = new SessionActivePresenceController(
+      {
+        publishSessionPresence: () => {},
+        clearSessionPresence: () => {},
+      } as unknown as LoroDocumentManager,
+      'machine-1' as MachineId,
+      createSilentLogger()
+    );
+    deps.startSessionActivePresence = (id, phase) => {
+      presence.start(id, phase);
+    };
+    deps.setSessionActivePresencePhase = (id, phase, detail) => {
+      presence.setPhase(id, phase, detail);
+    };
+    deps.clearSessionActivePresence = (id) => presence.clear(id);
+    deps.createAssistantEntryForTurn = async () => {
+      if (!history.some((entry) => entry.id === 'turn-1')) {
+        history.push({ id: 'turn-1', role: 'assistant', finished: false, items: [] });
+      }
+    };
+    const flushing = createDeferred<void>();
+    const releaseFlush = createDeferred<void>();
+    deps.turnFinalization.finalizeACPState = async () => {
+      const entry = history.find((candidate) => candidate.id === 'turn-1');
+      if (entry) entry.finished = true;
+    };
+    deps.turnFinalization.flushSessionUsage = async () => {
+      flushing.resolve();
+      await releaseFlush.promise;
+    };
+    const autoPromptStatuses: unknown[] = [];
+    deps.turnFinalization.autoCommitAndPushForPR = async (ctx) => {
+      autoPromptStatuses.push(presence.getStatus(goalSessionId));
+      await ctx.onAutoPromptStart?.();
+      autoPromptStatuses.push(presence.getStatus(goalSessionId));
+      await ctx.onAutoPromptEnd?.();
+      autoPromptStatuses.push(presence.getStatus(goalSessionId));
+    };
+
+    try {
+      expect(await service.controlSessionGoal({ ...goalArgs, action: 'resume' })).toMatchObject({
+        accepted: true,
+        disposition: 'queued',
+      });
+      await Promise.race([
+        submitted.promise,
+        failed.promise.then(() => {
+          throw new Error(failures.join('; '));
+        }),
+      ]);
+      expect(service.getExecutionSnapshot(goalSessionId).hasActiveTurn).toBe(true);
+      expect(presence.getStatus(goalSessionId)).toEqual({ type: 'running' });
+      expect(history.map((entry) => entry.id)).toEqual([
+        'earlier-user',
+        'earlier-assistant',
+        'turn-1',
+      ]);
+      expect(visibleHistory.map((entry) => entry.id)).toEqual([
+        'earlier-user',
+        'earlier-assistant',
+      ]);
+      completion.resolve();
+      await flushing.promise;
+      expect(history.at(-1)?.finished).toBe(true);
+      expect(presence.getStatus(goalSessionId)).toEqual({ type: 'running', phase: 'finalizing' });
+    } finally {
+      const released = service.waitForTurnRelease(goalSessionId, 'turn-1');
+      completion.resolve();
+      releaseFlush.resolve();
+      await released;
+      presence.clearAll();
+    }
+    expect(autoPromptStatuses).toEqual([
+      { type: 'running', phase: 'finalizing' },
+      { type: 'running' },
+      { type: 'running', phase: 'finalizing' },
+    ]);
   });
 
   it('retains an accepted goal across more than three competing turns', async () => {

--- a/apps/cli/tests/session-execution-service.test.ts
+++ b/apps/cli/tests/session-execution-service.test.ts
@@ -2094,6 +2094,12 @@ describe('SessionExecutionService', () => {
       startSessionActivePresence: vi.fn(() => {
         events.push('active-start');
       }),
+      setSessionActivePresencePhase: vi.fn((_sessionId, phase) => {
+        events.push(`phase:${phase}`);
+      }),
+      createAssistantEntryForTurn: vi.fn(async () => {
+        events.push('assistant-entry');
+      }),
       clearSessionActivePresence: vi.fn(() => {
         events.push('active-clear');
       }),
@@ -2137,6 +2143,10 @@ describe('SessionExecutionService', () => {
     expect(idleAfterPromptAt).toBeGreaterThan(promptResolvedAt);
     expect(finalizeStartedAt).toBeGreaterThan(idleAfterPromptAt);
     expect(activeClearedAt).toBeGreaterThan(finalizeStartedAt);
+    const assistantEntryAt = events.indexOf('assistant-entry');
+    const thinkingAt = events.indexOf('phase:thinking');
+    expect(assistantEntryAt).toBeGreaterThanOrEqual(0);
+    expect(thinkingAt).toBeGreaterThan(assistantEntryAt);
   });
 
   it.each([undefined, 'delivery'] as const)(

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -184,7 +184,7 @@ import {
   writeStoredPathLauncherPreference,
   type PathLauncherOption,
 } from '@/lib/session-path-launchers';
-import { shouldHideThinkingUnderFinishedAssistant } from '@/lib/agent-activity-visibility';
+import { shouldHideThinkingDuringFinalization } from '@/lib/agent-activity-visibility';
 import { cn } from '@/lib/utils';
 import type { SessionSharingState } from '@/lib/session-sharing';
 import {
@@ -3616,17 +3616,14 @@ export const SessionChatInterface = memo(
       sessionProject,
       workspaceId,
     ]);
-    const hideThinkingUnderFinishedAssistant = shouldHideThinkingUnderFinishedAssistant(
-      sessionHistory,
-      liveSessionStatus?.type
-    );
+    const hideThinkingDuringFinalization = shouldHideThinkingDuringFinalization(liveSessionStatus);
     const agentActivityLabel =
       initStatusLabel && !isEmptyConversation
         ? initStatusLabel
         : isSessionActive
           ? liveSessionStatus?.type === 'requestPermission'
             ? t('sessions.statusIndicator.requestPermission')
-            : hideThinkingUnderFinishedAssistant
+            : hideThinkingDuringFinalization
               ? null
               : t(`sessions.statusIndicator.${runningActivity ?? 'thinking'}`)
           : hasPendingDispatch && statusStripState == null

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -3616,8 +3616,10 @@ export const SessionChatInterface = memo(
       sessionProject,
       workspaceId,
     ]);
-    const hideThinkingUnderFinishedAssistant =
-      shouldHideThinkingUnderFinishedAssistant(sessionHistory);
+    const hideThinkingUnderFinishedAssistant = shouldHideThinkingUnderFinishedAssistant(
+      sessionHistory,
+      liveSessionStatus?.type
+    );
     const agentActivityLabel =
       initStatusLabel && !isEmptyConversation
         ? initStatusLabel

--- a/packages/components/src/components/sessions/session-chat-interface.tsx
+++ b/packages/components/src/components/sessions/session-chat-interface.tsx
@@ -184,6 +184,7 @@ import {
   writeStoredPathLauncherPreference,
   type PathLauncherOption,
 } from '@/lib/session-path-launchers';
+import { shouldHideThinkingUnderFinishedAssistant } from '@/lib/agent-activity-visibility';
 import { cn } from '@/lib/utils';
 import type { SessionSharingState } from '@/lib/session-sharing';
 import {
@@ -3615,13 +3616,17 @@ export const SessionChatInterface = memo(
       sessionProject,
       workspaceId,
     ]);
+    const hideThinkingUnderFinishedAssistant =
+      shouldHideThinkingUnderFinishedAssistant(sessionHistory);
     const agentActivityLabel =
       initStatusLabel && !isEmptyConversation
         ? initStatusLabel
         : isSessionActive
           ? liveSessionStatus?.type === 'requestPermission'
             ? t('sessions.statusIndicator.requestPermission')
-            : t(`sessions.statusIndicator.${runningActivity ?? 'thinking'}`)
+            : hideThinkingUnderFinishedAssistant
+              ? null
+              : t(`sessions.statusIndicator.${runningActivity ?? 'thinking'}`)
           : hasPendingDispatch && statusStripState == null
             ? // Pre-start only while the turn can actually start: any
               // connection/machine problem (browser offline, machine removed or

--- a/packages/components/src/lib/agent-activity-visibility.ts
+++ b/packages/components/src/lib/agent-activity-visibility.ts
@@ -1,18 +1,23 @@
-import type { SessionHistoryInput } from '@lody/shared';
+import type { SessionHistoryInput, SessionStatus } from '@lody/shared';
 
 type HistoryEntry = Pick<SessionHistoryInput, 'role' | 'finished'> | undefined | null;
 
 /**
  * The session activity row is rendered under the last history bubble.
  * A finished assistant already shows completion chrome (timestamp / duration).
- * Keeping "Thinking" under that bubble is a false status for the same turn.
+ * Keeping "Thinking" under that bubble is a false status for leftover presence
+ * on the same turn. Initializing / permission presence is a new turn (goal
+ * resume has no user row) and must keep the presence-driven label.
  *
- * Do not use this to clear session presence. Presence stays session-scoped so a
- * following user turn, permission wait, or autoPrompt can still light the row.
+ * Do not use this to clear session presence.
  */
 export const shouldHideThinkingUnderFinishedAssistant = (
-  history: readonly HistoryEntry[] | null | undefined
+  history: readonly HistoryEntry[] | null | undefined,
+  liveStatusType?: SessionStatus['type'] | null
 ): boolean => {
+  if (liveStatusType === 'initializing' || liveStatusType === 'requestPermission') {
+    return false;
+  }
   if (!history?.length) {
     return false;
   }

--- a/packages/components/src/lib/agent-activity-visibility.ts
+++ b/packages/components/src/lib/agent-activity-visibility.ts
@@ -1,26 +1,10 @@
-import type { SessionHistoryInput, SessionStatus } from '@lody/shared';
-
-type HistoryEntry = Pick<SessionHistoryInput, 'role' | 'finished'> | undefined | null;
+import type { SessionStatus } from '@lody/shared';
 
 /**
- * The session activity row is rendered under the last history bubble.
- * A finished assistant already shows completion chrome (timestamp / duration).
- * Keeping "Thinking" under that bubble is a false status for leftover presence
- * on the same turn. Initializing / permission presence is a new turn (goal
- * resume has no user row) and must keep the presence-driven label.
- *
- * Do not use this to clear session presence.
+ * Only the execution owner's explicit phase can distinguish prompt activity
+ * from finalization. History and presence arrive independently, so a finished
+ * history entry cannot prove that the live turn has stopped thinking.
  */
-export const shouldHideThinkingUnderFinishedAssistant = (
-  history: readonly HistoryEntry[] | null | undefined,
-  liveStatusType?: SessionStatus['type'] | null
-): boolean => {
-  if (liveStatusType === 'initializing' || liveStatusType === 'requestPermission') {
-    return false;
-  }
-  if (!history?.length) {
-    return false;
-  }
-  const last = history[history.length - 1];
-  return last?.role === 'assistant' && last.finished === true;
-};
+export const shouldHideThinkingDuringFinalization = (
+  liveStatus: SessionStatus | null | undefined
+): boolean => liveStatus?.type === 'running' && liveStatus.phase === 'finalizing';

--- a/packages/components/src/lib/agent-activity-visibility.ts
+++ b/packages/components/src/lib/agent-activity-visibility.ts
@@ -1,0 +1,21 @@
+import type { SessionHistoryInput } from '@lody/shared';
+
+type HistoryEntry = Pick<SessionHistoryInput, 'role' | 'finished'> | undefined | null;
+
+/**
+ * The session activity row is rendered under the last history bubble.
+ * A finished assistant already shows completion chrome (timestamp / duration).
+ * Keeping "Thinking" under that bubble is a false status for the same turn.
+ *
+ * Do not use this to clear session presence. Presence stays session-scoped so a
+ * following user turn, permission wait, or autoPrompt can still light the row.
+ */
+export const shouldHideThinkingUnderFinishedAssistant = (
+  history: readonly HistoryEntry[] | null | undefined
+): boolean => {
+  if (!history?.length) {
+    return false;
+  }
+  const last = history[history.length - 1];
+  return last?.role === 'assistant' && last.finished === true;
+};

--- a/packages/components/tests/agent-activity-visibility.test.ts
+++ b/packages/components/tests/agent-activity-visibility.test.ts
@@ -1,60 +1,23 @@
 import { describe, expect, it } from 'vitest';
+import type { SessionStatus } from '@lody/shared';
+import { shouldHideThinkingDuringFinalization } from '../src/lib/agent-activity-visibility';
 
-import { shouldHideThinkingUnderFinishedAssistant } from '../src/lib/agent-activity-visibility';
-
-describe('shouldHideThinkingUnderFinishedAssistant', () => {
-  it('keeps the activity row when history is empty or still on the user turn', () => {
-    expect(shouldHideThinkingUnderFinishedAssistant(undefined)).toBe(false);
-    expect(shouldHideThinkingUnderFinishedAssistant([])).toBe(false);
-    expect(shouldHideThinkingUnderFinishedAssistant([{ role: 'user', finished: undefined }])).toBe(
-      false
+describe('shouldHideThinkingDuringFinalization', () => {
+  it('hides thinking only during an explicitly reported finalization', () => {
+    expect(shouldHideThinkingDuringFinalization({ type: 'running', phase: 'finalizing' })).toBe(
+      true
     );
   });
 
-  it('keeps the activity row while the last assistant turn is still open', () => {
-    expect(
-      shouldHideThinkingUnderFinishedAssistant([
-        { role: 'user' },
-        { role: 'assistant', finished: false },
-      ])
-    ).toBe(false);
-    expect(shouldHideThinkingUnderFinishedAssistant([{ role: 'assistant' }])).toBe(false);
-  });
-
-  it('hides thinking under a finished last assistant bubble', () => {
-    expect(
-      shouldHideThinkingUnderFinishedAssistant([
-        { role: 'user' },
-        { role: 'assistant', finished: true },
-      ])
-    ).toBe(true);
-    expect(
-      shouldHideThinkingUnderFinishedAssistant([{ role: 'assistant', finished: true }], 'running')
-    ).toBe(true);
-  });
-
-  it('keeps presence-driven activity when a new turn is initializing without a user row', () => {
-    expect(
-      shouldHideThinkingUnderFinishedAssistant(
-        [{ role: 'assistant', finished: true }],
-        'initializing'
-      )
-    ).toBe(false);
-    expect(
-      shouldHideThinkingUnderFinishedAssistant(
-        [{ role: 'assistant', finished: true }],
-        'requestPermission'
-      )
-    ).toBe(false);
-  });
-
-  it('shows thinking again when a later user turn is already in history', () => {
-    expect(
-      shouldHideThinkingUnderFinishedAssistant([
-        { role: 'user' },
-        { role: 'assistant', finished: true },
-        { role: 'user' },
-      ])
-    ).toBe(false);
+  it.each<SessionStatus | null | undefined>([
+    undefined,
+    null,
+    { type: 'idle' },
+    { type: 'running' },
+    { type: 'running', activity: 'image_generation' },
+    { type: 'initializing' },
+    { type: 'requestPermission' },
+  ])('honors live activity without inferring completion from history: %j', (status) => {
+    expect(shouldHideThinkingDuringFinalization(status)).toBe(false);
   });
 });

--- a/packages/components/tests/agent-activity-visibility.test.ts
+++ b/packages/components/tests/agent-activity-visibility.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldHideThinkingUnderFinishedAssistant } from '../src/lib/agent-activity-visibility';
+
+describe('shouldHideThinkingUnderFinishedAssistant', () => {
+  it('keeps the activity row when history is empty or still on the user turn', () => {
+    expect(shouldHideThinkingUnderFinishedAssistant(undefined)).toBe(false);
+    expect(shouldHideThinkingUnderFinishedAssistant([])).toBe(false);
+    expect(shouldHideThinkingUnderFinishedAssistant([{ role: 'user', finished: undefined }])).toBe(
+      false
+    );
+  });
+
+  it('keeps the activity row while the last assistant turn is still open', () => {
+    expect(
+      shouldHideThinkingUnderFinishedAssistant([
+        { role: 'user' },
+        { role: 'assistant', finished: false },
+      ])
+    ).toBe(false);
+    expect(shouldHideThinkingUnderFinishedAssistant([{ role: 'assistant' }])).toBe(false);
+  });
+
+  it('hides thinking under a finished last assistant bubble', () => {
+    expect(
+      shouldHideThinkingUnderFinishedAssistant([
+        { role: 'user' },
+        { role: 'assistant', finished: true },
+      ])
+    ).toBe(true);
+  });
+
+  it('shows thinking again when a later user turn is already in history', () => {
+    expect(
+      shouldHideThinkingUnderFinishedAssistant([
+        { role: 'user' },
+        { role: 'assistant', finished: true },
+        { role: 'user' },
+      ])
+    ).toBe(false);
+  });
+});

--- a/packages/components/tests/agent-activity-visibility.test.ts
+++ b/packages/components/tests/agent-activity-visibility.test.ts
@@ -28,6 +28,24 @@ describe('shouldHideThinkingUnderFinishedAssistant', () => {
         { role: 'assistant', finished: true },
       ])
     ).toBe(true);
+    expect(
+      shouldHideThinkingUnderFinishedAssistant([{ role: 'assistant', finished: true }], 'running')
+    ).toBe(true);
+  });
+
+  it('keeps presence-driven activity when a new turn is initializing without a user row', () => {
+    expect(
+      shouldHideThinkingUnderFinishedAssistant(
+        [{ role: 'assistant', finished: true }],
+        'initializing'
+      )
+    ).toBe(false);
+    expect(
+      shouldHideThinkingUnderFinishedAssistant(
+        [{ role: 'assistant', finished: true }],
+        'requestPermission'
+      )
+    ).toBe(false);
   });
 
   it('shows thinking again when a later user turn is already in history', () => {

--- a/packages/shared/src/presence.ts
+++ b/packages/shared/src/presence.ts
@@ -70,6 +70,7 @@ const ActiveSessionStatusSchema = z.preprocess(
     z.object({
       type: z.literal('running'),
       activity: z.enum(['image_generation']).optional(),
+      phase: z.literal('finalizing').optional(),
     }),
     z.object({
       type: z.literal('requestPermission'),

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -97,9 +97,11 @@ export type InitializingStage = 'git-clone' | 'managed-runtime' | 'acp' | 'resum
 export type SessionRunningActivity = 'image_generation';
 export type PermissionRequestKind = 'permission' | 'ask_user_question';
 
+export type SessionRunningPhase = 'finalizing';
+
 export type SessionStatus =
   | { type: 'idle' }
-  | { type: 'running'; activity?: SessionRunningActivity }
+  | { type: 'running'; activity?: SessionRunningActivity; phase?: SessionRunningPhase }
   | { type: 'requestPermission' }
   | {
       type: 'initializing';

--- a/packages/shared/tests/presence.test.ts
+++ b/packages/shared/tests/presence.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import {
   LODY_PRESENCE_TTL_MS,
   collectOnlineMachineIdsFromPresence,
@@ -13,11 +14,47 @@ import {
   type SessionId,
 } from '../src';
 
+// Shape of ActiveSessionStatusSchema's running object before optional `phase`.
+// z.object strips unknown keys, so old clients keep `{ type: 'running' }`.
+const legacyRunningStatus = z.object({
+  type: z.literal('running'),
+  activity: z.enum(['image_generation']).optional(),
+});
+
 const machineId = 'machine-1' as MachineId;
 const sessionId = 'session-1' as SessionId;
 const instanceId = 'instance-1' as LodyPresenceInstanceId;
 
 describe('presence helpers', () => {
+  it('keeps an optional running phase on session presence', () => {
+    const sessionKey = getLodySessionPresenceKey(sessionId, instanceId);
+    const parsed = parseLodyPresenceStates({
+      [sessionKey]: {
+        kind: 'session',
+        sessionId,
+        machineId,
+        instanceId,
+        status: { type: 'running', phase: 'finalizing' },
+        updatedAt: 120,
+      },
+    });
+    expect(parsed[sessionKey]).toMatchObject({
+      status: { type: 'running', phase: 'finalizing' },
+    });
+  });
+
+  it('lets an older running parser keep the session when phase is unknown', () => {
+    expect(legacyRunningStatus.parse({ type: 'running', phase: 'finalizing' })).toEqual({
+      type: 'running',
+    });
+  });
+
+  it('rejects a new activity enum value that older parsers cannot keep', () => {
+    expect(legacyRunningStatus.safeParse({ type: 'running', activity: 'finalizing' }).success).toBe(
+      false
+    );
+  });
+
   it('uses a 90 second presence TTL', () => {
     expect(LODY_PRESENCE_TTL_MS).toBe(90_000);
   });


### PR DESCRIPTION
## Related issue

Closes #613

## Problem / pressure

A human tester on Windows Lody 0.93.3 saw a completed first Codex reply, including its completion time, with Thinking / 思考中 still shown underneath until host finalization ended.

History and live presence arrive independently. Hiding Thinking whenever the last visible assistant is finished can also hide a new goal turn that is already running while its history update is still in transit.

A queued Codex image-generation status callback can read the old `running(image_generation)` snapshot, then write durable `running` and presence `thinking` after prompt-end has already published `finalizing` and idle. Checking phase around `setStatus` is not enough: the real document write also awaits `getDocMeta` / `upsert`.

## Summary

The execution owner reports optional `phase: 'finalizing'` on running presence when a prompt finishes. The UI hides Thinking only for that explicit phase. A resumed goal or autoPrompt reports ordinary running presence and keeps its activity indicator even when viewer history still shows the previous completed reply.

Codex image begin/end update presence activity only (`thinking` ↔ `image_generation`) through the presence owner. They do not write durable `SessionMeta.status`, so an in-flight image callback cannot undo `finalizing` or idle.

Presence remains owned by the execution scope through finalization. Initializing and permission labels retain their existing behavior. Older clients ignore the optional field and still recognize the running session; older hosts without the field retain the existing Thinking display during finalization.

## Visual explanation

```text
prompt in flight       → running                      → Thinking
image generating       → running + activity           → image activity
prompt complete        → running + phase: finalizing  → no Thinking row
late image end         → still finalizing             → no Thinking row
autoPrompt starts      → running                      → Thinking
turn scope released    → presence cleared             → idle
```

## Test plan

- Human confirmation of the original behavior on Windows 0.93.3:

![Windows 0.93.3: reply 123 already complete, Thinking still shown below](https://raw.githubusercontent.com/ladydd/Lody/screenshots/thinking-overlap-windows-0933/thinking-overlap-windows-0933.png)

- Execution-service regression: resume a goal while viewer history still ends on the previous finished assistant; preserve running presence, report finalizing while usage flush is held open, and restore running during autoPrompt.
- Presence-controller regression: retain ownership and heartbeat during finalization, then transition to thinking or permission.
- Image activity: presence-only begin/end; a queued image end after `finalizing` + idle does not restore `running`.
- UI tests: hide only for explicit finalizing presence.
- Shared tests: parse the new field and preserve compatibility with the earlier running-status shape.
- Independent review: the same two image-callback gates (stale meta read; in-flight `setStatus`) fail on `991558a2` and pass on `a3ce0746`. An expanded CLI suite of 136 tests (image-upload, activity-status, permission-notification, execution, presence controller) passed, including those two counterexamples.
- GitHub on `a3ce0746`: Tests, Static checks, and Desktop E2E (smoke) all passed.
- Packaged Windows/Electron click-through of the fix has not been repeated. Exact original overlap duration was not measured.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Prompt/autoPrompt phase transitions, optional presence-field compatibility, the UI's presence-only decision, and Codex image callbacks that must not write durable status.
- **Decisions to challenge:** Whether the shared prompt-completion boundary accurately identifies finalization while retaining execution ownership. Whether image activity should stay presence-only instead of serializing durable writes with prompt-end.
- **Plausible failures / evidence gaps:** Presence and history delivery can still differ in timing. This change uses the execution owner's reported phase; it does not make the two streams atomic. No packaged desktop retest of the fix.

### Authoring context

- **User goal / directives:** Fix the misleading Thinking label beneath a completed reply and address the goal-resume and image-callback regressions identified in review.
- **Constraints / non-goals:** Preserve execution-owned presence until scope release. Do not infer live completion from history, mix in #611, or describe the original transient overlap as a stuck turn.
- **Risk-bearing decisions:** Add optional display metadata to running presence. Old clients retain running status; old hosts without the field retain the old display behavior. Image generation activity is presence-only.
- **Destructive or irreversible behavior:** None introduced. No changes to persisted history, ACP packages, or cancellation ownership.
- **Deliberately not done or tested:** No packaged Windows retest of the fix and no claim of atomic cross-stream delivery.
- **Unknowns / confidence:** The original behavior was human-confirmed. Deterministic service/controller tests cover goal history lag and the two image-callback gates. Independent review: those gates fail on `991558a2` and pass on `a3ce0746`; 136 CLI tests passed. GitHub on `a3ce0746` is all green.

### Original user prompt

````text
After the assistant reply is finished, Thinking still appears under that message. Include the screenshot.
````

<!-- context-handoff:end -->
