### PR TITLE
fix(components): give terminal dock tabs a visible active/inactive state

### DIFF
--- a/packages/components/src/components/terminal/terminal-dock.tsx
+++ b/packages/components/src/components/terminal/terminal-dock.tsx
@@ -36,6 +36,18 @@ type RememberedTerminalSessionState = {
   activeTerminalId: string | null;
 };
 
+// The terminal tab strip's own canvas is already `bg-sidebar` (the floating
+// card's fill), unlike `SessionTabBar`/`TAB_PILL_*`, whose pill sits on the
+// app's plain `--background` canvas — reusing that treatment here stacked a
+// border + shadow on a fill that matched its parent 1:1, so the pill read as
+// heavy chrome instead of a lightweight selected state. Flat fill only, no
+// border/shadow, and a step down from the card's own tone in dark mode where
+// `--background`/`--sidebar` collapse together.
+const TERMINAL_TAB_ACTIVE_CLASS =
+  'bg-background text-tab-active-foreground dark:bg-muted-foreground/[0.16]';
+const TERMINAL_TAB_INACTIVE_CLASS =
+  'text-tab-inactive-foreground hover:bg-muted-foreground/[0.08] hover:text-tab-hover-foreground';
+
 // Chrome above the resizable body: the drag zone (h-1.5 = 6px) + the top tab
 // strip (h-8 = 32px). Added to `bodyHeight` for the floating card's height.
 const RESIZE_HANDLE_HEIGHT = 6;
@@ -497,15 +509,17 @@ export function TerminalDock({
                     return (
                       <div
                         key={term.terminalId}
-                        className="group flex h-full max-w-44 min-w-0 shrink-0 items-center gap-1"
+                        role="tab"
+                        aria-selected={isActive}
+                        className={cn(
+                          'group flex h-6 max-w-44 min-w-0 shrink-0 items-center gap-1 rounded-md px-2 transition-colors',
+                          isActive ? TERMINAL_TAB_ACTIVE_CLASS : TERMINAL_TAB_INACTIVE_CLASS
+                        )}
                       >
                         <button
                           type="button"
                           onClick={() => selectTerminal(term.terminalId)}
-                          className={cn(
-                            'flex min-w-0 items-center gap-1 hover:text-foreground',
-                            isActive ? 'text-foreground' : ''
-                          )}
+                          className="flex min-w-0 items-center gap-1"
                         >
                           <TerminalSquare className="h-3 w-3 shrink-0 opacity-70" />
                           <span className="min-w-0 truncate">{term.title || 'shell'}</span>
@@ -514,7 +528,12 @@ export function TerminalDock({
                           type="button"
                           aria-label="Close terminal"
                           onClick={() => handleCloseTerminal(term.terminalId)}
-                          className="shrink-0 rounded-sm opacity-0 hover:text-foreground group-hover:opacity-100"
+                          className={cn(
+                            'shrink-0 rounded-sm p-0.5 transition-opacity',
+                            isActive
+                              ? 'opacity-70 hover:opacity-100'
+                              : 'opacity-0 group-hover:opacity-100'
+                          )}
                         >
                           <X className="h-2.5 w-2.5" />
                         </button>

--- a/packages/components/tests/terminal-dock.test.tsx
+++ b/packages/components/tests/terminal-dock.test.tsx
@@ -116,11 +116,16 @@ function getTerminalTabButton(container: HTMLElement, title: string): HTMLButton
 }
 
 function expectActiveTerminal(container: HTMLElement, title: string): void {
-  // Active tab = brighter foreground text (no chip background in the slim tab
-  // strip). Match the resting foreground token, not the hover variant that
-  // inactive tabs also carry.
-  const classes = getTerminalTabButton(container, title).className.split(/\s+/);
-  expect(classes).toContain('text-foreground');
+  // Active tab = a flat fill against the strip's own `bg-sidebar` canvas (no
+  // border/shadow — this strip already lives inside the floating card's own
+  // border+shadow, so stacking another pair on a 24px tab read as heavy
+  // chrome). See the comment on `TERMINAL_TAB_ACTIVE_CLASS`.
+  const tab = getTerminalTab(container, title);
+  expect(tab.getAttribute('aria-selected')).toBe('true');
+  const classes = tab.className.split(/\s+/);
+  expect(classes).toContain('bg-background');
+  expect(classes).toContain('text-tab-active-foreground');
+  expect(classes).not.toContain('shadow-[0_1px_4px_-1px_rgba(0,0,0,0.18)]');
 }
 
 describe('TerminalDock', () => {
@@ -145,12 +150,7 @@ describe('TerminalDock', () => {
     root = createRoot(container);
 
     await act(async () => {
-      root?.render(
-        <TerminalDock
-          channel={channel}
-          sessionId="session-1"
-          defaultView="terminal"        />
-      );
+      root?.render(<TerminalDock channel={channel} sessionId="session-1" defaultView="terminal" />);
     });
     await flushReact();
     await flushReact();
@@ -176,11 +176,7 @@ describe('TerminalDock', () => {
     root = createRoot(container);
 
     await act(async () => {
-      root?.render(
-        <TerminalDock
-          channel={channel}
-          sessionId="session-memory-a"        />
-      );
+      root?.render(<TerminalDock channel={channel} sessionId="session-memory-a" />);
     });
     await flushReact();
     await flushReact();
@@ -192,22 +188,14 @@ describe('TerminalDock', () => {
     expectActiveTerminal(container, 'beta');
 
     await act(async () => {
-      root?.render(
-        <TerminalDock
-          channel={channel}
-          sessionId="session-memory-b"        />
-      );
+      root?.render(<TerminalDock channel={channel} sessionId="session-memory-b" />);
     });
     await flushReact();
     await flushReact();
     expect(hasOpenPanel(container)).toBe(false);
 
     await act(async () => {
-      root?.render(
-        <TerminalDock
-          channel={channel}
-          sessionId="session-memory-a"        />
-      );
+      root?.render(<TerminalDock channel={channel} sessionId="session-memory-a" />);
     });
     await flushReact();
     await flushReact();
@@ -220,11 +208,7 @@ describe('TerminalDock', () => {
     root = createRoot(container);
 
     await act(async () => {
-      root?.render(
-        <TerminalDock
-          channel={channel}
-          sessionId="session-memory-a"        />
-      );
+      root?.render(<TerminalDock channel={channel} sessionId="session-memory-a" />);
     });
     await flushReact();
     await flushReact();
@@ -246,10 +230,7 @@ describe('TerminalDock', () => {
 
     await act(async () => {
       root?.render(
-        <TerminalDock
-          channel={channel}
-          sessionId="session-stable-reload"
-          defaultView="terminal"        />
+        <TerminalDock channel={channel} sessionId="session-stable-reload" defaultView="terminal" />
       );
     });
     await flushReact();
@@ -264,7 +245,8 @@ describe('TerminalDock', () => {
         <TerminalDock
           channel={reloadChannel}
           sessionId="session-stable-reload"
-          canCreateTerminal={false}        />
+          canCreateTerminal={false}
+        />
       );
     });
     await flushReact();


### PR DESCRIPTION
## What

TerminalDock's terminal tabs only differentiated active vs. inactive by text color (`text-foreground` vs. inherited `text-muted-foreground`) — no background at all, so the two states were nearly impossible to tell apart.

## Why not just reuse `TAB_PILL_ACTIVE_CLASS`

The session/task tab bars' pill treatment (border + `bg-sidebar` + shadow) assumes the tab sits on the app's plain `--background` canvas. The terminal dock's floating card is already `bg-sidebar`, so nesting that pill inside it gave zero fill contrast — the border+shadow had to carry 100% of the differentiation, which read as heavy chrome on a 24px-tall tab.

## Fix

- Active tab: flat `bg-background` fill (a dark-mode-specific `muted-foreground` wash is used instead, since `--background`/`--sidebar` collapse together in dark themes), no border/shadow.
- Small vertical inset (`h-6` inside the 32px strip) so the pill isn't flush against the strip's edges.
- Kept centered alignment with the `+`/collapse-chevron buttons via the row's existing `items-center`.

## Testing

- `NODE_ENV=development pnpm --filter @lody/components exec vitest run tests/terminal-dock.test.tsx` — updated the active-tab assertion to check the new background/no-shadow treatment instead of just text color.
- `tsc --noEmit`, `oxlint`, `prettier --check` clean.
- Verified visually in Storybook (`Terminal/TerminalDock` → `InLocalSession`) in both light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)