### PR TITLE
feat(components): show agent icons in session rows

### DIFF
--- a/.agents/notes/implemented/feature/2026-09-12-sidebar-session-agent-icons.md
+++ b/.agents/notes/implemented/feature/2026-09-12-sidebar-session-agent-icons.md
@@ -1,0 +1,28 @@
+# Sidebar Session agent icons
+
+Status: implemented
+Translation: current
+
+[中文](2026-09-12-sidebar-session-agent-icons.zh.md)
+
+## Abstract
+
+Imported Sessions from different coding agents were indistinguishable in the sidebar when their titles were similar. Sidebar row models now retain the Session's ACP agent identity and every Workspace, Local Project, Updated, and Pinned row renders the existing agent icon immediately before its title. The icon is passive and does not compete with working, permission, or unread status at the trailing edge; older synthetic row models without agent metadata remain valid and simply omit it.
+
+## Decision
+
+Use the existing `AgentIcon` mapping instead of introducing sidebar-specific assets. Carry `cliType` and `agentType` through the pure sidebar view models so imported history and live Sessions follow the same rendering path.
+
+The shared row primitive renders the icon in a fixed 12px slot before the title. Author avatars and pin state remain separate facts, while the existing trailing status priority stays unchanged.
+
+## Alternatives
+
+A hover-only label would keep the compact row unchanged, but it would not satisfy the bulk-import workflow: users need to scan Claude, Codex, and other Sessions without opening each menu. Replacing the trailing status icon was rejected because it would hide the agent precisely while a Session is active or needs permission.
+
+## Verification
+
+Focused component tests cover identity propagation and rendering in both grouped and Updated lists. Type checking and repository checks validate the remaining Local Project path, which consumes `SessionMeta` directly.
+
+## Limits
+
+The row model intentionally carries only the persisted ACP identity. Provider-brand overrides that exist solely in a current machine configuration continue to use the generic icon for that ACP agent when the configuration is unavailable to the sidebar model.

--- a/.agents/notes/implemented/feature/2026-09-12-sidebar-session-agent-icons.zh.md
+++ b/.agents/notes/implemented/feature/2026-09-12-sidebar-session-agent-icons.zh.md
@@ -1,0 +1,28 @@
+# 侧边栏 Session Agent 图标
+
+Status: implemented
+Translation: current
+
+[English](2026-09-12-sidebar-session-agent-icons.md)
+
+## 摘要
+
+从不同 coding agent 批量导入的 Session 在标题相似时无法在侧边栏中快速区分。现在侧边栏行模型会保留 Session 的 ACP agent 身份，并在 Workspace、Local Project、Updated 和 Pinned 行的标题前显示现有 agent 图标。图标是被动身份信息，不会占用尾部的工作中、权限等待或未读状态槽；缺少 agent 元数据的旧测试或合成行仍可正常渲染，只是不显示图标。
+
+## 决策
+
+复用现有 `AgentIcon` 映射，不创建侧边栏专用图标资产。通过纯侧边栏视图模型传递 `cliType` 和 `agentType`，让导入历史与实时 Session 使用相同渲染路径。
+
+共享行组件在标题前使用固定 12px 槽位显示图标。作者头像和置顶状态仍表达各自独立信息，原有尾部状态优先级保持不变。
+
+## 备选方案
+
+仅在 hover 信息中显示 agent 可以保持原行不变，但无法满足批量导入的扫描场景：用户仍需逐项打开菜单才能区分 Claude、Codex 等 Session。也不使用尾部状态位置，因为那会在 Session 运行或等待权限时隐藏 agent 身份。
+
+## 验证
+
+定向组件测试覆盖 agent 身份在模型中的传递，以及 grouped 与 Updated 两种列表的渲染。类型检查和仓库检查覆盖直接读取 `SessionMeta` 的 Local Project 路径。
+
+## 限制
+
+行模型只携带持久化的 ACP 身份。如果 provider 品牌覆盖仅存在于当前机器配置而侧边栏模型无法读取该配置，则继续显示该 ACP agent 的通用图标。

--- a/packages/components/src/components/AGENTS.md
+++ b/packages/components/src/components/AGENTS.md
@@ -35,6 +35,9 @@ Ownership and explanations: [README.md](README.md).
   slot. Status replaces resting line diff, `Mergeable`, worktree glyph, PR icon, or mobile
   time with one 14px mark; retain metrics in the desktop hover info card. Mobile chat
   leading-node rules remain in [mobile/AGENTS.md](mobile/AGENTS.md).
+- Keep the Session's agent icon immediately before its title in Workspace, Local
+  Project, Updated, and Pinned rows; agent identity stays visible independently
+  from the trailing working/waiting/unread status slot.
 - Never hide a Session through nesting: missing, cross-section, cross-group, cycling,
   or deeper-than-one-level openers render top-level. `MAX_VISIBLE_SESSIONS` /
   `SHOW_FULL_BUCKET_THRESHOLD` count top-level rows. Every list passes `rootRank` for

--- a/packages/components/src/components/loro-app-sidebar.tsx
+++ b/packages/components/src/components/loro-app-sidebar.tsx
@@ -170,6 +170,7 @@ import { writePreferredWorkspaceSlug } from '@/lib/workspace';
 import {
   SessionOpenedByTreeRow,
   SessionPrIcon,
+  SessionRowAgentIcon,
   SessionRowAuthorAvatar,
   SessionRowLeadingSlot,
   SessionRowWorktreeIndicator,
@@ -720,6 +721,7 @@ const LocalProjectSessionItem = memo(function LocalProjectSessionItem({
           {isPinned ? (
             <Pin aria-hidden="true" className="h-3 w-3 shrink-0 text-sidebar-foreground-muted/80" />
           ) : null}
+          <SessionRowAgentIcon cliType={session.cliType} agentType={session.agentType} />
           {titleContent}
         </div>
         {/* ③ A relative time on mobile only (no hover info card on touch); on desktop
@@ -2203,6 +2205,8 @@ export function LoroAppSidebar({ className }: LoroAppSidebarProps) {
         id: task.sessionId,
         kind: 'chat',
         title: task.title,
+        cliType: task.cliType,
+        agentType: task.agentType,
         sectionLabel: chatsLabel,
         subtitle: null,
         machineName: task.machineName ?? null,
@@ -2227,6 +2231,8 @@ export function LoroAppSidebar({ className }: LoroAppSidebarProps) {
         id: task.sessionId,
         kind: 'github',
         title: task.title,
+        cliType: task.cliType,
+        agentType: task.agentType,
         sectionLabel: repoName || 'GitHub Worktrees',
         subtitle: repoName || null,
         repoFullName: repoName || null,
@@ -2276,6 +2282,8 @@ export function LoroAppSidebar({ className }: LoroAppSidebarProps) {
             id: session.id,
             kind: 'local',
             title,
+            cliType: session.cliType,
+            agentType: session.agentType,
             sectionLabel,
             subtitle: project.name,
             repoFullName: resolveProjectGitHubRepo(session.project) ?? null,

--- a/packages/components/src/components/session-list.tsx
+++ b/packages/components/src/components/session-list.tsx
@@ -55,6 +55,7 @@ import {
   ContextMenuTrigger,
 } from '@/ui/context-menu';
 import type {
+  AgentConfigCliType,
   LocalProjectHistoryProvider,
   MachineId,
   PrStatus,
@@ -84,6 +85,7 @@ import { formatCompactRelativeTime, type RelativeTimeValue } from '@/lib/format-
 import {
   GitHubOwnerIcon,
   SessionPrIcon,
+  SessionRowAgentIcon,
   SessionRowAuthorAvatar,
   SessionRowLeadingSlot,
   SidebarRowArchiveButton,
@@ -111,6 +113,8 @@ export type SessionListRowOwner = {
 export type SessionListRow = {
   sessionId: string;
   title: string;
+  cliType?: AgentConfigCliType;
+  agentType?: string;
   /**
    * PRECISE opener: the Session that created/opened this one
    * (`SessionMeta.openedBySessionId`). Presentation-only provenance; it is NOT
@@ -988,6 +992,7 @@ const SessionGroupSection = memo(function SessionGroupSection({
                         className="h-3 w-3 shrink-0 text-sidebar-foreground-muted/80"
                       />
                     ) : null}
+                    <SessionRowAgentIcon cliType={session.cliType} agentType={session.agentType} />
                     {renderTitle()}
                   </div>
                   {/* Keep PR at the right edge, with All Changes totals immediately before it. */}

--- a/packages/components/src/components/sessions/session-list-rows.ts
+++ b/packages/components/src/components/sessions/session-list-rows.ts
@@ -305,6 +305,8 @@ export function mapSessionMetaToSessionListRow(
   return {
     sessionId: session.id,
     title,
+    cliType: session.cliType,
+    agentType: session.agentType,
     // Presentation-only provenance: the Session that created this one (MCP
     // `lody_session_create` / `lody session create` from inside a session).
     // Deliberately NOT parentSessionId — see `lib/session-opened-by-tree.ts`.

--- a/packages/components/src/components/sidebar-row-shared.tsx
+++ b/packages/components/src/components/sidebar-row-shared.tsx
@@ -13,7 +13,7 @@ import {
   X,
   type LucideIcon,
 } from 'lucide-react';
-import type { PrStatus, SessionPullRequestCiState } from '@lody/shared';
+import type { AgentConfigCliType, PrStatus, SessionPullRequestCiState } from '@lody/shared';
 import { cn } from '@/lib/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/ui/tooltip';
 import { ContextMenuItem } from '@/ui/context-menu';
@@ -23,6 +23,7 @@ import { SidebarConfirmArchiveButton } from '@/components/sidebar-confirm-archiv
 import { CachedAvatarImg } from '@/components/cached-avatar-img';
 import { UserAvatar } from '@/components/user-avatar';
 import { WorktreeIcon } from '@/components/icons/worktree-icon';
+import { AgentIcon } from '@/components/icons/agent-icon';
 import { getGitHubOwnerAvatarUrl } from '@/lib/github-avatar';
 
 /**
@@ -31,7 +32,7 @@ import { getGitHubOwnerAvatarUrl } from '@/lib/github-avatar';
  * flat Updated list in `sidebar-updated-task-list.tsx`) render the same anatomy,
  * so the pieces live here once instead of being copied three times.
  *
- * Row anatomy: `[① tree affordance | more][② author avatar? + title][③ status | diff/mergeable? + worktree? + PR icon? | archive]`.
+ * Row anatomy: `[① tree affordance | more][② author avatar? + agent icon + title][③ status | diff/mergeable? + worktree? + PR icon? | archive]`.
  * The author avatar (`SessionRowAuthorAvatar`) only appears in team ("All Tasks") scope on a
  * multi-member workspace; otherwise the title owns the leading edge of slot ②. The leading slot
  * stays reserved even when empty (the ⋯ menu button reveals there on hover). A local worktree
@@ -275,6 +276,25 @@ export function SessionRowAuthorAvatar({
       className="h-[18px] w-[18px] shrink-0"
       fallbackClassName="text-[9px] font-medium"
     />
+  );
+}
+
+/** Identifies the ACP agent without consuming the row's status slot. */
+export function SessionRowAgentIcon({
+  cliType,
+  agentType,
+}: {
+  cliType?: AgentConfigCliType | null;
+  agentType?: string | null;
+}) {
+  if (!cliType || !agentType) return null;
+  return (
+    <span
+      data-session-agent-icon=""
+      className="inline-flex h-3 w-3 shrink-0 items-center justify-center text-sidebar-foreground-muted/80"
+    >
+      <AgentIcon cliType={cliType} agentType={agentType} className="h-3 w-3" />
+    </span>
   );
 }
 

--- a/packages/components/src/components/sidebar-updated-session-list.tsx
+++ b/packages/components/src/components/sidebar-updated-session-list.tsx
@@ -41,6 +41,7 @@ import {
   SessionOpenedByTreeRow,
   SessionPrIcon,
   SessionMergeablePill,
+  SessionRowAgentIcon,
   SessionRowAuthorAvatar,
   SessionRowLeadingSlot,
   SessionRowWorktreeIndicator,
@@ -67,6 +68,7 @@ import {
 } from '@/lib/session-opened-by-tree';
 import { SessionInfoHoverCard } from '@/components/session-info-hover-card';
 import type {
+  AgentConfigCliType,
   LocalProjectHistoryProvider,
   PrStatus,
   SessionId,
@@ -86,6 +88,8 @@ export type SidebarUpdatedItem = {
   id: string;
   kind: SidebarUpdatedItemKind;
   title: string;
+  cliType?: AgentConfigCliType;
+  agentType?: string;
   /**
    * PRECISE opener: the Session that created/opened this one
    * (`SessionMeta.openedBySessionId`). Presentation-only provenance; see
@@ -877,6 +881,7 @@ const UpdatedItemRow = memo(function UpdatedItemRow({
             className="relative -top-px h-3 w-3 shrink-0 text-sidebar-foreground-muted/80"
           />
         ) : null}
+        <SessionRowAgentIcon cliType={item.cliType} agentType={item.agentType} />
         <div
           className={cn('min-w-0 flex-1 flex items-center truncate text-sm')}
           // Double-click to rename is scoped to the title only, so double-clicking

--- a/packages/components/tests/session-list-rows.test.ts
+++ b/packages/components/tests/session-list-rows.test.ts
@@ -281,6 +281,23 @@ describe('getEffectiveSessionActivitySummary child-status aggregation', () => {
 });
 
 describe('buildSessionListRows repo + PR mapping', () => {
+  test('preserves the agent identity needed by sidebar rows', () => {
+    const session = makeSession({
+      id: 'session',
+      title: 'Imported session',
+      cliType: 'registry',
+      agentType: 'kimi',
+    });
+
+    const tasks = buildSessionListRows([session], {
+      scope: 'my',
+      currentUserId: 'user-1',
+      defaultTitle: 'Untitled',
+    });
+
+    expect(tasks[0]).toMatchObject({ cliType: 'registry', agentType: 'kimi' });
+  });
+
   test('resolves repoFullName from a github project when legacy repoFullName is absent', () => {
     const session = makeSession({
       id: 'session',

--- a/packages/components/tests/sidebar-share-only-menu.test.tsx
+++ b/packages/components/tests/sidebar-share-only-menu.test.tsx
@@ -108,6 +108,64 @@ describe('sidebar share-only context menus', () => {
     expect(onShareSessionWithTeam).toHaveBeenCalledWith('task-list-session');
   });
 
+  it('renders agent identity beside titles in grouped and Updated rows', () => {
+    flushSync(() => {
+      root?.render(
+        React.createElement(SessionList, {
+          sessions: [
+            {
+              sessionId: 'codex-session',
+              title: 'Imported Codex session',
+              cliType: 'builtin',
+              agentType: 'codex',
+              repoFullName: null,
+              branchName: '',
+              latestMessageAt: '2026-07-19T00:00:00.000Z',
+              addedLines: 0,
+              deletedLines: 0,
+              isWorking: false,
+              hasUnreadMessages: false,
+              isOffline: false,
+              isWaitingPermission: false,
+            },
+          ],
+          repos: [],
+        })
+      );
+    });
+
+    expect(
+      container
+        ?.querySelector('[data-sidebar-session-id="codex-session"]')
+        ?.querySelector('[data-session-agent-icon]')
+    ).not.toBeNull();
+
+    flushSync(() => {
+      root?.render(
+        React.createElement(SidebarUpdatedSessionList, {
+          now: new Date('2026-07-19T01:00:00.000Z'),
+          items: [
+            {
+              id: 'claude-session',
+              kind: 'chat',
+              title: 'Imported Claude session',
+              cliType: 'builtin',
+              agentType: 'claude',
+              sectionLabel: 'Chats',
+              latestMessageAt: new Date('2026-07-19T00:00:00.000Z'),
+            },
+          ],
+        })
+      );
+    });
+
+    expect(
+      container
+        ?.querySelector('[data-sidebar-updated-id="claude-session"]')
+        ?.querySelector('[data-session-agent-icon]')
+    ).not.toBeNull();
+  });
+
   it('keeps the Updated list menu reachable when Share is its only action', () => {
     const onShareItemWithTeam = vi.fn();
 


### PR DESCRIPTION
## Related issue

Closes #155

## Problem / pressure

After importing sessions from different coding agents, the sidebar titles alone do not make their source agent scannable. Hover-only detail does not help when comparing many sessions at once.

## Summary

Show the existing `AgentIcon` before session titles in the Workspace/GitHub/Chat, Local Project, Updated, and Pinned sidebar rows. Carry `cliType` and `agentType` through the pure row models so the identity icon remains independent from the trailing working, waiting, and unread status indicators.

Add focused model and DOM regressions for the grouped and Updated list paths, and document the shared row contract in the scoped Agent instructions and implementation notes.

## Visual explanation

Simple change: every affected row gains the same existing agent icon immediately before its title; the compact component diff is clearer than a separate diagram.

## Before / after

| Before | After |
| ------ | ----- |
| Imported session rows expose the agent only through secondary detail. | Each session title has a consistent source-agent icon for list scanning. |
| Row models omit agent identity in some grouped paths. | Pure row models retain `cliType` and `agentType` across all rendered list paths. |
| Agent identity and activity are easy to conflate. | The leading identity icon and trailing working/waiting/unread state remain separate. |

## Test plan

- `pnpm --dir packages/components vitest run src/components/tests/session-list-rows.test.ts src/components/tests/sidebar-share-only-menu.test.tsx` — 24 tests passed.
- `pnpm --dir packages/components typecheck` — passed.
- Type-aware `oxlint` on the seven changed TypeScript/TSX files — passed with zero errors.
- Prettier check on all changed files — passed.
- Documentation check — passed with zero errors; existing size warnings remain warnings.
- `git diff --check upstream/main...HEAD` — passed.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Verify agent identity reaches every sidebar row path and that `SidebarSessionRow` preserves the existing trailing status layout.
- **Decisions to challenge:** Confirm reusing `AgentIcon` at the shared row boundary is preferable to per-list icon rendering.
- **Plausible failures / evidence gaps:** The focused DOM tests cover grouped and Updated rows; visual spacing was not checked on every platform density.

### Authoring context

- **User goal / directives:** Select eligible issues, implement and validate them in the same run, and deliver each ready case under its repository rules.
- **Constraints / non-goals:** Keep this under the community size limit and do not change session grouping, sorting, hover details, or activity semantics.
- **Risk-bearing decisions:** Agent identity is passed through pure row models and rendered once by the shared session-row component.
- **Destructive or irreversible behavior:** None; this changes display metadata and tests without migrations, cleanup, or persistent-data writes.
- **Deliberately not done or tested:** No cross-platform pixel screenshot matrix was run because the change reuses the existing icon component and spacing primitives.
- **Unknowns / confidence:** Focused rendering and type checks are strong; residual risk is compact-sidebar spacing with unusually long localized titles.

### Original user prompt

<details>
<summary>Show original prompt</summary>

````text
达到真实门槛并被本轮选中的 case，必须在同一轮交给明确 owner 继续调查、实现、验证和交付。
````

</details>

<!-- context-handoff:end -->
