### PR TITLE
fix(ui): restore semantic color contracts

### DIFF
--- a/.agents/notes/implemented/architecture/2026-09-11-ui-semantic-color-contracts.md
+++ b/.agents/notes/implemented/architecture/2026-09-11-ui-semantic-color-contracts.md
@@ -1,0 +1,157 @@
+# UI semantic colour contracts
+
+Status: implemented
+Translation: pending
+
+## Abstract
+
+The original `@lody/ui` palette was a coherent Button-sized StyleX foundation,
+but later primitives reused its aspirational roles without a contrast contract
+and relayed semantic colours through component variable groups that had to be
+manually re-themed. This change restores one semantic colour layer, keeps
+component variables for component-specific dimensions, and makes normal text and
+required non-text indicators meet explicit WCAG contrast thresholds in both
+palettes. Subtle fills remain for visual texture, but an inset edge or ring now
+carries identification and keyboard focus when the fill cannot.
+
+## Problem
+
+The first UI package change defined semantic `colors` and `shadow` groups, then a
+Button group whose colour values pointed back at those semantic variables. That
+worked when the forced theme lived on the document root. A gallery later forced
+two themes on subtrees and exposed that an inherited component custom property
+had already resolved its semantic alias where the component group was declared.
+The repair added a component `createTheme` and registered it centrally; Field and
+Popup copied that relay, so every colour-bearing component group expanded the
+theme registry and portal handoff.
+
+The palette values themselves were copied from the existing Lody Light and
+Vesper designs rather than selected against declared foreground/background
+pairs. Chromium resolution exposed the consequences once more primitives used
+the planned roles:
+
+- light `accent` used by a 13px link reached only 3.22:1 on the page;
+- `tertiaryLabel` used for placeholders and help reached 2.29:1 in light fields
+  and 3.59:1 in dark fields;
+- the off switch thumb and well fill differed by about 1.1:1;
+- a popup's 6% highlighted fill differed from its surface by about 1.15:1 even
+  though it was the row's only package-owned keyboard focus signal.
+
+The structural gallery test proved that every token had a sample. It did not say
+whether a rendered pairing was readable or identifiable.
+
+## Decision
+
+There remains one themeable semantic colour group. Component styles reference
+`colors` and `shadow` directly, while Button, Field and Popup variable groups keep
+only dimensions and other component-specific metrics. The component palette
+themes and `componentPaletteThemes` registry are removed; a forced or portalled
+theme now carries only the semantic colour and shadow themes it actually changes.
+
+Semantic roles now distinguish readable hint text from tertiary non-text ink.
+`label`, `secondaryLabel`, `hintLabel`, `accent` when used as link text, and
+`destructive` maintain 4.5:1 against every surface rung. `tertiaryLabel`,
+`controlEdge`, focus and invalid indicators maintain 3:1. The light accent and
+destructive values move darker, while light secondary and hint labels move only
+as far as their worst allowed surface requires; the dark hint moves lighter.
+
+Interactive wells include a one-pixel `controlEdge` in `shadow.inset`. The switch
+thumb composes that edge with its raised shadow. Popup selected and highlighted
+rows retain their quiet OKLab-derived fills, but highlighted rows additionally
+carry a two-pixel accent inset ring; the tick remains the redundant selected
+indicator. Decorative separators and disabled controls are not promoted into
+contrast-bearing roles.
+
+`test/color-contrast.test.ts` reads the literal light and dark theme maps and
+enforces the semantic contracts. This test deliberately validates palette
+invariants without requiring a browser download in unit-test environments. The
+same values and every remaining `color-mix(in oklab, ...)` are separately resolved
+through Chromium for rendered-colour evidence.
+
+## Alternatives
+
+A public Neutral/Blue/Red numbered palette would make raw colour selection more
+regular, but it would not state which foreground/background combinations are
+valid and would give components a second, non-semantic API. It may still be a
+private authoring input if the number of themes or hues grows.
+
+Keeping component colour variables and applying their palette theme on every
+component root would avoid the central registry. No current consumer overrides
+those internal colour groups, however, so the extra variables and classes would
+preserve machinery without a capability.
+
+Making the popup fill itself differ by 3:1 would satisfy a numerical state delta,
+but produces a much louder selected-list language. A high-contrast inset ring
+keeps the quiet fill and gives keyboard focus an independent signal.
+
+## Relationship to earlier decisions
+
+This decision narrows the component-token and no-line portions of the historical
+[token gallery note](../feature/2026-09-09-ui-token-gallery.md),
+[field note](../feature/2026-09-09-ui-field-primitives.md),
+[choice-controls note](../feature/2026-09-10-ui-choice-controls.md), and
+[Select/Combobox note](../feature/2026-09-10-ui-select-combobox.md). Those notes
+remain useful records of why each primitive was introduced; the current contract
+lives in the draft [Shared UI primitives Spec](../../../../specs/ui-primitives.md)
+and `packages/ui/src/tokens/RULES.md`.
+
+## Verification
+
+The package unit suite and typecheck cover the token surface and component
+composition. A Chromium audit resolves both palettes, including the OKLab mixes,
+and checks the resulting sRGB contrast pairs. The remaining low-contrast fills
+are supplemental or decorative rather than the only signal. Screenshot-based
+pixel regression remains out of scope, so the exact antialiased shape of the new
+one-pixel edges is still a visual-review responsibility.
+
+### Chromium evidence
+
+Headless Chromium 148 resolved the complete colour group to these sRGB values.
+The overlay values retain their alpha; every other value is opaque.
+
+| token                 | Lody Light          | Vesper           |
+| --------------------- | ------------------- | ---------------- |
+| `background`          | `#ffffff`           | `#101010`        |
+| `elevatedBackground`  | `#ffffff`           | `#161616`        |
+| `raisedBackground`    | `#eef0f3`           | `#232323`        |
+| `secondaryBackground` | `#f7f8fa`           | `#161616`        |
+| `wellBackground`      | `#e8eaed`           | `#1c1c1c`        |
+| `label`               | `#1a1b1e`           | `#ffffff`        |
+| `secondaryLabel`      | `#5d636f`           | `#a0a0a0`        |
+| `hintLabel`           | `#636874`           | `#949494`        |
+| `tertiaryLabel`       | `#7e8491`           | `#737373`        |
+| `controlEdge`         | `#7e8491`           | `#737373`        |
+| `separator`           | `#e6e8ed`           | `#282828`        |
+| `hoverFill`           | `#f0f1f4`           | `#282828`        |
+| `selectedFill`        | `#e8eaef`           | `#232323`        |
+| `accent`              | `#175de8`           | `#ffc799`        |
+| `onAccent`            | `#ffffff`           | `#000000`        |
+| `destructive`         | `#ca212c`           | `#ff8080`        |
+| `onDestructive`       | `#ffffff`           | `#000000`        |
+| `overlay`             | `rgba(26,27,30,.5)` | `rgba(0,0,0,.6)` |
+| `gray`                | `#969ca6`           | `#6b6b6b`        |
+| `gray2`               | `#acb0b9`           | `#575757`        |
+| `gray3`               | `#c1c5cd`           | `#454545`        |
+| `gray4`               | `#d4d7de`           | `#383838`        |
+| `gray5`               | `#e6e8ed`           | `#2e2e2e`        |
+| `gray6`               | `#f7f8fa`           | `#232323`        |
+
+Chromium preserved the OKLab interpolation in computed style and rendered the
+six package mixes to the following sRGB pixels:
+
+| mix                                    | Lody Light  | Vesper      |
+| -------------------------------------- | ----------- | ----------- |
+| primary hover, 12% toward page         | `#313234`   | `#dedede`   |
+| secondary hover, 4% toward label       | `#e4e6e9`   | `#2a2a2a`   |
+| destructive hover, 10% toward label    | `#b7252c`   | `#ff8d8c`   |
+| destructive tone, 10% over transparent | `#ce1d271a` | `#ff80801a` |
+| popup highlight, 6% toward label       | `#e0e1e4`   | `#2e2e2e`   |
+| popup selected, 3% toward label        | `#e7e9ec`   | `#282828`   |
+
+Across all five surface rungs, the worst normal-text pair is light `accent` on
+`wellBackground` at 4.62:1 and dark `hintLabel` on `raisedBackground` at
+5.18:1. The worst required non-text pair is light `controlEdge` on
+`wellBackground` at 3.11:1 and dark `tertiaryLabel` on `raisedBackground` at
+3.31:1. The popup highlight ring reaches 4.26:1 in light and 8.98:1 in dark
+against its mixed fill. The quiet popup fills and destructive-tone wash remain
+below 3:1 by design because the ring, tick, or readable label carries the state.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -13,9 +13,11 @@ into one component at a time. Source-consumed; consumers compile it through
   reconstruct the deleted component's visual design.
 - Depends on React, `@base-ui/react` and `@stylexjs/stylex` only. Never on
   `@lody/components`, `@lody/platform`, or any cloud package.
-- No border token exists. Edges are wells, raised shadows, elevation shadows
-  and the focus ring. See `src/tokens/RULES.md` before adding a token or a
-  component style.
+- There is no generic border token. An interactive well or thumb that needs an
+  identifiable boundary takes `colors.controlEdge` through an inset or outer
+  shadow; separators remain row dividers only. See `src/tokens/RULES.md` before
+  adding a token or a component style, and the
+  [colour-contract decision](../../.agents/notes/implemented/architecture/2026-09-11-ui-semantic-color-contracts.md).
 - A focus or invalid ring is a 2px `box-shadow` composed with the control's own
   shadow, never an `outline`: the product shell resets every outline with
   `!important`, which no layer order overrides. A control that changes its edge
@@ -57,15 +59,14 @@ into one component at a time. Source-consumed; consumers compile it through
   evaluate helpers. Vars are imported from that file by a specifier ending in
   `.stylex` (`@lody/ui/tokens/colors.stylex`), never through a barrel.
 - Component tokens live beside the component as
-  `<name>/<name>.tokens.stylex.ts` and reference semantic tokens or literal px.
-  A component token that points at a semantic colour also belongs in that file's
-  `createTheme` palette theme, listed in `componentPaletteThemes` in
-  `src/theme/theme.tsx` so `ThemeRoot` applies it with every forced palette; a
-  custom property declared only at the document root keeps the root palette
-  inside a themed subtree. A family shares one group (`field` covers the label,
-  Input, Textarea, Checkbox, Radio, Switch, the Select and Combobox triggers,
-  help and error; `popup` covers the lists they open) rather than one group per
-  component.
+  `<name>/<name>.tokens.stylex.ts` and hold component-specific dimensions or
+  other values without a semantic equivalent. Component styles reference
+  semantic colours and shadows directly: do not relay them through a second
+  `defineVars` group, because inherited custom-property aliases resolve where
+  they are declared and force every subtree theme to redeclare the relay. A
+  family shares one dimensional group (`field` covers Input, Textarea,
+  Checkbox, Radio, Switch and the Select and Combobox triggers; `popup` covers
+  the lists they open) rather than one group per component.
 - `src/gallery` is the visual reference for the package. A new token, variant,
   size, tone or shape lands with its board entry in the same change, and the
   board reads sample values back off the rendered node instead of repeating a

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -5,15 +5,15 @@ tokens. Product surfaces compose these primitives through
 `@lody/components`; the package does not contain product workflows or platform
 behavior.
 
-| Area                | Responsibility                                                      |
-| ------------------- | ------------------------------------------------------------------- |
-| `src/tokens`        | Semantic color, type, spacing, motion, radius, and elevation tokens |
-| `src/theme`         | Applies light or dark StyleX themes to a subtree                    |
-| `src/button`        | Base UI Button behavior and Lody variants, sizes, tones, and shapes |
+| Area                | Responsibility                                                                                                |
+| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `src/tokens`        | Semantic color, type, spacing, motion, radius, and elevation tokens                                           |
+| `src/theme`         | Applies light or dark StyleX themes to a subtree                                                              |
+| `src/button`        | Base UI Button behavior and Lody variants, sizes, tones, and shapes                                           |
 | `src/field`         | Base UI Field composition: label, Input, Textarea, Checkbox, Radio, Switch, Select, Combobox, help, and error |
-| `src/popup`         | The floating list a Select or Combobox opens, and its tokens        |
-| `src/gallery`       | The token board: every token and primitive state, in both palettes  |
-| `stylex-options.ts` | Shared compiler configuration for source-consuming hosts            |
+| `src/popup`         | The floating list a Select or Combobox opens, and its tokens                                                  |
+| `src/gallery`       | The token board: every token and primitive state, in both palettes                                            |
+| `stylex-options.ts` | Shared compiler configuration for source-consuming hosts                                                      |
 
 Consumers compile this package's source with `@stylexjs/unplugin` and its exported
 StyleX options. Visual choices use component props. `className` is available for
@@ -73,7 +73,7 @@ const themes = [
       ))}
     </Select.Content>
   </Select.Root>
-</Field.Root>
+</Field.Root>;
 ```
 
 `Combobox` is the same list with a query in front of it. On its own the input is
@@ -88,13 +88,19 @@ treated as outside it. `@lody/components`' `DialogContent` already does this.
 
 The state mapping every control in this family shares — rest, placeholder,
 focus, invalid, disabled, checked, selected — is in
-[token rules](src/tokens/RULES.md#fields).
+[token rules](src/tokens/RULES.md#fields). Semantic colours are referenced
+directly from component styles; component token groups hold dimensions rather
+than relaying colour variables through a second theme layer. Normal text is
+checked at 4.5:1 and required non-text indicators at 3:1 across both palettes.
 
 The intended behavior is specified in [Shared UI primitives](../../specs/ui-primitives.md).
 The integration decision is recorded in the
 [UI Button migration takeover note](../../.agents/notes/implemented/architecture/2026-09-08-ui-button-migration-takeover.md);
 the field family and the Tailwind field concepts it replaces are recorded in the
 [UI field primitives note](../../.agents/notes/implemented/feature/2026-09-09-ui-field-primitives.md).
+The semantic colour contrast guarantees and removal of component colour relays
+are recorded in the
+[UI semantic colour contracts note](../../.agents/notes/implemented/architecture/2026-09-11-ui-semantic-color-contracts.md).
 
 Open the gallery with `pnpm storybook` and pick _Design System / UI Gallery_.
 It renders each sample once per palette and reads its values back off the

--- a/packages/ui/src/button/button.tokens.stylex.ts
+++ b/packages/ui/src/button/button.tokens.stylex.ts
@@ -1,5 +1,4 @@
 import * as stylex from '@stylexjs/stylex';
-import { colors, shadow } from '../tokens/colors.stylex';
 import { control, radius, text } from '../tokens/scales.stylex';
 
 export const button = stylex.defineVars({
@@ -20,32 +19,5 @@ export const button = stylex.defineVars({
   textMini: text.footnoteSize,
   text: text.subheadlineSize,
   gap: '6px',
-  primaryBackground: colors.label,
-  primaryLabel: colors.background,
-  primaryEdge: shadow.inkEdge,
-  secondaryBackground: colors.raisedBackground,
-  secondaryShadow: shadow.raised,
-  ghostLabel: colors.secondaryLabel,
-  ghostHover: colors.hoverFill,
-  ring: colors.accent,
   ringWidth: '2px',
-});
-
-/**
- * The colour-valued tokens above are declared once at the document root, so a
- * custom property that points at a semantic token resolves against the palette
- * in force there and inherits that resolved value. A theme applied to a subtree
- * would leave a button carrying the root palette. This theme re-declares those
- * tokens on the element that carries the palette, where they resolve again.
- * `ThemeRoot` applies it with every forced palette.
- */
-export const buttonPaletteTheme = stylex.createTheme(button, {
-  primaryBackground: colors.label,
-  primaryLabel: colors.background,
-  primaryEdge: shadow.inkEdge,
-  secondaryBackground: colors.raisedBackground,
-  secondaryShadow: shadow.raised,
-  ghostLabel: colors.secondaryLabel,
-  ghostHover: colors.hoverFill,
-  ring: colors.accent,
 });

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -1,7 +1,7 @@
 import { Button as BaseButton } from '@base-ui/react/button';
 import * as stylex from '@stylexjs/stylex';
 import { forwardRef, type ComponentProps } from 'react';
-import { colors } from '../tokens/colors.stylex';
+import { colors, shadow } from '../tokens/colors.stylex';
 import { corner, duration, ease, radius, text } from '../tokens/scales.stylex';
 import { button } from './button.tokens.stylex';
 
@@ -22,7 +22,7 @@ export interface ButtonProps extends Omit<BaseProps, 'className'> {
 }
 
 const PRESS = { transform: 'translateY(1px)' };
-const RING = `0 0 0 ${button.ringWidth} ${button.ring}`;
+const RING = `0 0 0 ${button.ringWidth} ${colors.accent}`;
 
 const styles = stylex.create({
   base: {
@@ -90,33 +90,33 @@ const styles = stylex.create({
   pill: { borderRadius: radius.full, cornerShape: corner.round },
   primary: {
     backgroundColor: {
-      default: button.primaryBackground,
-      ':hover': `color-mix(in oklab, ${button.primaryBackground}, ${button.primaryLabel} 12%)`,
+      default: colors.label,
+      ':hover': `color-mix(in oklab, ${colors.label}, ${colors.background} 12%)`,
     },
-    color: button.primaryLabel,
+    color: colors.background,
     boxShadow: {
-      default: button.primaryEdge,
-      ':focus-visible': `${button.primaryEdge}, ${RING}`,
+      default: shadow.inkEdge,
+      ':focus-visible': `${shadow.inkEdge}, ${RING}`,
       ':active': 'none',
     },
     transform: { default: 'none', ':active': PRESS.transform },
   },
   secondary: {
     backgroundColor: {
-      default: button.secondaryBackground,
-      ':hover': `color-mix(in oklab, ${button.secondaryBackground}, ${colors.label} 4%)`,
+      default: colors.raisedBackground,
+      ':hover': `color-mix(in oklab, ${colors.raisedBackground}, ${colors.label} 4%)`,
     },
     color: colors.label,
     boxShadow: {
-      default: button.secondaryShadow,
-      ':focus-visible': `${button.secondaryShadow}, ${RING}`,
+      default: shadow.raised,
+      ':focus-visible': `${shadow.raised}, ${RING}`,
       ':active': 'none',
     },
     transform: { default: 'none', ':active': PRESS.transform },
   },
   ghost: {
-    backgroundColor: { default: 'transparent', ':hover': button.ghostHover },
-    color: { default: button.ghostLabel, ':hover': colors.label },
+    backgroundColor: { default: 'transparent', ':hover': colors.hoverFill },
+    color: { default: colors.secondaryLabel, ':hover': colors.label },
     boxShadow: { default: 'none', ':focus-visible': RING },
   },
   destructive: {

--- a/packages/ui/src/field/combobox.tsx
+++ b/packages/ui/src/field/combobox.tsx
@@ -6,6 +6,7 @@ import { ChevronDownGlyph, TickGlyph } from '../internal/glyphs';
 import { usePopupContainer, type PopupContainer } from '../popup/portal-container';
 import { useForcedThemeClassNames } from '../theme/theme';
 import { surface } from '../popup/surface';
+import { colors } from '../tokens/colors.stylex';
 import { field } from './field.tokens.stylex';
 import { isInvalid } from './invalid';
 import { well } from './well';
@@ -118,7 +119,7 @@ const styles = stylex.create({
     borderWidth: 0,
     borderStyle: 'none',
     backgroundColor: 'transparent',
-    color: { default: field.icon, ':hover': field.value },
+    color: { default: colors.tertiaryLabel, ':hover': colors.label },
     cursor: { default: 'default', ':disabled': 'default' },
     outlineStyle: 'none',
   },

--- a/packages/ui/src/field/field.tokens.stylex.ts
+++ b/packages/ui/src/field/field.tokens.stylex.ts
@@ -1,12 +1,7 @@
 import * as stylex from '@stylexjs/stylex';
-import { colors, shadow } from '../tokens/colors.stylex';
 import { control, radius, space, text } from '../tokens/scales.stylex';
 
-/**
- * One token group for the whole field family — label, control, help and error.
- * Input, Textarea and every control that migrates next read these, so a state
- * has one colour in one place instead of one per component.
- */
+/** Dimensions shared by the whole field family. Colours remain semantic tokens. */
 export const field = stylex.defineVars({
   heightSmall: control.small,
   heightMedium: control.medium,
@@ -45,49 +40,4 @@ export const field = stylex.defineVars({
   // The rules put disabled at 45% opacity on the control. It is one value for
   // the whole family, so the control and its label cannot drift apart.
   disabledOpacity: '0.45',
-  background: colors.wellBackground,
-  well: shadow.inset,
-  value: colors.label,
-  label: colors.label,
-  placeholder: colors.tertiaryLabel,
-  hint: colors.tertiaryLabel,
-  // The chevron on a trigger and any icon at rest: a hint, not a label.
-  icon: colors.tertiaryLabel,
-  error: colors.destructive,
-  ring: colors.accent,
-  invalidRing: colors.destructive,
-  // Stored state is ink: the rules give a checked box and a switch that is on
-  // the `label` fill with `background` on top of it, the same pair the primary
-  // button uses, and the same ink edge as its top highlight. `accent` stays on
-  // live state and is not a fill.
-  checkedFill: colors.label,
-  checkedMark: colors.background,
-  checkedEdge: shadow.inkEdge,
-  // The switch thumb is raised on both tracks: it reads against the well when
-  // the switch is off and against the ink when it is on.
-  thumb: colors.raisedBackground,
-  thumbShadow: shadow.raised,
-});
-
-/**
- * Re-declares the colour-valued tokens on the element that carries a forced
- * palette; see the note in `button.tokens.stylex.ts` for why a group declared
- * only at the document root keeps the root palette inside a themed subtree.
- */
-export const fieldPaletteTheme = stylex.createTheme(field, {
-  background: colors.wellBackground,
-  well: shadow.inset,
-  value: colors.label,
-  label: colors.label,
-  placeholder: colors.tertiaryLabel,
-  hint: colors.tertiaryLabel,
-  icon: colors.tertiaryLabel,
-  error: colors.destructive,
-  ring: colors.accent,
-  invalidRing: colors.destructive,
-  checkedFill: colors.label,
-  checkedMark: colors.background,
-  checkedEdge: shadow.inkEdge,
-  thumb: colors.raisedBackground,
-  thumbShadow: shadow.raised,
 });

--- a/packages/ui/src/field/field.tsx
+++ b/packages/ui/src/field/field.tsx
@@ -10,6 +10,7 @@ import {
   type Ref,
 } from 'react';
 import { appendClassName } from '../internal/class-name';
+import { colors } from '../tokens/colors.stylex';
 import { text } from '../tokens/scales.stylex';
 import { field } from './field.tokens.stylex';
 
@@ -45,7 +46,7 @@ const styles = stylex.create({
     display: 'inline-flex',
     alignItems: 'center',
     gap: field.gap,
-    color: field.label,
+    color: colors.label,
     fontSize: field.labelSize,
     lineHeight: field.labelLeading,
     fontWeight: 500,
@@ -58,8 +59,8 @@ const styles = stylex.create({
     lineHeight: field.labelLeading,
     fontWeight: 400,
   },
-  hint: { color: field.hint },
-  error: { color: field.error },
+  hint: { color: colors.hintLabel },
+  error: { color: colors.destructive },
   // Disabled is one opacity for the family; the control dims through its own
   // `:disabled`, so nothing here stacks a second layer on top of it.
   dimmed: { opacity: field.disabledOpacity },

--- a/packages/ui/src/field/select.tsx
+++ b/packages/ui/src/field/select.tsx
@@ -6,6 +6,7 @@ import { appendClassName } from '../internal/class-name';
 import { usePopupContainer, type PopupContainer } from '../popup/portal-container';
 import { useForcedThemeClassNames } from '../theme/theme';
 import { surface } from '../popup/surface';
+import { colors } from '../tokens/colors.stylex';
 import { field } from './field.tokens.stylex';
 import { isInvalid } from './invalid';
 import { well } from './well';
@@ -108,13 +109,13 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
   },
   /** An empty trigger reads as a prompt, in the same hint colour as a placeholder. */
-  placeholder: { color: field.placeholder },
+  placeholder: { color: colors.hintLabel },
   icon: {
     display: 'flex',
     flexShrink: 0,
     width: field.iconSize,
     height: field.iconSize,
-    color: field.icon,
+    color: colors.tertiaryLabel,
   },
   /** The positioner carries no appearance; the popup inside it does. */
   positioner: { outlineStyle: 'none' },

--- a/packages/ui/src/field/switch.tsx
+++ b/packages/ui/src/field/switch.tsx
@@ -2,6 +2,7 @@ import { Switch as BaseSwitch } from '@base-ui/react/switch';
 import * as stylex from '@stylexjs/stylex';
 import { forwardRef, type ComponentProps } from 'react';
 import { appendClassName } from '../internal/class-name';
+import { colors, shadow } from '../tokens/colors.stylex';
 import { corner, duration, ease, radius } from '../tokens/scales.stylex';
 import { field } from './field.tokens.stylex';
 import { isInvalid } from './invalid';
@@ -34,8 +35,8 @@ const styles = stylex.create({
     width: field.switchThumbSize,
     height: field.switchThumbSize,
     borderRadius: radius.full,
-    backgroundColor: field.thumb,
-    boxShadow: field.thumbShadow,
+    backgroundColor: colors.raisedBackground,
+    boxShadow: `0 0 0 1px ${colors.controlEdge}, ${shadow.raised}`,
     transform: 'translateX(0)',
     transitionProperty: 'transform',
     transitionDuration: duration.fast,

--- a/packages/ui/src/field/well.ts
+++ b/packages/ui/src/field/well.ts
@@ -1,4 +1,5 @@
 import * as stylex from '@stylexjs/stylex';
+import { colors, shadow } from '../tokens/colors.stylex';
 import { corner, duration, ease, text } from '../tokens/scales.stylex';
 import { field } from './field.tokens.stylex';
 
@@ -15,8 +16,8 @@ import { field } from './field.tokens.stylex';
  * a checked box swaps the well for the ink highlight — restates the ring with
  * it, the way each Button variant does.
  */
-const RING = `0 0 0 ${field.ringWidth} ${field.ring}`;
-const INVALID_RING = `0 0 0 ${field.ringWidth} ${field.invalidRing}`;
+const RING = `0 0 0 ${field.ringWidth} ${colors.accent}`;
+const INVALID_RING = `0 0 0 ${field.ringWidth} ${colors.destructive}`;
 
 export const well = stylex.create({
   base: {
@@ -26,10 +27,10 @@ export const well = stylex.create({
     margin: 0,
     borderWidth: 0,
     borderStyle: 'none',
-    backgroundColor: field.background,
+    backgroundColor: colors.wellBackground,
     // A text control is always focus-visible, so this covers pointer focus too.
-    boxShadow: { default: field.well, ':focus-visible': `${field.well}, ${RING}` },
-    color: field.value,
+    boxShadow: { default: shadow.inset, ':focus-visible': `${shadow.inset}, ${RING}` },
+    color: colors.label,
     fontFamily: 'inherit',
     // Controls are 13 at weight 500 with controlTracking; the size step sets
     // the size, this sets the weight and tracking for every control here.
@@ -42,15 +43,15 @@ export const well = stylex.create({
     transitionProperty: 'box-shadow, opacity',
     transitionDuration: duration.fast,
     transitionTimingFunction: ease.standard,
-    '::placeholder': { color: field.placeholder, opacity: 1 },
+    '::placeholder': { color: colors.hintLabel, opacity: 1 },
   },
   // StyleX keys a conditional value per condition, so the focused case is
   // restated here; otherwise an invalid control would flip back to the accent
   // ring the moment it takes focus.
   invalid: {
     boxShadow: {
-      default: `${field.well}, ${INVALID_RING}`,
-      ':focus-visible': `${field.well}, ${INVALID_RING}`,
+      default: `${shadow.inset}, ${INVALID_RING}`,
+      ':focus-visible': `${shadow.inset}, ${INVALID_RING}`,
     },
   },
   /**
@@ -70,9 +71,9 @@ export const well = stylex.create({
     margin: 0,
     borderWidth: 0,
     borderStyle: 'none',
-    backgroundColor: field.background,
-    boxShadow: { default: field.well, ':focus-within': `${field.well}, ${RING}` },
-    color: field.value,
+    backgroundColor: colors.wellBackground,
+    boxShadow: { default: shadow.inset, ':focus-within': `${shadow.inset}, ${RING}` },
+    color: colors.label,
     cornerShape: corner.shape,
     outlineStyle: 'none',
     cursor: 'text',
@@ -82,8 +83,8 @@ export const well = stylex.create({
   },
   shellInvalid: {
     boxShadow: {
-      default: `${field.well}, ${INVALID_RING}`,
-      ':focus-within': `${field.well}, ${INVALID_RING}`,
+      default: `${shadow.inset}, ${INVALID_RING}`,
+      ':focus-within': `${shadow.inset}, ${INVALID_RING}`,
     },
   },
   /** The control inside a shell: the shell already is the well. */
@@ -104,7 +105,7 @@ export const well = stylex.create({
     letterSpacing: text.controlTracking,
     outlineStyle: 'none',
     cursor: { default: 'auto', ':disabled': 'default' },
-    '::placeholder': { color: field.placeholder, opacity: 1 },
+    '::placeholder': { color: colors.hintLabel, opacity: 1 },
   },
   /** The family's one disabled value, for a part `:disabled` cannot reach. */
   dimmed: { opacity: field.disabledOpacity },
@@ -125,9 +126,9 @@ export const well = stylex.create({
     padding: 0,
     borderWidth: 0,
     borderStyle: 'none',
-    backgroundColor: field.background,
-    boxShadow: { default: field.well, ':focus-visible': `${field.well}, ${RING}` },
-    color: field.checkedMark,
+    backgroundColor: colors.wellBackground,
+    boxShadow: { default: shadow.inset, ':focus-visible': `${shadow.inset}, ${RING}` },
+    color: colors.background,
     cornerShape: corner.shape,
     outlineStyle: 'none',
     opacity: { default: 1, ':disabled': field.disabledOpacity },
@@ -138,14 +139,14 @@ export const well = stylex.create({
   },
   /** Stored state: the ink fill and its top highlight in place of the well. */
   checked: {
-    backgroundColor: field.checkedFill,
-    boxShadow: { default: field.checkedEdge, ':focus-visible': `${field.checkedEdge}, ${RING}` },
+    backgroundColor: colors.label,
+    boxShadow: { default: shadow.inkEdge, ':focus-visible': `${shadow.inkEdge}, ${RING}` },
   },
   /** The invalid ring on that ink edge, at rest and while focused. */
   checkedInvalid: {
     boxShadow: {
-      default: `${field.checkedEdge}, ${INVALID_RING}`,
-      ':focus-visible': `${field.checkedEdge}, ${INVALID_RING}`,
+      default: `${shadow.inkEdge}, ${INVALID_RING}`,
+      ':focus-visible': `${shadow.inkEdge}, ${INVALID_RING}`,
     },
   },
 });

--- a/packages/ui/src/gallery/gallery.tsx
+++ b/packages/ui/src/gallery/gallery.tsx
@@ -192,7 +192,7 @@ const styles = stylex.create({
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
     fontSize: text.captionSize,
     lineHeight: text.captionLeading,
-    color: colors.tertiaryLabel,
+    color: colors.hintLabel,
   },
   matrix: {
     display: 'grid',
@@ -213,7 +213,7 @@ const styles = stylex.create({
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
     fontSize: text.captionSize,
     lineHeight: text.captionLeading,
-    color: colors.tertiaryLabel,
+    color: colors.hintLabel,
     overflowWrap: 'anywhere',
   },
   // A board cannot show an open popup without covering the samples under it, so
@@ -255,8 +255,8 @@ const styles = stylex.create({
     paddingInline: '12px',
     borderRadius: radius.medium,
     cornerShape: corner.shape,
-    backgroundColor: button.secondaryBackground,
-    boxShadow: `${button.secondaryShadow}, 0 0 0 ${button.ringWidth} ${button.ring}`,
+    backgroundColor: colors.raisedBackground,
+    boxShadow: `${shadow.raised}, 0 0 0 ${button.ringWidth} ${colors.accent}`,
     color: colors.label,
     fontSize: text.subheadlineSize,
     fontWeight: 500,
@@ -268,11 +268,11 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     height: field.heightMedium,
     paddingInline: field.paddingXMedium,
-    backgroundColor: field.background,
-    boxShadow: `${field.well}, 0 0 0 ${field.ringWidth} ${field.ring}`,
+    backgroundColor: colors.wellBackground,
+    boxShadow: `${shadow.inset}, 0 0 0 ${field.ringWidth} ${colors.accent}`,
     borderRadius: field.radiusMedium,
     cornerShape: corner.shape,
-    color: field.value,
+    color: colors.label,
     fontSize: field.text,
     fontWeight: 500,
     letterSpacing: text.controlTracking,
@@ -290,7 +290,8 @@ const SURFACES = [
 const CONTENT_COLORS = [
   { name: 'label', value: colors.label, note: 'the thing' },
   { name: 'secondaryLabel', value: colors.secondaryLabel, note: 'about the thing' },
-  { name: 'tertiaryLabel', value: colors.tertiaryLabel, note: 'placeholder, hint, icon at rest' },
+  { name: 'hintLabel', value: colors.hintLabel, note: 'placeholder and help text' },
+  { name: 'tertiaryLabel', value: colors.tertiaryLabel, note: 'icon at rest' },
 ];
 
 const FILLS = [
@@ -305,6 +306,7 @@ const ROLE_COLORS = [
   { name: 'onAccent', value: colors.onAccent, note: 'content on accent' },
   { name: 'destructive', value: colors.destructive, note: 'destructive fill, invalid ring' },
   { name: 'onDestructive', value: colors.onDestructive, note: 'content on destructive' },
+  { name: 'controlEdge', value: colors.controlEdge, note: 'identifiable well and thumb edge' },
 ];
 
 const GRAYS = [
@@ -448,26 +450,34 @@ const CONSTS = [
 ];
 
 const FIELD_COLORS = [
-  { name: 'field.background', value: field.background, note: 'the control is a well' },
-  { name: 'field.value', value: field.value, note: 'what the person typed' },
-  { name: 'field.label', value: field.label, note: 'the field label' },
-  { name: 'field.placeholder', value: field.placeholder, note: 'the empty prompt' },
-  { name: 'field.hint', value: field.hint, note: 'help under the control' },
-  { name: 'field.icon', value: field.icon, note: 'the chevron on a trigger' },
-  { name: 'field.error', value: field.error, note: 'the error message' },
-  { name: 'field.ring', value: field.ring, note: 'focus' },
-  { name: 'field.invalidRing', value: field.invalidRing, note: 'invalid' },
+  { name: 'field.background', value: colors.wellBackground, note: 'colors.wellBackground' },
+  { name: 'field.value', value: colors.label, note: 'colors.label' },
+  { name: 'field.label', value: colors.label, note: 'colors.label' },
+  { name: 'field.placeholder', value: colors.hintLabel, note: 'colors.hintLabel' },
+  { name: 'field.hint', value: colors.hintLabel, note: 'colors.hintLabel' },
+  { name: 'field.icon', value: colors.tertiaryLabel, note: 'colors.tertiaryLabel' },
+  { name: 'field.error', value: colors.destructive, note: 'colors.destructive' },
+  { name: 'field.ring', value: colors.accent, note: 'colors.accent' },
+  { name: 'field.invalidRing', value: colors.destructive, note: 'colors.destructive' },
 ];
 
 const POPUP_COLORS = [
-  { name: 'popup.background', value: popup.background, note: 'the floating rung' },
-  { name: 'popup.label', value: popup.label, note: 'a row' },
-  { name: 'popup.indicator', value: popup.indicator, note: 'the tick on the current row' },
-  { name: 'popup.highlight', value: popup.highlight, note: 'where the keyboard or pointer is' },
-  { name: 'popup.selected', value: popup.selected, note: 'the row that holds the value' },
-  { name: 'popup.groupLabel', value: popup.groupLabel, note: 'a group heading' },
-  { name: 'popup.separator', value: popup.separator, note: 'between groups' },
-  { name: 'popup.hint', value: popup.hint, note: 'no matches, scroll arrows' },
+  { name: 'popup.background', value: colors.raisedBackground, note: 'colors.raisedBackground' },
+  { name: 'popup.label', value: colors.label, note: 'colors.label' },
+  { name: 'popup.indicator', value: colors.label, note: 'colors.label' },
+  {
+    name: 'popup.highlight',
+    value: `color-mix(in oklab, ${colors.raisedBackground}, ${colors.label} 6%)`,
+    note: 'subtle fill plus an accent inset ring',
+  },
+  {
+    name: 'popup.selected',
+    value: `color-mix(in oklab, ${colors.raisedBackground}, ${colors.label} 3%)`,
+    note: 'subtle fill plus the tick',
+  },
+  { name: 'popup.groupLabel', value: colors.secondaryLabel, note: 'colors.secondaryLabel' },
+  { name: 'popup.separator', value: colors.separator, note: 'colors.separator' },
+  { name: 'popup.hint', value: colors.hintLabel, note: 'colors.hintLabel' },
 ];
 
 const SELECT_SIZES = [
@@ -485,9 +495,9 @@ const FRUIT = [
 const LANGUAGES = ['TypeScript', 'Rust', 'Python', 'Ruby'];
 
 const CHOICE_COLORS = [
-  { name: 'field.checkedFill', value: field.checkedFill, note: 'a control that holds a value' },
-  { name: 'field.checkedMark', value: field.checkedMark, note: 'the tick and the dot on it' },
-  { name: 'field.thumb', value: field.thumb, note: 'the switch thumb, on both tracks' },
+  { name: 'field.checkedFill', value: colors.label, note: 'colors.label' },
+  { name: 'field.checkedMark', value: colors.background, note: 'colors.background' },
+  { name: 'field.thumb', value: colors.raisedBackground, note: 'colors.raisedBackground' },
 ];
 
 const FIELD_SIZES = [
@@ -994,7 +1004,7 @@ export function UiGallery({ palettes = 'both' }: UiGalleryProps) {
 
       <Section
         title="Content"
-        rule="label is the thing, secondaryLabel is about the thing, tertiaryLabel is a hint."
+        rule="label is the thing, secondaryLabel is about it, hintLabel is readable prompt or help text, and tertiaryLabel is non-text icon ink."
       >
         <PaletteSplit palettes={palettes}>
           <div {...stylex.props(styles.textSample)}>
@@ -1002,9 +1012,7 @@ export function UiGallery({ palettes = 'both' }: UiGalleryProps) {
             <span {...stylex.props(dyn.text(colors.secondaryLabel))}>
               secondaryLabel — 4 files changed
             </span>
-            <span {...stylex.props(dyn.text(colors.tertiaryLabel))}>
-              tertiaryLabel — Describe the task
-            </span>
+            <span {...stylex.props(dyn.text(colors.hintLabel))}>hintLabel — Describe the task</span>
           </div>
           <Grid>
             {CONTENT_COLORS.map((token) => (
@@ -1299,10 +1307,10 @@ export function UiGallery({ palettes = 'both' }: UiGalleryProps) {
             ))}
             <ShadowChip
               name="field.well"
-              box={field.well}
-              fill={field.background}
+              box={shadow.inset}
+              fill={colors.wellBackground}
               ink={false}
-              note="the control is sunken, not outlined"
+              note="sunken control with a contrast-checked inset edge"
             />
           </Grid>
         </PaletteSplit>
@@ -1403,17 +1411,17 @@ export function UiGallery({ palettes = 'both' }: UiGalleryProps) {
             ))}
             <ShadowChip
               name="field.checkedEdge"
-              box={field.checkedEdge}
-              fill={field.checkedFill}
+              box={shadow.inkEdge}
+              fill={colors.label}
               ink
               note="the ink highlight a checked control carries"
             />
             <ShadowChip
               name="field.thumbShadow"
-              box={field.thumbShadow}
-              fill={field.thumb}
+              box={`0 0 0 1px ${colors.controlEdge}, ${shadow.raised}`}
+              fill={colors.raisedBackground}
               ink={false}
-              note="the thumb is raised on both tracks"
+              note="the thumb is raised and identifiable on both tracks"
             />
           </Grid>
         </PaletteSplit>
@@ -1454,8 +1462,8 @@ export function UiGallery({ palettes = 'both' }: UiGalleryProps) {
             ))}
             <ShadowChip
               name="popup.shadow"
-              box={popup.shadow}
-              fill={popup.background}
+              box={shadow.popover}
+              fill={colors.raisedBackground}
               ink={false}
               note="the floating rung, above the page"
             />

--- a/packages/ui/src/gallery/parts.tsx
+++ b/packages/ui/src/gallery/parts.tsx
@@ -105,7 +105,7 @@ const styles = stylex.create({
     fontWeight: 500,
     letterSpacing: '0.06em',
     textTransform: 'uppercase',
-    color: colors.tertiaryLabel,
+    color: colors.hintLabel,
   },
   grid: {
     display: 'grid',
@@ -132,7 +132,7 @@ const styles = stylex.create({
     fontFamily: MONO,
     fontSize: text.captionSize,
     lineHeight: text.captionLeading,
-    color: colors.tertiaryLabel,
+    color: colors.hintLabel,
     overflowWrap: 'anywhere',
   },
   legendKey: {

--- a/packages/ui/src/popup/popup.tokens.stylex.ts
+++ b/packages/ui/src/popup/popup.tokens.stylex.ts
@@ -1,19 +1,16 @@
 import * as stylex from '@stylexjs/stylex';
-import { colors, shadow } from '../tokens/colors.stylex';
 import { control, radius, space, text } from '../tokens/scales.stylex';
 
 /**
  * One token group for every list that floats over the page — the Select popup,
  * the Combobox popup, and the menus that follow. It is deliberately not part of
  * the `field` group: a trigger is a control on the well rung and reads `field`,
- * while the list it opens is on the floating rung and shares its vocabulary with
- * a menu rather than with an input. A menu that reached for `field.background`
- * would be naming the wrong thing to get the right colour.
+ * while the list it opens is on the floating rung and shares its dimensions with
+ * a menu rather than with an input. Colours stay in the semantic group and are
+ * referenced directly by `surface.ts`, so a forced subtree theme needs no second
+ * component-variable theme to relay them.
  */
 export const popup = stylex.defineVars({
-  // The floating rung: raised background plus the popover shadow, together.
-  background: colors.raisedBackground,
-  shadow: shadow.popover,
   // Nested radius is outer minus inset: a 14px surface with a 4px inset holds
   // 10px rows. The row radius is derived from that pair rather than picked.
   radius: radius.large,
@@ -31,41 +28,4 @@ export const popup = stylex.defineVars({
   // The rules put popups at 4px below at opacity 0, rising over duration.regular.
   rise: '4px',
   scrollArrowHeight: '20px',
-  label: colors.label,
-  hint: colors.tertiaryLabel,
-  groupLabel: colors.secondaryLabel,
-  separator: colors.separator,
-  // Two different facts about a row: `highlighted` is where the keyboard or the
-  // pointer is right now, `selected` is the row that holds the value, and the
-  // tick keeps saying which is current when the highlight moves onto it.
-  //
-  // Both are derived from the rung they sit on rather than taken from
-  // `hoverFill` and `selectedFill`, which the rules name for a row but which
-  // were tuned against the page and card rungs at 100% lightness. On the
-  // floating rung they collapse: measured in Chromium, `hoverFill` lands 2/255
-  // from `raisedBackground` in Lody Light and `selectedFill` resolves to
-  // exactly `raisedBackground` in Vesper, so one state is invisible in each
-  // palette. Mixing toward `label` steps away from the surface in both
-  // directions at once — darker in a light palette, lighter in a dark one —
-  // which is the same derivation `Button` uses for a secondary button's hover.
-  highlight: `color-mix(in oklab, ${colors.raisedBackground}, ${colors.label} 6%)`,
-  selected: `color-mix(in oklab, ${colors.raisedBackground}, ${colors.label} 3%)`,
-  indicator: colors.label,
-});
-
-/**
- * Re-declares the colour-valued tokens on the element carrying a forced palette;
- * see `button.tokens.stylex.ts` for why a group declared only at the document
- * root keeps the root palette inside a themed subtree.
- */
-export const popupPaletteTheme = stylex.createTheme(popup, {
-  background: colors.raisedBackground,
-  shadow: shadow.popover,
-  label: colors.label,
-  hint: colors.tertiaryLabel,
-  groupLabel: colors.secondaryLabel,
-  separator: colors.separator,
-  highlight: `color-mix(in oklab, ${colors.raisedBackground}, ${colors.label} 6%)`,
-  selected: `color-mix(in oklab, ${colors.raisedBackground}, ${colors.label} 3%)`,
-  indicator: colors.label,
 });

--- a/packages/ui/src/popup/surface.ts
+++ b/packages/ui/src/popup/surface.ts
@@ -1,4 +1,5 @@
 import * as stylex from '@stylexjs/stylex';
+import { colors, shadow } from '../tokens/colors.stylex';
 import { corner, duration, ease, text, z } from '../tokens/scales.stylex';
 import { popup } from './popup.tokens.stylex';
 
@@ -11,10 +12,10 @@ import { popup } from './popup.tokens.stylex';
  * together.
  *
  * A row states two different facts at once. `highlighted` is where the keyboard
- * or the pointer is right now and takes `popup.highlight`; `selected` is the row
- * that holds the value and takes `popup.selected`. When the highlight lands on
- * the selected row the highlight wins the fill, because that is the one that
- * moves — the tick keeps saying which row is current.
+ * or the pointer is right now and carries an accent inset ring; `selected` is
+ * the row that holds the value and carries a tick. When the highlight lands on
+ * the selected row it wins the fill, while the tick keeps saying which row is
+ * current.
  */
 export const surface = stylex.create({
   /** The floating rung: raised background and the popover shadow, together. */
@@ -26,11 +27,11 @@ export const surface = stylex.create({
     maxHeight: 'var(--available-height)',
     maxWidth: 'var(--available-width)',
     padding: popup.inset,
-    backgroundColor: popup.background,
-    boxShadow: popup.shadow,
+    backgroundColor: colors.raisedBackground,
+    boxShadow: shadow.popover,
     borderRadius: popup.radius,
     cornerShape: corner.shape,
-    color: popup.label,
+    color: colors.label,
     fontFamily: 'inherit',
     fontSize: popup.text,
     fontWeight: 500,
@@ -80,27 +81,30 @@ export const surface = stylex.create({
     borderRadius: popup.itemRadius,
     cornerShape: corner.shape,
     backgroundColor: 'transparent',
-    color: popup.label,
+    color: colors.label,
     // A list row is not a button: the pointer picks it, it does not press it.
     cursor: 'default',
     userSelect: 'none',
     outlineStyle: 'none',
-    // A row owns its edge, which is no edge. Base UI moves DOM focus onto the
-    // highlighted row, and the product shell puts an inset accent ring on any
-    // focused `[tabindex]` through a zero-specificity `:where()` rule — it
-    // already exempts `[role="menuitem"]` for this exact reason, and an option
-    // is the same case. Stating `none` here means the row cannot pick up a ring
-    // from any host: the fill is how this system says where the keyboard is.
+    // A row owns its edge. Base UI moves DOM focus onto the highlighted row,
+    // and the product shell puts a ring on focused `[tabindex]` through a
+    // zero-specificity rule. The rest state suppresses that host ring; the
+    // highlighted state below supplies the package's contrast-checked one.
     boxShadow: 'none',
     scrollMarginBlock: popup.inset,
-    transitionProperty: 'background-color, opacity',
+    transitionProperty: 'background-color, box-shadow, opacity',
     transitionDuration: duration.fast,
     transitionTimingFunction: ease.standard,
   },
   /** The row that holds the value. */
-  itemSelected: { backgroundColor: popup.selected },
+  itemSelected: {
+    backgroundColor: `color-mix(in oklab, ${colors.raisedBackground}, ${colors.label} 3%)`,
+  },
   /** Where the keyboard or the pointer is; it wins over the selected fill. */
-  itemHighlighted: { backgroundColor: popup.highlight },
+  itemHighlighted: {
+    backgroundColor: `color-mix(in oklab, ${colors.raisedBackground}, ${colors.label} 6%)`,
+    boxShadow: `inset 0 0 0 2px ${colors.accent}`,
+  },
   /** The same 45% the whole library uses, and no pointer. */
   itemDisabled: { opacity: 0.45, pointerEvents: 'none' },
   /**
@@ -126,7 +130,7 @@ export const surface = stylex.create({
     flexShrink: 0,
     width: popup.indicatorSize,
     height: popup.indicatorSize,
-    color: popup.indicator,
+    color: colors.label,
   },
   indicatorGlyph: { display: 'block', width: popup.indicatorSize, height: popup.indicatorSize },
   /** A group heading: about the rows under it, so the secondary label colour. */
@@ -136,7 +140,7 @@ export const surface = stylex.create({
     alignItems: 'center',
     minHeight: popup.itemHeight,
     paddingInline: popup.itemPaddingX,
-    color: popup.groupLabel,
+    color: colors.secondaryLabel,
     fontSize: popup.groupLabelSize,
     lineHeight: popup.groupLabelLeading,
     fontWeight: 500,
@@ -150,7 +154,7 @@ export const surface = stylex.create({
     flexShrink: 0,
     marginBlock: popup.inset,
     marginInline: `calc(-1 * ${popup.inset})`,
-    backgroundColor: popup.separator,
+    backgroundColor: colors.separator,
   },
   /**
    * "No matches": a hint rather than a row, because it cannot be picked.
@@ -170,7 +174,7 @@ export const surface = stylex.create({
     alignItems: 'center',
     minHeight: { default: popup.itemHeight, ':empty': 0 },
     paddingInline: { default: popup.itemPaddingX, ':empty': 0 },
-    color: popup.hint,
+    color: colors.hintLabel,
     fontWeight: 400,
     userSelect: 'none',
   },
@@ -181,8 +185,8 @@ export const surface = stylex.create({
     justifyContent: 'center',
     flexShrink: 0,
     height: popup.scrollArrowHeight,
-    backgroundColor: popup.background,
-    color: popup.hint,
+    backgroundColor: colors.raisedBackground,
+    color: colors.tertiaryLabel,
     cursor: 'default',
     userSelect: 'none',
   },

--- a/packages/ui/src/theme/theme.tsx
+++ b/packages/ui/src/theme/theme.tsx
@@ -1,18 +1,8 @@
 import * as stylex from '@stylexjs/stylex';
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
-import { buttonPaletteTheme } from '../button/button.tokens.stylex';
-import { fieldPaletteTheme } from '../field/field.tokens.stylex';
-import { popupPaletteTheme } from '../popup/popup.tokens.stylex';
 import { darkShadowTheme, darkTheme, lightShadowTheme, lightTheme } from '../tokens/colors.stylex';
 
 export type ThemeMode = 'system' | 'light' | 'dark';
-
-/**
- * Every component token group that points at a semantic colour. These are
- * re-declared on the element carrying a forced palette so they resolve against
- * it; a group declared only at the document root keeps the root palette.
- */
-const componentPaletteThemes = [buttonPaletteTheme, fieldPaletteTheme, popupPaletteTheme];
 
 const styles = stylex.create({
   system: { colorScheme: 'light dark' },
@@ -23,9 +13,7 @@ const styles = stylex.create({
 export function forcedThemeClassNames(mode: ThemeMode): string[] {
   if (mode === 'system') return [];
   const palette = mode === 'dark' ? [darkTheme, darkShadowTheme] : [lightTheme, lightShadowTheme];
-  return (stylex.props(...palette, ...componentPaletteThemes).className ?? '')
-    .split(' ')
-    .filter(Boolean);
+  return (stylex.props(...palette).className ?? '').split(' ').filter(Boolean);
 }
 
 /**
@@ -35,9 +23,8 @@ export function forcedThemeClassNames(mode: ThemeMode): string[] {
  * element and everything under it inherits. A popup breaks that, because it is
  * portalled out to the document and inherits the root palette instead — so a
  * light panel on a dark page opens a dark list. The subtree publishes which
- * palette it is under, and the parts that portal re-declare it on the element
- * they mount, which is the same fix the component token groups already make for
- * a custom property declared only at the root.
+ * palette it is under, and the parts that portal re-declare the same semantic
+ * colour and shadow themes on the element they mount.
  */
 const ForcedTheme = createContext<ThemeMode>('system');
 
@@ -68,7 +55,6 @@ export function ThemeRoot({ mode, children }: { mode: ThemeMode; children: React
           mode === 'dark' && darkShadowTheme,
           mode === 'light' && lightTheme,
           mode === 'light' && lightShadowTheme,
-          mode !== 'system' && componentPaletteThemes,
           styles[mode]
         )}
       >

--- a/packages/ui/src/tokens/RULES.md
+++ b/packages/ui/src/tokens/RULES.md
@@ -1,7 +1,8 @@
 # Token usage rules
 
-Construction: depth without lines. No border token exists. Surfaces separate by
-luminance step and shadow; controls are wells (sunken) or raised.
+Construction: depth without generic borders. Surfaces separate by luminance step
+and shadow; controls are wells (sunken) or raised. An interactive part that needs
+its boundary to be understood carries the semantic `controlEdge` in its shadow.
 
 ## Elevation ladder
 
@@ -20,7 +21,8 @@ One rung per component. The rung fixes background and shadow together.
 
 - `separator`: next row. Dividers between list and table rows only. Never
   around a surface, never under a header.
-- well: you can put something here. `wellBackground` + `shadow.inset`.
+- well: you can put something here. `wellBackground` + `shadow.inset`; the
+  shadow includes a 1px `controlEdge` so the boundary reaches 3:1.
 - raised: you can press this. `raisedBackground` + `shadow.raised`. Primary and
   destructive buttons are raised with `shadow.inkEdge` as their top highlight.
 - shadow: above the page. Strength by rung.
@@ -30,8 +32,9 @@ One rung per component. The rung fixes background and shadow together.
 
 ## Color
 
-- `label` is the thing, `secondaryLabel` is about the thing, `tertiaryLabel`
-  is a hint: placeholder, help text, chevron, icon at rest.
+- `label` is the thing and `secondaryLabel` is about the thing. `hintLabel` is
+  readable prompt or help text. `tertiaryLabel` is non-text icon ink; do not use
+  it for normal text.
 - Ink for stored state: primary button, checked, on. `label` fill,
   `background` text.
 - `accent` for live state only: focus ring, link, live switch, running
@@ -39,44 +42,49 @@ One rung per component. The rung fixes background and shadow together.
 - Disabled is 45% opacity on the whole control, not a color.
 - Semantic first, gray second. `gray…gray6` only for things with no role:
   scrollbar, tracks, kbd, skeleton.
+- Normal-text colours reach 4.5:1 on every surface rung. `tertiaryLabel`,
+  `controlEdge`, focus and invalid indicators reach 3:1. These are contracts,
+  not descriptions; `test/color-contrast.test.ts` enforces the palette values.
 
 ## Fields
 
-A control is the well rung: `wellBackground` plus `shadow.inset`, never a
-border. One component token group, `field`, serves the whole family — input,
-textarea, checkbox, radio, switch and the Select and Combobox triggers — so a
-state has one colour in one place instead of one per component. The lists those
-triggers open are on the floating rung and read `popup` instead; see below.
+A control is the well rung: `wellBackground` plus `shadow.inset`; the inset
+`controlEdge` is its identifiable boundary rather than a generic border. The
+`field` variable group holds the dimensions shared by input, textarea, checkbox,
+radio, switch and the Select and Combobox triggers. Their colours reference the
+semantic group directly, so a forced subtree palette does not need a component
+theme to relay it. The lists those triggers open are on the floating rung and
+share the `popup` dimensions instead; see below.
 
-| state       | what it is                                                                     |
-| ----------- | ------------------------------------------------------------------------------ |
-| rest        | `field.background` and `field.well`; the value in `field.value`                |
-| placeholder | `field.placeholder`, the hint colour; it is a prompt, not a label              |
-| focus       | 2px `field.ring` (accent), tight to the control, no offset                     |
-| invalid     | 2px `field.invalidRing` (destructive), at rest and while focused               |
-| disabled    | 45% opacity on the control; the label and help dim with it                     |
-| checked, on | ink: `field.checkedFill` under `field.checkedMark`, `field.checkedEdge` on top |
-| mixed       | the checked appearance with the dash, and it announces `mixed`                 |
-| selected    | the tick, and a quiet fill on the row that is current, not on the control      |
+| state       | what it is                                                                |
+| ----------- | ------------------------------------------------------------------------- |
+| rest        | `wellBackground` and `shadow.inset`; the value is in `label`              |
+| placeholder | `hintLabel`, a readable prompt rather than non-text tertiary ink          |
+| focus       | 2px `accent`, tight to the control, no offset                             |
+| invalid     | 2px `destructive`, at rest and while focused                              |
+| disabled    | 45% opacity on the control; the label and help dim with it                |
+| checked, on | ink: `label` under the `background` mark, with `shadow.inkEdge` on top    |
+| mixed       | the checked appearance with the dash, and it announces `mixed`            |
+| selected    | the tick, and a quiet fill on the row that is current, not on the control |
 
 A checkbox and a radio are the "16px things" the corner rule names: a
 `field.boxSize` box at `radius.mini`, round for a radio. A switch is a
 `field.switchWidth` by `field.switchHeight` track at `radius.full` holding a
-`field.thumb` thumb raised with `field.thumbShadow`, the same height as the box
-so a settings row carrying both lines up. Off is the well; on is the ink, which
-is where the well's shadow gives way to `field.checkedEdge`. Because CSS cannot
-append to a box-shadow list, a control that changes its edge restates the ring
-with it, the way each Button variant does.
+`raisedBackground` thumb with `shadow.raised` and a `controlEdge`, the same height
+as the box so a settings row carrying both lines up. Off is the well; on is the
+ink, which is where the well's shadow gives way to `shadow.inkEdge`. Because CSS
+cannot append to a box-shadow list, a control that changes its edge restates the
+ring with it, the way each Button variant does.
 
 These three render a real `<button>` with Base UI's hidden input beside it, so
 `:disabled` and `:focus-visible` reach them the way they reach an `<input>` and
 a `<label>` can point at them.
 
 The control's own text follows the control rule at every size on the ladder: 13
-at weight 500 with `text.controlTracking`. Label at 12 weight 500 in
-`field.label`, help at 12 weight 400 in `field.hint`, error at 12 weight 400 in
-`field.error`, stacked at `field.gap`. Disabled reads `field.disabledOpacity`
-rather than a literal, so the control and its label cannot drift apart.
+at weight 500 with `text.controlTracking`. Label at 12 weight 500 in `label`,
+help at 12 weight 400 in `hintLabel`, error at 12 weight 400 in `destructive`,
+stacked at `field.gap`. Disabled reads `field.disabledOpacity` rather than a
+literal, so the control and its label cannot drift apart.
 
 `Field.Root` owns the name, the disabled flag and validity. A control reads that
 state and picks its own classes from it; it does not take a second `invalid` or
@@ -90,21 +98,21 @@ ARIA value except `false` is invalid, `grammar` and `spelling` included.
 
 ### Popups and lists
 
-A control on the well rung opens a list on the floating rung, and the two do not
-share a token group. `field` covers the trigger — the size ladder, the ring, the
-invalid ring, the disabled opacity — and `popup` covers the list, because that
-list has more in common with a menu than with an input. A menu reaching for
-`field.background` would be naming the wrong thing to get the right colour.
+A control on the well rung opens a list on the floating rung. `field` covers the
+trigger dimensions and `popup` covers the list dimensions, because that list has
+more in common with a menu than with an input. Both reference semantic colours
+directly; neither duplicates the palette in a component variable group.
 
-A popup is `popup.background` with `popup.shadow` at `popup.radius`, inset by
+A popup is `raisedBackground` with `shadow.popover` at `popup.radius`, inset by
 `popup.inset`, so its rows take `popup.itemRadius` — outer minus inset, 14 less
 4, rather than a token of their own. A row is a `popup.itemHeight` control that
 happens to live in a list, so it follows the control type rule.
 
 A row states two facts at once. `highlighted` is where the keyboard or the
-pointer is right now; `selected` is the row that holds the value, and carries
-the tick. The highlight wins the fill, because it is the one that moves; the
-tick keeps saying which row is current when it lands there.
+pointer is right now and carries a 2px accent inset ring; `selected` is the row
+that holds the value, and carries the tick. The highlight wins the quiet fill,
+because it is the one that moves; the tick keeps saying which row is current
+when it lands there.
 
 Both fills are derived from the rung rather than taken from `hoverFill` and
 `selectedFill`, which this table names for a row but which were tuned against
@@ -119,13 +127,11 @@ A popup opens anchored 4px under its control and rises into place, rather than
 overlapping it to line the current row up with the value. That is the motion
 rule applied: a popup rises from 4px below at `duration.regular`.
 
-A row has no edge of its own, and says so. A popup moves keyboard focus onto the
-highlighted row, and a host that rings any focused element would draw a border
-around it; the fill is how this system marks where the keyboard is, so the row
-declares `box-shadow: none` rather than leaving the property unclaimed. The
-"nothing matches" line collapses to nothing while it holds nothing, because it
-stays mounted for a screen reader to announce into and would otherwise open
-every popup with a blank row.
+A row suppresses the host's generic focus edge and supplies its own accent inset
+ring while highlighted. The fill may remain subtle because it is no longer the
+only focus signal. The "nothing matches" line collapses to nothing while it holds
+nothing, because it stays mounted for a screen reader to announce into and would
+otherwise open every popup with a blank row.
 
 ## Corners
 

--- a/packages/ui/src/tokens/colors.stylex.ts
+++ b/packages/ui/src/tokens/colors.stylex.ts
@@ -9,14 +9,16 @@ export const colors = stylex.defineVars({
   secondaryBackground: { default: 'hsl(220 23% 97.5%)', [DARK]: 'hsl(0 0% 8.6%)' },
   wellBackground: { default: 'hsl(216 12% 92%)', [DARK]: 'hsl(0 0% 11%)' },
   label: { default: 'hsl(225 7% 11%)', [DARK]: 'hsl(0 0% 100%)' },
-  secondaryLabel: { default: 'hsl(220 9% 46%)', [DARK]: 'hsl(0 0% 62.7%)' },
-  tertiaryLabel: { default: 'hsl(220 8% 62%)', [DARK]: 'hsl(0 0% 45%)' },
+  secondaryLabel: { default: 'hsl(220 9% 40%)', [DARK]: 'hsl(0 0% 62.7%)' },
+  hintLabel: { default: 'hsl(220 8% 42%)', [DARK]: 'hsl(0 0% 58%)' },
+  tertiaryLabel: { default: 'hsl(220 8% 53%)', [DARK]: 'hsl(0 0% 45%)' },
+  controlEdge: { default: 'hsl(220 8% 53%)', [DARK]: 'hsl(0 0% 45%)' },
   separator: { default: 'hsl(223 16% 91.6%)', [DARK]: 'hsl(0 0% 15.7%)' },
   hoverFill: { default: 'hsl(225 15% 94.9%)', [DARK]: 'hsl(0 0% 15.7%)' },
   selectedFill: { default: 'hsl(223 18% 92.4%)', [DARK]: 'hsl(0 0% 13.7%)' },
-  accent: { default: 'hsl(220 82% 65%)', [DARK]: 'hsl(27 100% 80%)' },
+  accent: { default: 'hsl(220 82% 50%)', [DARK]: 'hsl(27 100% 80%)' },
   onAccent: { default: 'hsl(0 0% 100%)', [DARK]: 'hsl(0 0% 0%)' },
-  destructive: { default: 'hsl(356 72% 47%)', [DARK]: 'hsl(0 100% 75%)' },
+  destructive: { default: 'hsl(356 72% 46%)', [DARK]: 'hsl(0 100% 75%)' },
   onDestructive: { default: 'hsl(0 0% 100%)', [DARK]: 'hsl(0 0% 0%)' },
   overlay: { default: 'hsl(225 7% 11% / 0.5)', [DARK]: 'hsl(0 0% 0% / 0.6)' },
   gray: { default: 'hsl(220 8% 62%)', [DARK]: 'hsl(0 0% 42%)' },
@@ -29,8 +31,8 @@ export const colors = stylex.defineVars({
 
 export const shadow = stylex.defineVars({
   inset: {
-    default: 'inset 0 1px 2px hsl(225 10% 11% / 0.07)',
-    [DARK]: 'inset 0 1px 2px hsl(0 0% 0% / 0.7)',
+    default: `inset 0 0 0 1px ${colors.controlEdge}, inset 0 1px 2px hsl(225 10% 11% / 0.07)`,
+    [DARK]: `inset 0 0 0 1px ${colors.controlEdge}, inset 0 1px 2px hsl(0 0% 0% / 0.7)`,
   },
   raised: {
     default: '0 1px 2px hsl(225 10% 11% / 0.12), 0 0 0 0.5px hsl(225 10% 11% / 0.05)',
@@ -66,7 +68,9 @@ export const darkTheme = stylex.createTheme(colors, {
   wellBackground: 'hsl(0 0% 11%)',
   label: 'hsl(0 0% 100%)',
   secondaryLabel: 'hsl(0 0% 62.7%)',
+  hintLabel: 'hsl(0 0% 58%)',
   tertiaryLabel: 'hsl(0 0% 45%)',
+  controlEdge: 'hsl(0 0% 45%)',
   separator: 'hsl(0 0% 15.7%)',
   hoverFill: 'hsl(0 0% 15.7%)',
   selectedFill: 'hsl(0 0% 13.7%)',
@@ -90,14 +94,16 @@ export const lightTheme = stylex.createTheme(colors, {
   secondaryBackground: 'hsl(220 23% 97.5%)',
   wellBackground: 'hsl(216 12% 92%)',
   label: 'hsl(225 7% 11%)',
-  secondaryLabel: 'hsl(220 9% 46%)',
-  tertiaryLabel: 'hsl(220 8% 62%)',
+  secondaryLabel: 'hsl(220 9% 40%)',
+  hintLabel: 'hsl(220 8% 42%)',
+  tertiaryLabel: 'hsl(220 8% 53%)',
+  controlEdge: 'hsl(220 8% 53%)',
   separator: 'hsl(223 16% 91.6%)',
   hoverFill: 'hsl(225 15% 94.9%)',
   selectedFill: 'hsl(223 18% 92.4%)',
-  accent: 'hsl(220 82% 65%)',
+  accent: 'hsl(220 82% 50%)',
   onAccent: 'hsl(0 0% 100%)',
-  destructive: 'hsl(356 72% 47%)',
+  destructive: 'hsl(356 72% 46%)',
   onDestructive: 'hsl(0 0% 100%)',
   overlay: 'hsl(225 7% 11% / 0.5)',
   gray: 'hsl(220 8% 62%)',
@@ -109,7 +115,7 @@ export const lightTheme = stylex.createTheme(colors, {
 });
 
 export const darkShadowTheme = stylex.createTheme(shadow, {
-  inset: 'inset 0 1px 2px hsl(0 0% 0% / 0.7)',
+  inset: `inset 0 0 0 1px ${colors.controlEdge}, inset 0 1px 2px hsl(0 0% 0% / 0.7)`,
   raised: 'inset 0 1px 0 hsl(0 0% 100% / 0.07), 0 1px 2px hsl(0 0% 0% / 0.5)',
   inkEdge: 'inset 0 1px 0 hsl(0 0% 100% / 0.55)',
   card: 'inset 0 1px 0 hsl(0 0% 100% / 0.04), 0 10px 30px hsl(0 0% 0% / 0.45)',
@@ -119,7 +125,7 @@ export const darkShadowTheme = stylex.createTheme(shadow, {
 });
 
 export const lightShadowTheme = stylex.createTheme(shadow, {
-  inset: 'inset 0 1px 2px hsl(225 10% 11% / 0.07)',
+  inset: `inset 0 0 0 1px ${colors.controlEdge}, inset 0 1px 2px hsl(225 10% 11% / 0.07)`,
   raised: '0 1px 2px hsl(225 10% 11% / 0.12), 0 0 0 0.5px hsl(225 10% 11% / 0.05)',
   inkEdge: 'inset 0 1px 0 hsl(0 0% 100% / 0.16)',
   card: '0 1px 2px hsl(225 10% 11% / 0.05), 0 10px 30px hsl(225 10% 11% / 0.06)',

--- a/packages/ui/test/color-contrast.test.ts
+++ b/packages/ui/test/color-contrast.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'vitest';
+import source from '../src/tokens/colors.stylex.ts?raw';
+
+type Rgb = readonly [number, number, number];
+type Palette = Record<string, string>;
+
+function theme(name: 'lightTheme' | 'darkTheme'): Palette {
+  const start = source.indexOf(`export const ${name} =`);
+  const end = source.indexOf('\n});', start);
+  expect(start, `${name} is declared`).toBeGreaterThanOrEqual(0);
+  expect(end, `${name} is closed`).toBeGreaterThan(start);
+  return Object.fromEntries(
+    [...source.slice(start, end).matchAll(/^  (\w+): '([^']+)'/gm)].map((match) => [
+      match[1],
+      match[2],
+    ])
+  );
+}
+
+function hslToRgb(value: string): Rgb {
+  const match = /^hsl\(([\d.]+) ([\d.]+)% ([\d.]+)%\)$/.exec(value);
+  if (!match) throw new Error(`Contrast contract needs an opaque HSL colour, received ${value}`);
+  const hue = Number(match[1]);
+  const saturation = Number(match[2]) / 100;
+  const lightness = Number(match[3]) / 100;
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const secondary = chroma * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const offset = lightness - chroma / 2;
+  const channels: Rgb =
+    hue < 60
+      ? [chroma, secondary, 0]
+      : hue < 120
+        ? [secondary, chroma, 0]
+        : hue < 180
+          ? [0, chroma, secondary]
+          : hue < 240
+            ? [0, secondary, chroma]
+            : hue < 300
+              ? [secondary, 0, chroma]
+              : [chroma, 0, secondary];
+  return channels.map((channel) => channel + offset) as unknown as Rgb;
+}
+
+function luminance(color: Rgb): number {
+  const [red, green, blue] = color.map((channel) =>
+    channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  );
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+function contrast(foreground: string, background: string): number {
+  const foregroundLuminance = luminance(hslToRgb(foreground));
+  const backgroundLuminance = luminance(hslToRgb(background));
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  );
+}
+
+const SURFACES = [
+  'background',
+  'elevatedBackground',
+  'raisedBackground',
+  'secondaryBackground',
+  'wellBackground',
+] as const;
+
+const palettes = { light: theme('lightTheme'), dark: theme('darkTheme') };
+
+describe('semantic colour contrast contracts', () => {
+  test.each(Object.entries(palettes))('%s palette keeps normal text at 4.5:1', (_, palette) => {
+    for (const foreground of ['label', 'secondaryLabel', 'hintLabel', 'accent', 'destructive']) {
+      for (const background of SURFACES) {
+        expect(
+          contrast(palette[foreground], palette[background]),
+          `${foreground} on ${background}`
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+    expect(contrast(palette.onAccent, palette.accent), 'onAccent on accent').toBeGreaterThanOrEqual(
+      4.5
+    );
+    expect(
+      contrast(palette.onDestructive, palette.destructive),
+      'onDestructive on destructive'
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+
+  test.each(Object.entries(palettes))(
+    '%s palette keeps non-text ink and control edges at 3:1',
+    (_, palette) => {
+      for (const foreground of ['tertiaryLabel', 'controlEdge', 'accent', 'destructive']) {
+        for (const background of SURFACES) {
+          expect(
+            contrast(palette[foreground], palette[background]),
+            `${foreground} on ${background}`
+          ).toBeGreaterThanOrEqual(3);
+        }
+      }
+      expect(
+        contrast(palette.controlEdge, palette.wellBackground),
+        'controlEdge on wellBackground'
+      ).toBeGreaterThanOrEqual(3);
+    }
+  );
+});

--- a/packages/ui/test/field.test.tsx
+++ b/packages/ui/test/field.test.tsx
@@ -1,11 +1,9 @@
-import * as stylex from '@stylexjs/stylex';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, test } from 'vitest';
 import { Field } from '../src/field/field';
-import { field, fieldPaletteTheme } from '../src/field/field.tokens.stylex';
+import { field } from '../src/field/field.tokens.stylex';
 import { Input } from '../src/field/input';
 import { Textarea } from '../src/field/textarea';
-import { forcedThemeClassNames } from '../src/theme/theme';
 
 function classesOf(html: string, tag: string): string[] {
   const open = new RegExp(`<${tag}\\b[^>]*>`).exec(html)?.[0] ?? '';
@@ -186,20 +184,9 @@ describe('Input and Textarea', () => {
 });
 
 describe('field tokens', () => {
-  test('compile to custom property references', () => {
-    expect(field.background).toMatch(/^var\(--/);
-    expect(field.ring).toMatch(/^var\(--/);
-    expect(field.invalidRing).toMatch(/^var\(--/);
-  });
-
-  test('the palette theme rides along with every forced palette', () => {
-    const themeClasses = (stylex.props(fieldPaletteTheme).className ?? '')
-      .split(' ')
-      .filter(Boolean);
-    expect(themeClasses.length).toBeGreaterThan(0);
-    for (const name of themeClasses) {
-      expect(forcedThemeClassNames('light')).toContain(name);
-      expect(forcedThemeClassNames('dark')).toContain(name);
-    }
+  test('keep component dimensions in their own variable group', () => {
+    expect(field.heightMedium).toMatch(/^var\(--/);
+    expect(field.ringWidth).toMatch(/^var\(--/);
+    expect(field.switchWidth).toMatch(/^var\(--/);
   });
 });

--- a/packages/ui/test/raw.d.ts
+++ b/packages/ui/test/raw.d.ts
@@ -1,0 +1,4 @@
+declare module '*?raw' {
+  const source: string;
+  export default source;
+}

--- a/packages/ui/test/select.test.tsx
+++ b/packages/ui/test/select.test.tsx
@@ -265,14 +265,12 @@ describe('Select list', () => {
     await press('ArrowDown');
     const selectedOnly = classesOf(options()[0]);
     const highlightedOnly = classesOf(options()[1]);
-    const selectedFill = selectedOnly.filter((name) => !highlightedOnly.includes(name));
-    const highlightFill = highlightedOnly.filter((name) => !selectedOnly.includes(name));
-    expect(selectedFill).toHaveLength(1);
-    expect(highlightFill).toHaveLength(1);
-    // Both fills are the same CSS property, so StyleX resolves them to one
-    // class: a row that is both wears the highlight and not the selected fill.
-    expect(both).toContain(highlightFill[0]);
-    expect(both).not.toContain(selectedFill[0]);
+    expect(selectedOnly).not.toEqual(highlightedOnly);
+    // The highlight owns both the fill and its contrast-checked inset ring.
+    // StyleX resolves the competing background declarations, so a row that is
+    // both selected and highlighted has exactly the highlighted row's classes;
+    // its separately rendered tick continues to communicate selection.
+    expect(both).toEqual(highlightedOnly);
   });
 
   test('a caller className lands on the popup after the compiled classes', async () => {

--- a/specs/ui-primitives.md
+++ b/specs/ui-primitives.md
@@ -45,11 +45,11 @@ that panel is unreachable in it; the surface names the panel once and the lists
 under it follow. Product surfaces do not otherwise place these lists.
 
 Every control in this family shares one set of state appearances: a sunken
-resting surface with no border, a placeholder in the hint colour, an accent ring
-on focus, a destructive ring while invalid that persists when the control is
-focused, and reduced opacity on the whole control when disabled. The states are
-defined once for the family, so a control added later inherits them rather than
-choosing its own.
+resting surface whose inset edge remains identifiable against adjacent surfaces,
+a readable placeholder, an accent ring on focus, a destructive ring while
+invalid that persists when the control is focused, and reduced opacity on the
+whole control when disabled. The states are defined once for the family, so a
+control added later inherits them rather than choosing its own.
 
 A control that stores a value — a ticked checkbox, the selected radio option, a
 switch that is on — shows that as ink, because the accent colour marks live
@@ -69,7 +69,14 @@ viewer. Those classes must leave the primitive's visual identity under its props
 Semantic StyleX tokens provide light and dark values. A theme applies to a subtree
 so a primitive responds without product code selecting raw palette values. Token
 names describe meaning and interaction role; component tokens derive from those
-semantic values or documented fixed dimensions.
+semantic values or documented fixed dimensions. Component styles read semantic
+colours directly; a component variable group does not repeat a semantic colour
+only to rename it.
+
+Normal-size text tokens maintain at least 4.5:1 contrast on every surface rung on
+which the package permits them. Non-text icon ink, control edges, focus rings and
+invalid rings maintain at least 3:1. A subtle mixed fill may supplement a state,
+but keyboard focus does not rely on that fill as its only visible signal.
 
 A forced theme applies to the subtree it is placed on, including the primitives
 inside it. A component token that derives from a semantic colour resolves against
@@ -116,3 +123,6 @@ stored value, are recorded in the
 The select and the combobox, the separate token group their lists take, and the
 container a modal names for them are recorded in the
 [UI select and combobox note](../.agents/notes/implemented/feature/2026-09-10-ui-select-combobox.md).
+The semantic contrast contracts, identifiable control edge and removal of
+component colour relays are recorded in the
+[UI semantic colour contracts note](../.agents/notes/implemented/architecture/2026-09-11-ui-semantic-color-contracts.md).


### PR DESCRIPTION
## Summary

- restore a single semantic StyleX color/shadow layer and remove component palette relays
- separate readable hint text from tertiary icon ink, and add contrast-bearing control edges
- enforce WCAG contrast contracts and document Chromium-resolved OKLab mixes

## Verification

- `pnpm --filter @lody/ui test` (90 tests passed)
- `pnpm --filter @lody/ui typecheck`
- `pnpm lint:fast` (0 errors)
- `pnpm run docs check`
- `pnpm format`
- Chromium 148 token/color-mix audit and Storybook visual review

Full-repo note: `pnpm check` passed the repository typechecks, lint, script tests, and `@lody/ui`, then reached broad failures in unchanged `@lody/components` React suites with `act is not a function`; this PR does not modify that package.