### PR TITLE
fix(components): preserve scroll position on turn completion

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-12-completion-scroll-position.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-12-completion-scroll-position.md
@@ -1,0 +1,53 @@
+# Preserve the reader during Turn completion
+
+Status: implemented
+Translation: pending
+
+## Abstract
+
+Finishing an assistant Turn changes the conversation from its streaming row layout to the
+collapsed `Worked for …` layout while also retiring the activity row. When bottom-follow has
+already been released, either contraction can remove enough virtual height to clamp the viewport
+to the new end and discard the reader's position. Completion still folds immediately; the
+conversation now preserves a stable visible row's viewport coordinate across that layout commit.
+
+## Decision
+
+The follow lock is mirrored synchronously from `useStickyScroll` into the conversation renderer.
+This is necessary because upward-wheel intent and completion can arrive before an effect reports
+the changed lock. When either the latest Turn folds or its activity row retires while follow is
+released, render captures the nearest mounted row whose key survives the new virtual layout and
+records its offset from the viewport top.
+
+The same commit renders the ordinary finished rows and a provisional trailing spacer. The spacer
+temporarily preserves at least the old scroll range, preventing the browser and sticky-scroll
+tolerance from clamping or re-locking before React layout effects run. The layout effect measures
+the surviving anchor again, scrolls by the coordinate delta, and reduces the spacer to only the
+height needed to keep that compensated offset outside the library's follow tolerance. A bounded
+four-frame correction follows Virtua's asynchronous row measurements; real reader input cancels
+that correction. Reaching the bottom or choosing “scroll to latest” removes the spacer. No finished
+message is represented as structurally streaming.
+
+## Alternatives
+
+- Restoring the old numeric `scrollTop` ignores height removed before the reader's content, so it
+  does not preserve the content's screen coordinate.
+- Applying only an anchor delta after contraction is too late when the new scroll range has already
+  clamped the viewport; the provisional spacer prevents that destructive intermediate state.
+- Suppressing every completion auto-scroll would also detach readers who intentionally remained at
+  the bottom.
+- Deferring `Worked for …` folding preserves height but changes the completion UX. Folding remains
+  immediate and only scroll geometry receives transient state.
+
+## Evidence and limits
+
+`tests/chat-virtual-rows-identity.test.ts` verifies that an interleaved tool/text Turn folds
+immediately at completion. `tests/completion-visual-anchor.test.ts` covers both completion event
+orders, stable-row selection, anchor-delta geometry, and the trailing follow-release guard.
+`tests/use-sticky-scroll.test.ts` verifies that programmatic suppression updates the synchronous
+follow mirror, upward wheel intent reaches it before React reports the new lock, and a suppressed
+content contraction overrides the dependency's near-bottom re-lock.
+
+The existing streaming Playwright story does not transition its message to `finished` or its live
+status to idle; it stops at an `indicator-only` phase. A browser-level completion transition remains
+useful future coverage, particularly for touch and scrollbar-drag release paths.

--- a/packages/components/src/components/ai-gui/AGENTS.md
+++ b/packages/components/src/components/ai-gui/AGENTS.md
@@ -29,6 +29,9 @@ File-by-file ownership and coverage pointers: [README.md](README.md).
 - Finished turns keep the answer/result tail visible and fold earlier work;
   streaming turns stay expanded. Details remain sibling rows, and search opens
   both the worked region and the activity group.
+- Completion folding is immediate even after the reader releases bottom-follow. Preserve a stable
+  visible row's viewport coordinate across the contraction; transient trailing scroll range may
+  prevent native clamping, but finished rows must never masquerade as streaming rows.
 - The final answer is the final contiguous run of text before trailing
   never-collapsed items, not necessarily the last item: walk backward through
   adjacent text blocks until a non-text boundary.

--- a/packages/components/src/components/ai-gui/completion-visual-anchor.ts
+++ b/packages/components/src/components/ai-gui/completion-visual-anchor.ts
@@ -1,0 +1,97 @@
+export interface CompletionAnchorAdjustment {
+  scrollTop: number;
+  spacerHeight: number;
+}
+
+// `use-stick-to-bottom@1.1.6` treats <=70px as near-bottom and re-locks after
+// negative content resizes. Keep one extra pixel while preserving an anchor.
+const COMPLETION_ANCHOR_FOLLOW_GUARD_PX = 71;
+
+export interface CompletionLayoutState {
+  messageId: string | null;
+  finished: boolean;
+  activityVisible: boolean;
+}
+
+export const resolveCompletionContractionMessageId = (
+  previous: CompletionLayoutState,
+  current: CompletionLayoutState
+): string | null =>
+  current.messageId !== null &&
+  previous.messageId === current.messageId &&
+  ((!previous.finished && current.finished) ||
+    (previous.activityVisible && !current.activityVisible))
+    ? current.messageId
+    : null;
+
+export interface CompletionVisualAnchorSnapshot {
+  messageId: string;
+  rowKey: string | null;
+  viewportOffset: number | null;
+  scrollTop: number;
+  provisionalSpacerHeight: number;
+}
+
+export const captureCompletionVisualAnchor = (
+  scrollElement: HTMLDivElement,
+  messageId: string,
+  survivingRowKeys: ReadonlySet<string>
+): CompletionVisualAnchorSnapshot => {
+  const viewportRect = scrollElement.getBoundingClientRect();
+  const candidates = Array.from(
+    scrollElement.querySelectorAll<HTMLElement>('[data-chat-virtual-row-key]')
+  )
+    .flatMap((element) => {
+      const rowKey = element.dataset.chatVirtualRowKey;
+      if (rowKey === undefined || !survivingRowKeys.has(rowKey)) return [];
+      const rect = element.getBoundingClientRect();
+      return [{ rowKey, rect }];
+    })
+    .sort(
+      (left, right) =>
+        Math.abs(left.rect.top - viewportRect.top) - Math.abs(right.rect.top - viewportRect.top)
+    );
+  const visible = candidates.find(
+    ({ rect }) => rect.bottom > viewportRect.top && rect.top < viewportRect.bottom
+  );
+  const anchor = visible ?? candidates[0] ?? null;
+  return {
+    messageId,
+    rowKey: anchor?.rowKey ?? null,
+    viewportOffset: anchor === null ? null : anchor.rect.top - viewportRect.top,
+    scrollTop: scrollElement.scrollTop,
+    // The completion commit adds this before removing work/status rows, so the
+    // browser always has enough range to avoid clamping the reader first.
+    provisionalSpacerHeight: Math.max(1, scrollElement.scrollHeight),
+  };
+};
+
+export const resolveCompletionAnchorAdjustment = ({
+  currentScrollTop,
+  oldAnchorOffset,
+  newAnchorOffset,
+  viewportHeight,
+  scrollHeightWithSpacer,
+  provisionalSpacerHeight,
+}: {
+  currentScrollTop: number;
+  oldAnchorOffset: number | null;
+  newAnchorOffset: number | null;
+  viewportHeight: number;
+  scrollHeightWithSpacer: number;
+  provisionalSpacerHeight: number;
+}): CompletionAnchorAdjustment => {
+  const anchorDelta =
+    oldAnchorOffset === null || newAnchorOffset === null ? 0 : newAnchorOffset - oldAnchorOffset;
+  const scrollTop = Math.max(0, currentScrollTop + anchorDelta);
+  const collapsedScrollHeight = Math.max(0, scrollHeightWithSpacer - provisionalSpacerHeight);
+  return {
+    scrollTop,
+    spacerHeight: Math.max(
+      0,
+      Math.ceil(
+        scrollTop + viewportHeight + COMPLETION_ANCHOR_FOLLOW_GUARD_PX - collapsedScrollHeight
+      )
+    ),
+  };
+};

--- a/packages/components/src/components/ai-gui/message-selection.tsx
+++ b/packages/components/src/components/ai-gui/message-selection.tsx
@@ -258,10 +258,12 @@ export function MessageSelectionOverlay() {
 export function MessageSelectionRow({
   id,
   first,
+  virtualRowKey,
   children,
 }: {
   id?: string;
   first: boolean;
+  virtualRowKey?: string;
   children: ReactNode;
 }) {
   const selection = useContext(MessageSelectionContext);
@@ -272,6 +274,7 @@ export function MessageSelectionRow({
   return (
     <div
       className={`relative ${selectable ? 'flow-root select-none cursor-default' : ''} ${selected ? 'bg-primary/10' : ''}`}
+      data-chat-virtual-row-key={virtualRowKey}
       data-message-selection-id={selectable ? id : undefined}
       onPointerDownCapture={
         selectable

--- a/packages/components/src/components/ai-gui/view.tsx
+++ b/packages/components/src/components/ai-gui/view.tsx
@@ -25,6 +25,13 @@ import {
   MessageSelectionRow,
 } from './message-selection';
 import {
+  captureCompletionVisualAnchor,
+  resolveCompletionAnchorAdjustment,
+  resolveCompletionContractionMessageId,
+  type CompletionLayoutState,
+  type CompletionVisualAnchorSnapshot,
+} from './completion-visual-anchor';
+import {
   ZoomableImageViewer,
   type ImagePreviewPortalAnchorRef,
 } from '@/components/shared/zoomable-image-viewer';
@@ -328,6 +335,9 @@ const OUTLINE_JUMP_TOLERANCE_PX = 2;
  * genuinely cannot reach the top (the list's tail) stops retrying.
  */
 const OUTLINE_JUMP_MAX_CORRECTIONS = 3;
+/** Bounded settling window for Virtua's ResizeObserver-driven row measurements. */
+const COMPLETION_ANCHOR_CORRECTION_FRAMES = 4;
+const COMPLETION_ANCHOR_TOLERANCE_PX = 0.5;
 
 export type ChatStreamItem = SessionMessageItem | EmptySessionItem;
 
@@ -1218,6 +1228,41 @@ export const SessionChatStreamView = forwardRef<
     const search = useSessionSearch();
     const activeSearchBlockId = search?.activeBlockId ?? null;
     const shouldShowAgentActivity = Boolean(agentActivityLabel);
+    const stickyStateRef = useRef(true);
+    const latestAssistant = useMemo(
+      () =>
+        lastAssistantMessageId === null
+          ? null
+          : (items.find(
+              (item): item is SessionMessageItem =>
+                item.type === 'message' &&
+                item.message.role === 'assistant' &&
+                item.message.id === lastAssistantMessageId
+            )?.message ?? null),
+      [items, lastAssistantMessageId]
+    );
+    const latestAssistantFinished = latestAssistant?.finished === true;
+    const committedCompletionLayoutRef = useRef<CompletionLayoutState>({
+      messageId: latestAssistant?.id ?? null,
+      finished: latestAssistantFinished,
+      activityVisible: shouldShowAgentActivity,
+    });
+    const completionAnchorPendingRef = useRef<CompletionVisualAnchorSnapshot | null>(null);
+    const completionAnchorRetentionRef = useRef<{
+      rowKey: string;
+      viewportOffset: number;
+      framesRemaining: number;
+    } | null>(null);
+    const completionScrollElementRef = useRef<HTMLDivElement | null>(null);
+    const [completionAnchorSpacerHeight, setCompletionAnchorSpacerHeight] = useState(0);
+    const handleAtBottomChange = useCallback(
+      (atBottom: boolean) => {
+        stickyStateRef.current = atBottom;
+        if (atBottom) setCompletionAnchorSpacerHeight(0);
+        onAtBottomChange?.(atBottom);
+      },
+      [onAtBottomChange]
+    );
     const [assistantExpansionVersion, setAssistantExpansionVersion] = useState(0);
     const [hoveredAssistantMessageId, setHoveredAssistantMessageId] = useState<string | null>(null);
     const pendingExpandedGroupRowKeyRef = useRef<string | null>(null);
@@ -1242,6 +1287,8 @@ export const SessionChatStreamView = forwardRef<
             groupExpansionAutoScrollSuppressedRef.current ||
             messageSelection !== null ||
             pendingOutlineJumpRef.current !== null ||
+            completionAnchorPendingRef.current !== null ||
+            completionAnchorRetentionRef.current !== null ||
             Boolean(suppressStickyAutoScrollRef?.current)
           );
         },
@@ -1371,7 +1418,7 @@ export const SessionChatStreamView = forwardRef<
       scrollRef: scrollContainerRef,
       scrollElement: scrollViewportElement,
       isSticky,
-      scrollToBottom,
+      scrollToBottom: scrollToBottomImmediately,
       initialScrollRestored,
       handleScroll,
     } = useStickyScroll({
@@ -1380,10 +1427,142 @@ export const SessionChatStreamView = forwardRef<
       // `leadingContent` is a real first Virtua row, so it counts here — sticky
       // scroll otherwise targets an index short of the true bottom.
       itemCount: virtualRows.length + leadingRowCount + (shouldShowAgentActivity ? 1 : 0),
-      onAtBottomChange,
+      onAtBottomChange: handleAtBottomChange,
       skipNextViewportResizeAutoScrollRef,
       suppressAutoScrollRef: autoScrollSuppressedRef,
+      stickyStateRef,
     });
+    completionScrollElementRef.current = scrollViewportElement;
+    // Read the mirror only after useStickyScroll has refreshed it from the
+    // library's mutable lock for this render. This covers touch/scrollbar
+    // release as well as the wheel handler's synchronous fast path.
+    const currentCompletionLayout: CompletionLayoutState = {
+      messageId: latestAssistant?.id ?? null,
+      finished: latestAssistantFinished,
+      activityVisible: shouldShowAgentActivity,
+    };
+    const completionContractionMessageId = resolveCompletionContractionMessageId(
+      committedCompletionLayoutRef.current,
+      currentCompletionLayout
+    );
+    if (
+      completionContractionMessageId !== null &&
+      !stickyStateRef.current &&
+      completionAnchorPendingRef.current === null &&
+      completionScrollElementRef.current !== null
+    ) {
+      completionAnchorPendingRef.current = captureCompletionVisualAnchor(
+        completionScrollElementRef.current,
+        completionContractionMessageId,
+        new Set(virtualRows.map((row) => row.key))
+      );
+    }
+    const renderedCompletionSpacerHeight =
+      completionAnchorPendingRef.current?.provisionalSpacerHeight ?? completionAnchorSpacerHeight;
+
+    const scrollToBottom = useCallback(() => {
+      setCompletionAnchorSpacerHeight(0);
+      scrollToBottomImmediately();
+    }, [scrollToBottomImmediately]);
+
+    useLayoutEffect(() => {
+      const pending = completionAnchorPendingRef.current;
+      const scrollElement = completionScrollElementRef.current;
+      if (
+        pending !== null &&
+        scrollElement !== null &&
+        pending.messageId === currentCompletionLayout.messageId
+      ) {
+        const anchorElement = Array.from(
+          scrollElement.querySelectorAll<HTMLElement>('[data-chat-virtual-row-key]')
+        ).find((element) => element.dataset.chatVirtualRowKey === pending.rowKey);
+        const viewportTop = scrollElement.getBoundingClientRect().top;
+        const newAnchorOffset =
+          anchorElement === undefined
+            ? null
+            : anchorElement.getBoundingClientRect().top - viewportTop;
+        const adjustment = resolveCompletionAnchorAdjustment({
+          currentScrollTop: scrollElement.scrollTop,
+          oldAnchorOffset: pending.viewportOffset,
+          newAnchorOffset,
+          viewportHeight: scrollElement.clientHeight,
+          scrollHeightWithSpacer: scrollElement.scrollHeight,
+          provisionalSpacerHeight: pending.provisionalSpacerHeight,
+        });
+        vlistRef.current?.scrollTo(adjustment.scrollTop);
+        completionAnchorRetentionRef.current =
+          pending.rowKey === null || pending.viewportOffset === null
+            ? null
+            : {
+                rowKey: pending.rowKey,
+                viewportOffset: pending.viewportOffset,
+                framesRemaining: COMPLETION_ANCHOR_CORRECTION_FRAMES,
+              };
+        completionAnchorPendingRef.current = null;
+        setCompletionAnchorSpacerHeight(adjustment.spacerHeight);
+      } else if (pending !== null) {
+        completionAnchorPendingRef.current = null;
+        setCompletionAnchorSpacerHeight(0);
+      }
+      committedCompletionLayoutRef.current = {
+        messageId: currentCompletionLayout.messageId,
+        finished: currentCompletionLayout.finished,
+        activityVisible: currentCompletionLayout.activityVisible,
+      };
+    }, [
+      currentCompletionLayout.activityVisible,
+      currentCompletionLayout.finished,
+      currentCompletionLayout.messageId,
+      renderedCompletionSpacerHeight,
+      virtualRows,
+    ]);
+
+    useLayoutEffect(() => {
+      let animationFrameId: number | null = null;
+      const retainAnchor = () => {
+        const retention = completionAnchorRetentionRef.current;
+        const scrollElement = completionScrollElementRef.current;
+        if (retention === null || scrollElement === null || retention.framesRemaining <= 0) {
+          completionAnchorRetentionRef.current = null;
+          return;
+        }
+        const anchorElement = Array.from(
+          scrollElement.querySelectorAll<HTMLElement>('[data-chat-virtual-row-key]')
+        ).find((element) => element.dataset.chatVirtualRowKey === retention.rowKey);
+        if (anchorElement === undefined) {
+          completionAnchorRetentionRef.current = null;
+          return;
+        }
+        const viewportTop = scrollElement.getBoundingClientRect().top;
+        const newAnchorOffset = anchorElement.getBoundingClientRect().top - viewportTop;
+        const spacerElement = scrollElement.querySelector<HTMLElement>(
+          '[data-completion-anchor-spacer]'
+        );
+        const adjustment = resolveCompletionAnchorAdjustment({
+          currentScrollTop: scrollElement.scrollTop,
+          oldAnchorOffset: retention.viewportOffset,
+          newAnchorOffset,
+          viewportHeight: scrollElement.clientHeight,
+          scrollHeightWithSpacer: scrollElement.scrollHeight,
+          provisionalSpacerHeight: spacerElement?.getBoundingClientRect().height ?? 0,
+        });
+        if (Math.abs(newAnchorOffset - retention.viewportOffset) > COMPLETION_ANCHOR_TOLERANCE_PX) {
+          vlistRef.current?.scrollTo(adjustment.scrollTop);
+        }
+        setCompletionAnchorSpacerHeight(adjustment.spacerHeight);
+        completionAnchorRetentionRef.current = {
+          ...retention,
+          framesRemaining: retention.framesRemaining - 1,
+        };
+        animationFrameId = requestAnimationFrame(retainAnchor);
+      };
+      if (completionAnchorRetentionRef.current !== null) {
+        animationFrameId = requestAnimationFrame(retainAnchor);
+      }
+      return () => {
+        if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
+      };
+    }, [completionAnchorSpacerHeight, renderedCompletionSpacerHeight, virtualRows]);
 
     // useStickyScroll's layout effect runs before this one in hook order and
     // consumes the suppression for the expansion commit. Release it at the end
@@ -1546,14 +1725,17 @@ export const SessionChatStreamView = forwardRef<
       if (!scrollViewportElement) return undefined;
       const abandon = () => {
         pendingOutlineJumpRef.current = null;
+        completionAnchorRetentionRef.current = null;
       };
       const options = { passive: true } as const;
       scrollViewportElement.addEventListener('wheel', abandon, options);
       scrollViewportElement.addEventListener('touchstart', abandon, options);
+      scrollViewportElement.addEventListener('pointerdown', abandon, options);
       scrollViewportElement.addEventListener('keydown', abandon, options);
       return () => {
         scrollViewportElement.removeEventListener('wheel', abandon);
         scrollViewportElement.removeEventListener('touchstart', abandon);
+        scrollViewportElement.removeEventListener('pointerdown', abandon);
         scrollViewportElement.removeEventListener('keydown', abandon);
       };
     }, [scrollViewportElement]);
@@ -1726,6 +1908,7 @@ export const SessionChatStreamView = forwardRef<
                         key={row.key}
                         id={row.item.type === 'message' ? row.item.message.id : undefined}
                         first
+                        virtualRowKey={row.key}
                       >
                         <ChatItem
                           item={row.item}
@@ -1751,6 +1934,7 @@ export const SessionChatStreamView = forwardRef<
                       key={row.key}
                       id={row.item.message.id}
                       first={virtualRows[rowIndex - 1]?.messageIndex !== row.messageIndex}
+                      virtualRowKey={row.key}
                     >
                       <AssistantChatItem
                         row={row}
@@ -1779,6 +1963,13 @@ export const SessionChatStreamView = forwardRef<
                   <AgentActivityRow label={agentActivityLabel} tone={agentActivityTone} />
                 )}
               </Virtualizer>
+              {renderedCompletionSpacerHeight > 0 ? (
+                <div
+                  aria-hidden="true"
+                  data-completion-anchor-spacer=""
+                  style={{ height: renderedCompletionSpacerHeight }}
+                />
+              ) : null}
               <MessageSelectionOverlay />
             </div>
             {/* Top fade into the bg-background canvas above (desktop only),

--- a/packages/components/src/hooks/README.md
+++ b/packages/components/src/hooks/README.md
@@ -44,6 +44,13 @@ changing keyboard, terminal, or window-resize follow behavior, which is why it i
 consumed for exactly one height resize and is not merged into programmatic-jump
 suppression.
 
+The hook also mirrors the follow lock synchronously into the conversation renderer.
+When the latest Turn finishes after the reader has released follow, the renderer
+captures a stable visible row before the immediate `Worked for …` contraction and
+compensates its viewport coordinate in the following layout effect. A temporary
+trailing spacer prevents native scroll-range clamping before that compensation runs;
+bounded follow-up corrections absorb Virtua's asynchronous row measurements.
+
 ## `useStableSession`
 
 A single HTTP 401 can be a stale response, so it is verified once against the

--- a/packages/components/src/hooks/use-sticky-scroll.ts
+++ b/packages/components/src/hooks/use-sticky-scroll.ts
@@ -31,6 +31,8 @@ export interface UseStickyScrollOptions {
    * can resize the list underneath it.
    */
   suppressAutoScrollRef?: RefObject<boolean>;
+  /** Synchronous mirror used when a render must avoid collapsing content under a reader. */
+  stickyStateRef?: MutableRefObject<boolean>;
 }
 
 export interface UseStickyScrollResult {
@@ -124,6 +126,35 @@ function useStickyViewportResizeObserver(options: {
   ]);
 }
 
+/**
+ * `use-stick-to-bottom` intentionally re-locks after a negative content resize
+ * lands within its bottom tolerance. Programmatic layout preservation needs the
+ * opposite rule: keep follow released until the caller finishes compensating.
+ * Register after the library observer so this callback wins the same delivery.
+ */
+function useStickyContentResizeSuppression(options: {
+  scrollElement: HTMLElement | null;
+  suppressAutoScrollRef?: RefObject<boolean>;
+  stickyStateRef?: MutableRefObject<boolean>;
+  stopScroll: () => void;
+}): void {
+  const { scrollElement, suppressAutoScrollRef, stickyStateRef, stopScroll } = options;
+
+  useEffect(() => {
+    const contentElement = scrollElement?.firstElementChild;
+    if (!(contentElement instanceof HTMLElement) || typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+    const observer = new ResizeObserver(() => {
+      if (!suppressAutoScrollRef?.current) return;
+      if (stickyStateRef) stickyStateRef.current = false;
+      stopScroll();
+    });
+    observer.observe(contentElement);
+    return () => observer.disconnect();
+  }, [scrollElement, stickyStateRef, stopScroll, suppressAutoScrollRef]);
+}
+
 export function useStickyScroll({
   sessionId,
   vlistRef,
@@ -131,6 +162,7 @@ export function useStickyScroll({
   onAtBottomChange,
   skipNextViewportResizeAutoScrollRef,
   suppressAutoScrollRef,
+  stickyStateRef,
 }: UseStickyScrollOptions): UseStickyScrollResult {
   const cachedPositionAtMountRef = useRef(getScrollPosition(sessionId));
   const stickToBottom = useStickToBottom({
@@ -151,6 +183,7 @@ export function useStickyScroll({
   // `escapedFromLock` here would leave the UI permanently escaped after that
   // explicit re-lock because it records history rather than the current lock.
   const isSticky = state.isAtBottom;
+  if (stickyStateRef) stickyStateRef.current = isSticky;
   const stickyBottomRef = useRef(isSticky);
   stickyBottomRef.current = isSticky;
 
@@ -164,9 +197,12 @@ export function useStickyScroll({
 
   const handleWheelUp = useCallback(
     (event: WheelEvent) => {
-      if (event.deltaY < 0) stopScroll();
+      if (event.deltaY < 0) {
+        if (stickyStateRef) stickyStateRef.current = false;
+        stopScroll();
+      }
     },
-    [stopScroll]
+    [stickyStateRef, stopScroll]
   );
 
   const setScrollRef = useCallback<RefCallback<HTMLDivElement>>(
@@ -214,30 +250,35 @@ export function useStickyScroll({
       if (!currentVlist) return;
 
       if (cachedState?.type === 'offset') {
+        if (stickyStateRef) stickyStateRef.current = false;
         stopScroll();
         currentVlist.scrollTo(cachedState.scrollOffset);
       } else {
+        if (stickyStateRef) stickyStateRef.current = true;
         void scrollToBottomWithLock({ animation: 'instant' });
         scrollToRealBottom();
       }
       initialScrollRestoredRef.current = true;
       setInitialScrollRestored(true);
     });
-  }, [itemCount, scrollToBottomWithLock, scrollToRealBottom, stopScroll, vlistRef]);
+  }, [itemCount, scrollToBottomWithLock, scrollToRealBottom, stickyStateRef, stopScroll, vlistRef]);
 
   // Search jumps and group expansion are deliberate reading-position changes.
   // Release follow in a layout effect so ResizeObserver cannot pull the list to
   // the end between the React commit and the caller's programmatic jump.
   useLayoutEffect(() => {
-    if (suppressAutoScrollRef?.current) stopScroll();
+    if (!suppressAutoScrollRef?.current) return;
+    if (stickyStateRef) stickyStateRef.current = false;
+    stopScroll();
   });
 
   const scrollToBottom = useCallback(() => {
     saveScrollPosition(sessionId, { type: 'end' });
     if (itemCountRef.current <= 0) return;
+    if (stickyStateRef) stickyStateRef.current = true;
     void scrollToBottomWithLock({ animation: 'instant' });
     scrollToRealBottom();
-  }, [itemCountRef, scrollToBottomWithLock, scrollToRealBottom, sessionId]);
+  }, [itemCountRef, scrollToBottomWithLock, scrollToRealBottom, sessionId, stickyStateRef]);
 
   const handleScroll = useCallback(
     (offset: number) => {
@@ -275,6 +316,12 @@ export function useStickyScroll({
     scrollToRealBottom,
     skipNextViewportResizeAutoScrollRef,
     suppressAutoScrollRef,
+  });
+  useStickyContentResizeSuppression({
+    scrollElement,
+    suppressAutoScrollRef,
+    stickyStateRef,
+    stopScroll,
   });
 
   return {

--- a/packages/components/tests/chat-virtual-rows-identity.test.ts
+++ b/packages/components/tests/chat-virtual-rows-identity.test.ts
@@ -130,6 +130,31 @@ describe('buildChatVirtualRows per-turn row identity', () => {
     });
   });
 
+  it('folds work immediately when a streaming turn finishes', () => {
+    const streaming = wrap(
+      makeMessage(
+        'turn-completing',
+        'assistant',
+        [toolCall(), text('checkpoint'), toolCall(), text('final answer')],
+        false
+      )
+    );
+    const beforeCompletion = build([streaming]);
+    const finished = wrap({ ...streaming.message, finished: true });
+
+    const folded = build([finished]);
+    expect(
+      folded.some((row) => row.type === 'assistant' && row.content.kind === 'worked_group_header')
+    ).toBe(true);
+    const beforeContentKeys = beforeCompletion
+      .filter((row) => row.type === 'assistant' && row.content.kind !== 'footer')
+      .map((row) => row.key);
+    const foldedContentKeys = folded
+      .filter((row) => row.type === 'assistant' && row.content.kind !== 'footer')
+      .map((row) => row.key);
+    expect(foldedContentKeys).not.toEqual(beforeContentKeys);
+  });
+
   it('an index shift (prepended message) invalidates cached rows', () => {
     const { finishedTurn, streamingTurn, items } = makeConversation();
     const first = build(items);

--- a/packages/components/tests/completion-visual-anchor.test.ts
+++ b/packages/components/tests/completion-visual-anchor.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import {
+  captureCompletionVisualAnchor,
+  resolveCompletionAnchorAdjustment,
+  resolveCompletionContractionMessageId,
+} from '../src/components/ai-gui/completion-visual-anchor';
+
+describe('completion visual anchor', () => {
+  it('protects both presence-first and finished-first contractions', () => {
+    const working = { messageId: 'turn-a', finished: false, activityVisible: true };
+    const activityRetired = { ...working, activityVisible: false };
+    const finishedWithActivity = { ...working, finished: true };
+
+    expect(resolveCompletionContractionMessageId(working, activityRetired)).toBe('turn-a');
+    expect(
+      resolveCompletionContractionMessageId(activityRetired, {
+        ...activityRetired,
+        finished: true,
+      })
+    ).toBe('turn-a');
+    expect(resolveCompletionContractionMessageId(working, finishedWithActivity)).toBe('turn-a');
+    expect(
+      resolveCompletionContractionMessageId(finishedWithActivity, {
+        ...finishedWithActivity,
+        activityVisible: false,
+      })
+    ).toBe('turn-a');
+    expect(
+      resolveCompletionContractionMessageId(working, {
+        messageId: 'turn-b',
+        finished: true,
+        activityVisible: false,
+      })
+    ).toBeNull();
+  });
+
+  it('anchors the nearest visible mounted row that survives folding', () => {
+    const viewport = document.createElement('div');
+    Object.defineProperties(viewport, {
+      scrollTop: { configurable: true, value: 640 },
+      scrollHeight: { configurable: true, value: 1_800 },
+    });
+    viewport.getBoundingClientRect = () =>
+      ({ top: 100, bottom: 500, left: 0, right: 400, width: 400, height: 400 }) as DOMRect;
+    const addRow = (key: string, top: number, bottom: number) => {
+      const row = document.createElement('div');
+      row.dataset.chatVirtualRowKey = key;
+      row.getBoundingClientRect = () =>
+        ({ top, bottom, left: 0, right: 400, width: 400, height: bottom - top }) as DOMRect;
+      viewport.appendChild(row);
+    };
+    addRow('removed-tool', 108, 160);
+    addRow('surviving-answer', 180, 260);
+    addRow('later-footer', 320, 360);
+
+    expect(
+      captureCompletionVisualAnchor(
+        viewport,
+        'turn-a',
+        new Set(['surviving-answer', 'later-footer'])
+      )
+    ).toEqual({
+      messageId: 'turn-a',
+      rowKey: 'surviving-answer',
+      viewportOffset: 80,
+      scrollTop: 640,
+      provisionalSpacerHeight: 1_800,
+    });
+  });
+
+  it('compensates the anchor and keeps the follow tolerance released', () => {
+    expect(
+      resolveCompletionAnchorAdjustment({
+        currentScrollTop: 1_000,
+        oldAnchorOffset: 140,
+        newAnchorOffset: -260,
+        viewportHeight: 400,
+        scrollHeightWithSpacer: 2_900,
+        provisionalSpacerHeight: 2_000,
+      })
+    ).toEqual({ scrollTop: 600, spacerHeight: 171 });
+
+    expect(
+      resolveCompletionAnchorAdjustment({
+        currentScrollTop: 1_000,
+        oldAnchorOffset: null,
+        newAnchorOffset: null,
+        viewportHeight: 400,
+        scrollHeightWithSpacer: 2_900,
+        provisionalSpacerHeight: 2_000,
+      })
+    ).toEqual({ scrollTop: 1_000, spacerHeight: 571 });
+  });
+});

--- a/packages/components/tests/use-sticky-scroll.test.ts
+++ b/packages/components/tests/use-sticky-scroll.test.ts
@@ -74,6 +74,8 @@ type HarnessProps = {
   itemCount: number;
   onAtBottomChange?: (atBottom: boolean) => void;
   skipNextViewportResizeAutoScrollRef?: React.MutableRefObject<boolean>;
+  suppressAutoScrollRef?: React.MutableRefObject<boolean>;
+  stickyStateRef?: React.MutableRefObject<boolean>;
 };
 
 async function advanceAnimationFrames(): Promise<void> {
@@ -222,6 +224,8 @@ function HookHarness({
   itemCount,
   onAtBottomChange,
   skipNextViewportResizeAutoScrollRef,
+  suppressAutoScrollRef,
+  stickyStateRef,
 }: HarnessProps) {
   const vlistRef = useRef<VirtualizerHandle | null>(vlist);
   vlistRef.current = vlist;
@@ -232,6 +236,8 @@ function HookHarness({
     itemCount,
     onAtBottomChange,
     skipNextViewportResizeAutoScrollRef,
+    suppressAutoScrollRef,
+    stickyStateRef,
   });
   const { scrollRef } = result;
 
@@ -371,6 +377,29 @@ describe('useStickyScroll Virtua adapter', () => {
     expect(fixture.getScrollTop()).toBe(320);
   });
 
+  it('mirrors upward wheel intent before React reports the changed lock', async () => {
+    const sessionId = 'session-wheel-mirror' as SessionId;
+    const fixture = createScrollFixture();
+    const vlist = createMockVirtualizerHandle(fixture.scrollElement);
+    const stickyStateRef = { current: true };
+
+    await renderHarness({
+      sessionId,
+      vlist,
+      scrollElement: fixture.scrollElement,
+      itemCount: 4,
+      stickyStateRef,
+    });
+    await act(async () => {
+      await advanceAnimationFrames();
+    });
+
+    act(() => {
+      fixture.scrollElement.dispatchEvent(new WheelEvent('wheel', { deltaY: -1 }));
+      expect(stickyStateRef.current).toBe(false);
+    });
+  });
+
   it('keeps the viewport pinned to the real bottom when sticky content grows', async () => {
     const sessionId = 'session-streaming-growth' as SessionId;
     const fixture = createScrollFixture();
@@ -488,6 +517,70 @@ describe('useStickyScroll Virtua adapter', () => {
     expect(fixture.getScrollTop()).toBe(240);
     expect(skipNextViewportResizeAutoScrollRef.current).toBe(false);
     expect(latestResult?.isSticky).toBe(true);
+  });
+
+  it('synchronously mirrors a suppressed follow as unstuck', async () => {
+    const sessionId = 'session-suppressed-follow' as SessionId;
+    const fixture = createScrollFixture();
+    const vlist = createMockVirtualizerHandle(fixture.scrollElement);
+    const suppressAutoScrollRef = { current: false };
+    const stickyStateRef = { current: true };
+
+    await renderHarness({
+      sessionId,
+      vlist,
+      scrollElement: fixture.scrollElement,
+      itemCount: 4,
+      suppressAutoScrollRef,
+      stickyStateRef,
+    });
+    await act(async () => {
+      await advanceAnimationFrames();
+    });
+
+    suppressAutoScrollRef.current = true;
+    await renderHarness({
+      sessionId,
+      vlist,
+      scrollElement: fixture.scrollElement,
+      itemCount: 4,
+      suppressAutoScrollRef,
+      stickyStateRef,
+    });
+
+    expect(stickyStateRef.current).toBe(false);
+    expect(latestResult?.isSticky).toBe(false);
+  });
+
+  it('keeps follow released when suppressed content contraction enters the bottom tolerance', async () => {
+    const sessionId = 'session-suppressed-content-resize' as SessionId;
+    const fixture = createScrollFixture();
+    const vlist = createMockVirtualizerHandle(fixture.scrollElement);
+    const suppressAutoScrollRef = { current: false };
+    const stickyStateRef = { current: true };
+
+    await renderHarness({
+      sessionId,
+      vlist,
+      scrollElement: fixture.scrollElement,
+      itemCount: 4,
+      suppressAutoScrollRef,
+      stickyStateRef,
+    });
+    await act(async () => {
+      await advanceAnimationFrames();
+    });
+
+    suppressAutoScrollRef.current = true;
+    fixture.setContentHeight(560);
+    fixture.setScrollHeight(584);
+    await act(async () => {
+      emitResize(fixture.contentElement);
+      await advanceAnimationFrames();
+    });
+
+    expect(stickyStateRef.current).toBe(false);
+    expect(latestResult?.isSticky).toBe(false);
   });
 
   it('attaches when the scroll viewport mounts after the empty state', async () => {


### PR DESCRIPTION
## Related issue

Same-repository maintainer branch; no intake issue was created.

## Problem / pressure

When a reader releases bottom-follow during a streaming assistant Turn, completion replaces the expanded work timeline with a compact `Worked for …` row and removes the live activity row. That sudden virtual-list contraction can clamp the viewport to its new end, after which the sticky-scroll near-bottom tolerance re-enables follow and appears to jump the conversation to the bottom.

## Summary

- Keep normal completion semantics: work folds into `Worked for …` and the activity row retires immediately.
- Before either contraction commits, capture the nearest mounted virtual row whose key survives the finished layout and its viewport-relative top.
- Add provisional trailing scroll range in the same commit to prevent native clamping, then compensate the anchor delta and trim the range after layout; bounded follow-up corrections absorb Virtua measurements.
- Mirror and defend the released follow lock synchronously, including activity-first/finished-first event ordering and the dependency's negative-resize near-bottom re-lock.

## Visual explanation

```mermaid
sequenceDiagram
    participant Reader
    participant View
    participant Virtua
    Reader->>View: release bottom follow
    View->>View: capture surviving row and viewport top
    View->>Virtua: commit folded rows and provisional tail range
    Virtua-->>View: measure finished layout
    View->>View: compensate anchor delta and trim tail range
```

The tail range is scroll geometry only. It prevents the browser from clamping before compensation and disappears when the reader returns to the end; finished messages never render with streaming structure.

## Before / after

| Before | After |
| ------ | ----- |
| Completion contraction can clamp the virtual viewport and re-lock sticky scrolling. | Completion still contracts immediately, while a surviving row keeps the same viewport coordinate. |
| Activity retirement and `finished` can arrive in either order and each can move the reader. | Both event orders receive independent anchor compensation. |
| Virtua may refine folded row sizes after the commit and introduce a second drift. | A bounded correction follows those measurements and yields to real reader input. |

## Test plan

- `packages/components/node_modules/.bin/vitest run tests/use-sticky-scroll.test.ts tests/worked-group-collapse-gate.test.ts tests/plan-turn-virtual-rows.test.ts tests/chat-virtual-rows-identity.test.ts tests/completion-visual-anchor.test.ts` — 29 tests passed.
- `node_modules/.bin/tsgo --noEmit` from `packages/components` — passed.
- `node_modules/.bin/oxlint --type-aware` on the seven changed TypeScript files — 0 errors; existing warnings only.
- Prettier check and `git diff --check` — passed.
- `node scripts/docs/main.mjs check` — no errors; existing AGENTS size warnings remain.
- Browser E2E was not added because the current streaming story stops at `indicator-only` and never emits the real `finished + idle` transition; touch and scrollbar-drag completion remain useful follow-up coverage.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** Inspect pre-commit row capture and post-commit correction in `ai-gui/view.tsx`/`completion-visual-anchor.ts`, plus resize suppression in `use-sticky-scroll.ts`.
- **Decisions to challenge:** Confirm the provisional trailing range prevents clamp without changing immediate finished-row rendering, and that four correction frames are a sufficient Virtua settling bound.
- **Plausible failures / evidence gaps:** The geometry and event-order paths are deterministic tests, but the repository still lacks a real browser fixture that emits `finished + idle`.

### Authoring context

- **User goal / directives:** Fix completion scroll jumps while preserving immediate `Worked for …` folding and the reader's visual anchor.
- **Constraints / non-goals:** Do not delay folding, retain activity rows, or change normal bottom-follow behavior for readers already at the end.
- **Risk-bearing decisions:** A trailing spacer temporarily preserves scroll range; row-key anchoring and a bounded correction compensate Virtua's immediate and measured layouts.
- **Destructive or irreversible behavior:** The change performs no deletion, migration, persistence rewrite, or irreversible operation; removing the patch restores prior behavior.
- **Deliberately not done or tested:** No browser E2E was added because the existing fixture does not enter the actual finished-and-idle state.
- **Unknowns / confidence:** Unit coverage includes both completion event orders, anchor geometry, immediate folding, wheel intent, and resize re-lock; real touch and scrollbar integration remain residual risk.

### Original user prompt

<details>
<summary>Show original prompt</summary>

````text
去看看 lodyai/lody，好像对话完成的时候，对话滚动会自动突然跳到末尾？不确定，你要去 fact check 一下

你能直接修复么..
````

</details>

<!-- context-handoff:end -->
