### PR TITLE
fix(cli): author agent commits with the GitHub no-reply address

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-12-github-noreply-commit-email.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-12-github-noreply-commit-email.md
@@ -1,0 +1,57 @@
+# Prefer the GitHub no-reply address for the requester's commit email
+
+Status: implemented
+Translation: current
+
+[中文](2026-09-12-github-noreply-commit-email.zh.md)
+
+## Abstract
+
+A session turn exports the requester's resolved commit identity as `GIT_AUTHOR_*`/`GIT_COMMITTER_*`,
+and those variables override `~/.gitconfig`, so whatever Lody resolves is what the agent's commits
+carry. The resolver preferred the stored account email and fell back to the GitHub no-reply address
+only for missing-email placeholders; for an account that enables "Keep my email addresses private"
+together with "Block command line pushes that expose my email", that real address makes GitHub
+reject every push of an agent commit with GH007, leaving the user unable to ship the work. The fix
+inverts that single preference: whenever the profile carries both a GitHub account id and login, the
+requester's commit email is `<id>+<login>@users.noreply.github.com`, and the account email is used
+only when no such pair exists. The trade-off is that a user whose account email is public and who
+expected it on the commit object now sees the no-reply address instead; GitHub attributes both to
+the same account, so attribution is unchanged.
+
+## Decision
+
+The GitHub no-reply address is the strictly better commit email whenever it exists. It attributes
+the commit to the same GitHub account that later opens the pull request, it is never rejected by
+the private-email push block, and it does not publish an address the account chose to keep private.
+The stored account email carries no capability the no-reply lacks, so the previous preference only
+ever traded a working push for a cosmetically nicer address.
+
+The change is confined to `SessionUserResolver.toSessionUserProfile`. The downstream ownership
+policy in `git-identity.ts` is untouched:
+
+- machine owner: effective machine/repository Git identity, then this resolved identity, then the
+  neutral `LodyAI <agent@lody.ai>`;
+- non-owner requester: this resolved identity, then the neutral identity.
+
+Two alternatives were rejected. Skipping the `GIT_*` export entirely when the host `user.email` is
+set would let a remote or multi-user daemon attribute a teammate's turn to the machine owner, which
+is exactly what the ownership policy exists to prevent. Adding a user-facing setting was rejected as
+out of proportion: the no-reply address is correct for every account that has one, so there is
+nothing left to configure.
+
+The worktree archive backup identity is deliberately unchanged; it is machine-local bookkeeping, not
+requester attribution.
+
+## Evidence and verification
+
+`apps/cli/src/session/session-user-resolver.ts` implements the preference;
+`apps/cli/tests/session-user-resolver.test.ts` covers a real account email plus a complete GitHub
+profile resolving to the no-reply address, an incomplete GitHub profile keeping the account email,
+and the pre-existing placeholder and fallback paths. Intent is recorded in
+`specs/git-commit-identity.md` (still `draft`). The ownership policy this builds on is
+[the machine-owner Git identity note](../feature/2026-09-08-machine-owner-git-identity.md).
+
+Verification is the CLI unit suite and typecheck; the GH007 rejection itself is reproduced from the
+GitHub push-protection behavior rather than executed in CI, so end-to-end acceptance against a
+private-email account remains unverified here.

--- a/.agents/notes/implemented/bug-fix/2026-09-12-github-noreply-commit-email.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-12-github-noreply-commit-email.md
@@ -1,4 +1,4 @@
-# Prefer the GitHub no-reply address for the requester's commit email
+# Use the GitHub no-reply commit email on GitHub remotes only
 
 Status: implemented
 Translation: current
@@ -9,49 +9,68 @@ Translation: current
 
 A session turn exports the requester's resolved commit identity as `GIT_AUTHOR_*`/`GIT_COMMITTER_*`,
 and those variables override `~/.gitconfig`, so whatever Lody resolves is what the agent's commits
-carry. The resolver preferred the stored account email and fell back to the GitHub no-reply address
-only for missing-email placeholders; for an account that enables "Keep my email addresses private"
-together with "Block command line pushes that expose my email", that real address makes GitHub
-reject every push of an agent commit with GH007, leaving the user unable to ship the work. The fix
-inverts that single preference: whenever the profile carries both a GitHub account id and login, the
-requester's commit email is `<id>+<login>@users.noreply.github.com`, and the account email is used
-only when no such pair exists. The trade-off is that a user whose account email is public and who
-expected it on the commit object now sees the no-reply address instead; GitHub attributes both to
-the same account, so attribution is unchanged.
+carry. Lody resolved the stored account email, which for an account with "Keep my email addresses
+private" plus "Block command line pushes that expose my email" is exactly the address GitHub
+rejects: every push of an agent commit failed with GH007 and the user could not ship the work. The
+fix makes the account's `<id>+<login>@users.noreply.github.com` address win, but only in a session
+workdir that pushes to github.com — the address attributes nothing on GitLab or a GitHub Enterprise
+host and may be rejected there, so those repositories keep resolving through Git configuration and
+the account email as before. Because the resolver is cached per user and never sees a workdir, the
+no-reply address is now reported beside the account email and the workdir's remotes decide between
+them; the residual limit is that hosts such as `ssh.github.com` are not recognised as GitHub, which
+costs those users the fix rather than breaking them.
 
 ## Decision
 
-The GitHub no-reply address is the strictly better commit email whenever it exists. It attributes
-the commit to the same GitHub account that later opens the pull request, it is never rejected by
-the private-email push block, and it does not publish an address the account chose to keep private.
-The stored account email carries no capability the no-reply lacks, so the previous preference only
-ever traded a working push for a cosmetically nicer address.
+Two facts do not live in the same place. `SessionUserResolver` knows the requester's GitHub account
+but is cached per user across every session, so it cannot see a workdir. `resolveSessionGitIdentity`
+runs per turn with the session `cwd` but knows nothing about the account. The no-reply address is
+therefore resolved as a second, clearly-typed value (`SessionUserProfile.githubNoreplyEmail`,
+carried to the turn as the optional `userGitHubNoreplyEmail` request field) and the decision is
+taken where `cwd` exists. The account email keeps its own meaning, so the non-GitHub fallback order
+is unchanged rather than silently replaced by a GitHub address.
 
-The change is confined to `SessionUserResolver.toSessionUserProfile`. The downstream ownership
-policy in `git-identity.ts` is untouched:
+The resulting order in `resolveSessionGitIdentity` is:
 
-- machine owner: effective machine/repository Git identity, then this resolved identity, then the
-  neutral `LodyAI <agent@lody.ai>`;
-- non-owner requester: this resolved identity, then the neutral identity.
+- github.com remote and a usable GitHub account id and login: the no-reply address, ahead of the
+  machine Git identity, because that identity is what GH007 rejects for these accounts;
+- otherwise the existing policy — machine owner: effective machine/repository Git identity, then
+  the requester's account email, then neutral `LodyAI <agent@lody.ai>`; non-owner: the requester's
+  account email, then the neutral identity, never the machine owner's configuration.
 
-Two alternatives were rejected. Skipping the `GIT_*` export entirely when the host `user.email` is
-set would let a remote or multi-user daemon attribute a teammate's turn to the machine owner, which
-is exactly what the ownership policy exists to prevent. Adding a user-facing setting was rejected as
-out of proportion: the no-reply address is correct for every account that has one, so there is
-nothing left to configure.
+`origin` decides the host alone when it exists: a repository whose origin is GitLab is not a GitHub
+repository because it also has a GitHub mirror. Only `github.com` and `gist.github.com` count, so a
+GitHub Enterprise installation — whose accounts have different ids and no `users.noreply.github.com`
+attribution — is excluded. The push URL wins over the fetch URL because the push is what GitHub can
+reject. `GIT_*` stays exported in every branch: dropping it when the host Git configuration is set
+would attribute a teammate's turn on a shared daemon to the machine owner, which the ownership
+policy exists to prevent.
 
-The worktree archive backup identity is deliberately unchanged; it is machine-local bookkeeping, not
-requester attribution.
+Two alternatives were rejected. Letting the resolver keep choosing the no-reply address and having
+the Git layer merely demote it off GitHub needs no new plumbing, but the account email is gone by
+then, so a GitLab user without Git configuration would commit as `LodyAI` instead of themselves.
+Re-resolving the requester profile at `updateGitIdentity` time avoids the request field but reads
+identity outside the frozen turn, which [the session rules](../../../../apps/cli/src/session/AGENTS.md)
+forbid. A user-facing setting was rejected as disproportionate: on github.com the no-reply address
+is correct for every account that has one, and off it the address is simply wrong.
+
+The worktree archive backup identity is deliberately unchanged; it is machine-local bookkeeping,
+not requester attribution.
 
 ## Evidence and verification
 
-`apps/cli/src/session/session-user-resolver.ts` implements the preference;
-`apps/cli/tests/session-user-resolver.test.ts` covers a real account email plus a complete GitHub
-profile resolving to the no-reply address, an incomplete GitHub profile keeping the account email,
-and the pre-existing placeholder and fallback paths. Intent is recorded in
-`specs/git-commit-identity.md` (still `draft`). The ownership policy this builds on is
+`apps/cli/src/session/git-identity.ts` holds the remote inspection and the resolution order, and
+`apps/cli/src/session/session-user-resolver.ts` reports the address beside the account email.
+`apps/cli/tests/git-identity.test.ts` covers https and ssh GitHub origins, a gitlab.com origin, a
+remote-less repository, a GitHub mirror behind a GitLab origin, a GitHub Enterprise host, an
+incomplete GitHub profile, and the non-owner and neutral fallbacks — the last three cases through
+real temporary repositories so the `git remote -v` and `git config` reads are exercised, with the
+inherited `GIT_AUTHOR_*`/`GIT_COMMITTER_*` environment stubbed out so the repository configuration
+is what answers. `apps/cli/tests/session-user-resolver.test.ts` covers the split fields. Intent is
+recorded in `specs/git-commit-identity.md` (still `draft`). The ownership policy this builds on is
 [the machine-owner Git identity note](../feature/2026-09-08-machine-owner-git-identity.md).
 
-Verification is the CLI unit suite and typecheck; the GH007 rejection itself is reproduced from the
-GitHub push-protection behavior rather than executed in CI, so end-to-end acceptance against a
-private-email account remains unverified here.
+The full `apps/cli` suite passes except the pre-existing `tests/worktree-gc.test.ts` macOS
+`/private/var` path mismatch, which fails identically without these changes. The GH007 rejection
+itself is taken from GitHub's push protection rather than reproduced in CI, so end-to-end
+acceptance against a private-email account remains unverified.

--- a/.agents/notes/implemented/bug-fix/2026-09-12-github-noreply-commit-email.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-12-github-noreply-commit-email.zh.md
@@ -1,4 +1,4 @@
-# 请求者 commit 邮箱优先使用 GitHub no-reply 地址
+# 仅在 GitHub remote 上使用 GitHub no-reply commit 邮箱
 
 Status: implemented
 Translation: current
@@ -7,41 +7,58 @@ Translation: current
 
 ## 摘要
 
-每一轮 session 都会把请求者解析出的 commit 身份写入 `GIT_AUTHOR_*`/`GIT_COMMITTER_*`，
-而这些环境变量会覆盖 `~/.gitconfig`，因此 Lody 解析出什么，agent 的 commit 就带什么。
-此前解析器优先使用存储的账号邮箱，只有在邮箱是缺失占位符时才回退到 GitHub no-reply 地址；
-对于同时开启「邮箱保密」和「禁止命令行推送暴露邮箱」的账号，这个真实地址会让 GitHub 以
-GH007 拒绝每一次 agent commit 的推送，用户无法交付成果。修复只反转这一处优先级：只要
-profile 同时带有 GitHub account id 与 login，请求者的 commit 邮箱就是
-`<id>+<login>@users.noreply.github.com`，仅在拿不到这对值时才使用账号邮箱。权衡是：邮箱本
-就公开、并期望它出现在 commit 对象上的用户，现在会看到 no-reply 地址；由于 GitHub 把两者
-归属到同一账号，署名归属不变。
+每一轮 session 都会把请求者解析出的 commit 身份写入 `GIT_AUTHOR_*`/`GIT_COMMITTER_*`，而这些环境
+变量会覆盖 `~/.gitconfig`，因此 Lody 解析出什么，agent 的 commit 就带什么。Lody 此前解析的是存储
+的账号邮箱；对于同时开启「邮箱保密」和「禁止命令行推送暴露邮箱」的账号，这恰好是 GitHub 会拒绝
+的地址：每次推送 agent commit 都以 GH007 失败，用户无法交付成果。修复让账号的
+`<id>+<login>@users.noreply.github.com` 地址胜出，但仅限于推送到 github.com 的 session 工作目录
+——该地址在 GitLab 或 GitHub Enterprise 上无法归属、甚至可能被拒绝，所以这些仓库仍按 Git 配置与
+账号邮箱的原有顺序解析。由于解析器按用户缓存、看不到工作目录，no-reply 地址现在与账号邮箱并列
+上报，由工作目录的 remote 在两者之间选择；遗留限制是 `ssh.github.com` 之类的 host 不被识别为
+GitHub，这些用户因此拿不到修复，但不会被破坏。
 
 ## 决策
 
-只要存在 GitHub no-reply 地址，它就是严格更优的 commit 邮箱：它把 commit 归属到之后开 PR
-的同一个 GitHub 账号，不会被私密邮箱推送保护拒绝，也不会公开用户选择保密的地址。存储的账号
-邮箱并不提供 no-reply 没有的能力，所以旧的优先级只是用一次能成功的推送换一个更好看的地址。
+两项事实不在同一处。`SessionUserResolver` 知道请求者的 GitHub 账号，但它跨所有 session 按用户缓存，
+看不到工作目录；`resolveSessionGitIdentity` 每轮携带 session `cwd` 运行，却不知道账号信息。因此
+no-reply 地址作为独立且有明确类型的值解析（`SessionUserProfile.githubNoreplyEmail`，以可选请求
+字段 `userGitHubNoreplyEmail` 随该轮冻结传递），判断放在有 `cwd` 的地方。账号邮箱保留自身含义，
+非 GitHub 场景的回退顺序因此保持不变，而不是被一个 GitHub 地址悄悄替换。
 
-改动限定在 `SessionUserResolver.toSessionUserProfile`。`git-identity.ts` 中的所有权策略保持不变：
+`resolveSessionGitIdentity` 最终的顺序是：
 
-- 机器 owner：机器/仓库中生效的 Git identity，其次是本文解析出的身份，最后是中性的
-  `LodyAI <agent@lody.ai>`；
-- 非 owner 请求者：本文解析出的身份，其次是中性身份。
+- github.com remote 且 GitHub account id 与 login 可用：使用 no-reply 地址，优先于机器 Git
+  identity——对这些账号而言，正是机器 identity 会触发 GH007；
+- 其余情况沿用既有策略——机器 owner：机器/仓库中生效的 Git identity，其次是请求者账号邮箱，最后是
+  中性的 `LodyAI <agent@lody.ai>`；非 owner：请求者账号邮箱，其次是中性身份，绝不使用机器 owner
+  的配置。
 
-两个替代方案被否决。当 host 的 `user.email` 已配置时干脆不导出 `GIT_*`，会让远程或多用户
-daemon 把团队成员的轮次署名成机器 owner，而这正是所有权策略要避免的情况。新增用户可见设置
-同样被否决：对任何拥有 no-reply 地址的账号来说它都是正确选择，没有可配置的余地。
+存在 `origin` 时只由 `origin` 决定 host：origin 指向 GitLab 的仓库不会因为多了一个 GitHub 镜像就
+变成 GitHub 仓库。只有 `github.com` 与 `gist.github.com` 计入，因此排除 GitHub Enterprise 部署
+（其账号 id 不同，也没有 `users.noreply.github.com` 归属）。push URL 优先于 fetch URL，因为被
+GitHub 拒绝的是 push。每个分支都仍然导出 `GIT_*`：在 host Git 配置已存在时改为不注入，会让共享
+daemon 上团队成员的轮次被署名为机器 owner，而这正是所有权策略要防止的。
+
+两个替代方案被否决。让解析器继续选择 no-reply、再由 Git 层在非 GitHub 场景把它降级，无需新增管道，
+但那时账号邮箱已经丢失，没有 Git 配置的 GitLab 用户会被署名为 `LodyAI` 而不是本人。在
+`updateGitIdentity` 时重新解析请求者 profile 可以省去请求字段，但那是在冻结轮次之外重新读取身份，
+[session 规则](../../../../apps/cli/src/session/AGENTS.md)禁止这样做。新增用户可见设置同样被否决：
+在 github.com 上，对任何拥有 no-reply 的账号它都是正确选择；离开 github.com 它则根本是错的。
 
 worktree 归档备份身份刻意保持不变：那是机器本地的记录，不是请求者署名。
 
 ## 证据与验证
 
-优先级实现在 `apps/cli/src/session/session-user-resolver.ts`；
-`apps/cli/tests/session-user-resolver.test.ts` 覆盖了「真实账号邮箱 + 完整 GitHub profile 解析为
-no-reply 地址」「GitHub profile 不完整时保留账号邮箱」以及原有的占位符与回退路径。意图记录在
-`specs/git-commit-identity.md`（仍为 `draft`）。本修复所依赖的所有权策略见
+`apps/cli/src/session/git-identity.ts` 承载 remote 判断与解析顺序，
+`apps/cli/src/session/session-user-resolver.ts` 将该地址与账号邮箱并列上报。
+`apps/cli/tests/git-identity.test.ts` 覆盖 https 与 ssh 的 GitHub origin、gitlab.com origin、
+无 remote 的仓库、GitLab origin 背后的 GitHub 镜像、GitHub Enterprise host、不完整的 GitHub
+profile，以及非 owner 与中性回退；其中最后三种场景通过真实临时仓库执行，从而真正跑过
+`git remote -v` 与 `git config` 读取，并将继承的 `GIT_AUTHOR_*`/`GIT_COMMITTER_*` 环境变量置空，
+使仓库配置成为答案来源。`apps/cli/tests/session-user-resolver.test.ts` 覆盖拆分后的字段。意图记录
+在 `specs/git-commit-identity.md`（仍为 `draft`）。本修复所依赖的所有权策略见
 [机器 owner Git identity 笔记](../feature/2026-09-08-machine-owner-git-identity.zh.md)。
 
-验证手段是 CLI 单元测试与 typecheck；GH007 拒绝本身依据 GitHub 推送保护行为推导，并未在 CI 中
-实际执行，因此针对私密邮箱账号的端到端验收在此仍未验证。
+`apps/cli` 全量测试通过，仅 `tests/worktree-gc.test.ts` 的既有 macOS `/private/var` 路径不匹配失败，
+该用例在不含本次改动时同样失败。GH007 拒绝本身依据 GitHub 推送保护推导，并未在 CI 中实际执行，
+因此针对私密邮箱账号的端到端验收仍未验证。

--- a/.agents/notes/implemented/bug-fix/2026-09-12-github-noreply-commit-email.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-12-github-noreply-commit-email.zh.md
@@ -1,0 +1,47 @@
+# 请求者 commit 邮箱优先使用 GitHub no-reply 地址
+
+Status: implemented
+Translation: current
+
+[English](2026-09-12-github-noreply-commit-email.md)
+
+## 摘要
+
+每一轮 session 都会把请求者解析出的 commit 身份写入 `GIT_AUTHOR_*`/`GIT_COMMITTER_*`，
+而这些环境变量会覆盖 `~/.gitconfig`，因此 Lody 解析出什么，agent 的 commit 就带什么。
+此前解析器优先使用存储的账号邮箱，只有在邮箱是缺失占位符时才回退到 GitHub no-reply 地址；
+对于同时开启「邮箱保密」和「禁止命令行推送暴露邮箱」的账号，这个真实地址会让 GitHub 以
+GH007 拒绝每一次 agent commit 的推送，用户无法交付成果。修复只反转这一处优先级：只要
+profile 同时带有 GitHub account id 与 login，请求者的 commit 邮箱就是
+`<id>+<login>@users.noreply.github.com`，仅在拿不到这对值时才使用账号邮箱。权衡是：邮箱本
+就公开、并期望它出现在 commit 对象上的用户，现在会看到 no-reply 地址；由于 GitHub 把两者
+归属到同一账号，署名归属不变。
+
+## 决策
+
+只要存在 GitHub no-reply 地址，它就是严格更优的 commit 邮箱：它把 commit 归属到之后开 PR
+的同一个 GitHub 账号，不会被私密邮箱推送保护拒绝，也不会公开用户选择保密的地址。存储的账号
+邮箱并不提供 no-reply 没有的能力，所以旧的优先级只是用一次能成功的推送换一个更好看的地址。
+
+改动限定在 `SessionUserResolver.toSessionUserProfile`。`git-identity.ts` 中的所有权策略保持不变：
+
+- 机器 owner：机器/仓库中生效的 Git identity，其次是本文解析出的身份，最后是中性的
+  `LodyAI <agent@lody.ai>`；
+- 非 owner 请求者：本文解析出的身份，其次是中性身份。
+
+两个替代方案被否决。当 host 的 `user.email` 已配置时干脆不导出 `GIT_*`，会让远程或多用户
+daemon 把团队成员的轮次署名成机器 owner，而这正是所有权策略要避免的情况。新增用户可见设置
+同样被否决：对任何拥有 no-reply 地址的账号来说它都是正确选择，没有可配置的余地。
+
+worktree 归档备份身份刻意保持不变：那是机器本地的记录，不是请求者署名。
+
+## 证据与验证
+
+优先级实现在 `apps/cli/src/session/session-user-resolver.ts`；
+`apps/cli/tests/session-user-resolver.test.ts` 覆盖了「真实账号邮箱 + 完整 GitHub profile 解析为
+no-reply 地址」「GitHub profile 不完整时保留账号邮箱」以及原有的占位符与回退路径。意图记录在
+`specs/git-commit-identity.md`（仍为 `draft`）。本修复所依赖的所有权策略见
+[机器 owner Git identity 笔记](../feature/2026-09-08-machine-owner-git-identity.zh.md)。
+
+验证手段是 CLI 单元测试与 typecheck；GH007 拒绝本身依据 GitHub 推送保护行为推导，并未在 CI 中
+实际执行，因此针对私密邮箱账号的端到端验收在此仍未验证。

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -2711,6 +2711,7 @@ export class MessageHandler {
       userId: args.userId,
       userName: user.name,
       userEmail: user.email,
+      userGitHubNoreplyEmail: user.githubNoreplyEmail,
     });
   }
 

--- a/apps/cli/src/orchestration/operation-coordinator.ts
+++ b/apps/cli/src/orchestration/operation-coordinator.ts
@@ -1204,6 +1204,7 @@ export class LodyOperationCoordinator {
         userId: operation.requesterUserId,
         userName: requester.name,
         userEmail: requester.email,
+        userGitHubNoreplyEmail: requester.githubNoreplyEmail,
       },
       {
         dispatchSource: 'delivery',
@@ -1416,7 +1417,7 @@ export class LodyOperationCoordinator {
    */
   private async resolveRequesterIdentity(
     requesterUserId: string
-  ): Promise<{ name: string; email: string }> {
+  ): Promise<{ name: string; email: string; githubNoreplyEmail?: string }> {
     const fallback = {
       name: requesterUserId,
       email: buildMissingEmail('lody', requesterUserId),
@@ -1427,7 +1428,11 @@ export class LodyOperationCoordinator {
     }
     try {
       const profile = await resolver.resolve(requesterUserId);
-      return { name: profile.name, email: profile.email };
+      return {
+        name: profile.name,
+        email: profile.email,
+        ...(profile.githubNoreplyEmail ? { githubNoreplyEmail: profile.githubNoreplyEmail } : {}),
+      };
     } catch (error) {
       this.options.logger.debug(
         `[operation-coordinator] Failed to resolve requester identity ${requesterUserId}: ${

--- a/apps/cli/src/session/AGENTS.md
+++ b/apps/cli/src/session/AGENTS.md
@@ -19,8 +19,8 @@ Contract: specs/session-orchestration.md.
   exists; retries and recovery never reread mutable history.
 - Machine and Provider credentials stay execution-host scoped; attribution, authorization,
   GitHub, and Git identity use the frozen identity, never the Session owner.
-- Git identity: owner prefers machine then requester; others never read machine config; GitHub
-  no-reply outranks account email. Identity never restarts ACP/sandbox, even in preparations.
+- Git identity: no-reply ONLY on github.com remotes; else owner prefers machine then requester,
+  others never read machine config. Identity never restarts ACP/sandbox, even in preparations.
   Use `CloudPort`; reject placeholders.
 
 ## Dispatch

--- a/apps/cli/src/session/AGENTS.md
+++ b/apps/cli/src/session/AGENTS.md
@@ -19,8 +19,8 @@ Contract: specs/session-orchestration.md.
   exists; retries and recovery never reread mutable history.
 - Machine and Provider credentials stay execution-host scoped; attribution, authorization,
   GitHub, and Git identity use the frozen identity, never the Session owner.
-- Git identity: owner prefers machine then requester; others never read machine config.
-  Never restart ACP/sandbox for identity, even in preparations.
+- Git identity: owner prefers machine then requester; others never read machine config; GitHub
+  no-reply outranks account email. Identity never restarts ACP/sandbox, even in preparations.
   Use `CloudPort`; reject placeholders.
 
 ## Dispatch

--- a/apps/cli/src/session/README.md
+++ b/apps/cli/src/session/README.md
@@ -168,18 +168,25 @@ fetching/caching is in `../lib/github-token-manager.ts`; git HTTPS auth uses
 ### Commit identity
 
 The effective identity becomes `GIT_AUTHOR_*`/`GIT_COMMITTER_*` in the session env (`session.ts`
-`updateGitIdentity`, re-applied per turn via the execution service's `bindReadySession`). When
-the turn requester is the machine owner, the repository/machine Git identity wins and the
-resolved Lody/GitHub identity is its fallback. A non-owner requester always uses their resolved
-Lody/GitHub identity and can never inherit the machine owner's Git config; if no usable requester
-identity exists, the neutral LodyAI identity is used. Resolving that Lody/GitHub identity
-(`session-user-resolver.ts`) prefers the account's `<id>+<login>@users.noreply.github.com`
-address over the stored account email, because an account with "Keep my email addresses private"
-plus "Block command line pushes that expose my email" has GitHub reject every push carrying a
-commit authored with its real address (GH007), and the no-reply attributes the commit to the same
-account anyway. The account email is used only when the profile carries no usable GitHub id and
-login. The cloud composition root owns hosted user resolution because the daemon does not own an
-end-user browser session; the local access
+`updateGitIdentity`, re-applied per turn via the execution service's `bindReadySession`).
+
+The requester's GitHub no-reply address `<id>+<login>@users.noreply.github.com` is tried first,
+but only when the session workdir pushes to github.com. There it beats every other candidate: an
+account with "Keep my email addresses private" plus "Block command line pushes that expose my
+email" has GitHub reject every push carrying a commit authored with its real address (GH007),
+and the no-reply attributes the commit to the same account anyway. `git-identity.ts` reads the
+workdir remotes for this and lets `origin` decide alone when it exists, so a GitLab repository
+with a GitHub mirror is still a GitLab repository; `github.com` and `gist.github.com` are the
+only GitHub hosts, which deliberately excludes GitHub Enterprise. `session-user-resolver.ts`
+reports the address beside the account email rather than instead of it, because that resolver is
+cached per user and cannot see a workdir.
+
+Off github.com the older order stands. When the turn requester is the machine owner, the
+repository/machine Git identity wins and the resolved Lody/GitHub identity is its fallback. A
+non-owner requester always uses their resolved Lody/GitHub identity and can never inherit the
+machine owner's Git config; if no usable requester identity exists, the neutral LodyAI identity
+is used. The cloud composition root owns hosted user resolution because the daemon does not own
+an end-user browser session; the local access
 port resolves only its synthetic owner and never performs network I/O. PR and push identity
 itself comes from the requester-bound GitHub token, not from git config. Identity changes update the host Session environment without restarting ACP or its sandbox,
 including adopted preparations. Existing ACP children retain their launch environment; live

--- a/apps/cli/src/session/README.md
+++ b/apps/cli/src/session/README.md
@@ -172,8 +172,14 @@ The effective identity becomes `GIT_AUTHOR_*`/`GIT_COMMITTER_*` in the session e
 the turn requester is the machine owner, the repository/machine Git identity wins and the
 resolved Lody/GitHub identity is its fallback. A non-owner requester always uses their resolved
 Lody/GitHub identity and can never inherit the machine owner's Git config; if no usable requester
-identity exists, the neutral LodyAI identity is used. The cloud composition root owns hosted
-user resolution because the daemon does not own an end-user browser session; the local access
+identity exists, the neutral LodyAI identity is used. Resolving that Lody/GitHub identity
+(`session-user-resolver.ts`) prefers the account's `<id>+<login>@users.noreply.github.com`
+address over the stored account email, because an account with "Keep my email addresses private"
+plus "Block command line pushes that expose my email" has GitHub reject every push carrying a
+commit authored with its real address (GH007), and the no-reply attributes the commit to the same
+account anyway. The account email is used only when the profile carries no usable GitHub id and
+login. The cloud composition root owns hosted user resolution because the daemon does not own an
+end-user browser session; the local access
 port resolves only its synthetic owner and never performs network I/O. PR and push identity
 itself comes from the requester-bound GitHub token, not from git config. Identity changes update the host Session environment without restarting ACP or its sandbox,
 including adopted preparations. Existing ACP children retain their launch environment; live

--- a/apps/cli/src/session/git-identity.ts
+++ b/apps/cli/src/session/git-identity.ts
@@ -15,11 +15,23 @@ type PartialGitIdentity = {
   email?: string | null;
 };
 
+export type GitRemote = {
+  name: string;
+  url: string;
+};
+
 export type GitIdentityResolutionOptions = {
   /** Only machine-owner turns may read and prefer the machine's Git identity. */
   preferMachineIdentity: boolean;
   machineIdentity?: PartialGitIdentity;
   cwd?: string;
+  /**
+   * The requester's GitHub no-reply address. It is a commit identity only on a
+   * github.com remote, so it is never used as a generic fallback.
+   */
+  githubNoreplyEmail?: string | null;
+  /** Session workdir remotes; read from `cwd` when omitted. */
+  remotes?: readonly GitRemote[];
 };
 
 const trimNonEmpty = (value?: string | null): string | undefined => {
@@ -74,6 +86,90 @@ const readGitConfig = (key: 'user.name' | 'user.email', cwd?: string): string | 
   }
 };
 
+/** Hosts whose pushes GitHub itself authorizes, and therefore the only hosts a
+ * `users.noreply.github.com` author address can be attributed by. GitHub
+ * Enterprise installations and every other forge are deliberately excluded. */
+const GITHUB_REMOTE_HOSTS = new Set(['github.com', 'gist.github.com']);
+
+/**
+ * Host of a Git remote URL, or undefined for a local path or unparsable value.
+ *
+ * Handles the scp-like `git@host:owner/repo.git` form separately: it has no
+ * scheme, so `URL` rejects it.
+ */
+export const parseGitRemoteHost = (remoteUrl: string): string | undefined => {
+  const url = remoteUrl.trim();
+  if (!url) {
+    return undefined;
+  }
+  if (!url.includes('://')) {
+    const scpLike = /^(?:[^@\s/]+@)?([^\s/:]+):/.exec(url);
+    return scpLike?.[1]?.toLowerCase();
+  }
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+};
+
+const isGitHubRemote = (remote: GitRemote): boolean => {
+  const host = parseGitRemoteHost(remote.url);
+  return host !== undefined && GITHUB_REMOTE_HOSTS.has(host);
+};
+
+/**
+ * Whether commits made here are pushed to github.com.
+ *
+ * `origin` decides alone when it exists: a repository whose origin is another
+ * forge is not a GitHub repository just because it also has a GitHub mirror.
+ */
+export const remotesTargetGitHub = (remotes: readonly GitRemote[]): boolean => {
+  const origin = remotes.find((remote) => remote.name === 'origin');
+  if (origin) {
+    return isGitHubRemote(origin);
+  }
+  return remotes.some(isGitHubRemote);
+};
+
+/**
+ * Parse `git remote -v`. The push URL wins when it differs from the fetch URL,
+ * because the push is what GitHub's private-email protection rejects.
+ */
+export const parseGitRemoteList = (output: string): GitRemote[] => {
+  const fetchUrls = new Map<string, string>();
+  const pushUrls = new Map<string, string>();
+  for (const line of output.split('\n')) {
+    const [name, url, direction] = line.trim().split(/\s+/);
+    if (!name || !url) {
+      continue;
+    }
+    const target = direction === '(push)' ? pushUrls : fetchUrls;
+    if (!target.has(name)) {
+      target.set(name, url);
+    }
+  }
+  const names = new Set([...fetchUrls.keys(), ...pushUrls.keys()]);
+  return [...names].flatMap((name) => {
+    const url = pushUrls.get(name) ?? fetchUrls.get(name);
+    return url ? [{ name, url }] : [];
+  });
+};
+
+const readGitRemotes = (cwd?: string): GitRemote[] => {
+  try {
+    const output = execFileSync('git', ['remote', '-v'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    });
+    return parseGitRemoteList(output);
+  } catch {
+    return [];
+  }
+};
+
 export const readHostDefaultGitIdentity = (cwd?: string): PartialGitIdentity => ({
   name:
     trimNonEmpty(process.env.GIT_AUTHOR_NAME) ??
@@ -89,6 +185,22 @@ export const resolveSessionGitIdentity = (
   requested: PartialGitIdentity,
   options: GitIdentityResolutionOptions
 ): GitIdentity => {
+  // A GitHub no-reply address is the requester's best commit identity on a
+  // github.com remote: it attributes the commit to the same account that opens
+  // the pull request, and it is the only address accepted by an account that
+  // keeps its email private and blocks command-line pushes (GH007). It is worth
+  // nothing on any other host, so it never displaces Git configuration there.
+  const githubNoreplyEmail = trimNonEmpty(options.githubNoreplyEmail);
+  if (githubNoreplyEmail !== undefined) {
+    const remotes = options.remotes ?? readGitRemotes(options.cwd);
+    if (remotesTargetGitHub(remotes)) {
+      return {
+        name: normalizeName(trimNonEmpty(requested.name), githubNoreplyEmail),
+        email: githubNoreplyEmail,
+      };
+    }
+  }
+
   if (options.preferMachineIdentity) {
     const machineIdentity = options.machineIdentity ?? readHostDefaultGitIdentity(options.cwd);
     const machineEmail = trimNonEmpty(machineIdentity.email);

--- a/apps/cli/src/session/session-dispatch-watcher.ts
+++ b/apps/cli/src/session/session-dispatch-watcher.ts
@@ -1979,6 +1979,7 @@ export class SessionDispatchWatcher {
       userId: entry.userId ?? meta.userId,
       userName: user.name,
       userEmail: user.email,
+      userGitHubNoreplyEmail: user.githubNoreplyEmail,
     };
   }
 
@@ -2026,6 +2027,7 @@ export class SessionDispatchWatcher {
       userId: entry.userId ?? meta.userId,
       userName: user.name,
       userEmail: user.email,
+      userGitHubNoreplyEmail: user.githubNoreplyEmail,
       parentSessionId: meta.parentSessionId,
     };
   }

--- a/apps/cli/src/session/session-edit-and-resend-service.ts
+++ b/apps/cli/src/session/session-edit-and-resend-service.ts
@@ -531,6 +531,7 @@ export class SessionEditAndResendService {
         parentSessionId: meta.parentSessionId,
         userName: user.name,
         userEmail: user.email,
+        userGitHubNoreplyEmail: user.githubNoreplyEmail,
       },
       {
         resumeSessionId: meta.acpSessionId,

--- a/apps/cli/src/session/session-execution-service.ts
+++ b/apps/cli/src/session/session-execution-service.ts
@@ -249,6 +249,7 @@ type SessionGoalTurnRequest = {
   userId: string;
   userName: string;
   userEmail: string;
+  userGitHubNoreplyEmail?: string;
 };
 
 type TurnInvocation = {
@@ -1220,6 +1221,7 @@ export class SessionExecutionService {
     userId: string;
     userName: string;
     userEmail: string;
+    userGitHubNoreplyEmail?: string;
   }): Promise<SessionGoalResponse> {
     const { sessionId, action } = options;
     const respond = (
@@ -1267,6 +1269,7 @@ export class SessionExecutionService {
       userId: options.userId,
       userName: options.userName,
       userEmail: options.userEmail,
+      userGitHubNoreplyEmail: options.userGitHubNoreplyEmail,
     };
     // Acceptance is not prompt completion (or even a claim of turn ownership).
     // The worker reports startup failures through the session's existing history.
@@ -1367,6 +1370,7 @@ export class SessionExecutionService {
         userId: request.userId,
         userName: request.userName,
         userEmail: request.userEmail,
+        userGitHubNoreplyEmail: request.userGitHubNoreplyEmail,
       },
       {
         dispatchSource: 'goal',
@@ -3860,6 +3864,7 @@ export class SessionExecutionService {
     prepareOptions?: { sessionDoc?: SessionDocument }
   ): Promise<VisibleSessionTurnPlan> {
     const { sessionId, acpSessionConfig, userId, userName, userEmail, userTurnId } = message;
+    const userGitHubNoreplyEmail = message.userGitHubNoreplyEmail;
     // System-caused turns own an assistant entry, not a user dispatch pointer.
     const executionUserTurnId =
       dispatchOptions?.dispatchSource === 'delivery' || dispatchOptions?.dispatchSource === 'goal'
@@ -4027,6 +4032,7 @@ export class SessionExecutionService {
           parentSessionId: meta?.parentSessionId,
           userName,
           userEmail,
+          userGitHubNoreplyEmail,
           onPresencePhase: (phase, detail) =>
             self.deps.setSessionActivePresencePhase(sessionId, phase, detail),
         };
@@ -4232,6 +4238,7 @@ export class SessionExecutionService {
           ctx.bindSession(nextSession);
           nextSession.updateGitIdentity(userName, userEmail, message.userId, {
             preferMachineIdentity: message.userId === self.deps.userId,
+            githubNoreplyEmail: message.userGitHubNoreplyEmail,
           });
         };
 
@@ -4875,6 +4882,7 @@ export class SessionExecutionService {
       parentSessionId: message.parentSessionId,
       userName: message.userName,
       userEmail: message.userEmail,
+      userGitHubNoreplyEmail: message.userGitHubNoreplyEmail,
       onPresencePhase: (phase, detail) =>
         this.deps.setSessionActivePresencePhase(sessionId, phase, detail),
     };

--- a/apps/cli/src/session/session-fork-service.ts
+++ b/apps/cli/src/session/session-fork-service.ts
@@ -50,7 +50,7 @@ type WorktreeForkPreparedInput = {
   historyResult: NonNullable<ReturnType<typeof cloneHistoryThroughTurn>>;
   sourceSnapshot: StoredHistorySnapshot;
   agentConfig: NonNullable<Awaited<ReturnType<LoroDocumentManager['getAgentConfigById']>>>;
-  user: { name: string; email: string };
+  user: { name: string; email: string; githubNoreplyEmail?: string };
   operation: SessionForkOperation;
   targetWorkdir?: string;
 };
@@ -838,6 +838,9 @@ export class SessionForkService {
             parentSessionId,
             userName: user.name,
             userEmail: user.email,
+            ...('githubNoreplyEmail' in user
+              ? { userGitHubNoreplyEmail: user.githubNoreplyEmail }
+              : {}),
           },
           {
             forkSessionId: source.acpSessionId,
@@ -962,6 +965,7 @@ export class SessionForkService {
       ...(targetWorkdir ? { workdir: targetWorkdir } : {}),
       userName: user.name,
       userEmail: user.email,
+      userGitHubNoreplyEmail: user.githubNoreplyEmail,
     };
     try {
       await this.deps.sessionManager.createSession(config, {

--- a/apps/cli/src/session/session-manager.ts
+++ b/apps/cli/src/session/session-manager.ts
@@ -325,7 +325,7 @@ export interface ISession {
     userName: string,
     userEmail: string,
     userId: string | undefined,
-    options: { preferMachineIdentity: boolean }
+    options: { preferMachineIdentity: boolean; githubNoreplyEmail?: string }
   ): void;
   /**
    * Return the already-resolved effective git identity only when it belongs to
@@ -938,6 +938,7 @@ export class SessionManager extends EventEmitter<SessionManagerEvents> {
       workdir: spec.project?.kind === 'local' ? provisionalWorkdir : undefined,
       userName: user.name,
       userEmail: user.email,
+      userGitHubNoreplyEmail: user.githubNoreplyEmail,
     };
     const compatibility = buildSessionPreparationCompatibility(
       config,
@@ -1210,6 +1211,7 @@ export class SessionManager extends EventEmitter<SessionManagerEvents> {
       session.ghTokenInjected = prepared.session.ghTokenInjected;
       session.updateGitIdentity(config.userName, config.userEmail, config.requesterUserId, {
         preferMachineIdentity: config.requesterUserId === this.cloudPort.identity.userId,
+        githubNoreplyEmail: config.userGitHubNoreplyEmail,
       });
       const acpSessionId = await prepared.agentResult;
       const sessionDoc = await this.workspaceDocument.getOrCreateSessionDoc(sessionId);
@@ -1359,6 +1361,7 @@ export class SessionManager extends EventEmitter<SessionManagerEvents> {
     this.logger.debug(`[${sessionId}] Session workdir resolved: ${session.getWorkdir()}`);
     session.updateGitIdentity(config.userName, config.userEmail, config.requesterUserId, {
       preferMachineIdentity: config.requesterUserId === this.cloudPort.identity.userId,
+      githubNoreplyEmail: config.userGitHubNoreplyEmail,
     });
     let acpSessionId: string | undefined;
 

--- a/apps/cli/src/session/session-user-resolver.ts
+++ b/apps/cli/src/session/session-user-resolver.ts
@@ -1,4 +1,4 @@
-import { buildMissingEmail, isMissingEmail, type WorkspaceId } from '@lody/shared';
+import { buildMissingEmail, type WorkspaceId } from '@lody/shared';
 import type { Logger } from '@/utils/logger';
 import { formatErrorMessage } from '@/utils/format-error';
 import { buildGitHubNoreplyEmail } from './git-identity';
@@ -8,6 +8,13 @@ export type SessionUserProfile = {
   id: string;
   name: string;
   email: string;
+  /**
+   * Canonical GitHub attribution address for the account, when it has one.
+   *
+   * Kept separate from `email` because it is a commit identity only on a
+   * github.com remote, and this resolver cannot see the session workdir.
+   */
+  githubNoreplyEmail?: string;
 };
 
 /** Raw workspace-member profile as returned by the CLI-token Convex query. */
@@ -90,20 +97,15 @@ export class SessionUserResolver {
     profile: CloudWorkspaceUserProfile
   ): SessionUserProfile {
     const accountEmail = trimNonEmpty(profile.email);
-    // The GitHub no-reply address wins over the stored account email whenever the
-    // profile carries a GitHub account: it attributes the commit to the same
-    // GitHub account that opens the pull request AND it is the only address that
-    // survives "Keep my email addresses private" + "Block command line pushes
-    // that expose my email" (pushing a commit authored with the private account
-    // email is rejected with GH007). A stored missing-email placeholder is not a
-    // commit identity at all, so it only survives as the last resort.
-    const email =
-      buildGitHubNoreplyEmail(profile.githubAccountId, profile.githubLogin) ??
-      (accountEmail && !isMissingEmail(accountEmail) ? accountEmail : undefined) ??
-      accountEmail ??
-      buildMissingEmail('lody', userId);
+    const email = accountEmail ?? buildMissingEmail('lody', userId);
     const name = trimNonEmpty(profile.name) ?? trimNonEmpty(profile.githubLogin) ?? email;
-    return { id: userId, name, email };
+    // Reported alongside the account email rather than instead of it: only the
+    // session workdir's remote decides which of the two can attribute a commit.
+    const githubNoreplyEmail = buildGitHubNoreplyEmail(
+      profile.githubAccountId,
+      profile.githubLogin
+    );
+    return { id: userId, name, email, ...(githubNoreplyEmail ? { githubNoreplyEmail } : {}) };
   }
 
   private fallbackUser(userId: string): SessionUserProfile {

--- a/apps/cli/src/session/session-user-resolver.ts
+++ b/apps/cli/src/session/session-user-resolver.ts
@@ -90,12 +90,16 @@ export class SessionUserResolver {
     profile: CloudWorkspaceUserProfile
   ): SessionUserProfile {
     const accountEmail = trimNonEmpty(profile.email);
-    // A stored missing-email placeholder is not a commit identity; a GitHub
-    // no-reply address is, and it keeps the commit attributed to the same
-    // GitHub account that opens the pull request.
+    // The GitHub no-reply address wins over the stored account email whenever the
+    // profile carries a GitHub account: it attributes the commit to the same
+    // GitHub account that opens the pull request AND it is the only address that
+    // survives "Keep my email addresses private" + "Block command line pushes
+    // that expose my email" (pushing a commit authored with the private account
+    // email is rejected with GH007). A stored missing-email placeholder is not a
+    // commit identity at all, so it only survives as the last resort.
     const email =
-      (accountEmail && !isMissingEmail(accountEmail) ? accountEmail : undefined) ??
       buildGitHubNoreplyEmail(profile.githubAccountId, profile.githubLogin) ??
+      (accountEmail && !isMissingEmail(accountEmail) ? accountEmail : undefined) ??
       accountEmail ??
       buildMissingEmail('lody', userId);
     const name = trimNonEmpty(profile.name) ?? trimNonEmpty(profile.githubLogin) ?? email;

--- a/apps/cli/src/session/session.ts
+++ b/apps/cli/src/session/session.ts
@@ -373,7 +373,7 @@ export class Session extends EventEmitter<SessionEvents> implements ISession {
     userName: string,
     userEmail: string,
     userId: string | undefined,
-    options: { preferMachineIdentity: boolean }
+    options: { preferMachineIdentity: boolean; githubNoreplyEmail?: string }
   ): void {
     const configEnv = this.config.env ?? {};
     // Set git identity using Git's recognized environment variables directly
@@ -382,6 +382,7 @@ export class Session extends EventEmitter<SessionEvents> implements ISession {
       {
         preferMachineIdentity: options.preferMachineIdentity,
         cwd: this.getWorkdir(),
+        githubNoreplyEmail: options.githubNoreplyEmail,
       }
     );
     configEnv.GIT_AUTHOR_NAME = name;

--- a/apps/cli/src/session/types.ts
+++ b/apps/cli/src/session/types.ts
@@ -86,6 +86,8 @@ export interface SessionConfig {
   userName: string;
   /** Git commit author email (from session creator) */
   userEmail: string;
+  /** GitHub no-reply commit email; used only on a github.com remote. */
+  userGitHubNoreplyEmail?: string;
 }
 
 /**

--- a/apps/cli/tests/git-identity.test.ts
+++ b/apps/cli/tests/git-identity.test.ts
@@ -1,12 +1,24 @@
-import { describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { buildMissingEmail } from '@lody/shared';
 
 import {
   buildGitHubNoreplyEmail,
   DEFAULT_AI_GIT_AUTHOR_EMAIL,
   DEFAULT_AI_GIT_AUTHOR_NAME,
+  parseGitRemoteHost,
+  parseGitRemoteList,
   resolveSessionGitIdentity,
 } from '../src/session/git-identity';
+
+const NOREPLY = '4324+ada@users.noreply.github.com';
+const GITHUB_HTTPS = [{ name: 'origin', url: 'https://github.com/LodyAI/Lody.git' }];
+const GITHUB_SSH = [{ name: 'origin', url: 'git@github.com:LodyAI/Lody.git' }];
+const GITLAB_HTTPS = [{ name: 'origin', url: 'https://gitlab.com/lody/lody.git' }];
 
 describe('resolveSessionGitIdentity', () => {
   it('uses the machine identity first for the machine owner', () => {
@@ -92,6 +104,251 @@ describe('resolveSessionGitIdentity', () => {
       name: 'Ada',
       email: '4324+ada@users.noreply.github.com',
     });
+  });
+});
+
+describe('resolveSessionGitIdentity with a GitHub no-reply address', () => {
+  const requested = { name: 'Ada', email: 'ada@example.com' };
+
+  it('commits as the no-reply address on an https github.com origin', () => {
+    // Beats both the account email and the host Git identity: only this address
+    // survives private-email push protection (GH007).
+    expect(
+      resolveSessionGitIdentity(requested, {
+        preferMachineIdentity: true,
+        machineIdentity: { name: 'Local User', email: 'local@example.com' },
+        githubNoreplyEmail: NOREPLY,
+        remotes: GITHUB_HTTPS,
+      })
+    ).toEqual({ name: 'Ada', email: NOREPLY });
+  });
+
+  it('commits as the no-reply address on an ssh github.com origin', () => {
+    expect(
+      resolveSessionGitIdentity(requested, {
+        preferMachineIdentity: true,
+        machineIdentity: { name: 'Local User', email: 'local@example.com' },
+        githubNoreplyEmail: NOREPLY,
+        remotes: GITHUB_SSH,
+      })
+    ).toEqual({ name: 'Ada', email: NOREPLY });
+  });
+
+  it('keeps the host Git identity on a gitlab.com origin', () => {
+    expect(
+      resolveSessionGitIdentity(requested, {
+        preferMachineIdentity: true,
+        machineIdentity: { name: 'Local User', email: 'local@example.com' },
+        githubNoreplyEmail: NOREPLY,
+        remotes: GITLAB_HTTPS,
+      })
+    ).toEqual({ name: 'Local User', email: 'local@example.com' });
+  });
+
+  it('keeps the host Git identity when the workdir has no remote', () => {
+    expect(
+      resolveSessionGitIdentity(requested, {
+        preferMachineIdentity: true,
+        machineIdentity: { name: 'Local User', email: 'local@example.com' },
+        githubNoreplyEmail: NOREPLY,
+        remotes: [],
+      })
+    ).toEqual({ name: 'Local User', email: 'local@example.com' });
+  });
+
+  it('never substitutes the no-reply address for the requester email off GitHub', () => {
+    // A non-owner still cannot read machine config, so the account email is the
+    // only remaining identity; the GitHub address would not attribute here.
+    expect(
+      resolveSessionGitIdentity(requested, {
+        preferMachineIdentity: false,
+        machineIdentity: { name: 'Machine Owner', email: 'owner@example.com' },
+        githubNoreplyEmail: NOREPLY,
+        remotes: GITLAB_HTTPS,
+      })
+    ).toEqual({ name: 'Ada', email: 'ada@example.com' });
+  });
+
+  it('falls back to the LodyAI identity off GitHub without a usable requester email', () => {
+    expect(
+      resolveSessionGitIdentity(
+        { name: 'github-user', email: buildMissingEmail('github', '123') },
+        {
+          preferMachineIdentity: false,
+          githubNoreplyEmail: NOREPLY,
+          remotes: GITLAB_HTTPS,
+        }
+      )
+    ).toEqual({ name: DEFAULT_AI_GIT_AUTHOR_NAME, email: DEFAULT_AI_GIT_AUTHOR_EMAIL });
+  });
+
+  it('ignores a GitHub mirror when origin points at another forge', () => {
+    expect(
+      resolveSessionGitIdentity(requested, {
+        preferMachineIdentity: true,
+        machineIdentity: { email: 'local@example.com' },
+        githubNoreplyEmail: NOREPLY,
+        remotes: [...GITLAB_HTTPS, { name: 'mirror', url: 'https://github.com/lody/lody.git' }],
+      })
+    ).toEqual({ name: 'local@example.com', email: 'local@example.com' });
+  });
+
+  it('uses a non-origin remote when the repository has no origin', () => {
+    expect(
+      resolveSessionGitIdentity(requested, {
+        preferMachineIdentity: true,
+        machineIdentity: { email: 'local@example.com' },
+        githubNoreplyEmail: NOREPLY,
+        remotes: [{ name: 'upstream', url: 'https://github.com/LodyAI/Lody.git' }],
+      })
+    ).toEqual({ name: 'Ada', email: NOREPLY });
+  });
+
+  it('does not treat a GitHub Enterprise host as github.com', () => {
+    expect(
+      resolveSessionGitIdentity(requested, {
+        preferMachineIdentity: true,
+        machineIdentity: { email: 'local@example.com' },
+        githubNoreplyEmail: NOREPLY,
+        remotes: [{ name: 'origin', url: 'https://github.acme.example/lody/lody.git' }],
+      })
+    ).toEqual({ name: 'local@example.com', email: 'local@example.com' });
+  });
+
+  it('keeps the existing fallback when the account has no usable GitHub identity', () => {
+    expect(
+      resolveSessionGitIdentity(requested, {
+        preferMachineIdentity: false,
+        githubNoreplyEmail: buildGitHubNoreplyEmail('4324', undefined),
+        remotes: GITHUB_HTTPS,
+      })
+    ).toEqual({ name: 'Ada', email: 'ada@example.com' });
+  });
+});
+
+describe('parseGitRemoteHost', () => {
+  it.each([
+    ['https://github.com/LodyAI/Lody.git', 'github.com'],
+    ['https://x-access-token:ghs_secret@github.com/LodyAI/Lody.git', 'github.com'],
+    ['git@github.com:LodyAI/Lody.git', 'github.com'],
+    ['ssh://git@github.com/LodyAI/Lody.git', 'github.com'],
+    ['ssh://git@github.com:22/LodyAI/Lody.git', 'github.com'],
+    ['git://github.com/LodyAI/Lody.git', 'github.com'],
+    ['https://GitHub.com/LodyAI/Lody.git', 'github.com'],
+    ['git@gist.github.com:abc123.git', 'gist.github.com'],
+    ['https://gitlab.com/lody/lody.git', 'gitlab.com'],
+    ['git@ssh.github.com:LodyAI/Lody.git', 'ssh.github.com'],
+  ])('reads the host of %s', (url, host) => {
+    expect(parseGitRemoteHost(url)).toBe(host);
+  });
+
+  it('has no host for a local path or an empty value', () => {
+    expect(parseGitRemoteHost('/srv/git/lody.git')).toBeUndefined();
+    expect(parseGitRemoteHost('../sibling-repo')).toBeUndefined();
+    expect(parseGitRemoteHost('   ')).toBeUndefined();
+  });
+});
+
+describe('parseGitRemoteList', () => {
+  it('prefers the push URL, which is the one GitHub can reject', () => {
+    expect(
+      parseGitRemoteList(
+        [
+          'origin\thttps://gitlab.com/lody/lody.git (fetch)',
+          'origin\tgit@github.com:LodyAI/Lody.git (push)',
+        ].join('\n')
+      )
+    ).toEqual([{ name: 'origin', url: 'git@github.com:LodyAI/Lody.git' }]);
+  });
+
+  it('keeps every remote and ignores blank lines', () => {
+    expect(
+      parseGitRemoteList(
+        [
+          'origin\thttps://github.com/LodyAI/Lody.git (fetch)',
+          'origin\thttps://github.com/LodyAI/Lody.git (push)',
+          '',
+          'upstream\thttps://gitlab.com/lody/lody.git (fetch)',
+          'upstream\thttps://gitlab.com/lody/lody.git (push)',
+        ].join('\n')
+      )
+    ).toEqual([
+      { name: 'origin', url: 'https://github.com/LodyAI/Lody.git' },
+      { name: 'upstream', url: 'https://gitlab.com/lody/lody.git' },
+    ]);
+  });
+});
+
+describe('resolveSessionGitIdentity reading a real repository', () => {
+  const repositories: string[] = [];
+
+  const createRepository = (originUrl?: string, localEmail?: string): string => {
+    const path = mkdtempSync(join(tmpdir(), 'lody-git-identity-'));
+    repositories.push(path);
+    const git = (...args: string[]): void => {
+      execFileSync('git', args, { cwd: path, stdio: 'ignore', windowsHide: true });
+    };
+    git('init', '-q');
+    if (originUrl) {
+      git('remote', 'add', 'origin', originUrl);
+    }
+    if (localEmail) {
+      git('config', 'user.email', localEmail);
+      git('config', 'user.name', 'Local User');
+    }
+    return path;
+  };
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    while (repositories.length > 0) {
+      rmSync(repositories.pop() as string, { recursive: true, force: true });
+    }
+  });
+
+  const withoutInheritedGitEnv = (): void => {
+    // readHostDefaultGitIdentity prefers these over the repository config.
+    for (const key of [
+      'GIT_AUTHOR_NAME',
+      'GIT_AUTHOR_EMAIL',
+      'GIT_COMMITTER_NAME',
+      'GIT_COMMITTER_EMAIL',
+    ]) {
+      vi.stubEnv(key, '');
+    }
+  };
+
+  it('commits as the no-reply address in a repository cloned from GitHub over ssh', () => {
+    withoutInheritedGitEnv();
+    const cwd = createRepository('git@github.com:LodyAI/Lody.git', 'local@example.com');
+    expect(
+      resolveSessionGitIdentity(
+        { name: 'Ada', email: 'ada@example.com' },
+        { preferMachineIdentity: true, cwd, githubNoreplyEmail: NOREPLY }
+      )
+    ).toEqual({ name: 'Ada', email: NOREPLY });
+  });
+
+  it('commits with the repository Git config in a GitLab repository', () => {
+    withoutInheritedGitEnv();
+    const cwd = createRepository('https://gitlab.com/lody/lody.git', 'local@example.com');
+    expect(
+      resolveSessionGitIdentity(
+        { name: 'Ada', email: 'ada@example.com' },
+        { preferMachineIdentity: true, cwd, githubNoreplyEmail: NOREPLY }
+      )
+    ).toEqual({ name: 'Local User', email: 'local@example.com' });
+  });
+
+  it('commits with the repository Git config when there is no remote at all', () => {
+    withoutInheritedGitEnv();
+    const cwd = createRepository(undefined, 'local@example.com');
+    expect(
+      resolveSessionGitIdentity(
+        { name: 'Ada', email: 'ada@example.com' },
+        { preferMachineIdentity: true, cwd, githubNoreplyEmail: NOREPLY }
+      )
+    ).toEqual({ name: 'Local User', email: 'local@example.com' });
   });
 });
 

--- a/apps/cli/tests/session-user-resolver.test.ts
+++ b/apps/cli/tests/session-user-resolver.test.ts
@@ -36,7 +36,28 @@ describe('SessionUserResolver', () => {
     expect(queryProfile).toHaveBeenCalledWith('user_a');
   });
 
-  it('uses the GitHub no-reply address when the stored email is a missing-email placeholder', async () => {
+  it('reports the GitHub no-reply address beside a real account email', async () => {
+    // Both are real identities; only the session workdir's remote can decide
+    // which one attributes a commit, so the resolver reports both.
+    const resolver = createResolver(
+      vi.fn(async () => ({
+        id: 'user_a',
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+        githubLogin: 'ada',
+        githubAccountId: '4324',
+      }))
+    );
+
+    await expect(resolver.resolve('user_a')).resolves.toEqual({
+      id: 'user_a',
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      githubNoreplyEmail: '4324+ada@users.noreply.github.com',
+    });
+  });
+
+  it('reports the GitHub no-reply address when the stored email is a placeholder', async () => {
     const resolver = createResolver(
       vi.fn(async () => ({
         id: 'user_a',
@@ -50,31 +71,12 @@ describe('SessionUserResolver', () => {
     await expect(resolver.resolve('user_a')).resolves.toEqual({
       id: 'user_a',
       name: 'Ada Lovelace',
-      email: '4324+ada@users.noreply.github.com',
+      email: buildMissingEmail('github', '4324'),
+      githubNoreplyEmail: '4324+ada@users.noreply.github.com',
     });
   });
 
-  it('prefers the GitHub no-reply address over a real account email', async () => {
-    const resolver = createResolver(
-      vi.fn(async () => ({
-        id: 'user_a',
-        name: 'Ada Lovelace',
-        email: 'ada@example.com',
-        githubLogin: 'ada',
-        githubAccountId: '4324',
-      }))
-    );
-
-    // A real account email is exactly the address GitHub rejects with GH007 when
-    // the account keeps its email private and blocks command-line pushes.
-    await expect(resolver.resolve('user_a')).resolves.toEqual({
-      id: 'user_a',
-      name: 'Ada Lovelace',
-      email: '4324+ada@users.noreply.github.com',
-    });
-  });
-
-  it('keeps the account email when the GitHub profile is incomplete', async () => {
+  it('reports no GitHub no-reply address when the GitHub profile is incomplete', async () => {
     const resolver = createResolver(
       vi.fn(async () => ({
         id: 'user_a',
@@ -104,7 +106,8 @@ describe('SessionUserResolver', () => {
     await expect(resolver.resolve('user_a')).resolves.toEqual({
       id: 'user_a',
       name: 'ada',
-      email: '4324+ada@users.noreply.github.com',
+      email: 'ada@example.com',
+      githubNoreplyEmail: '4324+ada@users.noreply.github.com',
     });
   });
 

--- a/apps/cli/tests/session-user-resolver.test.ts
+++ b/apps/cli/tests/session-user-resolver.test.ts
@@ -54,7 +54,7 @@ describe('SessionUserResolver', () => {
     });
   });
 
-  it('prefers the real account email over the GitHub no-reply address', async () => {
+  it('prefers the GitHub no-reply address over a real account email', async () => {
     const resolver = createResolver(
       vi.fn(async () => ({
         id: 'user_a',
@@ -65,7 +65,28 @@ describe('SessionUserResolver', () => {
       }))
     );
 
-    await expect(resolver.resolve('user_a')).resolves.toMatchObject({
+    // A real account email is exactly the address GitHub rejects with GH007 when
+    // the account keeps its email private and blocks command-line pushes.
+    await expect(resolver.resolve('user_a')).resolves.toEqual({
+      id: 'user_a',
+      name: 'Ada Lovelace',
+      email: '4324+ada@users.noreply.github.com',
+    });
+  });
+
+  it('keeps the account email when the GitHub profile is incomplete', async () => {
+    const resolver = createResolver(
+      vi.fn(async () => ({
+        id: 'user_a',
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+        githubLogin: 'ada',
+      }))
+    );
+
+    await expect(resolver.resolve('user_a')).resolves.toEqual({
+      id: 'user_a',
+      name: 'Ada Lovelace',
       email: 'ada@example.com',
     });
   });
@@ -83,7 +104,7 @@ describe('SessionUserResolver', () => {
     await expect(resolver.resolve('user_a')).resolves.toEqual({
       id: 'user_a',
       name: 'ada',
-      email: 'ada@example.com',
+      email: '4324+ada@users.noreply.github.com',
     });
   });
 

--- a/packages/shared/src/message-schemas.ts
+++ b/packages/shared/src/message-schemas.ts
@@ -571,6 +571,7 @@ export const SessionCreateRequestSchema = z
     userId: z.string(),
     userName: z.string(),
     userEmail: z.string(),
+    userGitHubNoreplyEmail: z.string().optional(),
     parentSessionId: SessionIdSchema.optional(),
   })
   .strict();
@@ -603,6 +604,7 @@ export const SessionChatRequestSchema = z
     userId: z.string(),
     userName: z.string(),
     userEmail: z.string(),
+    userGitHubNoreplyEmail: z.string().optional(),
   })
   .strict();
 

--- a/packages/shared/src/message.ts
+++ b/packages/shared/src/message.ts
@@ -71,6 +71,12 @@ export interface SessionCreateRequest {
   userId: string;
   userName: string;
   userEmail: string;
+  /**
+   * Requester's GitHub no-reply commit email, when their account has one.
+   * Used only when the session workdir pushes to github.com; absent requests
+   * keep committing with `userEmail`.
+   */
+  userGitHubNoreplyEmail?: string;
   /** If set, this is a child tab session that should reuse the parent's workspace directory. */
   parentSessionId?: SessionId;
 }
@@ -107,6 +113,12 @@ export type SessionChatRequest = {
   userId: string;
   userName: string;
   userEmail: string;
+  /**
+   * Requester's GitHub no-reply commit email, when their account has one.
+   * Used only when the session workdir pushes to github.com; absent requests
+   * keep committing with `userEmail`.
+   */
+  userGitHubNoreplyEmail?: string;
 };
 
 export interface SessionChatResponse {

--- a/specs/git-commit-identity.md
+++ b/specs/git-commit-identity.md
@@ -15,6 +15,13 @@ Lody/GitHub identity. For a turn requested by any other workspace member, Lody u
 requester's resolved Lody/GitHub identity and never reads or falls back to the machine Git
 identity.
 
+A requester's resolved Lody/GitHub identity uses the GitHub no-reply address
+`<id>+<login>@users.noreply.github.com` whenever the profile carries both a GitHub account id and
+login, in preference to the stored account email. That address attributes the commit to the same
+GitHub account, and it is the only one accepted by an account that keeps its email private and
+blocks command-line pushes that expose it. The stored account email is used only when no GitHub
+account id and login are available.
+
 A missing-email placeholder is not usable. When neither an allowed machine identity nor the
 requester's resolved identity is usable, Lody uses the neutral `LodyAI <agent@lody.ai>` identity.
 The selected name and email are exported as both Git author and committer environment variables.
@@ -29,7 +36,8 @@ propagation without restarting remains unimplemented.
 
 ## Evidence
 
-Identity selection is implemented in `apps/cli/src/session/git-identity.ts`. Initial session
+Identity selection is implemented in `apps/cli/src/session/git-identity.ts`, and the requester's
+Lody/GitHub identity in `apps/cli/src/session/session-user-resolver.ts`. Initial session
 creation applies the ownership policy in `apps/cli/src/session/session-manager.ts`; continued
 turns reapply it in `apps/cli/src/session/session-execution-service.ts`.
 

--- a/specs/git-commit-identity.md
+++ b/specs/git-commit-identity.md
@@ -5,22 +5,25 @@ Translation: current
 
 [中文](git-commit-identity.zh.md)
 
-Lody resolves the host Session Git identity for every turn based on machine ownership,
-rather than workspace size or sharing state. The rules below govern identity resolution;
-live ACP propagation has the limitation described below.
+Lody resolves the host Session Git identity for every turn from the repository's remote host and
+machine ownership, rather than workspace size or sharing state. The rules below govern identity
+resolution; live ACP propagation has the limitation described below.
+
+The GitHub no-reply address `<id>+<login>@users.noreply.github.com` is the requester's commit
+email ahead of every other candidate, but only when the session workdir pushes to github.com and
+the requester's account has both a GitHub account id and login. That address attributes the
+commit to the same GitHub account, and it is the only one accepted by an account that keeps its
+email private and blocks command-line pushes that expose it. Lody reads the workdir's Git
+remotes to decide: `origin` decides alone when it exists, otherwise any remote does, and only
+`github.com` and `gist.github.com` count as GitHub. Every other host, including a GitHub
+Enterprise installation, resolves by the rules below, because a GitHub no-reply address
+attributes nothing there and can be rejected.
 
 For a turn requested by the machine owner, Lody first uses the Git identity effective in the
 session worktree. If the machine has no usable Git email, Lody uses the owner's resolved
 Lody/GitHub identity. For a turn requested by any other workspace member, Lody uses only that
 requester's resolved Lody/GitHub identity and never reads or falls back to the machine Git
 identity.
-
-A requester's resolved Lody/GitHub identity uses the GitHub no-reply address
-`<id>+<login>@users.noreply.github.com` whenever the profile carries both a GitHub account id and
-login, in preference to the stored account email. That address attributes the commit to the same
-GitHub account, and it is the only one accepted by an account that keeps its email private and
-blocks command-line pushes that expose it. The stored account email is used only when no GitHub
-account id and login are available.
 
 A missing-email placeholder is not usable. When neither an allowed machine identity nor the
 requester's resolved identity is usable, Lody uses the neutral `LodyAI <agent@lody.ai>` identity.
@@ -36,8 +39,9 @@ propagation without restarting remains unimplemented.
 
 ## Evidence
 
-Identity selection is implemented in `apps/cli/src/session/git-identity.ts`, and the requester's
-Lody/GitHub identity in `apps/cli/src/session/session-user-resolver.ts`. Initial session
+Identity selection and the remote host check are implemented in
+`apps/cli/src/session/git-identity.ts`, and the requester's Lody/GitHub identity in
+`apps/cli/src/session/session-user-resolver.ts`. Initial session
 creation applies the ownership policy in `apps/cli/src/session/session-manager.ts`; continued
 turns reapply it in `apps/cli/src/session/session-execution-service.ts`.
 

--- a/specs/git-commit-identity.zh.md
+++ b/specs/git-commit-identity.zh.md
@@ -5,19 +5,21 @@ Translation: current
 
 [English](git-commit-identity.md)
 
-Lody 每轮依据机器所有权选择 host Session 的 Git identity，而不是 workspace 成员数或共享状态。
-下述规则约束身份解析；已运行 ACP 的身份更新存在下面说明的限制。
+Lody 每轮依据仓库的 remote host 与机器所有权选择 host Session 的 Git identity，而不是 workspace
+成员数或共享状态。下述规则约束身份解析；已运行 ACP 的身份更新存在下面说明的限制。
+
+只有当 session 工作目录推送到 github.com、且请求者账号同时带有 GitHub account id 与 login 时，
+GitHub no-reply 地址 `<id>+<login>@users.noreply.github.com` 才作为请求者的 commit 邮箱，
+并优先于其余所有候选。该地址把 commit 归属到同一个 GitHub 账号，并且对于开启了邮箱保密、
+且禁止命令行推送暴露邮箱的账号，它是唯一被接受的地址。Lody 读取工作目录的 Git remote 来判断：
+存在 `origin` 时只由 `origin` 决定，否则任意 remote 均可，且只有 `github.com` 与
+`gist.github.com` 算作 GitHub。其他任何 host（包括 GitHub Enterprise 部署）都按下文规则解析，
+因为 GitHub no-reply 地址在那里无法归属，甚至可能被拒绝。
 
 当前轮次由机器 owner 发起时，Lody 优先使用 session worktree 中生效的 Git identity；
 如果机器没有可用的 Git email，则使用 owner 经 Lody/GitHub 解析出的身份。当前轮次由
 其他 workspace 成员发起时，Lody 只使用该请求者经 Lody/GitHub 解析出的身份，绝不读取
 或回退到机器 Git identity。
-
-当请求者的 profile 同时带有 GitHub account id 与 login 时，其经 Lody/GitHub 解析出的身份
-使用 GitHub no-reply 地址 `<id>+<login>@users.noreply.github.com`，优先于存储的账号邮箱。
-该地址同样把 commit 归属到同一个 GitHub 账号，并且对于开启了邮箱保密、且禁止命令行推送
-暴露邮箱的账号，它是唯一被接受的地址。只有在拿不到 GitHub account id 与 login 时，才使用
-存储的账号邮箱。
 
 缺失邮箱占位符不是可用身份。如果允许使用的机器身份和请求者解析身份都不可用，Lody
 使用中性的 `LodyAI <agent@lody.ai>` 身份。最终选择的名字和邮箱会同时写入 Git author
@@ -30,8 +32,8 @@ Lody 每轮依据机器所有权选择 host Session 的 Git identity，而不是
 
 ## 证据
 
-身份选择实现在 `apps/cli/src/session/git-identity.ts`，请求者的 Lody/GitHub 身份解析实现在
-`apps/cli/src/session/session-user-resolver.ts`。初次创建 session 时，
+身份选择与 remote host 判断实现在 `apps/cli/src/session/git-identity.ts`，请求者的 Lody/GitHub
+身份解析实现在 `apps/cli/src/session/session-user-resolver.ts`。初次创建 session 时，
 `apps/cli/src/session/session-manager.ts` 应用所有权策略；后续轮次由
 `apps/cli/src/session/session-execution-service.ts` 重新应用。
 

--- a/specs/git-commit-identity.zh.md
+++ b/specs/git-commit-identity.zh.md
@@ -13,6 +13,12 @@ Lody 每轮依据机器所有权选择 host Session 的 Git identity，而不是
 其他 workspace 成员发起时，Lody 只使用该请求者经 Lody/GitHub 解析出的身份，绝不读取
 或回退到机器 Git identity。
 
+当请求者的 profile 同时带有 GitHub account id 与 login 时，其经 Lody/GitHub 解析出的身份
+使用 GitHub no-reply 地址 `<id>+<login>@users.noreply.github.com`，优先于存储的账号邮箱。
+该地址同样把 commit 归属到同一个 GitHub 账号，并且对于开启了邮箱保密、且禁止命令行推送
+暴露邮箱的账号，它是唯一被接受的地址。只有在拿不到 GitHub account id 与 login 时，才使用
+存储的账号邮箱。
+
 缺失邮箱占位符不是可用身份。如果允许使用的机器身份和请求者解析身份都不可用，Lody
 使用中性的 `LodyAI <agent@lody.ai>` 身份。最终选择的名字和邮箱会同时写入 Git author
 与 committer 环境变量。GitHub 鉴权仍是独立的、绑定请求者的决策，不会改变 commit 对象
@@ -24,7 +30,8 @@ Lody 每轮依据机器所有权选择 host Session 的 Git identity，而不是
 
 ## 证据
 
-身份选择实现在 `apps/cli/src/session/git-identity.ts`。初次创建 session 时，
+身份选择实现在 `apps/cli/src/session/git-identity.ts`，请求者的 Lody/GitHub 身份解析实现在
+`apps/cli/src/session/session-user-resolver.ts`。初次创建 session 时，
 `apps/cli/src/session/session-manager.ts` 应用所有权策略；后续轮次由
 `apps/cli/src/session/session-execution-service.ts` 重新应用。
 


### PR DESCRIPTION
## Related issue

None. No existing Issue covers this. #521 is related but insufficient — it only addresses the owner machine's gitconfig, not which email the requester resolves to.

## Problem / pressure

`Session.updateGitIdentity` exports the resolved requester identity as `GIT_AUTHOR_*`/`GIT_COMMITTER_*`, and those variables override `~/.gitconfig`. Lody resolved the stored account email, which for an account with GitHub's **Keep my email addresses private** plus **Block command line pushes that expose my email** is exactly the address GitHub refuses: every push of an agent commit fails with `GH007: Your push would publish a private email address`. The user cannot ship the work the agent just did, and the address they chose to keep private ends up in the commit object.

The obvious fix — always prefer the account's GitHub no-reply address — is wrong in the other direction: it ignores where the session actually pushes. A repository on GitLab, on a GitHub Enterprise host, or with no remote at all would commit with a `users.noreply.github.com` address that attributes nothing there and can be rejected.

## Summary

Use `<id>+<login>@users.noreply.github.com` as the requester's commit email **only when the session workdir pushes to github.com**.

- `git-identity.ts` owns the decision, because `resolveSessionGitIdentity` already has the session `cwd`. It reads the workdir remotes, lets `origin` decide alone when it exists (a GitLab repo with a GitHub mirror is still a GitLab repo), prefers each remote's push URL, and counts only `github.com` / `gist.github.com` as GitHub — GitHub Enterprise is deliberately excluded.
- `session-user-resolver.ts` cannot make this call: it is cached per user across sessions and never sees a workdir. It now reports `githubNoreplyEmail` **beside** the account email instead of replacing it, so the non-GitHub fallback order keeps its own meaning.
- The turn carries the address as the optional `userGitHubNoreplyEmail` request field, frozen with the rest of the requester identity rather than re-read at execution time.

Resulting order: on a github.com remote the no-reply address wins (the machine identity is exactly what GH007 rejects for these accounts); everywhere else the existing policy is unchanged — machine owner prefers the repository/machine Git identity, non-owners never read it, then the account email, then `LodyAI <agent@lody.ai>`.

Deliberately unchanged: `GIT_*` is still always exported (dropping it when host gitconfig is set would attribute a teammate's turn on a shared daemon to the machine owner); worktree archive backup identity; no new user-facing setting.

## Visual explanation

Simple change: one new branch at the top of `resolveSessionGitIdentity`, plus an optional field threaded beside the existing `userName`/`userEmail`. The full order is written out in the Summary, the Spec, and the Note.

## Before / after

| Before | After |
| ------ | ----- |
| github.com origin, private account email → account email → push rejected with GH007 | → `4324+ada@users.noreply.github.com`, push accepted, attributed to the same account |
| gitlab.com origin, GitHub-connected account, gitconfig set → account email (overrides gitconfig) | → gitconfig `user.email`, no github.com address on a GitLab commit |
| No remote / GitHub Enterprise origin | → gitconfig, then account email, then `agent@lody.ai` (unchanged) |
| GitHub origin, incomplete GitHub profile | → existing fallback (unchanged) |
| Teammate's turn on a shared daemon | Never the machine owner's identity (unchanged) |

## Test plan

- `apps/cli`: `pnpm test tests/git-identity.test.ts tests/session-user-resolver.test.ts` → 43 passed. Covers https and ssh GitHub origins, gitlab.com, no remote, a GitHub mirror behind a GitLab origin, a GitHub Enterprise host, an incomplete GitHub profile, the non-owner and neutral fallbacks, remote-URL host parsing, and `git remote -v` parsing with push-URL precedence. Three cases run against real temporary git repositories so the `git remote -v` / `git config` reads are actually exercised, with inherited `GIT_AUTHOR_*`/`GIT_COMMITTER_*` stubbed out.
- `apps/cli`: `pnpm test` → **2737 passed, 1 failed, 4 skipped (262 files)**. The failure is `tests/worktree-gc.test.ts`, a macOS `/private/var` vs `/var` tmpdir realpath mismatch; verified pre-existing by re-running it against `HEAD` without these changes.
- `packages/shared`: `pnpm test` → 1127 passed.
- Root `pnpm typecheck` clean; `pnpm lint` 0 errors; `pnpm check:public-boundary` and `pnpm check:platform-boundaries` pass; `pnpm run docs check` → 0 errors.
- Not executed: an end-to-end push from an account with private-email push protection. GH007 is taken from GitHub's push protection behavior, not reproduced in CI.

Docs updated in the same PR: `apps/cli/src/session/AGENTS.md`, `apps/cli/src/session/README.md`, `specs/git-commit-identity.md` + `.zh.md` (still `draft`), and the bilingual Agent Note `.agents/notes/implemented/bug-fix/2026-09-12-github-noreply-commit-email.md`.

**Risk: medium · Confidence: high** — `risk:medium`. The blast radius is every agent commit's author/committer email, and this adds one optional field to `SessionCreateRequest`/`SessionChatRequest`; it is additive and only ever set by daemon-internal producers, so no client sends it to an older strict validator. Known limitation: hosts such as `ssh.github.com` are not recognised as GitHub, which costs those users the fix rather than breaking them.
