### PR TITLE
fix(cli): accept an unsplit ACP terminal command line [risk:medium]

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-12-acp-terminal-unsplit-command-line.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-12-acp-terminal-unsplit-command-line.md
@@ -95,4 +95,5 @@ Not verified here: a live agent that sends an unsplit line (the reporter's
 branch is covered only through the injected platform, and the real-process cases
 skip on Windows.
 
-Issue: [#469](https://github.com/LodyAI/Lody/issues/469).
+PR: [#645](https://github.com/LodyAI/Lody/pull/645), closing
+[#469](https://github.com/LodyAI/Lody/issues/469).

--- a/.agents/notes/implemented/bug-fix/2026-09-12-acp-terminal-unsplit-command-line.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-12-acp-terminal-unsplit-command-line.md
@@ -1,0 +1,98 @@
+# Accept an unsplit ACP terminal command line
+
+Status: implemented
+Translation: pending
+
+## Abstract
+
+ACP `terminal/create` carries an executable plus argv, but several agents send
+the whole shell line in `command` with empty `args`; spawned literally it fails
+with `ENOENT`, and the failure was invisible or fatal depending on the sandbox —
+Linux surfaced an untyped errno `-2` that made agents drop the session, darwin
+returned a terminal id whose `wait_for_exit` never resolved. Lody now spawns the
+protocol pair as before and rebuilds a command only in that one shape (empty
+`args`, whitespace, no file at that path), through a non-interactive, non-login
+`sh -c` (`cmd.exe /c` on Windows). A spawn that still fails rejects
+`terminal/create` with a JSON-RPC code and records an exit status, so no waiter
+hangs. The fallback cannot tell a genuine one-word-with-spaces intent from an
+unsplit line beyond the file check, so it stays deliberately narrow rather than
+becoming a general shell mode.
+
+## Problem and ownership
+
+Splitting a command line is the agent's job under the Agent Client Protocol, and
+`ShellTerminalManager` owns process execution. The compatibility handling is
+therefore interoperability at the execution boundary, not a correction of Lody's
+protocol reading: `command` + `args` stays the contract and the default path.
+
+Two distinct defects met in the same call. The first is resolution: cross-spawn
+gets `ls -al` as `argv[0]` and the OS has no such executable. The second is
+reporting. `sandbox.spawn` behaves differently per platform — the cgroup sandbox
+awaits the child's pid and rejects, while the POSIX fallback resolves the handle
+and lets the error arrive later on the process error channel. The terminal's
+`onError` hook only logged, so the late error resolved nothing: `createTerminal`
+had already returned an id and `waitForTerminalExit` waited forever. Both
+platforms therefore needed the same typed answer.
+
+## Decision
+
+Three changes, each narrow:
+
+1. `resolveTerminalSpawnTarget` rebuilds a command only when `args` is empty,
+   `command` contains whitespace, and `stat` finds no file at that path relative
+   to the workdir. The file check is what preserves an executable path that
+   contains a space; `args.length > 0` is never wrapped, so a caller that
+   already split its argv keeps exact spawn semantics.
+2. `waitForSpawnConfirmation` awaits the child's pid when it is not already set,
+   so a spawn failure rejects `createTerminal` instead of publishing a terminal
+   that can never exit. A started process costs nothing here: Node assigns `pid`
+   synchronously, so the check returns immediately.
+3. `ENOENT`/`EACCES` become `TerminalSpawnError`, which `AgentClient.createTerminal`
+   answers as `acp.RequestError.invalidParams` (`-32602`). A command that cannot
+   be executed is a bad request, and a numeric JSON-RPC code is what lets an
+   agent report the failure instead of treating it as a dead connection. The
+   terminal's `onError` hook now also records an exit status, so a process error
+   after a successful start completes pending waits rather than hanging them.
+
+`sh -c` is intentional. `bash -lc` would run the user's login profile, changing
+`PATH`, shell options and environment behind a command the agent asked to run in
+the session's own environment, and would fail where bash is absent.
+
+Separately, `resolveCustomACPSetting` now expands a leading `~` in a custom
+agent's launch command, which is typed by a human and is not expanded by
+`spawn`. Terminal command lines are deliberately excluded: those come from the
+agent, and the shell fallback already expands `~` when it is the one running.
+
+## Alternatives
+
+- Wrap whenever `args` is empty, without the file check ([#470](https://github.com/LodyAI/Lody/pull/470)).
+  Simpler, but it sends an executable whose path contains a space through the
+  shell, where quoting and metacharacters then apply to a path Lody was given
+  verbatim.
+- Split the line in Lody and spawn `argv[0]` directly. That requires a
+  shell-accurate parser for quoting, escapes and operators; `sh` already has one
+  and is what the agent's own line was written for.
+- Report the failure only as terminal output with a non-zero exit status. The
+  agent would see a terminal that "ran" and print nothing useful, and the
+  session-level cause would stay invisible.
+
+## Verification
+
+`apps/cli/tests/terminal-manager.test.ts` covers the spawn decision against a
+stub sandbox — the unsplit line on POSIX and Windows, an untouched split argv, an
+executable path containing a space, a command line that already carries args,
+both spawn-failure shapes (sandbox rejection and late error channel), and a
+pending wait completed by a process error — plus two POSIX cases against a real
+process through `createNoopSessionSandbox`: an unsplit `printf` line whose output
+and exit code come back, and an unresolvable executable that rejects instead of
+publishing a terminal. `apps/cli/tests/agent-setting.test.ts` covers the `~`
+expansion. Ablation: removing the file check fails the space-in-path test,
+removing the spawn confirmation fails the late-error test, and removing the
+`onError` exit record leaves the wait test hanging until its timeout.
+
+Not verified here: a live agent that sends an unsplit line (the reporter's
+`codebuddy-code`), and Windows `cmd.exe` behavior on a real host — the Windows
+branch is covered only through the injected platform, and the real-process cases
+skip on Windows.
+
+Issue: [#469](https://github.com/LodyAI/Lody/issues/469).

--- a/.agents/notes/implemented/bug-fix/2026-09-12-acp-terminal-unsplit-command-line.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-12-acp-terminal-unsplit-command-line.md
@@ -1,7 +1,9 @@
 # Accept an unsplit ACP terminal command line
 
 Status: implemented
-Translation: pending
+Translation: current
+
+[中文](2026-09-12-acp-terminal-unsplit-command-line.zh.md)
 
 ## Abstract
 

--- a/.agents/notes/implemented/bug-fix/2026-09-12-acp-terminal-unsplit-command-line.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-12-acp-terminal-unsplit-command-line.zh.md
@@ -1,0 +1,80 @@
+# 接受未拆分的 ACP 终端命令行
+
+Status: implemented
+Translation: current
+
+[English](2026-09-12-acp-terminal-unsplit-command-line.md)
+
+## 摘要
+
+ACP `terminal/create`传递的是可执行文件加 argv，但有些 Agent 会把整条 shell 命令行放进
+`command`、并让 `args` 为空；按字面 spawn 会以 `ENOENT` 失败，而这个失败根据 sandbox 的不同
+要么不可见、要么致命——Linux 上暴露为未分类的 errno `-2`，使 Agent 直接丢弃会话；darwin 上则
+返回一个 `wait_for_exit` 永不完成的 terminal id。现在 Lody 仍按协议原样 spawn 这一对参数，只
+在上述这一种形态（`args` 为空、`command` 含空白、该路径上没有文件）下重建命令，交给非交互、
+非登录的 `sh -c`（Windows 上为 `cmd.exe /c`）执行。若 spawn 仍然失败，`terminal/create` 会带
+JSON-RPC 错误码拒绝，并记录退出状态，因此不会有等待方被挂起。除文件检查之外，这个回退无法
+分辨"确实只有一个含空格的可执行文件"与"未拆分的命令行"，所以它刻意保持狭窄，而不是变成一种
+通用的 shell 模式。
+
+## 问题与归属
+
+按 Agent Client Protocol，拆分命令行是 Agent 的职责，而进程执行由
+`ShellTerminalManager` 负责。因此这里的兼容处理是执行边界上的互操作，而不是修正 Lody 对协议
+的理解：`command` + `args` 仍然是契约，也仍然是默认路径。
+
+同一次调用里叠加了两个不同的缺陷。第一个是解析：cross-spawn 把 `ls -al` 当作 `argv[0]`，而
+操作系统并没有这样一个可执行文件。第二个是上报。`sandbox.spawn` 在各平台上的行为并不一致——
+cgroup sandbox 会等待子进程 pid 并因此 reject，而 POSIX 回退实现会先把 handle 解析出来，让错误
+稍后从进程错误通道到达。终端的 `onError` 钩子当时只记录日志，因此这个迟到的错误什么也没有收
+敛：`createTerminal` 早已返回 id，而 `waitForTerminalExit` 会永远等下去。两个平台因此需要同一个
+有类型的答复。
+
+## 决策
+
+三处改动，每一处都很窄：
+
+1. `resolveTerminalSpawnTarget` 只在 `args` 为空、`command` 含空白，且 `stat` 在相对于 workdir
+   的该路径上找不到文件时才重建命令。正是这个文件检查保住了路径中含空格的可执行文件；
+   `args.length > 0` 永远不会被包裹，因此已经自行拆分好 argv 的调用方保持完全一致的 spawn 语义。
+2. `waitForSpawnConfirmation` 在 pid 尚未就绪时等待子进程 pid，于是 spawn 失败会让
+   `createTerminal` reject，而不是对外发布一个永远无法退出的终端。已经启动的进程在这里没有任何
+   代价：Node 会同步赋值 `pid`，检查随即返回。
+3. `ENOENT`/`EACCES` 会转成 `TerminalSpawnError`，再由 `AgentClient.createTerminal` 答复为
+   `acp.RequestError.invalidParams`（`-32602`）。无法执行的命令属于错误的请求，而一个数值化的
+   JSON-RPC 错误码才能让 Agent 报告这次失败，而不是把它当成连接已断。终端的 `onError` 钩子现在
+   也会记录退出状态，因此启动成功之后才发生的进程错误会让等待中的调用完成，而不是被挂起。
+
+选择 `sh -c` 是有意的。`bash -lc` 会执行用户的登录 profile，在 Agent 只是想在会话自身环境中运行
+一条命令的情况下改变 `PATH`、shell 选项和环境变量，而且在没有 bash 的机器上还会直接失败。
+
+另外，`resolveCustomACPSetting` 现在会展开自定义 Agent 启动命令开头的 `~`：它由人手工填写，而
+`spawn` 并不会展开它。终端命令行被刻意排除在外：那些命令来自 Agent，而当 shell 回退真正运行时，
+它自己已经会展开 `~`。
+
+## 备选方案
+
+- 只要 `args` 为空就包裹，不做文件检查（[#470](https://github.com/LodyAI/Lody/pull/470)）。
+  更简单，但会把路径中含空格的可执行文件送进 shell，于是引号和元字符开始作用在一条 Lody 本应
+  原样接收的路径上。
+- 在 Lody 内部拆分命令行并直接 spawn `argv[0]`。这需要一个在引号、转义和运算符上都与 shell 一致
+  的解析器；`sh` 已经有一个，而 Agent 写下的那条命令行本来就是给它的。
+- 只把失败作为终端输出加非零退出码上报。这样 Agent 会看到一个"运行过"却没有有用输出的终端，
+  而会话层面的原因仍然不可见。
+
+## 验证
+
+`apps/cli/tests/terminal-manager.test.ts` 用 stub sandbox 覆盖 spawn 决策——POSIX 与 Windows 上的
+未拆分命令行、保持原样的已拆分 argv、路径中含空格的可执行文件、已经带有 args 的命令行、两种
+spawn 失败形态（sandbox reject 与迟到的错误通道），以及由进程错误完成的挂起等待——另外通过
+`createNoopSessionSandbox` 覆盖两个针对真实进程的 POSIX 用例：一条未拆分的 `printf` 命令行能取回
+输出与退出码，以及一个无法解析的可执行文件会 reject 而不是发布终端。`~` 展开由
+`apps/cli/tests/agent-setting.test.ts` 覆盖。消融验证：去掉文件检查会让含空格路径的用例失败，去掉
+spawn 确认会让迟到错误的用例失败，去掉 `onError` 的退出状态记录会让等待用例一直挂到超时。
+
+此处未验证：真实发送未拆分命令行的 Agent（报告者使用的 `codebuddy-code`），以及真实 Windows 主机
+上的 `cmd.exe` 行为——Windows 分支仅通过注入的 platform 覆盖，针对真实进程的用例在 Windows 上会被
+跳过。
+
+PR：[#645](https://github.com/LodyAI/Lody/pull/645)，关闭
+[#469](https://github.com/LodyAI/Lody/issues/469)。

--- a/apps/cli/src/agent/agent-client.ts
+++ b/apps/cli/src/agent/agent-client.ts
@@ -44,7 +44,7 @@ import {
 import { getLocalControlSocketPath } from '@lody/shared/node/local-ipc';
 import { getLodyMcpHttpEndpoint } from '@/mcp/lody-mcp-http-server';
 import { buildLodyMcpHttpHeaders } from '@/mcp/lody-mcp-http-protocol';
-import { TerminalManager } from '@/session/terminal-manager';
+import { TerminalManager, TerminalSpawnError } from '@/session/terminal-manager';
 import { reportError } from 'src/utils/telemetry';
 import { formatErrorMessage } from '@/utils/format-error';
 import { LODY_AUTH_SITE_URL, LODY_AUTH_URL, LODY_SERVER_URL } from '@/utils/const';
@@ -1273,19 +1273,29 @@ export class AgentClient implements acp.Client {
         return acc;
       }, {}) ?? undefined;
 
-    const terminalId = await this.terminalManager.createTerminal(
-      params.sessionId,
-      params.command,
-      params.args ?? [],
-      params.cwd ?? undefined,
-      env,
-      typeof params.outputByteLimit === 'bigint'
-        ? params.outputByteLimit > BigInt(Number.MAX_SAFE_INTEGER)
-          ? Number.MAX_SAFE_INTEGER
-          : Number(params.outputByteLimit)
-        : (params.outputByteLimit ?? undefined)
-    );
-    return { terminalId };
+    try {
+      const terminalId = await this.terminalManager.createTerminal(
+        params.sessionId,
+        params.command,
+        params.args ?? [],
+        params.cwd ?? undefined,
+        env,
+        typeof params.outputByteLimit === 'bigint'
+          ? params.outputByteLimit > BigInt(Number.MAX_SAFE_INTEGER)
+            ? Number.MAX_SAFE_INTEGER
+            : Number(params.outputByteLimit)
+          : (params.outputByteLimit ?? undefined)
+      );
+      return { terminalId };
+    } catch (error) {
+      if (error instanceof TerminalSpawnError) {
+        // An unusable command is a bad request, not a transport failure: answer
+        // with a JSON-RPC code the agent can classify. A raw errno (`-2`) is
+        // untyped on the wire and some agents abandon the ACP session over it.
+        throw acp.RequestError.invalidParams({ details: error.message }, error.message);
+      }
+      throw error;
+    }
   }
   async terminalOutput?(params: acp.TerminalOutputRequest): Promise<acp.TerminalOutputResponse> {
     this.ensureSessionMatch(params.sessionId as ACPSessionId);

--- a/apps/cli/src/agent/setting.ts
+++ b/apps/cli/src/agent/setting.ts
@@ -312,10 +312,13 @@ export function resolveCustomACPSetting(
   agentType: string,
   customAcp: CustomAcpLaunchSpec | undefined
 ): ResolvedACPSetting {
-  const command = customAcp?.command.trim();
-  if (!command) {
+  const configured = customAcp?.command.trim();
+  if (!configured) {
     throw new Error(`Custom ACP ${agentType} has no launch command configured`);
   }
+  // The launch command is typed by a human, so it can start with `~`. spawn()
+  // does not expand it and the agent would fail to start with ENOENT.
+  const command = expandHomePath(configured);
   return {
     status: { agent: `custom:${agentType}`, command },
     exec: { command, args: [...(customAcp?.args ?? [])] },

--- a/apps/cli/src/session/AGENTS.md
+++ b/apps/cli/src/session/AGENTS.md
@@ -72,9 +72,9 @@ Contract: specs/session-orchestration.md.
 
 ## Lifecycle
 
-- `Session.createAgent` acquires the shared ACP start gate before spawn. ACP terminal creation
-  passes the protocol's executable and argv straight to `SessionSandbox.spawn`, never a rebuilt
-  shell command.
+- `Session.createAgent` takes the shared ACP start gate before spawn. ACP terminal creation spawns
+  the protocol's executable and argv; the only rebuild is the unsplit `sh -c` fallback. A failed
+  spawn is a JSON-RPC rejection, not a hung wait.
 - Child tab sessions reuse the parent workspace directory. Never write per-session workspace paths
   into `MachineMeta`: the machine publishes `['dotlodyPath']` and frontends derive them.
 - INVARIANT: any `sandbox.spawn` whose OUTPUT is the result must pass `captureOutput: true` (ACP

--- a/apps/cli/src/session/README.md
+++ b/apps/cli/src/session/README.md
@@ -136,6 +136,22 @@ a failed command is indistinguishable from an empty one. This is what made a ses
 just opened a PR report "detached HEAD" and never associate it. Long-lived ACP stdio
 deliberately does not capture: it streams and would grow unbounded.
 
+### Why an unsplit terminal command line falls back to `sh -c`
+
+ACP `terminal/create` carries the executable in `command` and its argv in `args`, and that pair
+is spawned directly. Some agents instead send the whole shell line in `command` with empty `args`
+(a bare `ls -al`, or a relayed `bash -lc …`). Spawned literally, no such executable exists: on
+Linux the cgroup sandbox awaits the child's pid and the agent sees an untyped errno `-2`, while
+on the darwin fallback the handle resolves first, so `terminal/create` returns an id whose
+`wait_for_exit` never completes.
+
+The fallback is deliberately narrow — empty `args`, whitespace in `command`, and no file at
+that path — so a spec-conformant call is untouched and an executable whose path contains a
+space is still spawned directly. The shell is non-interactive and non-login (`sh -c`, not
+`bash -lc`): the agent asked for one command, not for the user's login profile to run and
+change its environment. A spawn that still fails answers with a JSON-RPC code instead of a bare
+errno, and its error is recorded as an exit status so no waiter is left pending.
+
 ### Fork saga recovery
 
 Because a preparing target publishes no Session meta until its final commit, the repo meta

--- a/apps/cli/src/session/terminal-manager.ts
+++ b/apps/cli/src/session/terminal-manager.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from 'crypto';
+import { stat } from 'fs/promises';
+import path from 'path';
+
+import type { ChildProcess } from 'child_process';
 
 import type { Logger } from '@/utils/logger';
 import { decodeBuffer } from '@/utils/encoding';
@@ -9,6 +13,32 @@ import type {
 } from './session-sandbox';
 
 export type TerminalExitStatus = { exitCode: number | null; signal?: string | null };
+
+/**
+ * The terminal command never started: its executable could not be resolved
+ * (`ENOENT`) or could not be executed (`EACCES`).
+ *
+ * `createTerminal` rejects with this instead of resolving a terminal id, so the
+ * ACP layer can answer with a typed JSON-RPC error. A bare errno (`-2`) leaves
+ * agents unable to tell a bad command from a broken connection, and several
+ * drop the whole ACP session over it.
+ */
+export class TerminalSpawnError extends Error {
+  readonly spawnCode: 'ENOENT' | 'EACCES';
+  readonly command: string;
+
+  constructor(spawnCode: 'ENOENT' | 'EACCES', command: string, cause: unknown) {
+    super(
+      spawnCode === 'ENOENT'
+        ? `Terminal command not found: ${command}`
+        : `Terminal command is not executable: ${command}`,
+      { cause }
+    );
+    this.name = 'TerminalSpawnError';
+    this.spawnCode = spawnCode;
+    this.command = command;
+  }
+}
 
 export interface TerminalManager {
   createTerminal(
@@ -98,6 +128,11 @@ abstract class BaseTerminalManager<THandle> implements TerminalManager {
       onExit: (exitCode, signal) => this.handleExit(state, exitCode, signal),
       onError: (error) => {
         this.logger.error(`[${this.sessionLabel}] Terminal ${terminalId} error: ${error.message}`);
+        // A process error is terminal for this handle: the child either never
+        // started or died outside the exit path. Without recording an exit
+        // status here `terminal/wait_for_exit` would never resolve and the
+        // agent's turn would hang forever.
+        this.handleExit(state, null, null);
       },
     };
 
@@ -224,7 +259,10 @@ abstract class BaseTerminalManager<THandle> implements TerminalManager {
     exitCode: number | null,
     signal: NodeJS.Signals | null
   ) {
-    if (!this.terminals.has(state.id)) {
+    // A released terminal keeps the status `releaseTerminal` already recorded.
+    // A terminal that fails between `startProcess` and registration has no map
+    // entry yet and still needs one, or a later wait would never resolve.
+    if (!this.terminals.has(state.id) && state.exitStatus) {
       return;
     }
     state.exitStatus = {
@@ -255,6 +293,8 @@ export interface ShellTerminalManagerOptions extends BaseTerminalManagerOptions 
   buildEnv: (overrides?: Record<string, string>) => NodeJS.ProcessEnv;
   sandbox: SessionSandbox;
   onResourceLimitExceeded?: (violation: SessionResourceLimitViolation) => Promise<void> | void;
+  /** Defaults to the host platform; injected so both shell branches are testable. */
+  platform?: NodeJS.Platform;
 }
 
 interface ShellTerminalHandle {
@@ -270,6 +310,7 @@ export class ShellTerminalManager
   private readonly buildEnv: ShellTerminalManagerOptions['buildEnv'];
   private readonly sandbox: ShellTerminalManagerOptions['sandbox'];
   private readonly onResourceLimitExceeded?: ShellTerminalManagerOptions['onResourceLimitExceeded'];
+  private readonly platform: NodeJS.Platform;
 
   constructor(options: ShellTerminalManagerOptions) {
     super(options);
@@ -277,6 +318,7 @@ export class ShellTerminalManager
     this.buildEnv = options.buildEnv;
     this.sandbox = options.sandbox;
     this.onResourceLimitExceeded = options.onResourceLimitExceeded;
+    this.platform = options.platform ?? process.platform;
   }
 
   protected async startProcess(
@@ -291,14 +333,25 @@ export class ShellTerminalManager
   ): Promise<ShellTerminalHandle> {
     const workdir = this.resolveWorkdir(params.cwd);
     const env = this.buildEnv(params.env);
-    const processHandle = await this.sandbox.spawn(params.command, params.args, {
-      cwd: workdir,
-      env,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      // A fast terminal command can exit before spawn() returns; without
-      // capture its output would be dropped before the agent ever sees it.
-      captureOutput: true,
-    });
+    const target = await resolveTerminalSpawnTarget(
+      params.command,
+      params.args,
+      workdir,
+      this.platform
+    );
+    let processHandle: SessionProcessHandle;
+    try {
+      processHandle = await this.sandbox.spawn(target.command, target.args, {
+        cwd: workdir,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        // A fast terminal command can exit before spawn() returns; without
+        // capture its output would be dropped before the agent ever sees it.
+        captureOutput: true,
+      });
+    } catch (error) {
+      throw toTerminalSpawnError(error, target.command);
+    }
 
     const stdoutListener = (chunk: Buffer) => hooks.onData(chunk);
     const stderrListener = (chunk: Buffer) => hooks.onData(chunk);
@@ -327,16 +380,24 @@ export class ShellTerminalManager
     const unsubscribeStderr = processHandle.onStderr(stderrListener);
     const unsubscribeClose = processHandle.onClose(closeListener);
     const unsubscribeError = processHandle.onError(errorListener);
-
-    return {
-      processHandle,
-      dispose: () => {
-        unsubscribeStdout();
-        unsubscribeStderr();
-        unsubscribeClose();
-        unsubscribeError();
-      },
+    const dispose = () => {
+      unsubscribeStdout();
+      unsubscribeStderr();
+      unsubscribeClose();
+      unsubscribeError();
     };
+
+    // Sandboxes that do not await the child's pid hand back a handle before the
+    // OS has reported the failure, so an unresolvable executable would become a
+    // live terminal id whose exit never arrives. Fail the request instead.
+    try {
+      await waitForSpawnConfirmation(processHandle);
+    } catch (error) {
+      dispose();
+      throw toTerminalSpawnError(error, target.command);
+    }
+
+    return { processHandle, dispose };
   }
 
   protected async killHandle(state: TerminalState<ShellTerminalHandle>): Promise<void> {
@@ -348,6 +409,77 @@ export class ShellTerminalManager
   protected async disposeHandle(state: TerminalState<ShellTerminalHandle>): Promise<void> {
     state.handle.dispose();
   }
+}
+
+/**
+ * ACP `terminal/create` carries the executable in `command` and its argv in
+ * `args`, and that pair is what gets spawned (see AGENTS.md). Some agents
+ * instead put the whole shell line in `command` and leave `args` empty; spawned
+ * literally, that fails with `ENOENT` and the agent loses its terminal.
+ *
+ * Only that exact shape falls back to a shell, and only when the line does not
+ * name an existing file, so an executable path that merely contains a space is
+ * still spawned directly. The shell is non-interactive and non-login (`sh -c`,
+ * not `bash -lc`): the agent asked for one command, not for the user's login
+ * profile to run.
+ */
+async function resolveTerminalSpawnTarget(
+  command: string,
+  args: string[],
+  workdir: string,
+  platform: NodeJS.Platform
+): Promise<{ command: string; args: string[] }> {
+  if (args.length > 0 || !/\s/.test(command)) {
+    return { command, args };
+  }
+  if (await isExistingFile(path.resolve(workdir, command))) {
+    return { command, args };
+  }
+  return platform === 'win32'
+    ? { command: 'cmd.exe', args: ['/c', command] }
+    : { command: '/bin/sh', args: ['-c', command] };
+}
+
+async function isExistingFile(candidate: string): Promise<boolean> {
+  try {
+    return (await stat(candidate)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve once the child has a pid, reject with its spawn error otherwise.
+ * Node sets `pid` synchronously on success, so a started process costs nothing
+ * here; only a failing spawn waits for the buffered `error` event.
+ */
+function waitForSpawnConfirmation(handle: SessionProcessHandle): Promise<void> {
+  const child: ChildProcess = handle.child;
+  if (typeof child.pid === 'number' && child.pid > 0) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const disposers: Array<() => void> = [];
+    const settle = (report: () => void) => {
+      if (settled) return;
+      settled = true;
+      for (const dispose of disposers) dispose();
+      report();
+    };
+    const handleSpawn = () => settle(resolve);
+    child.once('spawn', handleSpawn);
+    disposers.push(() => child.off('spawn', handleSpawn));
+    disposers.push(handle.onError((error) => settle(() => reject(error))));
+  });
+}
+
+function toTerminalSpawnError(error: unknown, command: string): unknown {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  if (code === 'ENOENT' || code === 'EACCES') {
+    return new TerminalSpawnError(code, command, error);
+  }
+  return error;
 }
 
 function truncateBuffer(buffer: Buffer, limit: number): Buffer {

--- a/apps/cli/tests/agent-setting.test.ts
+++ b/apps/cli/tests/agent-setting.test.ts
@@ -485,6 +485,17 @@ describe('custom ACP resolution', () => {
     expect(resolved.exec).toEqual({ command: 'my-acp', args: [] });
   });
 
+  it('expands a leading ~ in the custom launch command', () => {
+    const resolved = resolveACPSetting({
+      cliType: 'custom',
+      agentType: 'custom-1234',
+      customAcp: { command: '~/bin/my-acp', args: ['--acp'] },
+    });
+
+    expect(resolved.exec).toEqual({ command: join(homedir(), 'bin/my-acp'), args: ['--acp'] });
+    expect(resolved.status.command).toBe(join(homedir(), 'bin/my-acp'));
+  });
+
   it('throws when a custom provider has no launch command', () => {
     expect(() => resolveACPSetting({ cliType: 'custom', agentType: 'custom-1234' })).toThrow(
       /no launch command/

--- a/apps/cli/tests/terminal-manager.test.ts
+++ b/apps/cli/tests/terminal-manager.test.ts
@@ -1,10 +1,20 @@
 import { EventEmitter } from 'events';
+import { chmodSync, mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { PassThrough } from 'stream';
 
 import { describe, expect, it, vi } from 'vitest';
 import type { ChildProcess } from 'child_process';
+import type { ACPSessionId, SessionId } from '@lody/shared';
 
-import { ShellTerminalManager } from '../src/session/terminal-manager';
+import { AgentClient } from '../src/agent/agent-client';
+import { createNoopSessionSandbox } from '../src/session/session-sandbox';
+import {
+  ShellTerminalManager,
+  TerminalSpawnError,
+  type TerminalManager,
+} from '../src/session/terminal-manager';
 import type { SessionProcessHandle, SessionSandbox } from '../src/session/session-sandbox';
 import type { Logger } from '../src/utils/logger';
 
@@ -19,9 +29,13 @@ const createSilentLogger = (): Logger => ({
   close: async () => {},
 });
 
-function createProcessHandle(terminate: SessionProcessHandle['terminate']): SessionProcessHandle {
+function createProcessHandle(
+  terminate: SessionProcessHandle['terminate'],
+  options: { pid?: number | null } = {}
+): SessionProcessHandle {
   const child = new EventEmitter() as ChildProcess;
-  child.pid = 4321;
+  // `null` models a child that never started: node leaves `pid` unset there.
+  child.pid = options.pid === null ? undefined : (options.pid ?? 4321);
   child.killed = false;
   child.exitCode = null;
   child.stdout = new PassThrough();
@@ -35,16 +49,55 @@ function createProcessHandle(terminate: SessionProcessHandle['terminate']): Sess
     };
   };
 
+  const subscribeEvent =
+    (event: 'exit' | 'close' | 'error') =>
+    (listener: (...args: never[]) => void) => {
+      child.on(event, listener as (...args: unknown[]) => void);
+      return () => {
+        child.off(event, listener as (...args: unknown[]) => void);
+      };
+    };
+
   return {
     child,
     inspectExit: async () => null,
     terminate,
-    onExit: () => () => {},
-    onClose: () => () => {},
-    onError: () => () => {},
+    onExit: subscribeEvent('exit') as SessionProcessHandle['onExit'],
+    onClose: subscribeEvent('close') as SessionProcessHandle['onClose'],
+    onError: subscribeEvent('error') as SessionProcessHandle['onError'],
     onStdout: subscribe(child.stdout as NodeJS.ReadableStream),
     onStderr: subscribe(child.stderr as NodeJS.ReadableStream),
   };
+}
+
+function createSandbox(spawn: SessionSandbox['spawn']): SessionSandbox {
+  return {
+    enabled: false,
+    description: 'noop',
+    applyLimits: async () => {},
+    readResourceAccounting: async () => ({
+      kind: 'process-tree',
+      rootPids: [],
+      memoryLimitBytes: null,
+      cpuLimitCores: null,
+      pidsLimit: null,
+    }),
+    spawn,
+    terminate: async () => {},
+    cleanup: async () => {},
+  };
+}
+
+function createManager(sandbox: SessionSandbox, platform?: NodeJS.Platform, workdir?: string) {
+  return new ShellTerminalManager({
+    logger: createSilentLogger(),
+    sessionLabel: 'test-session',
+    getActiveAcpSessionId: () => 'acp-1',
+    resolveWorkdir: (cwd) => cwd ?? workdir ?? process.cwd(),
+    buildEnv: () => process.env,
+    sandbox,
+    platform,
+  });
 }
 
 describe('ShellTerminalManager', () => {
@@ -103,5 +156,170 @@ describe('ShellTerminalManager', () => {
 
     expect(terminate).toHaveBeenCalledWith(false);
     expect(processHandle.child.kill).not.toHaveBeenCalled();
+  });
+
+  it('runs an unsplit command line through a non-login shell', async () => {
+    const spawn = vi.fn(async () => createProcessHandle(async () => {}));
+    const manager = createManager(createSandbox(spawn), 'darwin');
+
+    await manager.createTerminal('acp-1', 'ls -al', [], tmpdir());
+
+    expect(spawn).toHaveBeenCalledWith(
+      '/bin/sh',
+      ['-c', 'ls -al'],
+      expect.objectContaining({ cwd: tmpdir(), captureOutput: true })
+    );
+  });
+
+  it('runs an unsplit command line through cmd.exe on Windows', async () => {
+    const spawn = vi.fn(async () => createProcessHandle(async () => {}));
+    const manager = createManager(createSandbox(spawn), 'win32');
+
+    await manager.createTerminal('acp-1', 'dir /b', [], tmpdir());
+
+    expect(spawn).toHaveBeenCalledWith('cmd.exe', ['/c', 'dir /b'], expect.anything());
+  });
+
+  it('spawns a split executable and argv unchanged', async () => {
+    const spawn = vi.fn(async () => createProcessHandle(async () => {}));
+    const manager = createManager(createSandbox(spawn), 'darwin');
+
+    await manager.createTerminal('acp-1', 'git', ['status', '--short'], tmpdir());
+
+    expect(spawn).toHaveBeenCalledWith('git', ['status', '--short'], expect.anything());
+  });
+
+  it('spawns an executable path containing spaces directly', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'lody-terminal-'));
+    const executable = join(dir, 'my tool');
+    writeFileSync(executable, '#!/bin/sh\necho hi\n');
+    chmodSync(executable, 0o755);
+    const spawn = vi.fn(async () => createProcessHandle(async () => {}));
+    const manager = createManager(createSandbox(spawn), 'darwin');
+
+    await manager.createTerminal('acp-1', executable, [], dir);
+    await manager.createTerminal('acp-1', 'my tool', [], dir);
+
+    expect(spawn).toHaveBeenNthCalledWith(1, executable, [], expect.anything());
+    expect(spawn).toHaveBeenNthCalledWith(2, 'my tool', [], expect.anything());
+  });
+
+  it('never rebuilds a command line that already carries arguments', async () => {
+    const spawn = vi.fn(async () => createProcessHandle(async () => {}));
+    const manager = createManager(createSandbox(spawn), 'darwin');
+
+    await manager.createTerminal('acp-1', 'my tool', ['--version'], tmpdir());
+
+    expect(spawn).toHaveBeenCalledWith('my tool', ['--version'], expect.anything());
+  });
+
+  it('rejects with a spawn error when the sandbox reports ENOENT', async () => {
+    const enoent = Object.assign(new Error('spawn nope ENOENT'), { code: 'ENOENT' });
+    const manager = createManager(
+      createSandbox(async () => {
+        throw enoent;
+      }),
+      'darwin'
+    );
+
+    const failure = await manager.createTerminal('acp-1', 'nope', ['--version']).catch((e) => e);
+
+    expect(failure).toBeInstanceOf(TerminalSpawnError);
+    expect((failure as TerminalSpawnError).spawnCode).toBe('ENOENT');
+    expect((failure as TerminalSpawnError).cause).toBe(enoent);
+  });
+
+  it('rejects instead of handing out a terminal whose child never started', async () => {
+    // A sandbox that does not await the child's pid resolves the handle first
+    // and only then surfaces the failure on the process error channel.
+    const processHandle = createProcessHandle(async () => {}, { pid: null });
+    const manager = createManager(
+      createSandbox(async () => {
+        setImmediate(() => {
+          processHandle.child.emit(
+            'error',
+            Object.assign(new Error('spawn nope ENOENT'), { code: 'ENOENT' })
+          );
+        });
+        return processHandle;
+      }),
+      'darwin'
+    );
+
+    const failure = await manager.createTerminal('acp-1', 'nope', ['--version']).catch((e) => e);
+
+    expect(failure).toBeInstanceOf(TerminalSpawnError);
+    expect((failure as TerminalSpawnError).spawnCode).toBe('ENOENT');
+  });
+
+  it('completes a pending wait when the process errors after it started', async () => {
+    const processHandle = createProcessHandle(async () => {});
+    const manager = createManager(createSandbox(async () => processHandle), 'darwin');
+
+    const terminalId = await manager.createTerminal('acp-1', 'node', ['-v']);
+    const exitStatus = manager.waitForTerminalExit('acp-1', terminalId);
+    processHandle.child.emit('error', new Error('stream closed unexpectedly'));
+
+    await expect(exitStatus).resolves.toEqual({ exitCode: null, signal: undefined });
+  });
+});
+
+describe.skipIf(process.platform === 'win32')('ShellTerminalManager against a real process', () => {
+  it('runs an unsplit command line and returns its output', async () => {
+    const manager = createManager(createNoopSessionSandbox());
+
+    const terminalId = await manager.createTerminal(
+      'acp-1',
+      "printf 'hello from %s' sh",
+      [],
+      tmpdir()
+    );
+    const exitStatus = await manager.waitForTerminalExit('acp-1', terminalId);
+    const result = await manager.terminalOutput('acp-1', terminalId);
+    await manager.releaseTerminal('acp-1', terminalId);
+
+    expect(exitStatus).toEqual({ exitCode: 0, signal: undefined });
+    expect(result.output).toBe('hello from sh');
+  });
+
+  it('rejects an unresolvable executable instead of leaving a hung terminal', async () => {
+    const manager = createManager(createNoopSessionSandbox());
+
+    const failure = await manager
+      .createTerminal('acp-1', 'lody-no-such-command', ['--version'], tmpdir())
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(TerminalSpawnError);
+    expect((failure as TerminalSpawnError).spawnCode).toBe('ENOENT');
+  });
+});
+
+describe('AgentClient terminal/create', () => {
+  it('answers an unspawnable command with a numeric JSON-RPC error code', async () => {
+    const terminalManager = {
+      createTerminal: async () => {
+        throw new TerminalSpawnError('ENOENT', 'nope', new Error('spawn nope ENOENT'));
+      },
+    } as unknown as TerminalManager;
+    const client = new AgentClient({
+      sessionId: 'test-session' as SessionId,
+      logger: createSilentLogger(),
+      terminalManager,
+      onUpdateMessage: () => {},
+      onRequestPermission: async () => ({
+        outcome: { outcome: 'selected' as const, optionId: 'opt-1' },
+      }),
+    });
+    // Simulate session startup by setting the internal field directly.
+    // @ts-expect-error - accessing a private field for test setup
+    client.acpSessionId = 'acp-1' as ACPSessionId;
+
+    const failure = await client
+      .createTerminal?.({ sessionId: 'acp-1', command: 'nope' })
+      .catch((error: unknown) => error);
+
+    expect(typeof (failure as { code?: unknown }).code).toBe('number');
+    expect(failure).toMatchObject({ code: -32602 });
+    expect((failure as Error).message).toContain('nope');
   });
 });


### PR DESCRIPTION
Risk: 🟡 medium | Confidence: high — the shell fallback is gated on three conditions and covered by tests, but no live agent that sends an unsplit line was exercised, and the Windows branch is verified only through an injected platform.

## Related issue

Closes #469

## Problem / pressure

ACP `terminal/create` carries the executable in `command` and its argv in `args`. Several agents instead send the whole shell line in `command` with empty `args` (a bare `ls -al`, or a relayed `bash -lc …`). Lody spawned that literally, so the OS had no such executable, and the failure surfaced differently per sandbox:

- Linux: the cgroup sandbox awaits the child's pid, so `spawn` rejected and the agent received an untyped JSON-RPC error carrying errno `-2`. Several agents drop the ACP session over it.
- darwin: the fallback sandbox resolves the handle before the OS reports the failure, so `terminal/create` returned a terminal id and `terminal/wait_for_exit` never resolved — the turn hung.

`ShellTerminalManager`'s `onError` hook only logged, so no spawn failure ever completed a waiter on either platform.

## Summary

- `resolveTerminalSpawnTarget` rebuilds a command only when `args` is empty, `command` contains whitespace, and `stat` finds no file at that path relative to the workdir: `sh -c` on POSIX, `cmd.exe /c` on Windows. Non-login and non-interactive, so no user profile runs.
- Split `command` + `args` keeps going straight to `SessionSandbox.spawn`; `args.length > 0` is never wrapped, and an executable path that contains a space is still spawned directly.
- `waitForSpawnConfirmation` awaits the child's pid when it is not already set, so a spawn failure rejects `createTerminal` instead of publishing a terminal that can never exit. Node assigns `pid` synchronously on success, so a started process does not wait.
- `ENOENT`/`EACCES` become `TerminalSpawnError`, which `AgentClient.createTerminal` answers as `acp.RequestError.invalidParams` (`-32602`) instead of a bare errno.
- The terminal `onError` hook now records an exit status, so a process error after a successful start completes pending `wait_for_exit` calls.
- `resolveCustomACPSetting` expands a leading `~` in a custom agent's launch command (human-typed, not expanded by `spawn`). Terminal command lines are deliberately excluded.

## Visual explanation

```mermaid
flowchart TD
  A["terminal/create(command, args)"] --> B{"args.length > 0?"}
  B -- yes --> S["spawn(command, args)"]
  B -- no --> C{"whitespace in command?"}
  C -- no --> S
  C -- yes --> D{"stat(workdir/command) is a file?"}
  D -- yes --> S
  D -- no --> E["spawn(sh -c | cmd.exe /c, line)"]
  S --> F{"pid assigned?"}
  E --> F
  F -- yes --> G["terminalId"]
  F -- "no: ENOENT / EACCES" --> H["RequestError.invalidParams (-32602)"]
  G -.-> I["process error later"] --> J["record exit status, release waiters"]
```

## Before / after

| Before | After |
| ------ | ----- |
| `command: "ls -al"`, `args: []` spawned `ls -al` as `argv[0]` and failed. | The same call runs through `sh -c` (`cmd.exe /c` on Windows) and returns output. |
| `command: "git"`, `args: ["status"]` spawned directly. | Unchanged: split argv never goes through a shell. |
| `command: "/tmp/my tool"`, `args: []` spawned directly. | Unchanged: an existing file is spawned directly, never quoted into a shell. |
| A spawn `ENOENT` reached the agent as an untyped errno `-2`, or (darwin) as a live terminal id whose `wait_for_exit` hung. | `terminal/create` rejects with JSON-RPC `-32602`, and any late process error records an exit status. |
| A custom agent launched with `~/bin/agent` failed to start with `ENOENT`. | The leading `~` is expanded before spawn. |

## Test plan

- `vitest run tests/terminal-manager.test.ts tests/agent-setting.test.ts`: 44 passed (13 + 31). Against a stub sandbox: the unsplit line on POSIX and Windows, untouched split argv, an executable path containing a space, a command line that already carries args, both spawn-failure shapes (sandbox rejection and late error channel), a pending wait completed by a process error, and the `-32602` mapping at the ACP boundary. Against a real process (`createNoopSessionSandbox`, POSIX only): an unsplit `printf` line returns its output with exit code 0, and an unresolvable executable rejects instead of publishing a terminal.
- Ablation: removing the `stat` guard fails the space-in-path case, removing the spawn confirmation fails the late-error case, and removing the `onError` exit record leaves the wait hanging until its timeout.
- `pnpm check`: typecheck, lint, i18n, and boundary checks passed; 2722 of 2727 CLI tests passed. The one failure, `tests/worktree-gc.test.ts`, fails identically on the unmodified base commit `702b5aa1` — a local macOS `os.tmpdir()` `/var` vs `/private/var` mismatch, unrelated to this change.
- `pnpm format` and `pnpm run docs check` (no errors).
- Not exercised: a live agent that sends an unsplit line, and real `cmd.exe` behavior on Windows (that branch is covered through an injected platform, and the real-process cases skip on Windows).

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `resolveTerminalSpawnTarget` and `waitForSpawnConfirmation` in `apps/cli/src/session/terminal-manager.ts`, plus the relaxed `handleExit` registration guard.
- **Decisions to challenge:** whether the `stat`-is-a-file check is the right line between an unsplit command line and a space-containing executable path, and whether `invalidParams` (rather than `internalError`) is the correct code for a command that cannot be executed.
- **Plausible failures / evidence gaps:** a sandbox handle that neither assigns a pid nor emits `spawn`/`error` would now block `createTerminal` where it previously returned; real Windows `cmd.exe` quoting is untested on a Windows host.

### Authoring context

- **User goal / directives:** fix #469 surgically — keep the spec path as the default, add the narrow shell fallback, and never let a spawn failure hang `wait_for_exit`.
- **Constraints / non-goals:** no `/bin/bash -lc`, no wrapping when `args` is non-empty, no shell rebuilding for `terminal/create` lines beyond the documented case, and no change to agent-side command splitting.
- **Risk-bearing decisions:** the shell fallback executes an agent-supplied line under `sh -c`, where metacharacters apply; it is reachable only for a line the agent already intended as a shell command, and the `stat` guard keeps real executable paths out of it.
- **Destructive or irreversible behavior:** none; no migration, no persisted state, no cleanup path changed.
- **Deliberately not done or tested:** `~` is not expanded for terminal command lines (agent-supplied, and the shell already expands it when it runs), and PR #470 was not merged as-is because it lacks the file check and both failure paths.
- **Unknowns / confidence:** high confidence in the gated fallback and the typed rejection; residual risk is live-agent behavior and Windows `cmd.exe` quoting.

<!-- context-handoff:end -->
