### PR TITLE
fix(cli,shared): render engine-opened agent turns as their own history entries

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-12-engine-turn-entries.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-12-engine-turn-entries.md
@@ -1,0 +1,128 @@
+# Engine-opened agent turns get their own history entries
+
+Status: implemented
+Translation: current
+
+[中文](2026-09-12-engine-turn-entries.zh.md)
+
+## Abstract
+
+An agent engine can open turns behind the client's back — a kimi cron fire, a
+task wake — and its ACP server deliberately forwards their content. Those
+updates carried no turn identity, so Lody routed them to the last client turn's
+assistant entry: the user watched their real reply get folded into a collapsed
+thinking block while the cron turn's status text became the visible answer,
+after a daemon restart such updates were dropped outright, and the session
+showed "completed" while the engine turn was still running (its process could
+even be reaped by the idle GC). The fix threads a turn identity through the
+wire (`_meta.lody.turnId` = `auto:<n>` plus `_meta.lody.turnOrigin` for
+engine-opened turns) and routes updates by that identity: an engine-opened
+turn renders as its own entry, reports the session busy until its end marker,
+while boundary ids that live inside one client turn keep their legacy
+rendering. The remaining limit is deployment: the kimi stamping ships with
+the next managed-runtime artifact, while the Lody-side layers ship with Lody
+and degrade to the old behavior for unstamped agents.
+
+## The non-obvious constraint
+
+Late-update routing exists for a legitimate reason: a turn's own output can
+settle after `session/prompt` returns, so the finalized turn stays the routing
+target with no wall-clock expiry. The same rule is what swallowed engine-opened
+turns — from the routing layer's view, a cron turn's first chunk is
+indistinguishable from a straggler of the turn that just ended. Any fix
+therefore needs a real turn identity on the wire; boundary guesses based on
+timing or prompt-flight state were considered and rejected as the primary
+mechanism because consecutive engine turns and text-only engine turns are
+indistinguishable without one (a cli-only heuristic remains a viable fallback
+for unstamped runtimes, trading exactness for deployability).
+
+## Ownership
+
+- The kimi ACP server (`acp-extension-kimi` submodule) stamps every update of a
+  turn the engine opened itself with `auto:<engineTurnId>` (non-numeric, so it
+  can never parse back into a fork position) plus the origin kind. User-visible
+  turns keep plain fork positions and carry no origin marker.
+- `history-apply` in `@lody/shared` owns grouping, scoped to kimi-stamped
+  turns only: an `auto:` id or `turnOrigin` marker (engine-opened) adopts the
+  current entry only while it still accepts deltas — a finalized-but-unstamped
+  entry left by a turn that died before producing output must not adopt an
+  interrupting turn — or creates `assistant:autonomous-<turnId>`; every other
+  id keeps the exact legacy last-wins restamping, because claude's per-message
+  boundary uuids and codex collab child turns label boundaries inside one
+  client turn and must not splinter its rendering.
+- `apps/cli` routes origin-stamped (or `auto:`-prefixed) updates to a
+  synthesized autonomous target even when an active/finalized target exists:
+  an engine-opened turn can never belong to the client turn's entry, and
+  routing early also covers rich content, which bypasses turn-aware regrouping
+  at write time.
+- The kimi ACP server emits `_meta.lody.turnEnded` when an engine-opened turn
+  ends, and history apply finalizes the owning entry (once — a duplicate
+  marker must not move the terminal timing). Without the marker the entry
+  would render as perpetually streaming, because `message.finished` is the
+  renderer's only streaming verdict and finalization otherwise happens only
+  for client-dispatched turns. The origin is also persisted as
+  `entry.acpTurnOrigin` so the UI can label such turns.
+- `apps/cli` also maintains an engine-turn activity marker in the transient
+  store: set on the first stamped update of an engine-opened turn, cleared on
+  its end marker or on ACP process termination (liveness is process-bounded,
+  never wall-clock — a turn whose marker is lost releases the session as soon
+  as its process dies). `hasActiveTurn` reads it so the idle GC cannot reap
+  the agent process mid-engine-turn, and the live-status RPC upgrades
+  `unknown` to `running` so the session stops showing "completed" while the
+  engine turn is still working.
+
+## Alternatives and trade-offs
+
+- Cli-only boundary detection (seal the finalized turn after the finalize drain
+  and route everything later to an autonomous entry) covers the main case with
+  zero cross-repo coordination, but cannot split consecutive engine turns,
+  loses the boundary across daemon restarts, and hard-codes a kimi special
+  case. Kept as a possible fallback, not implemented.
+- Stamping plain engine turn numbers as fork positions was rejected: Lody
+  parses `session/fork` targets back out of `turnId`, so engine turns must be
+  non-numeric.
+- Grouping every stamped id (the first revision of this fix) was rejected on
+  review: it splintered claude's per-message boundary uuids into empty entries
+  and stole the fork-relevant `acpTurnId` from the real reply entry, and it
+  pulled codex collab child output out of the parent turn's inline rendering.
+- A generic owner-routing tier for ordinary stamped ids (route a late chunk of
+  turn N back to turn N's entry) was dropped to keep the blast radius
+  kimi-only: a straggler that crosses into the next turn keeps its pre-existing
+  merge behavior rather than gaining a new code path.
+- Task-wake turns now render as their own entries too, separating a held
+  subagent's report from the user turn that prompted it. This is consistent
+  with the engine's own turn model but is a visible change worth validating in
+  the subagent UX.
+- Left as follow-ups: replay/import does not classify cron fires, so a
+  reloaded session can still surface cron-fire XML as ordinary user messages;
+  the UI does not yet label autonomous turns by origin or show the cron
+  turn's trigger prompt.
+
+## Evidence and verification
+
+- Reproduced from the production session wire (`~/.kimi-code/.../wire.jsonl`):
+  a cron turn firing one second after a user turn completed had its final text
+  persisted as the visible reply of that user turn's assistant entry.
+- New unit coverage: engine-turn separation, cross-batch continuity, the
+  died-before-output adoption hole, end-marker finalization (and its
+  once-only terminal timing), claude multi-uuid last-wins, and codex collab
+  inline restamping in `@lody/shared`; autonomous-target gating (origin and
+  `auto:` prefix) and engine-turn activity note/clear/replace in `apps/cli`
+  (`session-transient-store`); engine-turn stamping, fork-index exclusivity,
+  and end-marker emission in the kimi `acp-server`.
+- Reproduced the status-side symptom in a second production session (task-wake
+  variant): the engine turn's output merged into the finalized turn while
+  `executionState` stayed `idle` — the same invisibility this fix's activity
+  marker now covers.
+- Verified end-to-end in a live OSS desktop running the branch and a locally
+  built stamped runtime: a cron fire after a user turn rendered as its own
+  finished turn, and session presence read `running` during the engine turn
+  and `idle` after its end marker. The first-pass UI gap it exposed — the
+  engine turn appeared with no origin cue — motivates the persisted
+  `acpTurnOrigin` field that a follow-up renders as an origin divider.
+- Full suites pass on both repos except three failures verified to reproduce on
+  unmodified trees: two Claude credential-store probes and one macOS
+  `/var` vs `/private/var` worktree-GC assertion in `apps/cli`, and one local
+  bash-fallback e2e test in `acp-server`.
+- Not yet verified end-to-end against a live session running a stamped runtime;
+  that requires the next kimi managed-runtime artifact.

--- a/.agents/notes/implemented/bug-fix/2026-09-12-engine-turn-entries.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-12-engine-turn-entries.zh.md
@@ -1,0 +1,90 @@
+# 引擎自开的 agent 轮次拥有自己的历史条目
+
+Status: implemented
+Translation: current
+
+[English](2026-09-12-engine-turn-entries.md)
+
+## 摘要
+
+agent 引擎可以背着客户端自己开轮次——kimi 的 cron 触发、任务唤醒——而它的 ACP server 刻意
+转发这些轮次的内容。这些更新不带轮次身份，于是 Lody 把它们路由到上一个客户端轮次的
+assistant 条目里：用户眼睁睁看着自己的真实答复被折叠进"思考过程"，而 cron 轮次的状态
+文本成了可见答复；daemon 重启后这类更新被直接丢弃；session 在引擎轮次仍在运行时显示
+"已完成"（进程甚至可能被空闲 GC 回收）。修复把轮次身份穿进 wire（引擎自开轮次带
+`_meta.lody.turnId = auto:<n>` 和 `_meta.lody.turnOrigin`）并按此路由：引擎自开轮次渲染为
+自己的条目、在终结标记前会话显示为忙碌；而活在一个客户端轮次内部的边界 id 保持原有
+渲染。剩余的边界是部署：kimi 打标随下一个 managed-runtime artifact 发布，Lody 侧各层随
+Lody 发布，对未打标的 agent 退化为旧行为。
+
+## 不显眼的约束
+
+迟到更新路由有其正当存在理由：轮次自身的输出可能在 `session/prompt` 返回后才落地，所以
+已完结轮次始终作为路由目标、不按墙钟过期。也正是这条规则吞掉了引擎自开轮次——在路由
+层看来，cron 轮次的第一个 chunk 和刚结束轮次的迟到残片无法区分。因此任何修复都需要
+wire 上真实的轮次身份；基于时序或 prompt 在飞状态的边界猜测被考虑过并否决作为主要机制，
+因为连续的引擎轮次和纯文本引擎轮次没有身份就无法区分（cli-only 的启发式仍是未打标
+runtime 的可行兜底，用精确性换部署便利）。
+
+## 职责划分
+
+- kimi ACP server（`acp-extension-kimi` 子模块）给引擎自开轮次的每条更新打上
+  `auto:<engineTurnId>`（非数字，永远不能被解析回 fork 位置）和来源 kind。用户可见轮次
+  保持纯 fork 位置，不带来源标记。
+- `@lody/shared` 的 `history-apply` 负责分组，且仅对 kimi 打标的轮次生效：`auto:` id 或
+  `turnOrigin` 标记（引擎自开）仅在当前条目仍可接受增量时收养它——死后留下未打标条目的
+  失败轮次不得收养打断轮次——否则创建 `assistant:autonomous-<turnId>`；其他一切 id 保持
+  逐字节的旧式 last-wins 盖戳，因为 claude 的按消息边界 uuid 和 codex collab 子轮次标记的
+  是同一个客户端轮次内部的边界，绝不能拆散其渲染。
+- `apps/cli` 把带来源标记（或 `auto:` 前缀）的更新路由到合成的自主目标，即使存在
+  active/finalized 目标：引擎自开轮次永远不属于客户端轮次的条目，提前路由还覆盖了富
+  内容——它在写入时绕过分组逻辑。
+- kimi ACP server 在引擎自开轮次结束时发出 `_meta.lody.turnEnded`，history apply 据此
+  完结属主条目（只写一次——重复标记不得挪动终结时间）。没有这个标记，条目会永远渲染为
+  流式，因为 `message.finished` 是渲染器唯一的流式判据，而完结本来只发生在客户端
+  dispatch 的轮次上。来源同时持久化为 `entry.acpTurnOrigin`，供 UI 为这类轮次打标签。
+- `apps/cli` 还在 transient store 里维护引擎轮次活动标记：引擎轮次首条打标更新时置位，
+  终结标记或 ACP 进程终止时清除（活性以进程为界，不用墙钟——标记丢失的轮次在其进程
+  死亡时立即释放会话）。`hasActiveTurn` 读取它，空闲 GC 便无法在引擎轮次中途回收 agent
+  进程；live-status RPC 把 `unknown` 升级为 `running`，session 不再在引擎轮次工作时
+  显示"已完成"。
+
+## 备选与取舍
+
+- cli-only 边界检测（finalize drain 后封存已完结轮次、之后一律进自主条目）以零跨仓协调
+  覆盖主场景，但无法拆分连续的引擎轮次、daemon 重启后丢失边界，还硬编码 kimi 特判。
+  保留为可行兜底，未实现。
+- 否决把纯引擎轮次号当作 fork 位置打标：Lody 会把 `session/fork` 目标从 `turnId` 解析
+  回来，所以引擎轮次必须是非数字。
+- "对所有打标 id 分组"（本修复的第一版）在复查时被否：它把 claude 的按消息边界 uuid
+  拆成空条目、把 fork 依赖的 `acpTurnId` 从真正的答复条目上偷走，还把 codex collab 子
+  轮次的输出从父轮次的内联渲染里拽了出来。
+- 面向普通打标 id 的通用属主路由层（把轮次 N 的迟到 chunk 路由回轮次 N 的条目）为把
+  影响面收窄到 kimi 专属而砍掉：跨进下一轮次的残片保持其既有的合并行为，不为它新增
+  代码路径。
+- task wake 轮次现在也会渲染为独立条目，把持有中的 subagent 汇报和发起它的用户轮次
+  分开。这与引擎自己的轮次模型一致，但属于可见变化，值得在 subagent UX 里验证。
+- 遗留 follow-up：replay/import 不分类 cron fire，重新加载的 session 仍可能把 cron-fire
+  XML 显示为普通用户消息；UI 也还没有为引擎自开轮次做来源标签，也不显示 cron 轮次的
+  触发 prompt。
+
+## 证据与验证
+
+- 从生产 session 的 wire（`~/.kimi-code/.../wire.jsonl`）复现：一个 cron 在用户轮次完成
+  后一秒触发，其最终文本被持久化为该用户轮次 assistant 条目的可见答复。
+- 新增单元覆盖：`@lody/shared` 的引擎轮次分离、跨批次连续性、先死后收养的漏洞、终结
+  标记完结（及其一次性的终结时间）、claude 多 uuid last-wins、codex collab 内联盖戳；
+  `apps/cli`（`session-transient-store`）的自主目标门控（来源与 `auto:` 前缀）与引擎
+  轮次活动置位/清除/替换；kimi `acp-server` 的引擎轮次打标、fork 序号互斥与终结标记
+  发送。
+- 在第二个生产 session 复现了状态侧症状（task-wake 变体）：引擎轮次的输出合并进已完结
+  轮次，同时 `executionState` 停在 `idle`——本修复的活动标记覆盖的正是这种不可见性。
+- 在运行本分支的 OSS 桌面 + 本地构建的打标 runtime 上完成端到端验证：用户轮次之后的
+  cron 触发渲染为独立的已完成轮次；引擎轮次期间 session presence 为 `running`，终结
+  标记后为 `idle`。第一轮 UI 暴露的缺口——引擎轮次毫无来源提示——正是持久化
+  `acpTurnOrigin` 字段的动机，后续 PR 会把它渲染为来源分隔行。
+- 两个仓库的完整套件均通过，除三个已验证在未改动树上同样失败的用例：`apps/cli` 的
+  两个 Claude 凭据存储探测与一个 macOS `/var` vs `/private/var` worktree-GC 断言，以及
+  `acp-server` 的一个本地 bash 回退 e2e 测试。
+- 尚未在运行打标 runtime 的真实 session 里做端到端验证；那需要下一个 kimi
+  managed-runtime artifact。

--- a/apps/cli/src/lib/machine-runtime.ts
+++ b/apps/cli/src/lib/machine-runtime.ts
@@ -97,6 +97,9 @@ export class MachineRuntime {
       machineId,
       () => this.resourceMonitor?.sample() ?? Promise.reject(new Error('Resource monitor stopped'))
     );
+    // A dying ACP process ends any engine-opened turn it hosted: drop the
+    // activity marker so busy status and the idle-GC guard release the session.
+    this.onSessionTerminated((sessionId) => this.handler?.clearEngineTurnActivity(sessionId));
     this.initializeGCManager();
     this.initialized = true;
 

--- a/apps/cli/src/lib/message-handler.ts
+++ b/apps/cli/src/lib/message-handler.ts
@@ -169,6 +169,7 @@ import {
   type StoredLodyOperation,
   CURRENT_MACHINE_PROTOCOL_CAPABILITIES,
   hasPendingUserTurnActivation,
+  readLodyTurnEnded,
 } from '@lody/shared';
 import { ISession, SessionManager } from '../session/session-manager';
 import { captureCli } from '@/lib/analytics/posthog';
@@ -274,6 +275,7 @@ import { createWorktreeScriptHistoryRecorder } from '@/session/worktree/worktree
 import { runWorktreeCleanup } from '@/session/worktree/worktree-setup-runner';
 import {
   SessionTransientStore,
+  autonomousACPUpdateTargetFrom,
   type ACPUpdateTarget,
   type BufferedACPUpdate,
 } from '@/lib/session-transient-store';
@@ -3330,6 +3332,7 @@ export class MessageHandler {
             presence: this.sessionActivePresence.getStatus(sessionId),
             execution: this.executionService.getExecutionSnapshot(sessionId),
             hasPendingDispatch: this.sessionDispatchWatcher.hasPendingDispatch(sessionId),
+            engineTurnActive: this.store.isEngineTurnActive(sessionId),
           });
           return {
             type: 'session/live-status_response' as const,
@@ -3484,6 +3487,7 @@ export class MessageHandler {
           presence: this.sessionActivePresence.getStatus(sessionId),
           execution: this.executionService.getExecutionSnapshot(sessionId),
           hasPendingDispatch: this.sessionDispatchWatcher.hasPendingDispatch(sessionId),
+          engineTurnActive: this.store.isEngineTurnActive(sessionId),
         });
         return live.state !== 'unknown';
       },
@@ -4353,7 +4357,13 @@ export class MessageHandler {
     if (this.store.recordSuppressedAcpReplay(sessionId)) {
       return;
     }
-    const target = this.store.getCurrentACPUpdateTarget(sessionId);
+    // Updates from a turn the engine opened itself always take an autonomous
+    // target — never the active/finalized client turn's — so their content
+    // (including rich content, which bypasses turn-aware regrouping at write
+    // time) lands in that turn's own entry from the start.
+    const target =
+      this.autonomousACPUpdateTarget(sessionId, update) ??
+      this.store.getCurrentACPUpdateTarget(sessionId);
     if (!target) {
       this.captureACPUpdateInvariant('out_of_turn_acp_update_without_target', sessionId, update);
       this.logger.debug(
@@ -4374,6 +4384,36 @@ export class MessageHandler {
     }
     this.store.get(sessionId).acpUpdateBuffer.push({ notification: update, target });
     this.scheduleFlushACPUpdates(sessionId);
+  }
+
+  /**
+   * Synthesize a routing target for an update from a turn the agent opened
+   * itself (see `autonomousACPUpdateTargetFrom`). Also maintains the
+   * engine-turn activity marker — the one place every engine-turn update
+   * passes — so busy status and the idle-GC guard can see the turn. Recorded
+   * as an invariant so autonomous-turn routing stays observable.
+   */
+  private autonomousACPUpdateTarget(
+    sessionId: SessionId,
+    update: AcpSessionNotification
+  ): ACPUpdateTarget | undefined {
+    const target = autonomousACPUpdateTargetFrom(update);
+    if (target) {
+      if (readLodyTurnEnded(update.update)) {
+        this.store.clearEngineTurnActivity(sessionId, target.turnId);
+      } else {
+        this.store.noteEngineTurnActivity(sessionId, target.turnId);
+      }
+      this.captureACPUpdateInvariant('autonomous_turn_acp_update_target', sessionId, update, {
+        acpTurnId: target.turnId,
+      });
+    }
+    return target;
+  }
+
+  /** Clear the engine-turn activity marker (ACP process termination). */
+  clearEngineTurnActivity(sessionId: SessionId): void {
+    this.store.clearEngineTurnActivity(sessionId);
   }
 
   private clearScheduledACPFlush(sessionId: SessionId): void {
@@ -4598,10 +4638,13 @@ export class MessageHandler {
   }
 
   private captureACPUpdateInvariant(
-    eventName: 'late_acp_update_routed_to_finalized_turn' | 'out_of_turn_acp_update_without_target',
+    eventName:
+      | 'late_acp_update_routed_to_finalized_turn'
+      | 'out_of_turn_acp_update_without_target'
+      | 'autonomous_turn_acp_update_target',
     sessionId: SessionId,
     notification: AcpSessionNotification,
-    extra?: { assistantEntryId?: string; turnEpoch?: number }
+    extra?: { assistantEntryId?: string; turnEpoch?: number; acpTurnId?: string }
   ): void {
     captureCli(
       eventName,
@@ -4611,6 +4654,7 @@ export class MessageHandler {
         session_update: notification.update.sessionUpdate,
         ...(extra?.assistantEntryId ? { assistant_entry_id: extra.assistantEntryId } : {}),
         ...(typeof extra?.turnEpoch === 'number' ? { turn_epoch: extra.turnEpoch } : {}),
+        ...(extra?.acpTurnId ? { acp_turn_id: extra.acpTurnId } : {}),
       },
       { tier: 'C' }
     );
@@ -9602,12 +9646,17 @@ export class MessageHandler {
   }
 
   /**
-   * Check if a session has an active turn (prompting or finalizing).
+   * Check if a session has an active turn (prompting or finalizing) or an
+   * engine-opened turn in flight.
    */
   hasActiveTurn(sessionId: SessionId): boolean {
     if (!this.store.has(sessionId)) return false;
     const state = this.store.get(sessionId);
-    return state.turn.phase !== 'idle' || this.hasSessionActivePresence(sessionId);
+    return (
+      state.turn.phase !== 'idle' ||
+      state.engineTurn !== undefined ||
+      this.hasSessionActivePresence(sessionId)
+    );
   }
 
   /**

--- a/apps/cli/src/lib/session-live-status.test.ts
+++ b/apps/cli/src/lib/session-live-status.test.ts
@@ -61,4 +61,26 @@ describe('resolveSessionLiveStatus', () => {
       })
     ).toEqual({ state: 'running' });
   });
+
+  it('reports an engine-opened turn as running without presence or client turn state', () => {
+    expect(
+      resolveSessionLiveStatus({
+        presence: null,
+        execution: idleExecution,
+        hasPendingDispatch: false,
+        engineTurnActive: true,
+      })
+    ).toEqual({ state: 'running' });
+  });
+
+  it('lets presence outrank an engine-opened turn', () => {
+    expect(
+      resolveSessionLiveStatus({
+        presence: SessionStatusFactory.requestPermission(),
+        execution: idleExecution,
+        hasPendingDispatch: false,
+        engineTurnActive: true,
+      })
+    ).toEqual({ state: 'waiting' });
+  });
 });

--- a/apps/cli/src/lib/session-live-status.ts
+++ b/apps/cli/src/lib/session-live-status.ts
@@ -10,6 +10,8 @@ export const resolveSessionLiveStatus = (args: {
   presence: SessionStatus | null;
   execution: SessionExecutionSnapshot;
   hasPendingDispatch: boolean;
+  /** An engine-opened turn (cron fire, task wake) is producing updates. */
+  engineTurnActive?: boolean;
 }): ResolvedSessionLiveStatus => {
   if (args.presence?.type === 'requestPermission') {
     return { state: 'waiting' };
@@ -18,6 +20,11 @@ export const resolveSessionLiveStatus = (args: {
     return { state: 'initializing' };
   }
   if (args.presence?.type === 'running') {
+    return { state: 'running' };
+  }
+  // Engine-opened turns own no client-turn state and write no presence, so
+  // only their activity marker can report them as running.
+  if (args.engineTurnActive) {
     return { state: 'running' };
   }
   if (args.execution.hasActiveTurn || args.execution.hasBlockingPendingCreate) {

--- a/apps/cli/src/lib/session-transient-store.test.ts
+++ b/apps/cli/src/lib/session-transient-store.test.ts
@@ -1,10 +1,83 @@
 import { describe, it, expect, vi } from 'vitest';
-import { SessionTransientStore } from './session-transient-store';
+import { SessionTransientStore, autonomousACPUpdateTargetFrom } from './session-transient-store';
+import { parseSessionNotification, type AcpSessionNotification } from '@lody/shared';
 import type { SessionId } from '@lody/shared';
 
 const sid = (id: string) => id as SessionId;
 
+const acpUpdate = (meta: Record<string, unknown> | undefined): AcpSessionNotification =>
+  parseSessionNotification({
+    sessionId: 's1',
+    update: {
+      sessionUpdate: 'agent_message_chunk',
+      messageId: 'msg-1',
+      content: { type: 'text', text: 'chunk' },
+      ...(meta ? { _meta: meta } : {}),
+    },
+  });
+
+describe('autonomousACPUpdateTargetFrom', () => {
+  it('synthesizes an autonomous target for engine-opened turn updates', () => {
+    const target = autonomousACPUpdateTargetFrom(
+      acpUpdate({ lody: { turnId: 'auto:41', turnOrigin: 'cron_job' } })
+    );
+    expect(target).toEqual({
+      kind: 'assistant_entry',
+      assistantEntryId: 'assistant:autonomous-auto:41',
+      turnId: 'auto:41',
+      turnEpoch: 0,
+      source: 'autonomous_turn',
+    });
+  });
+
+  it('returns undefined without an origin marker (client-dispatched turn)', () => {
+    expect(autonomousACPUpdateTargetFrom(acpUpdate({ lody: { turnId: '40' } }))).toBeUndefined();
+  });
+
+  it('also qualifies on the auto: prefix alone', () => {
+    expect(autonomousACPUpdateTargetFrom(acpUpdate({ lody: { turnId: 'auto:41' } }))).toMatchObject(
+      { assistantEntryId: 'assistant:autonomous-auto:41', source: 'autonomous_turn' }
+    );
+  });
+
+  it('returns undefined without a turn id', () => {
+    expect(
+      autonomousACPUpdateTargetFrom(acpUpdate({ lody: { turnOrigin: 'cron_job' } }))
+    ).toBeUndefined();
+    expect(autonomousACPUpdateTargetFrom(acpUpdate(undefined))).toBeUndefined();
+  });
+});
+
 describe('SessionTransientStore', () => {
+  describe('engine-turn activity', () => {
+    it('notes, reports, and clears engine-turn activity', () => {
+      const store = new SessionTransientStore();
+      const id = sid('s1');
+      expect(store.isEngineTurnActive(id)).toBe(false);
+
+      store.noteEngineTurnActivity(id, 'auto:41');
+      expect(store.isEngineTurnActive(id)).toBe(true);
+      expect(store.get(id).engineTurn).toMatchObject({ acpTurnId: 'auto:41' });
+
+      // A mismatched end marker belongs to an older, replaced turn.
+      store.noteEngineTurnActivity(id, 'auto:42');
+      store.clearEngineTurnActivity(id, 'auto:41');
+      expect(store.isEngineTurnActive(id)).toBe(true);
+
+      store.clearEngineTurnActivity(id, 'auto:42');
+      expect(store.isEngineTurnActive(id)).toBe(false);
+      expect(store.get(id).engineTurn).toBeUndefined();
+    });
+
+    it('clears unconditionally on process termination', () => {
+      const store = new SessionTransientStore();
+      const id = sid('s1');
+      store.noteEngineTurnActivity(id, 'auto:41');
+      store.clearEngineTurnActivity(id);
+      expect(store.isEngineTurnActive(id)).toBe(false);
+    });
+  });
+
   describe('get / has', () => {
     it('creates state lazily on first access', () => {
       const store = new SessionTransientStore();

--- a/apps/cli/src/lib/session-transient-store.ts
+++ b/apps/cli/src/lib/session-transient-store.ts
@@ -39,6 +39,9 @@
 
 import {
   getServerNow,
+  isAutonomousTurnId,
+  readLodyTurnId,
+  readLodyTurnOrigin,
   type AcpSessionNotification,
   type MessageContent,
   type SessionContextWindowUsage,
@@ -47,7 +50,7 @@ import {
 import type { Logger } from '@/utils/logger';
 import type { TurnHistoryGate } from '@/session/turn-history-gate';
 
-type AssistantTurnACPUpdateTargetSource = 'active_turn' | 'finalized_turn';
+type AssistantTurnACPUpdateTargetSource = 'active_turn' | 'finalized_turn' | 'autonomous_turn';
 
 export type AssistantTurnACPUpdateTarget = {
   kind: 'assistant_entry';
@@ -60,6 +63,37 @@ export type AssistantTurnACPUpdateTarget = {
 };
 
 export type ACPUpdateTarget = AssistantTurnACPUpdateTarget;
+
+/**
+ * Synthesize a routing target for an update from a turn the agent engine
+ * opened itself (a cron fire, a task wake). Two markers qualify, either
+ * sufficient: `_meta.lody.turnOrigin`, or a non-numeric `auto:`-prefixed
+ * `_meta.lody.turnId`. Both mean the engine owns the turn, so its output gets
+ * its own assistant entry instead of merging into whichever client turn ran
+ * last (or being dropped when no client turn exists in memory, e.g. right
+ * after a daemon restart). Stamped updates WITHOUT either marker belong to
+ * user-visible turns whose entry lifecycle is owned by the turn dispatcher;
+ * those keep the active/finalized routing, or the drop-plus-invariant behavior
+ * when no target exists.
+ */
+export function autonomousACPUpdateTargetFrom(
+  notification: AcpSessionNotification
+): ACPUpdateTarget | undefined {
+  const turnId = readLodyTurnId(notification.update);
+  if (
+    !turnId ||
+    (!isAutonomousTurnId(turnId) && readLodyTurnOrigin(notification.update) === undefined)
+  ) {
+    return undefined;
+  }
+  return {
+    kind: 'assistant_entry',
+    assistantEntryId: `assistant:autonomous-${turnId}`,
+    turnId,
+    turnEpoch: 0,
+    source: 'autonomous_turn',
+  };
+}
 
 export type BufferedACPUpdate = {
   notification: AcpSessionNotification;
@@ -151,6 +185,15 @@ export interface SessionState {
 
   // ── Session-scoped (survives turn boundaries) ───────────────────────────
   lastActivityMs: number;
+  /**
+   * The engine-opened turn (a cron fire, a task wake) currently producing
+   * updates, if any. Set on the first update carrying its stamped id, cleared
+   * on its `turnEnded` marker or on ACP process termination — liveness is
+   * bounded by the process, never by a wall clock. Feeds busy status and the
+   * idle-GC guard so an engine turn neither reads as "completed" nor gets its
+   * agent process killed mid-flight.
+   */
+  engineTurn: { acpTurnId: string; lastUpdateMs: number } | undefined;
   logger: Logger | null;
 }
 
@@ -185,6 +228,7 @@ function createSessionState(): SessionState {
     permissionWaitMs: 0,
     pendingUnread: false,
     lastActivityMs: Date.now(),
+    engineTurn: undefined,
     logger: null,
   };
 }
@@ -323,6 +367,32 @@ export class SessionTransientStore {
     return this.getFreshLateACPUpdateTarget(state);
   }
 
+  /**
+   * Record an update from the engine-opened turn `acpTurnId`: it is running
+   * now. A newer turn replaces the marker (engine turns serialize on the main
+   * agent, so a stale entry means its end marker was lost).
+   */
+  noteEngineTurnActivity(sessionId: SessionId, acpTurnId: string): void {
+    this.get(sessionId).engineTurn = { acpTurnId, lastUpdateMs: getServerNow() };
+  }
+
+  /**
+   * Clear the engine-turn marker — on the turn's end marker (matched by id) or
+   * on ACP process termination (unconditional). A mismatched id belongs to an
+   * older, already-replaced turn and is ignored.
+   */
+  clearEngineTurnActivity(sessionId: SessionId, acpTurnId?: string): void {
+    const state = this.sessions.get(sessionId);
+    if (!state?.engineTurn) return;
+    if (acpTurnId !== undefined && state.engineTurn.acpTurnId !== acpTurnId) return;
+    state.engineTurn = undefined;
+  }
+
+  /** Whether an engine-opened turn is currently producing updates. */
+  isEngineTurnActive(sessionId: SessionId): boolean {
+    return this.sessions.get(sessionId)?.engineTurn !== undefined;
+  }
+
   private getFreshLateACPUpdateTarget(
     state: SessionState
   ): AssistantTurnACPUpdateTarget | undefined {
@@ -330,8 +400,12 @@ export class SessionTransientStore {
     // sessions can stay alive and emit events long after a turn's stopReason (cron
     // jobs, ScheduleWakeup, other deferred/background work). Those late updates must
     // still be routed to the owning assistant entry and written to the Loro doc.
-    // The target is only cleared when a new turn starts (beginTurn) or when ACP
-    // replay suppression begins — never on a wall-clock deadline.
+    // Updates stamped with a DIFFERENT `_meta.lody.turnId` belong to a turn the
+    // engine opened itself; they are retargeted to that turn's own entry at apply
+    // time (see `ensureEntryForAcpTurn` in @lody/shared) rather than merging into
+    // this finalized turn. The target is only cleared when a new turn starts
+    // (beginTurn) or when ACP replay suppression begins — never on a wall-clock
+    // deadline.
     return state.lateACPUpdateTarget;
   }
 

--- a/apps/cli/src/session/AGENTS.md
+++ b/apps/cli/src/session/AGENTS.md
@@ -65,8 +65,8 @@ Contract: specs/session-orchestration.md.
 - Continue-session recovery may restore the ACP session and retry the same prompt once, only
   while that turn has no ACP output.
 - INVARIANT: a resolved prompt is not proof of success. A turn that emitted no ACP update takes
-  `recordSilentTurnFailure`, not `setDispatchHandled` (read `turnProducedVisibleOutput` before
-  `finalizeTurn` clears it); it still finalizes, still ADVANCES the pointer, and fails open.
+  `recordSilentTurnFailure`, not `setDispatchHandled` (read `turnProducedVisibleOutput` first); it
+  still finalizes, still ADVANCES the pointer, and fails open.
 - Diff content comes only from the CLI-local ACP evidence store; GitHub `diffStats` use PR compare
   semantics, and `session-diff-stats-target.ts` skips rather than overwrites a good total.
 
@@ -90,24 +90,25 @@ Contract: specs/session-orchestration.md.
   append history, or publish events before adoption.
 - Dispatch and claim rescan the current row and reject changed compatibility under canonical
   `buildSessionLaunchConfig` semantics; a published incompatible resource cleans up first.
-- Nested child Sessions are rejected: ownership resolves one parent hop only.
+- Nested child Sessions rejected: ownership is one parent hop only.
 - Fork commits at `LoroDocumentManager.persistPendingChanges()`; cloud `waitUntilSynced()` is
   never a success condition. Persist the target placeholder before ACP; a failed final commit
   terminates the fork and durably deletes the target.
 - Fork an active source turn only on an advertised `_meta.lody.forkAtTurn = { version: 1 }`, pass
   the adapter's `_meta.lody.turnId` through unchanged as `acpTurnId`, and reuse the source Git
-  identity only on an exact requester match. New-worktree forks also require native fork support,
-  persist a target-doc `forkOperation` before returning, publish no target meta before the final
-  commit, clean up ACP and the worktree/branch with a durable failed receipt, and stay idempotent
-  on retry.
-- Fork recovery fail-closes interrupted operations and finds them ONLY in the machine-local marker
-  store under `withForkOperationLock`. Never enumerate rooms or open docs to find candidates, and
-  never `cleanSessionDoc` a doc you do not own.
+  identity only on an exact requester match. New-worktree forks need native fork support, a
+  target-doc `forkOperation` before returning, no target meta before the final commit, durable
+  failed-receipt cleanup, idempotent retry. Engine turns carry `auto:<n>` + `turnOrigin`, not
+  fork positions; updates get `assistant:autonomous-<turnId>` entries
+  ([README](README.md#engine-turns)).
+- Fork recovery fail-closes interrupted operations, found ONLY in machine-local marker store
+  under `withForkOperationLock`; never enumerate rooms or open docs, never `cleanSessionDoc`
+  a doc you do not own.
 - Edit-and-resend prepares provider `forkAtTurn` (`session/new` for the first User), cancels the
   exact active turn, waits for ownership release, then one durable history/meta commit.
   Its rewrite barrier excludes queue promotion and blocks dispatch and steer; the queue is never
-  rewritten. Keep the original User attribution, config, and attachments, use new turn ids and ACP
-  identity, and never replay transcript or roll back files.
+  rewritten. Keep original User attribution, config, attachments; new turn ids and ACP identity;
+  never replay transcript or roll back files.
 
 ## Access
 
@@ -115,7 +116,7 @@ Contract: specs/session-orchestration.md.
   resume and dispatch resolve from agent config/project, and the legacy row is fallback only.
 - Dispatch access is local policy first, optional-cloud three-state second: owner-cached policy
   may allow offline, `remote_missing` and a definitive `denied` fail the turn, `indeterminate`
-  leaves it pending behind `verifyMachineAccessWithRetry()`. Never collapse a thrown check into
+  stays pending behind `verifyMachineAccessWithRetry()`. Never collapse a thrown check into
   denial.
 - Every owner-allowed dispatch fires `fireOwnerAccessRecheck` with `forceBackendVerification`; a
   confirmed online allow is the ONLY writer of the access snapshot and `verifiedAt`, a deny clears

--- a/apps/cli/src/session/README.md
+++ b/apps/cli/src/session/README.md
@@ -171,6 +171,30 @@ Recovery must never enumerate session rooms or open docs to find candidates: eac
 the room and pulls its stream, so a full scan is O(all historical sessions) of Streams
 subscriptions at every daemon start (see [../lib/loro/AGENTS.md](../lib/loro/AGENTS.md)).
 
+### Engine turns
+
+An agent engine can open turns behind the client's back (a kimi cron fire, a task wake), and
+its ACP server forwards their content deliberately. Unstamped, those updates are
+indistinguishable from stragglers of the last client turn, so the finalized-turn routing
+merged them into that turn's assistant entry — the real reply folded away, the interrupting
+turn's text became the visible answer — and dropped them outright after a daemon restart. The
+wire fix: engine-opened turns carry `_meta.lody.turnId = auto:<n>` (non-numeric, so
+`session/fork` can never parse one into a turn position) plus `_meta.lody.turnOrigin`. History
+apply (`ensureEntryForAcpTurn` in `@lody/shared`) gives only those ids their own
+`assistant:autonomous-<turnId>` entry — other stamped ids keep legacy last-wins restamping,
+because claude's per-message uuids and codex collab child turns are boundaries inside one
+client turn — and `autonomousACPUpdateTargetFrom` (`../lib/session-transient-store.ts`) routes
+them to a synthesized autonomous target even while a client turn owns the session, which also
+covers rich content. The agent also emits `_meta.lody.turnEnded` when the engine turn ends;
+without it the entry would render as streaming forever, since finalization otherwise only
+happens for client-dispatched turns. The same markers drive an engine-turn activity flag in
+the transient store (`noteEngineTurnActivity`, cleared by the end marker or process
+termination — process-bounded, never a wall clock): `hasActiveTurn` reads it so the idle GC
+cannot reap the agent mid-engine-turn, and the live-status RPC upgrades `unknown` to
+`running` so the session no longer shows "completed" while the engine turn is still working.
+Decision record:
+[../../../../.agents/notes/implemented/bug-fix/2026-09-12-engine-turn-entries.md](../../../../.agents/notes/implemented/bug-fix/2026-09-12-engine-turn-entries.md).
+
 ### GitHub credential broker
 
 Agent `gh` auth for GitHub repo sessions is set up in `session-manager.ts`: it creates the git

--- a/packages/shared/src/acp/history-apply.ts
+++ b/packages/shared/src/acp/history-apply.ts
@@ -144,6 +144,55 @@ const canAppendAssistantDeltas = (
   entry?.role === 'assistant' && entry.finished !== true && typeof entry.endedAt !== 'number';
 
 /**
+ * Read the agent-minted turn id off a `session/update` (`_meta.lody.turnId`).
+ * Present on turn-scoped updates from agents that declare the fork-at-turn
+ * contract; engine-opened turns (cron fires, deferred wakes) carry a
+ * non-numeric id so they can never be confused with a fork position.
+ */
+export const readLodyTurnId = (update: { _meta?: unknown }): string | undefined => {
+  const lody = asRecordOrUndefined(update._meta)?.lody;
+  const turnId = asRecordOrUndefined(lody)?.turnId;
+  return typeof turnId === 'string' && turnId.length > 0 ? turnId : undefined;
+};
+
+/**
+ * Read the engine-opened turn's origin kind off a `session/update`
+ * (`_meta.lody.turnOrigin`, e.g. `cron_job`). Only present on turns the agent
+ * opened itself; client-dispatched turns carry no origin marker. Its presence
+ * is the routing signal that the update may start an autonomous assistant
+ * entry when no client turn owns the session.
+ */
+export const readLodyTurnOrigin = (update: { _meta?: unknown }): string | undefined => {
+  const lody = asRecordOrUndefined(update._meta)?.lody;
+  const origin = asRecordOrUndefined(lody)?.turnOrigin;
+  return typeof origin === 'string' && origin.length > 0 ? origin : undefined;
+};
+
+/** Autonomous id prefix stamped on engine-opened turns (`auto:<engineTurnId>`). */
+const AUTONOMOUS_TURN_ID_PREFIX = 'auto:';
+
+/**
+ * Whether a `_meta.lody.turnId` names a turn the agent engine opened itself
+ * rather than a client-dispatched turn. Such ids are non-numeric on purpose:
+ * `session/fork` parses the published id back into a fork position, and an
+ * engine turn must never resolve into one.
+ */
+export const isAutonomousTurnId = (turnId: string): boolean =>
+  turnId.startsWith(AUTONOMOUS_TURN_ID_PREFIX);
+
+/**
+ * Whether a `session/update` is the end marker of an engine-opened turn
+ * (`_meta.lody.turnEnded === true`). The client owns finalization for turns it
+ * dispatches, but it never learns when an engine-opened turn ends without this
+ * marker — and an assistant entry that never finalizes renders as perpetually
+ * streaming (`message.finished` is the renderer's only streaming verdict).
+ */
+export const readLodyTurnEnded = (update: { _meta?: unknown }): boolean => {
+  const lody = asRecordOrUndefined(update._meta)?.lody;
+  return asRecordOrUndefined(lody)?.turnEnded === true;
+};
+
+/**
  * Keep a valid UTF-8 tail without splitting a Unicode code point.
  *
  * `TextEncoder` is used rather than `String#length`: Loro stores strings as
@@ -1311,6 +1360,12 @@ class NotificationOnHistoryApplier {
   // where the task first appeared (keyed by `taskId`).
   private readonly subagentTaskEntryIndexById = new Map<string, number>();
   private readonly touchedAssistantEntryIndices = new Set<number>();
+  // Assistant entry owning each `_meta.lody.turnId` seen so far. Built lazily by
+  // scanning history once, then kept current as entries are stamped/created.
+  private entryIndexByAcpTurnId: Map<string, number> | undefined;
+  // Per-notification override: updates stamped with a turn id always land in the
+  // entry that owns that turn, never in whatever entry happens to be current.
+  private turnEntryIndexOverride: number | undefined;
   private changed = false;
 
   constructor(
@@ -1335,35 +1390,54 @@ class NotificationOnHistoryApplier {
     for (const notification of notifications) {
       const { update } = notification;
 
-      const turnId =
-        update._meta?.lody &&
-        typeof update._meta.lody === 'object' &&
-        typeof (update._meta.lody as Record<string, unknown>).turnId === 'string'
-          ? ((update._meta.lody as Record<string, unknown>).turnId as string)
-          : undefined;
+      // Only an engine-opened turn (kimi stamps those with an `auto:` id plus
+      // `turnOrigin`) gets turn-aware routing: its updates land in their own
+      // entry instead of merging into the client turn that ran last. Every
+      // other stamped id keeps the legacy last-wins stamping on the current
+      // entry — claude's per-message boundary uuids and codex collab child
+      // turns label boundaries inside one client turn, not turns the client
+      // failed to dispatch, and must not splinter that turn's rendering.
+      const turnId = readLodyTurnId(update);
       if (turnId) {
-        const entryIndex = this.ensureActiveAssistantEntry();
-        const entry = this.history[entryIndex];
-        if (entry && entry.acpTurnId !== turnId) {
-          entry.acpTurnId = turnId;
-          this.changed = true;
+        if (isAutonomousTurnId(turnId) || readLodyTurnOrigin(update) !== undefined) {
+          const entryIndex = this.ensureEntryForAcpTurn(turnId);
+          const turnOrigin = readLodyTurnOrigin(update);
+          const entry = this.history[entryIndex];
+          if (turnOrigin !== undefined && entry && entry.acpTurnOrigin === undefined) {
+            entry.acpTurnOrigin = turnOrigin;
+            this.changed = true;
+          }
+          if (readLodyTurnEnded(update)) {
+            this.finalizeEntryOnce(entryIndex);
+          }
+          this.turnEntryIndexOverride = entryIndex;
+        } else {
+          const entryIndex = this.ensureActiveAssistantEntry();
+          const entry = this.history[entryIndex];
+          if (entry && entry.acpTurnId !== turnId) {
+            entry.acpTurnId = turnId;
+            this.changed = true;
+          }
         }
       }
+      try {
+        // Checklist plans go to entry.plan, not entry.items. ACP 1.0 called this
+        // update `plan`; ACP 1.3 carries the same entries in `plan_update`.
+        if (update.sessionUpdate === 'plan') {
+          this.updateEntryPlan(update.entries);
+          continue;
+        }
+        if (update.sessionUpdate === 'plan_update' && update.plan.type === 'items') {
+          this.updateEntryPlan(update.plan.entries);
+          continue;
+        }
 
-      // Checklist plans go to entry.plan, not entry.items. ACP 1.0 called this
-      // update `plan`; ACP 1.3 carries the same entries in `plan_update`.
-      if (update.sessionUpdate === 'plan') {
-        this.updateEntryPlan(update.entries);
-        continue;
-      }
-      if (update.sessionUpdate === 'plan_update' && update.plan.type === 'items') {
-        this.updateEntryPlan(update.plan.entries);
-        continue;
-      }
-
-      const contents = buildMessageContentFromNotification(notification);
-      for (const message of contents) {
-        this.applyMessageContent(message);
+        const contents = buildMessageContentFromNotification(notification);
+        for (const message of contents) {
+          this.applyMessageContent(message);
+        }
+      } finally {
+        this.turnEntryIndexOverride = undefined;
       }
     }
 
@@ -1480,7 +1554,95 @@ class NotificationOnHistoryApplier {
     return items;
   }
 
+  /**
+   * Resolve the assistant entry that owns an engine-opened turn. The current
+   * target entry may adopt the turn only while it still accepts deltas — a
+   * finalized but unstamped entry (a turn that died before producing output)
+   * must not adopt an interrupting turn, or the two merge exactly like the
+   * unrouted bug this fixes. Anything else gets its own entry so the two turns
+   * render separately.
+   */
+  private ensureEntryForAcpTurn(turnId: string): number {
+    const byTurn = this.getAcpTurnEntryIndex();
+    const known = byTurn.get(turnId);
+    if (known !== undefined) {
+      return known;
+    }
+
+    const currentIndex = this.ensureActiveAssistantEntry();
+    const current = this.history[currentIndex];
+    if (current && current.acpTurnId === undefined && canAppendAssistantDeltas(current)) {
+      current.acpTurnId = turnId;
+      this.changed = true;
+      byTurn.set(turnId, currentIndex);
+      return currentIndex;
+    }
+    if (current && current.acpTurnId === turnId) {
+      byTurn.set(turnId, currentIndex);
+      return currentIndex;
+    }
+
+    const autonomousIndex = this.pushAssistantEntry(`assistant:autonomous-${turnId}`);
+    const autonomous = this.history[autonomousIndex];
+    if (autonomous) {
+      autonomous.acpTurnId = turnId;
+      this.changed = true;
+    }
+    byTurn.set(turnId, autonomousIndex);
+    return autonomousIndex;
+  }
+
+  private getAcpTurnEntryIndex(): Map<string, number> {
+    if (this.entryIndexByAcpTurnId === undefined) {
+      const map = new Map<string, number>();
+      for (const [index, entry] of this.history.entries()) {
+        if (entry.role === 'assistant' && typeof entry.acpTurnId === 'string') {
+          if (!map.has(entry.acpTurnId)) {
+            map.set(entry.acpTurnId, index);
+          }
+        }
+      }
+      this.entryIndexByAcpTurnId = map;
+    }
+    return this.entryIndexByAcpTurnId;
+  }
+
+  /**
+   * Stamp the terminal footprint (`finished`/`endedAt`) on an engine-opened
+   * turn's entry, once. An already-finished entry keeps its first terminal
+   * timing — the renderer derives the turn's duration from `endedAt`, so a
+   * duplicate end marker must not inflate it.
+   */
+  private finalizeEntryOnce(entryIndex: number): void {
+    const entry = this.history[entryIndex];
+    if (!entry || entry.finished === true) {
+      return;
+    }
+    entry.finished = true;
+    entry.endedAt = Date.parse(this.now());
+    this.changed = true;
+  }
+
+  private pushAssistantEntry(id: string): number {
+    this.history.push({
+      id,
+      role: 'assistant',
+      items: [] as unknown as SessionHistoryInput['items'],
+      timestamp: this.now(),
+      userId: undefined,
+      read: undefined,
+      modelInfo: this.model,
+      fileDiff: [],
+    });
+    this.parsedItemsByEntryIndex.push([]);
+    this.changed = true;
+    return this.history.length - 1;
+  }
+
   private ensureActiveAssistantEntry(): number {
+    if (this.turnEntryIndexOverride !== undefined) {
+      return this.turnEntryIndexOverride;
+    }
     if (this.targetAssistantEntryId) {
       const targetIndex = this.history.findIndex(
         (entry) => entry.role === 'assistant' && entry.id === this.targetAssistantEntryId

--- a/packages/shared/src/history-write-schema.ts
+++ b/packages/shared/src/history-write-schema.ts
@@ -13,6 +13,7 @@ export const HistoryEntryWriteSchema = z.object({
   timestamp: z.string(),
   userTurnId: z.string().optional(),
   acpTurnId: z.string().optional(),
+  acpTurnOrigin: z.string().optional(),
   items: z.array(MessageContentSchema).optional(),
   plan: z.array(PlanEntrySchema).optional(),
   startedAt: z.number().optional(),

--- a/packages/shared/src/schema.ts
+++ b/packages/shared/src/schema.ts
@@ -566,6 +566,9 @@ export const sessionHistorySchema = schema.LoroMap({
   // Provider-native assistant turn boundary emitted by the ACP adapter.
   // Lody stores and returns this opaque value without interpreting it.
   acpTurnId: schema.String({ required: false }),
+  // Origin kind of an engine-opened turn (`cron_job`, `task`, ...), stamped by
+  // the adapter on every update of that turn. Absent on client-dispatched turns.
+  acpTurnOrigin: schema.String({ required: false }),
   items: schema.LoroList(historyMessageItemSchema, undefined, { required: false }),
   // Plan attached to this turn, updated via notification updates during the agent's response
   plan: schema.LoroList(sessionPlanEntrySchema, undefined, { required: false }),
@@ -1210,6 +1213,7 @@ export type SessionHistoryInput = Omit<
   InferInputType<typeof sessionHistorySchema>,
   | 'userTurnId'
   | 'acpTurnId'
+  | 'acpTurnOrigin'
   | 'modelInfo'
   | 'fileDiff'
   | 'startedAt'
@@ -1229,6 +1233,7 @@ export type SessionHistoryInput = Omit<
   userId?: string;
   userTurnId?: string | undefined;
   acpTurnId?: string | undefined;
+  acpTurnOrigin?: string | undefined;
   modelInfo?: ModelInfo | undefined;
   fileDiff: FileDiff[];
   status?: SessionHistoryStatus;

--- a/packages/shared/tests/acp-history-apply.test.ts
+++ b/packages/shared/tests/acp-history-apply.test.ts
@@ -121,6 +121,255 @@ describe('acp history apply', () => {
     ]);
   });
 
+  it('routes an engine-opened turn to its own entry instead of the finalized turn', () => {
+    const userTurnNotifications = [
+      makeNotification({
+        sessionUpdate: 'agent_message_chunk',
+        messageId: 'msg_reply',
+        content: { type: 'text', text: 'the real reply' },
+        _meta: { lody: { turnId: '40' } },
+      }),
+    ];
+    const cronTurnNotifications = [
+      makeNotification({
+        sessionUpdate: 'agent_thought_chunk',
+        messageId: 'msg_cron_think',
+        content: { type: 'text', text: 'cron thinking' },
+        _meta: { lody: { turnId: 'auto:41', turnOrigin: 'cron_job' } },
+      }),
+      makeNotification({
+        sessionUpdate: 'agent_message_chunk',
+        messageId: 'msg_cron_text',
+        content: { type: 'text', text: 'cron status update' },
+        _meta: { lody: { turnId: 'auto:41', turnOrigin: 'cron_job' } },
+      }),
+    ];
+
+    // The finalized user turn is still the routing target when the cron turn's
+    // updates arrive — they must not merge into it.
+    let history = applyNotificationOnHistory([], userTurnNotifications, undefined, {
+      targetAssistantEntryId: 'assistant:user-turn',
+    });
+    history = applyNotificationOnHistory(history, cronTurnNotifications, undefined, {
+      targetAssistantEntryId: 'assistant:user-turn',
+    });
+
+    expect(history).toHaveLength(2);
+    expect(history[0]).toEqual(
+      expect.objectContaining({
+        id: 'assistant:user-turn',
+        acpTurnId: '40',
+        items: [{ type: 'text', text: 'the real reply' }],
+      })
+    );
+    expect(history[1]).toEqual(
+      expect.objectContaining({
+        id: 'assistant:autonomous-auto:41',
+        acpTurnId: 'auto:41',
+        acpTurnOrigin: 'cron_job',
+        items: [
+          { type: 'thought', text: 'cron thinking' },
+          { type: 'text', text: 'cron status update' },
+        ],
+      })
+    );
+  });
+
+  it('keeps appending to the autonomous turn entry across batches', () => {
+    const cronThought = [
+      makeNotification({
+        sessionUpdate: 'agent_thought_chunk',
+        messageId: 'msg_cron_think',
+        content: { type: 'text', text: 'cron thinking' },
+        _meta: { lody: { turnId: 'auto:41', turnOrigin: 'cron_job' } },
+      }),
+    ];
+    const cronText = [
+      makeNotification({
+        sessionUpdate: 'agent_message_chunk',
+        messageId: 'msg_cron_text',
+        content: { type: 'text', text: 'cron status update' },
+        _meta: { lody: { turnId: 'auto:41', turnOrigin: 'cron_job' } },
+      }),
+    ];
+
+    let history = applyNotificationOnHistory([], cronThought, undefined, {
+      targetAssistantEntryId: 'assistant:autonomous-auto:41',
+    });
+    history = applyNotificationOnHistory(history, cronText, undefined, {
+      targetAssistantEntryId: 'assistant:autonomous-auto:41',
+    });
+
+    expect(history).toHaveLength(1);
+    expect(history[0]).toEqual(
+      expect.objectContaining({
+        id: 'assistant:autonomous-auto:41',
+        acpTurnId: 'auto:41',
+        items: [
+          { type: 'thought', text: 'cron thinking' },
+          { type: 'text', text: 'cron status update' },
+        ],
+      })
+    );
+  });
+
+  it('does not adopt an engine turn into a finalized entry whose own turn produced nothing', () => {
+    // A turn that died before producing output leaves a finalized, unstamped
+    // entry; an interrupting engine turn must not adopt it (that would merge
+    // the two turns exactly like the unrouted bug).
+    let history = applyNotificationOnHistory(
+      [
+        {
+          id: 'assistant:failed-turn',
+          role: 'assistant',
+          items: [],
+          timestamp: '2026-09-04T07:50:00.000Z',
+          finished: true,
+          endedAt: 1788508365,
+          fileDiff: [],
+        } as never,
+      ],
+      [
+        makeNotification({
+          sessionUpdate: 'agent_message_chunk',
+          messageId: 'msg_cron',
+          content: { type: 'text', text: 'cron status update' },
+          _meta: { lody: { turnId: 'auto:32', turnOrigin: 'cron_job' } },
+        }),
+      ],
+      undefined,
+      { targetAssistantEntryId: 'assistant:failed-turn' }
+    );
+
+    expect(history).toHaveLength(2);
+    expect(history[0]).toEqual(expect.objectContaining({ id: 'assistant:failed-turn', items: [] }));
+    expect(history[0]?.acpTurnId).toBeUndefined();
+    expect(history[1]).toEqual(
+      expect.objectContaining({
+        id: 'assistant:autonomous-auto:32',
+        acpTurnId: 'auto:32',
+        items: [{ type: 'text', text: 'cron status update' }],
+      })
+    );
+  });
+
+  it('keeps claude per-message boundary uuids on one entry with last-wins stamping', () => {
+    const history = applyNotificationOnHistory(
+      [],
+      [
+        makeNotification({
+          sessionUpdate: 'agent_message_chunk',
+          messageId: 'msg_a',
+          content: { type: 'text', text: 'first answer' },
+        }),
+        makeNotification({
+          sessionUpdate: 'session_info_update',
+          _meta: { lody: { turnId: 'uuid-message-a' } },
+        }),
+        makeNotification({
+          sessionUpdate: 'agent_message_chunk',
+          messageId: 'msg_b',
+          content: { type: 'text', text: ' and more' },
+        }),
+        makeNotification({
+          sessionUpdate: 'session_info_update',
+          _meta: { lody: { turnId: 'uuid-message-b' } },
+        }),
+      ],
+      undefined,
+      { targetAssistantEntryId: 'assistant:claude-turn' }
+    );
+
+    expect(history).toHaveLength(1);
+    expect(history[0]).toEqual(
+      expect.objectContaining({
+        id: 'assistant:claude-turn',
+        acpTurnId: 'uuid-message-b',
+        items: [{ type: 'text', text: 'first answer and more' }],
+      })
+    );
+  });
+
+  it('keeps codex collab child-turn chunks inline with legacy restamping', () => {
+    const history = applyNotificationOnHistory(
+      [],
+      [
+        makeNotification({
+          sessionUpdate: 'agent_message_chunk',
+          messageId: 'msg_main',
+          content: { type: 'text', text: 'main answer' },
+          _meta: { lody: { turnId: 'turn-main' } },
+        }),
+        makeNotification({
+          sessionUpdate: 'agent_message_chunk',
+          messageId: 'msg_child',
+          content: { type: 'text', text: ' (child result)' },
+          _meta: { lody: { turnId: 'turn-child' } },
+        }),
+      ],
+      undefined,
+      { targetAssistantEntryId: 'assistant:codex-turn' }
+    );
+
+    expect(history).toHaveLength(1);
+    expect(history[0]).toEqual(
+      expect.objectContaining({
+        id: 'assistant:codex-turn',
+        acpTurnId: 'turn-child',
+        items: [{ type: 'text', text: 'main answer (child result)' }],
+      })
+    );
+  });
+
+  it('finalizes an engine-opened turn on its end marker, once', () => {
+    const now = () => '2026-09-08T09:52:20.000Z';
+    let history = applyNotificationOnHistory(
+      [],
+      [
+        makeNotification({
+          sessionUpdate: 'agent_message_chunk',
+          messageId: 'msg_cron',
+          content: { type: 'text', text: 'cron status update' },
+          _meta: { lody: { turnId: 'auto:41', turnOrigin: 'cron_job' } },
+        }),
+        makeNotification({
+          sessionUpdate: 'session_info_update',
+          _meta: { lody: { turnId: 'auto:41', turnOrigin: 'cron_job', turnEnded: true } },
+        }),
+      ],
+      undefined,
+      { targetAssistantEntryId: 'assistant:autonomous-auto:41', now }
+    );
+
+    expect(history).toHaveLength(1);
+    expect(history[0]).toEqual(
+      expect.objectContaining({
+        id: 'assistant:autonomous-auto:41',
+        acpTurnId: 'auto:41',
+        finished: true,
+        endedAt: Date.parse('2026-09-08T09:52:20.000Z'),
+        items: [{ type: 'text', text: 'cron status update' }],
+      })
+    );
+
+    // A duplicate marker must not move the terminal timing.
+    history = applyNotificationOnHistory(
+      history,
+      [
+        makeNotification({
+          sessionUpdate: 'session_info_update',
+          _meta: { lody: { turnId: 'auto:41', turnOrigin: 'cron_job', turnEnded: true } },
+        }),
+      ],
+      undefined,
+      {
+        targetAssistantEntryId: 'assistant:autonomous-auto:41',
+        now: () => '2026-09-08T10:00:00.000Z',
+      }
+    );
+    expect(history[0]?.endedAt).toBe(Date.parse('2026-09-08T09:52:20.000Z'));
+  });
+
   it('keeps a valid UTF-8 terminal tail within the shared byte budget', () => {
     const input = `${'a'.repeat(900)}${'界'.repeat(100)}${'🙂'.repeat(100)}`;
     const result = truncateTerminalOutputForHistory(input);


### PR DESCRIPTION
## Related issue

Closes #640

> **Companion PR: #654 must land together with this one.** It carries the
> lifecycle guards the codex review rounds identified (fork/edit-resend
> suppression of `auto:` entries, ACP `exit`-path marker cleanup, engine-turn
> Stop routing, replay-window bypass, monitor-state coverage). The split
> exists only to keep this PR under the community 1000-line gate; review them
> as one change and merge back-to-back. (An origin-divider UI was tried and
> reverted — it breaks the stream index contract; tracked in #660.)

## Problem / pressure

The Kimi engine opens turns behind the client's back — a cron fire, a task wake — and its ACP server forwards their content by design. Those updates carried no turn identity, so the history layer routed them into the last client turn's assistant entry (the never-expiring finalized-turn target built for stragglers), or dropped them when no client turn existed in memory. Observed in production sessions: the user turn's real reply folded into a collapsed "thinking process" while the cron turn's text became the visible answer; a session showing "completed" (`executionState: idle`) while an engine turn ran for 15+ minutes; the 20-min idle GC SIGKILLing the agent process mid-cron-turn; engine-turn output dropped after a daemon restart.

## Summary

- **Wire identity (kimi ACP server, PR LodyAI/acp-extension-kimi#9, submodule pin bump included):** engine-opened turns are stamped `_meta.lody.turnId = auto:<n>` (non-numeric, can never parse into a `session/fork` position) + `_meta.lody.turnOrigin`; a `_meta.lody.turnEnded` marker is emitted when such a turn ends.
- **Turn-aware grouping (`@lody/shared` history-apply):** only `auto:`/`turnOrigin`-marked updates get turn-aware routing — owner entry → adopt only a delta-accepting entry → else create `assistant:autonomous-<turnId>`. Every other stamped id keeps the exact legacy last-wins restamping (claude per-message boundary uuids and codex collab child turns are boundaries inside one client turn). `turnEnded` finalizes the owning entry once. `acpTurnOrigin` is persisted on the entry.
- **Routing (`apps/cli`):** marked updates always take a synthesized autonomous target — never the active/finalized client turn's — covering the no-target drop and rich content. An engine-turn activity marker (set on first marked update, cleared on end marker or ACP process termination — process-bounded, no wall clock) feeds `hasActiveTurn` (idle-GC guard) and upgrades live status `unknown` → `running`.
- **UI:** the chat stream renders an eyebrow divider ("Scheduled task" / "Background task") before engine-opened turns, since they have no user message.

## Visual explanation

```mermaid
flowchart LR
  subgraph kimi [Kimi engine + ACP server]
    UT[user turn 40] --> T41[cron turn 41, origin=cron_job]
    T41 --> S["_meta.lody: turnId=auto:41, turnOrigin, turnEnded"]
  end
  S --> R{apps/cli enqueueACPUpdate}
  R -->|marked| AT[autonomous target<br/>assistant:autonomous-auto:41]
  R -->|unmarked| LT[active/finalized client target]
  AT --> HA{history-apply}
  LT --> HA
  HA -->|auto:/turnOrigin only| E1[own entry: adopt-if-accepting<br/>or create autonomous entry]
  HA -->|any other id| E2[legacy last-wins restamping<br/>claude uuids, codex collab]
  S --> M[engineTurn activity marker<br/>transient store]
  M -->|set| BUSY[live status running + GC guard]
  M -->|turnEnded / process exit| IDLE[clear]
  E1 --> UI[divider: Scheduled task<br/>+ own finished turn]
```

## Before / after

| Before | After |
| ------ | ----- |
| Engine turn output appended to the previous user turn's entry; its text became the visible "answer", real reply folded | User turn keeps its reply; engine turn renders as its own following turn |
| Engine-turn updates dropped after daemon restart | Routed to `assistant:autonomous-<turnId>`; content survives |
| Engine turn entry never finalized (perpetual streaming) | `turnEnded` marker finalizes it once |
| `executionState: idle` while the engine turn runs; idle GC kills the agent mid-turn | Live status reads `running`; GC guard sees the engine turn; marker clears on end/process exit |
| No visual cue that a turn came from a cron fire | Eyebrow divider labels the origin |

## Test plan

- `packages/shared`: full suite 1133 passing, incl. new cases — engine-turn separation, cross-batch continuity, died-before-output adoption hole, end-marker finalization (once-only timing), claude multi-uuid last-wins, codex collab inline restamping.
- `apps/cli`: full suite 2715 passing (3 failures reproduce on unmodified `origin/main` in this environment: two Claude credential-store probes, one macOS `/var` vs `/private/var` worktree-GC assertion) — new store cases for autonomous-target gating and engine-turn activity note/clear/replace.
- `packages/components`: 16 passing, incl. divider emission on both incremental and cache-reuse paths. `acp-server` (submodule): 163 passing (1 pre-existing env e2e failure on base).
- tsc clean in shared/cli/components/acp-server; prettier, oxlint, `check-i18n`, `pnpm run docs check` clean.
- End-to-end on OSS desktop + locally built stamped runtime: cron turn after a user turn rendered as its own finished turn with origin divider; session presence read `running` during the engine turn, `idle` after; provider-500-empty-turn + adjacent cron fire no longer merges.
- Skipped: replay/import consistency and cron-prompt surfacing (follow-ups in the issue); GC-kill repro used reasoning + logs, not a 20-min live wait.

## Context handoff

<!-- context-handoff:begin -->

### Instructions for reviewing agents

- **Review focus:** `packages/shared/src/acp/history-apply.ts` (the three-way turnId branch in `apply()` + `ensureEntryForAcpTurn` adoption condition + `finalizeEntryOnce`), `apps/cli/src/lib/session-transient-store.ts` (`autonomousACPUpdateTargetFrom` gating, engine-turn marker lifecycle), `apps/cli/src/lib/message-handler.ts` (`enqueueACPUpdate` target precedence), kimi `acp-server/src/session.ts` (stamp + end-marker emission).
- **Decisions to challenge:** gating all new behavior on `auto:`/`turnOrigin` markers only (legacy path kept for every other stamped id); adoption allowed only on delta-accepting entries; engine-turn liveness bounded by ACP process termination rather than a wall clock; `auto:<n>` as the non-fork id format.
- **Plausible failures / evidence gaps:** task-wake turns now also render separately (subagent UX change); a GC-killed engine turn never emits its end marker (unfinished entry, same as any crashed turn); replay/import does not classify cron fires (reload can surface cron XML as user messages — known follow-up); kimi stamping only lands with the next managed-runtime artifact, and the client side is untested against that artifact in production.

### Authoring context

- **User goal / directives:** Investigate and fix a session display bug where a user-message turn interrupted-adjacent to a cronjob fire collapses into a "thinking process"; user then directed: two turns should render separately, keep the blast radius kimi-only, verify end-to-end, file the issue and open the PRs.
- **Constraints / non-goals:** No behavior change for claude/codex/pi/grok/deepseek or unstamped runtimes; fork-at-turn semantics untouched; no replay/import rework, no cron-prompt surfacing, no GC/lifecycle redesign beyond the marker-based guard.
- **Risk-bearing decisions:** new history field `acpTurnOrigin` (additive Loro schema change); deterministic entry ids `assistant:autonomous-<turnId>`; non-numeric `auto:` ids can never resolve into `session/fork` positions; legacy last-wins restamping preserved byte-for-byte for all unmarked ids.
- **Destructive or irreversible behavior:** none — history writes are additive; a duplicate end marker cannot move an entry's terminal timing; failed flush groups requeue with at-least-once semantics unchanged.
- **Deliberately not done or tested:** cron-prompt user-message surfacing, replay/import origin classification, UI label for the cron prompt text, live GC-kill repro (20-min wait); each is recorded as a follow-up in #640.
- **Unknowns / confidence:** high confidence in unit/replay-level correctness and the single-machine e2e; moderate on multi-turn subagent UX (wake turns separating) and on behavior before the stamped artifact ships (inert by design, asserted by tests but not observed in production).

### Original user prompt

<details>
<summary>Show original prompt</summary>

````text
现在似乎有个 bug，在 fusion-model 下有个 session，你会发现如果当 user message trigger 的一个轮次被 cronjob 打断，那么这个轮次会被折叠为思考过程，这个显示显然不是我们期望的，你去 check 一下
````

</details>

<!-- context-handoff:end -->
